### PR TITLE
fix: signal_queue に 'failed' ステータスを追加し mark_signal_failed.py の名称を統一 (Issue #160)

### DIFF
--- a/scripts/mark_signal_failed.py
+++ b/scripts/mark_signal_failed.py
@@ -99,7 +99,7 @@ def main() -> None:
             )
             sys.exit(1)
 
-        print(f"以下の {len(targets)} 件を status='error' に更新します:")
+        print(f"以下の {len(targets)} 件を status='failed' に更新します:")
         _print_records(targets)
 
         answer = input("続行しますか？ [y/N]: ").strip().lower()
@@ -113,7 +113,7 @@ def main() -> None:
         # SELECT 後に別プロセスが status を変更済みの行は更新しない。
         # DuckDB の rowcount は信頼できないため RETURNING で実更新件数を確認する。
         updated_rows = conn.execute(
-            f"UPDATE signal_queue SET status = 'error'"
+            f"UPDATE signal_queue SET status = 'failed'"
             f" WHERE signal_id IN ({placeholders})"
             f" AND status IN ('pending', 'processing')"
             f" RETURNING signal_id",
@@ -127,7 +127,7 @@ def main() -> None:
                 len(signal_ids), updated,
             )
         logger.info(
-            "signal_queue を更新しました（%d 件を status='error' に変更）。",
+            "signal_queue を更新しました（%d 件を status='failed' に変更）。",
             updated,
         )
 

--- a/src/kabusys/data/schema.py
+++ b/src/kabusys/data/schema.py
@@ -221,7 +221,7 @@ CREATE TABLE IF NOT EXISTS signal_queue (
     order_type      VARCHAR       NOT NULL CHECK (order_type IN ('market', 'limit', 'stop')),
     price           DECIMAL(18,4)          CHECK (price >= 0),
     status          VARCHAR       NOT NULL DEFAULT 'pending'
-                                  CHECK (status IN ('pending','processing','filled','cancelled','error')),
+                                  CHECK (status IN ('pending','processing','filled','cancelled','error','failed')),
     created_at      TIMESTAMP   NOT NULL DEFAULT current_timestamp,
     processed_at    TIMESTAMP
 )

--- a/tests/test_mark_signal_failed.py
+++ b/tests/test_mark_signal_failed.py
@@ -164,11 +164,11 @@ def test_updates_on_user_yes(tmp_path, monkeypatch):
          patch("mark_signal_failed.duckdb.connect", return_value=conn_mock):
         _run(["--code", "7203", "--date", "2026-04-17"])
 
-    # UPDATE が呼ばれ、status='error' と signal_id が含まれること
+    # UPDATE が呼ばれ、status='failed' と signal_id が含まれること
     sql_calls = [(str(c.args[0]), c.args[1] if len(c.args) > 1 else [])
                  for c in conn_mock.execute.call_args_list]
     update_call = next(c for c in sql_calls if "UPDATE" in c[0])
-    assert "error" in update_call[0]
+    assert "failed" in update_call[0]
     assert "RETURNING" in update_call[0]
     assert "sig-001" in update_call[1] and "sig-002" in update_call[1]
     conn_mock.close.assert_called_once()


### PR DESCRIPTION
## Summary

- `signal_queue` の CHECK 制約に `'failed'` を追加（`schema.py`）
- `mark_signal_failed.py` のステータスを `'error'` → `'failed'` に変更
- テスト・表示文言・ログを `'failed'` に統一

## 背景

PR #159 でスクリプト実装時、`schema.py` の CHECK 制約に `'failed'` が存在しなかったため `'error'` で代替していた。しかし `FailureRecovery.md §10.1` やスクリプト名 `mark_signal_failed.py` は `'failed'` を前提としており不一致が発生していた。

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `src/kabusys/data/schema.py` | CHECK 制約に `'failed'` を追加 |
| `scripts/mark_signal_failed.py` | `status='error'` → `'failed'`、表示文言・ログ統一 |
| `tests/test_mark_signal_failed.py` | アサーション `'error'` → `'failed'` |

## Test Plan

- [x] `tests/test_mark_signal_failed.py` 8件 全パス
- [x] フルテストスイート 702件パス（既存の無関係な失敗1件は本PR対象外）

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)