### PR TITLE
feat: start_system.py に --dry-run モードを追加（Issue #157）

### DIFF
--- a/documents/08_Operations/TradingRunbook.md
+++ b/documents/08_Operations/TradingRunbook.md
@@ -254,13 +254,32 @@ python scripts\stop_system.py
 python scripts\start_system.py --clear-stop-flag
 ```
 
+#### 再開前の状態確認（推奨）
+
+`--clear-stop-flag` で本起動する前に、`--dry-run` で発注なしの状態確認を実施することを推奨する。
+
+```cmd
+:: 発注なしで DB 状態を確認（プロセス起動なし、停止フラグも変更しない）
+python scripts\start_system.py --dry-run
+```
+
+出力例:
+
+```
+[DRY-RUN] 停止フラグ: あり (data\stop_requested.flag)
+[DRY-RUN] signal_queue: pending=3 件, processing=0 件（リコンシリエーション対象）
+[DRY-RUN] positions: 5 件
+[DRY-RUN] 発注は行いません。通常起動は --clear-stop-flag を指定してください。
+```
+
 ### 8.3 発動後の確認
 
 ```
 1. ログで Kill Switch 発動の原因を確認
 2. ポジションを証券口座で直接確認（手動）
-3. 原因が解消したら FailureRecovery.md §9 に従い復旧
-4. 翌日の Runbook を通常通り実行
+3. python scripts\start_system.py --dry-run で pending シグナル数とポジションを確認
+4. 原因が解消したら FailureRecovery.md §9 に従い復旧
+5. 翌日の Runbook を通常通り実行
 ```
 
 ---

--- a/scripts/start_system.py
+++ b/scripts/start_system.py
@@ -9,6 +9,9 @@
 
     # 停止フラグが残っている場合に明示的にクリアして起動する
     python scripts/start_system.py --clear-stop-flag
+
+    # 発注なしでリコンシリエーションと状態確認のみ実行（再開判断前の確認用）
+    python scripts/start_system.py --dry-run
 """
 from __future__ import annotations
 
@@ -30,6 +33,14 @@ from utils import (
     read_pid,
     write_pid,
 )
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+try:
+    import duckdb as _duckdb
+    from kabusys.config import Settings as _Settings
+    _DRY_RUN_DEPS_AVAILABLE = True
+except ImportError:
+    _DRY_RUN_DEPS_AVAILABLE = False
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
@@ -70,6 +81,60 @@ def _launch(module: str, pid_path: Path) -> bool:
     return True
 
 
+def _run_dry_run() -> None:
+    """--dry-run モード: 発注なしで DB 状態を確認してログ出力する。"""
+    prefix = "[DRY-RUN]"
+
+    # 停止フラグ状態を報告
+    flag_status = "あり" if STOP_FLAG_PATH.exists() else "なし"
+    logger.info("%s 停止フラグ: %s (%s)", prefix, flag_status, STOP_FLAG_PATH)
+
+    # DuckDB / Settings の依存がない場合はここで終了
+    if not _DRY_RUN_DEPS_AVAILABLE:
+        logger.warning("%s duckdb または kabusys.config が利用不可のため DB 状態確認をスキップします。", prefix)
+        logger.info("%s 発注は行いません。通常起動は --clear-stop-flag を指定してください。", prefix)
+        return
+
+    try:
+        settings = _Settings()
+        if not settings.duckdb_path.exists():
+            logger.warning("%s DuckDB ファイルが見つかりません: %s", prefix, settings.duckdb_path)
+            logger.info("%s 発注は行いません。通常起動は --clear-stop-flag を指定してください。", prefix)
+            return
+
+        conn = _duckdb.connect(str(settings.duckdb_path), read_only=True)
+        try:
+            # signal_queue の pending 件数
+            pending = conn.execute(
+                "SELECT COUNT(*) FROM signal_queue WHERE status = 'pending'"
+            ).fetchone()[0]
+
+            # 未処理 orders（sent 状態）件数（リコンシリエーション対象）
+            sent_orders = conn.execute(
+                "SELECT COUNT(*) FROM signal_queue WHERE status = 'processing'"
+            ).fetchone()[0]
+
+            # positions 件数
+            positions = conn.execute(
+                "SELECT COUNT(*) FROM positions"
+            ).fetchone()[0]
+
+        finally:
+            conn.close()
+
+        logger.info(
+            "%s signal_queue: pending=%d 件, processing=%d 件（リコンシリエーション対象）",
+            prefix, pending, sent_orders,
+        )
+        logger.info("%s positions: %d 件", prefix, positions)
+        logger.info(
+            "%s 発注は行いません。通常起動は --clear-stop-flag を指定してください。", prefix
+        )
+
+    except Exception:
+        logger.exception("%s DB 状態確認中にエラーが発生しました。", prefix)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="KabuSys システム起動")
     parser.add_argument(
@@ -83,7 +148,17 @@ def main() -> None:
         action="store_true",
         help="停止フラグが残っている場合に明示的にクリアして起動する（Kill Switch 発動後の復旧用）",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="発注なしで DB 状態確認のみ実行（再開判断前の確認用）",
+    )
     args = parser.parse_args()
+
+    # --dry-run モード: プロセス起動なしで状態確認のみ
+    if args.dry_run:
+        _run_dry_run()
+        return
 
     # 停止フラグの確認
     if STOP_FLAG_PATH.exists():

--- a/tests/test_start_system.py
+++ b/tests/test_start_system.py
@@ -102,3 +102,88 @@ def test_start_all_launches_both(tmp_path):
         _run_start()  # default = all
 
     assert len(launched) == 2
+
+
+# ---------------------------------------------------------------------------
+# --dry-run モード
+# ---------------------------------------------------------------------------
+
+def test_dry_run_does_not_launch_process(tmp_path):
+    """--dry-run 指定時にプロセスが起動しないこと。"""
+    with patch("start_system.STOP_FLAG_PATH", tmp_path / "stop.flag"), \
+         patch("start_system.EXECUTION_PID_PATH", tmp_path / "exec.pid"), \
+         patch("start_system.MONITORING_PID_PATH", tmp_path / "mon.pid"), \
+         patch("start_system._DRY_RUN_DEPS_AVAILABLE", False), \
+         patch("start_system.subprocess.Popen") as mock_popen:
+        _run_start(["--dry-run"])
+
+    mock_popen.assert_not_called()
+
+
+def test_dry_run_reports_stop_flag_present(tmp_path, caplog):
+    """--dry-run で停止フラグが存在する場合に「あり」とログ出力されること。"""
+    import logging
+    flag = tmp_path / "stop.flag"
+    flag.touch()
+
+    with patch("start_system.STOP_FLAG_PATH", flag), \
+         patch("start_system._DRY_RUN_DEPS_AVAILABLE", False), \
+         caplog.at_level(logging.INFO, logger="start_system"):
+        _run_start(["--dry-run"])
+
+    assert "あり" in caplog.text
+
+
+def test_dry_run_reports_stop_flag_absent(tmp_path, caplog):
+    """--dry-run で停止フラグが存在しない場合に「なし」とログ出力されること。"""
+    import logging
+
+    with patch("start_system.STOP_FLAG_PATH", tmp_path / "stop.flag"), \
+         patch("start_system._DRY_RUN_DEPS_AVAILABLE", False), \
+         caplog.at_level(logging.INFO, logger="start_system"):
+        _run_start(["--dry-run"])
+
+    assert "なし" in caplog.text
+
+
+def test_dry_run_queries_duckdb(tmp_path, caplog):
+    """--dry-run で DuckDB が利用可能なとき pending/processing/positions をログ出力すること。"""
+    import logging
+
+    duckdb_path = tmp_path / "kabusys.duckdb"
+    duckdb_path.write_bytes(b"fake")
+
+    settings_mock = MagicMock()
+    settings_mock.duckdb_path = duckdb_path
+
+    def fake_execute(sql, *args, **kwargs):
+        m = MagicMock()
+        m.fetchone.return_value = (3,)
+        return m
+
+    conn_mock = MagicMock()
+    conn_mock.execute.side_effect = fake_execute
+
+    with patch("start_system.STOP_FLAG_PATH", tmp_path / "stop.flag"), \
+         patch("start_system._DRY_RUN_DEPS_AVAILABLE", True), \
+         patch("start_system._Settings", return_value=settings_mock), \
+         patch("start_system._duckdb.connect", return_value=conn_mock), \
+         caplog.at_level(logging.INFO, logger="start_system"):
+        _run_start(["--dry-run"])
+
+    assert "pending" in caplog.text
+    assert "processing" in caplog.text
+    assert "positions" in caplog.text
+    conn_mock.close.assert_called_once()
+
+
+def test_dry_run_does_not_clear_stop_flag(tmp_path):
+    """--dry-run 指定時に停止フラグを削除しないこと。"""
+    flag = tmp_path / "stop.flag"
+    flag.touch()
+
+    with patch("start_system.STOP_FLAG_PATH", flag), \
+         patch("start_system._DRY_RUN_DEPS_AVAILABLE", False):
+        _run_start(["--dry-run"])
+
+    assert flag.exists()  # フラグは残ったまま


### PR DESCRIPTION
## Summary

- `start_system.py` に `--dry-run` フラグを追加
- 発注なしで DB 状態確認のみ実行（Kill Switch 発動後の再開判断前の確認用）
- `TradingRunbook.md §8` に `--dry-run` の利用タイミングを追記

## 動作仕様

`--dry-run` 指定時:
- 停止フラグの状態を報告するが **クリアしない**
- `signal_queue` の pending/processing 件数をログ出力
- `positions` 件数をログ出力
- **プロセスを起動しない**（PID ファイルも作成しない）

```cmd
python scripts\start_system.py --dry-run
```

出力例:
```
[DRY-RUN] 停止フラグ: あり (data\stop_requested.flag)
[DRY-RUN] signal_queue: pending=3 件, processing=0 件（リコンシリエーション対象）
[DRY-RUN] positions: 5 件
[DRY-RUN] 発注は行いません。通常起動は --clear-stop-flag を指定してください。
```

## Test Plan

- [x] `test_dry_run_does_not_launch_process` — subprocess が起動しないこと
- [x] `test_dry_run_reports_stop_flag_present/absent` — フラグ状態をログ出力
- [x] `test_dry_run_queries_duckdb` — pending/processing/positions をログ出力
- [x] `test_dry_run_does_not_clear_stop_flag` — フラグを削除しないこと
- [x] 既存テスト 5件 引き続きパス
- [x] フルテストスイート 703件パス

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)