### PR TITLE
feat: Phase10 — 環境設定ウィザード・YAML生成・検証CLI・ドキュメント整備 (Issues #136 #137 #138 #139)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,24 +90,50 @@ streamlit
    - pip install -r requirements.txt
    - または最低限: pip install duckdb psutil requests openai streamlit
 
-4. 環境変数設定:
-   - プロジェクトルートに `.env`（または `.env.local`）を作成できます。自動ロードはデフォルトで有効。
-   - 自動ロードを無効にする場合は環境変数 `KABUSYS_DISABLE_AUTO_ENV_LOAD=1` を設定してください。
+4. 環境変数設定（ウィザード推奨）:
 
-5. 必須環境変数（代表例）
-   - JQUANTS_REFRESH_TOKEN: J-Quants API トークン
-   - KABU_API_PASSWORD: kabuステーション API パスワード
-   - OPENAI_API_KEY: OpenAI API キー（AI モジュール使用時）
-   - KABUSYS_ENV: 実行環境（development / paper_trading / live）
-   - その他（オプション・既定値あり）:
-     - DUCKDB_PATH (default: data/kabusys.duckdb)
-     - SQLITE_PATH (default: data/monitoring.db)
-     - PAPER_TRADING_SQLITE_PATH (default: data/paper_trading.db)
-     - PAPER_FILL_MODE: instant | partial | never | reject
-     - PID_FILE_PATH, KILL_FLAG_PATH, LOG_LEVEL, など
+   対話式ウィザードで `.env` を作成できます:
+   ```cmd
+   python -m kabusys.config_setup
+   ```
+   手動設定する場合は `.env.example` をコピーして `.env` を作成してください。
+   - プロジェクトルートに `.env`（または `.env.local`）を置くと自動ロードされます。
+   - 自動ロードを無効にする場合は `KABUSYS_DISABLE_AUTO_ENV_LOAD=1` を設定してください。
 
-6. データディレクトリの作成:
+5. YAML 設定ファイルの生成:
+   ```cmd
+   python scripts/generate_config.py
+   ```
+   `config/` 配下に `system_config.yaml` など 6 ファイルが生成されます（既存ファイルはスキップ）。
+
+6. 設定を検証:
+   ```cmd
+   python -m kabusys.validate_config
+   ```
+   必須環境変数の欠落・YAML ファイルの異常・`live` 環境特有の警告を検出します。
+
+7. データディレクトリの作成:
    - mkdir -p data
+
+### 実行環境（KABUSYS_ENV）の使い分け
+
+| 値 | 用途 | 発注 |
+|----|------|------|
+| `development` | ローカル開発・単体テスト | なし |
+| `paper_trading` | 仮想発注・動作検証 | MockBrokerClient を使用 |
+| `live` | 本番稼働（実際に発注） | kabuステーション API |
+
+> ⚠️ `live` に切り替える前に必ず `python -m kabusys.validate_config --strict` で設定を確認してください。
+
+### 必須環境変数
+
+| 変数名 | 説明 |
+|--------|------|
+| `JQUANTS_REFRESH_TOKEN` | J-Quants API リフレッシュトークン |
+| `KABU_API_PASSWORD` | kabuステーション API パスワード |
+| `KABUSYS_ENV` | 実行環境（development / paper_trading / live） |
+
+その他の変数とデフォルト値は `.env.example` を参照してください。
 
 ---
 

--- a/config/data_config.yaml
+++ b/config/data_config.yaml
@@ -1,0 +1,15 @@
+# data_config.yaml — データ取得設定
+market_data:
+  provider: jquants
+  price_table: prices_daily
+  fundamental_table: fundamentals
+
+news_data:
+  provider: yahoo_news
+  table: news_articles
+
+feature_store:
+  table: features
+
+ai_scores:
+  table: ai_scores

--- a/config/execution_config.yaml
+++ b/config/execution_config.yaml
@@ -1,0 +1,14 @@
+# execution_config.yaml — 発注システム設定
+broker:
+  api: kabu_station
+  account_type: margin
+  retry_attempts: 3
+
+execution:
+  order_type: limit
+  slippage: 0.001
+  timeout_seconds: 10
+
+signal_queue:
+  table: signal_queue
+  polling_interval_seconds: 5

--- a/config/monitoring_config.yaml
+++ b/config/monitoring_config.yaml
@@ -1,0 +1,12 @@
+# monitoring_config.yaml — 監視設定
+monitoring:
+  dashboard: streamlit
+
+alerts:
+  line_enabled: true
+  max_drawdown_alert: 0.10
+  execution_failure_alert: true
+
+logging:
+  level: INFO
+  database: data/monitoring.db

--- a/config/risk_config.yaml
+++ b/config/risk_config.yaml
@@ -1,0 +1,14 @@
+# risk_config.yaml — リスク管理設定（安全側の初期値）
+risk:
+  # 1銘柄最大ウェイト（ポートフォリオ対比）
+  max_position_size: 0.05
+  # ポートフォリオ総投資比率上限
+  max_portfolio_exposure: 1.0
+  # 日次最大損失率（超過で Kill Switch 検討）
+  max_daily_loss: 0.02
+  # 最大ドローダウン（超過で Kill Switch 自動発動）
+  max_drawdown: 0.15
+
+position_sizing:
+  risk_per_trade: 0.01
+  volatility_adjustment: true

--- a/config/strategy_config.yaml
+++ b/config/strategy_config.yaml
@@ -1,0 +1,15 @@
+# strategy_config.yaml — 売買戦略パラメータ
+strategy:
+  name: momentum_strategy
+  universe_size: 500
+  rebalance_frequency: daily
+
+factors:
+  momentum_20_weight: 0.5
+  momentum_60_weight: 0.3
+  volume_factor_weight: 0.2
+
+ai_overlay:
+  enabled: true
+  # AIオーバーレイの影響度上限（RiskManagement.md §6 に準拠）
+  max_influence: 0.10

--- a/config/system_config.yaml
+++ b/config/system_config.yaml
@@ -1,0 +1,17 @@
+# system_config.yaml — システム全体設定
+# 環境: development / paper_trading / live
+environment: development
+
+timezone: Asia/Tokyo
+
+data_directory: data/
+
+log_directory: logs/
+
+database:
+  type: duckdb
+  path: data/kabusys.duckdb
+
+calendar:
+  source: jquants
+  table: market_calendar

--- a/scripts/generate_config.py
+++ b/scripts/generate_config.py
@@ -1,0 +1,162 @@
+# scripts/generate_config.py
+"""config/*.yaml テンプレートを生成するスクリプト。
+
+使い方:
+    python scripts/generate_config.py               # 存在しないファイルのみ生成
+    python scripts/generate_config.py --overwrite   # 既存ファイルを上書き
+
+documents/01_Data/config_schema.md に沿った安全側（保守的）な初期値を使用する。
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_CONFIG_DIR = _PROJECT_ROOT / "config"
+
+# ---------------------------------------------------------------------------
+# テンプレート定義（config_schema.md §3〜§8 に準拠、安全側の初期値）
+# ---------------------------------------------------------------------------
+
+_TEMPLATES: dict[str, str] = {
+    "system_config.yaml": """\
+# system_config.yaml — システム全体設定
+# 環境: development / paper_trading / live
+environment: development
+
+timezone: Asia/Tokyo
+
+data_directory: data/
+
+log_directory: logs/
+
+database:
+  type: duckdb
+  path: data/kabusys.duckdb
+
+calendar:
+  source: jquants
+  table: market_calendar
+""",
+    "data_config.yaml": """\
+# data_config.yaml — データ取得設定
+market_data:
+  provider: jquants
+  price_table: prices_daily
+  fundamental_table: fundamentals
+
+news_data:
+  provider: yahoo_news
+  table: news_articles
+
+feature_store:
+  table: features
+
+ai_scores:
+  table: ai_scores
+""",
+    "strategy_config.yaml": """\
+# strategy_config.yaml — 売買戦略パラメータ
+strategy:
+  name: momentum_strategy
+  universe_size: 500
+  rebalance_frequency: daily
+
+factors:
+  momentum_20_weight: 0.5
+  momentum_60_weight: 0.3
+  volume_factor_weight: 0.2
+
+ai_overlay:
+  enabled: true
+  # AIオーバーレイの影響度上限（RiskManagement.md §6 に準拠）
+  max_influence: 0.10
+""",
+    "risk_config.yaml": """\
+# risk_config.yaml — リスク管理設定（安全側の初期値）
+risk:
+  # 1銘柄最大ウェイト（ポートフォリオ対比）
+  max_position_size: 0.05
+  # ポートフォリオ総投資比率上限
+  max_portfolio_exposure: 1.0
+  # 日次最大損失率（超過で Kill Switch 検討）
+  max_daily_loss: 0.02
+  # 最大ドローダウン（超過で Kill Switch 自動発動）
+  max_drawdown: 0.15
+
+position_sizing:
+  risk_per_trade: 0.01
+  volatility_adjustment: true
+""",
+    "execution_config.yaml": """\
+# execution_config.yaml — 発注システム設定
+broker:
+  api: kabu_station
+  account_type: margin
+  retry_attempts: 3
+
+execution:
+  order_type: limit
+  slippage: 0.001
+  timeout_seconds: 10
+
+signal_queue:
+  table: signal_queue
+  polling_interval_seconds: 5
+""",
+    "monitoring_config.yaml": """\
+# monitoring_config.yaml — 監視設定
+monitoring:
+  dashboard: streamlit
+
+alerts:
+  line_enabled: true
+  max_drawdown_alert: 0.10
+  execution_failure_alert: true
+
+logging:
+  level: INFO
+  database: data/monitoring.db
+""",
+}
+
+
+def generate(overwrite: bool = False) -> int:
+    """テンプレートを config/ に生成する。生成したファイル数を返す。"""
+    _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    generated = 0
+    for filename, content in _TEMPLATES.items():
+        path = _CONFIG_DIR / filename
+        if path.exists() and not overwrite:
+            print(f"  SKIP    config/{filename} (既存・--overwrite で上書き可)")
+            continue
+        already_exists = path.exists()
+        path.write_text(content, encoding="utf-8")
+        action = "OVERWRITE" if already_exists else "CREATE  "
+        print(f"  {action} config/{filename}")
+        generated += 1
+    return generated
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="config/*.yaml テンプレートを生成する"
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="既存ファイルを上書きする（デフォルト: スキップ）",
+    )
+    args = parser.parse_args()
+
+    print(f"config/ テンプレートを生成します: {_CONFIG_DIR}")
+    count = generate(overwrite=args.overwrite)
+    print(f"完了: {count} ファイルを生成しました。")
+    if count == 0 and not args.overwrite:
+        print("ヒント: 既存ファイルを上書きする場合は --overwrite を指定してください。")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/kabusys/config_setup.py
+++ b/src/kabusys/config_setup.py
@@ -1,0 +1,265 @@
+# src/kabusys/config_setup.py
+"""環境設定ウィザード CLI。
+
+.env の初期作成・更新を対話式で支援する。
+
+使い方:
+    python -m kabusys.config_setup
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_ENV_PATH = _PROJECT_ROOT / ".env"
+
+# ---------------------------------------------------------------------------
+# 設定項目定義
+# ---------------------------------------------------------------------------
+
+_ITEMS: list[dict] = [
+    {
+        "key": "KABUSYS_ENV",
+        "label": "実行環境",
+        "choices": ["development", "paper_trading", "live"],
+        "default": "development",
+        "description": (
+            "  development  : ローカル開発・テスト用（発注なし）\n"
+            "  paper_trading: ペーパートレード（仮想発注）\n"
+            "  live         : 本番（実際に発注が行われます）"
+        ),
+    },
+    {
+        "key": "JQUANTS_REFRESH_TOKEN",
+        "label": "J-Quants リフレッシュトークン",
+        "secret": True,
+        "description": "  J-Quants API のリフレッシュトークン（必須）",
+    },
+    {
+        "key": "KABU_API_PASSWORD",
+        "label": "kabuステーション API パスワード",
+        "secret": True,
+        "description": "  kabuステーション API パスワード（必須）",
+    },
+    {
+        "key": "KABU_API_BASE_URL",
+        "label": "kabuステーション API ベース URL",
+        "default": "http://localhost:18080/kabusapi",
+        "description": "  通常はデフォルトのままで可",
+    },
+    {
+        "key": "DUCKDB_PATH",
+        "label": "DuckDB ファイルパス",
+        "default": "data/kabusys.duckdb",
+        "description": "  分析用 DuckDB データベースのパス",
+    },
+    {
+        "key": "SQLITE_PATH",
+        "label": "SQLite ファイルパス（監視 DB）",
+        "default": "data/monitoring.db",
+        "description": "  監視・注文履歴用 SQLite データベースのパス",
+    },
+    {
+        "key": "LINE_CHANNEL_ACCESS_TOKEN",
+        "label": "LINE チャンネルアクセストークン（任意）",
+        "secret": True,
+        "optional": True,
+        "description": "  アラート通知用 LINE Messaging API トークン（空欄でスキップ）",
+    },
+    {
+        "key": "LINE_USER_ID",
+        "label": "LINE ユーザー ID（任意）",
+        "optional": True,
+        "description": "  アラート送信先 LINE ユーザー ID（空欄でスキップ）",
+    },
+    {
+        "key": "LOG_LEVEL",
+        "label": "ログレベル",
+        "choices": ["DEBUG", "INFO", "WARNING", "ERROR"],
+        "default": "INFO",
+        "description": "  ログ出力レベル",
+    },
+    {
+        "key": "KILL_FLAG_CLEAR_ON_START",
+        "label": "起動時に Kill Flag を自動クリアする",
+        "choices": ["0", "1"],
+        "default": "0",
+        "description": "  0=クリアしない（本番推奨）/ 1=自動クリア（開発用）",
+    },
+]
+
+# ---------------------------------------------------------------------------
+# .env ファイル読み書き
+# ---------------------------------------------------------------------------
+
+def _read_env(path: Path) -> dict[str, str]:
+    """既存の .env ファイルを読み込む。存在しない場合は空 dict。"""
+    if not path.exists():
+        return {}
+    existing: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[7:].lstrip()
+        key, sep, value = line.partition("=")
+        if sep:
+            existing[key.strip()] = value.strip().strip('"').strip("'")
+    return existing
+
+
+def _write_env(path: Path, values: dict[str, str]) -> None:
+    """values を .env ファイルに書き込む。"""
+    lines = [
+        "# =============================================================",
+        "# KabuSys 環境変数設定ファイル",
+        "# このファイルは config_setup.py で生成されました",
+        "# .env は絶対に Git にコミットしないこと",
+        "# =============================================================",
+        "",
+        "# --- J-Quants API ---",
+        f"JQUANTS_REFRESH_TOKEN={values.get('JQUANTS_REFRESH_TOKEN', '')}",
+        "",
+        "# --- kabuステーション API ---",
+        f"KABU_API_PASSWORD={values.get('KABU_API_PASSWORD', '')}",
+        f"KABU_API_BASE_URL={values.get('KABU_API_BASE_URL', 'http://localhost:18080/kabusapi')}",
+        "",
+        "# --- LINE Messaging API (アラート通知用) ---",
+        f"LINE_CHANNEL_ACCESS_TOKEN={values.get('LINE_CHANNEL_ACCESS_TOKEN', '')}",
+        f"LINE_USER_ID={values.get('LINE_USER_ID', '')}",
+        "",
+        "# --- データベース ---",
+        f"DUCKDB_PATH={values.get('DUCKDB_PATH', 'data/kabusys.duckdb')}",
+        f"SQLITE_PATH={values.get('SQLITE_PATH', 'data/monitoring.db')}",
+        "",
+        "# --- システム設定 ---",
+        f"KABUSYS_ENV={values.get('KABUSYS_ENV', 'development')}",
+        f"LOG_LEVEL={values.get('LOG_LEVEL', 'INFO')}",
+        "",
+        "# --- Kill Switch ---",
+        f"KILL_FLAG_CLEAR_ON_START={values.get('KILL_FLAG_CLEAR_ON_START', '0')}",
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 対話ループ
+# ---------------------------------------------------------------------------
+
+def _prompt(item: dict, existing: dict[str, str]) -> str | None:
+    """1項目を対話式に入力してもらう。スキップ時は None を返す。"""
+    key = item["key"]
+    label = item["label"]
+    current = existing.get(key, item.get("default", ""))
+    choices = item.get("choices")
+    is_secret = item.get("secret", False)
+    is_optional = item.get("optional", False)
+
+    print(f"\n{'─' * 60}")
+    print(f"  {label} [{key}]")
+    if item.get("description"):
+        print(item["description"])
+
+    if choices:
+        print(f"  選択肢: {' / '.join(choices)}")
+
+    # 現在値の表示（シークレットはマスク）
+    if current:
+        display = "****" if is_secret else current
+        hint = f"Enter でそのまま使用 ({display})"
+    else:
+        default = item.get("default", "")
+        hint = f"Enter でデフォルト ({default})" if default else "入力してください"
+
+    try:
+        answer = input(f"  → {hint}: ").strip()
+    except (EOFError, KeyboardInterrupt):
+        print("\n中断されました。")
+        raise
+
+    if answer == "":
+        # Enter → 既存値またはデフォルトを使用
+        return current or item.get("default", "")
+
+    # 選択肢チェック
+    if choices and answer not in choices:
+        print(f"  ※ 無効な値です。選択肢から選んでください: {choices}")
+        return _prompt(item, existing)  # 再入力
+
+    return answer
+
+
+def run_wizard(env_path: Path = _ENV_PATH) -> dict[str, str]:
+    """ウィザードを実行し、設定値 dict を返す。"""
+    existing = _read_env(env_path)
+    values: dict[str, str] = dict(existing)
+
+    print("=" * 60)
+    print("  KabuSys 環境設定ウィザード")
+    print(f"  設定ファイル: {env_path}")
+    if existing:
+        print("  ※ 既存の .env を読み込みました。Enter で現在値を再利用できます。")
+    print("=" * 60)
+
+    for item in _ITEMS:
+        try:
+            result = _prompt(item, values)
+        except (EOFError, KeyboardInterrupt):
+            return values  # 途中キャンセル時は現在値を返す
+        if result is not None:
+            # オプション項目で空文字ならキーを削除（書き込み時に空値）
+            values[item["key"]] = result
+
+    return values
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+    parser = argparse.ArgumentParser(
+        description="KabuSys 環境設定ウィザード（.env の作成・更新）"
+    )
+    parser.add_argument(
+        "--env-file",
+        default=str(_ENV_PATH),
+        help=f".env ファイルのパス（デフォルト: {_ENV_PATH}）",
+    )
+    args = parser.parse_args(argv)
+    env_path = Path(args.env_file)
+
+    try:
+        values = run_wizard(env_path=env_path)
+    except (EOFError, KeyboardInterrupt):
+        print("\n設定ウィザードを中断しました。変更は保存されていません。")
+        return 1
+
+    print(f"\n{'─' * 60}")
+    print("  設定内容の確認")
+    print(f"{'─' * 60}")
+    for item in _ITEMS:
+        key = item["key"]
+        val = values.get(key, "")
+        display = "****" if item.get("secret") and val else (val or "(未設定)")
+        print(f"  {key}: {display}")
+
+    print(f"{'─' * 60}")
+    try:
+        confirm = input("\n  .env ファイルに保存しますか？ [y/N]: ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        print("\n中断しました。変更は保存されていません。")
+        return 1
+
+    if confirm != "y":
+        print("保存をキャンセルしました。")
+        return 0
+
+    _write_env(env_path, values)
+    print(f"\n✓ .env を保存しました: {env_path}")
+    print("  次のステップ: python -m kabusys.validate_config で設定を検証してください。")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kabusys/validate_config.py
+++ b/src/kabusys/validate_config.py
@@ -1,0 +1,229 @@
+# src/kabusys/validate_config.py
+"""設定検証 CLI。
+
+.env および config/*.yaml の設定不備を起動前に検出する。
+
+使い方:
+    python -m kabusys.validate_config
+    python -m kabusys.validate_config --strict   # 警告も FAIL 扱い
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_CONFIG_DIR = _PROJECT_ROOT / "config"
+
+# ---------------------------------------------------------------------------
+# 結果収集
+# ---------------------------------------------------------------------------
+
+_errors: list[str] = []
+_warnings: list[str] = []
+_infos: list[str] = []
+
+
+def _error(msg: str) -> None:
+    _errors.append(msg)
+
+
+def _warn(msg: str) -> None:
+    _warnings.append(msg)
+
+
+def _info(msg: str) -> None:
+    _infos.append(msg)
+
+
+# ---------------------------------------------------------------------------
+# 検証ロジック
+# ---------------------------------------------------------------------------
+
+_REQUIRED_ENV_VARS = [
+    "JQUANTS_REFRESH_TOKEN",
+    "KABU_API_PASSWORD",
+]
+
+_OPTIONAL_ENV_VARS = [
+    "KABUSYS_ENV",
+    "DUCKDB_PATH",
+    "SQLITE_PATH",
+    "LOG_LEVEL",
+    "KABU_API_BASE_URL",
+    "LINE_CHANNEL_ACCESS_TOKEN",
+    "LINE_USER_ID",
+]
+
+_VALID_KABUSYS_ENVS = frozenset({"development", "paper_trading", "live"})
+_VALID_LOG_LEVELS = frozenset({"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"})
+
+_CONFIG_FILES = [
+    "system_config.yaml",
+    "data_config.yaml",
+    "strategy_config.yaml",
+    "risk_config.yaml",
+    "execution_config.yaml",
+    "monitoring_config.yaml",
+]
+
+
+def _check_required_env_vars() -> None:
+    for var in _REQUIRED_ENV_VARS:
+        val = os.environ.get(var, "")
+        if not val:
+            _error(f"必須環境変数が未設定です: {var}")
+        elif val.endswith("_here") or val == "your_value":
+            _warn(f"環境変数 {var} がプレースホルダ値のままです。")
+        else:
+            _info(f"環境変数 {var}: 設定済み")
+
+
+def _check_kabusys_env() -> None:
+    env = os.environ.get("KABUSYS_ENV", "development").lower()
+    if env not in _VALID_KABUSYS_ENVS:
+        _error(
+            f"KABUSYS_ENV の値が不正です: '{env}'. "
+            f"有効な値: {sorted(_VALID_KABUSYS_ENVS)}"
+        )
+    elif env == "live":
+        _warn(
+            "KABUSYS_ENV=live が設定されています。"
+            "本番環境です。すべての設定を慎重に確認してください。"
+        )
+    else:
+        _info(f"KABUSYS_ENV: {env}")
+
+
+def _check_log_level() -> None:
+    level = os.environ.get("LOG_LEVEL", "INFO").upper()
+    if level not in _VALID_LOG_LEVELS:
+        _warn(
+            f"LOG_LEVEL の値が不正です: '{level}'. "
+            f"有効な値: {sorted(_VALID_LOG_LEVELS)}"
+        )
+    else:
+        _info(f"LOG_LEVEL: {level}")
+
+
+def _check_path(var: str, default: str, label: str) -> None:
+    raw = os.environ.get(var, default)
+    path = Path(raw).expanduser()
+    parent = path.parent
+    if not parent.exists():
+        _warn(
+            f"{label} の親ディレクトリが存在しません: {parent}"
+            " (起動時に自動作成される場合あり)"
+        )
+    else:
+        _info(f"{label}: {path} (親ディレクトリ存在)")
+
+
+def _check_db_paths() -> None:
+    _check_path("DUCKDB_PATH", "data/kabusys.duckdb", "DUCKDB_PATH")
+    _check_path("SQLITE_PATH", "data/monitoring.db", "SQLITE_PATH")
+
+
+def _check_config_yaml_files() -> None:
+    """config/*.yaml の存在確認。"""
+    try:
+        import yaml  # type: ignore[import]
+        _yaml_available = True
+    except ImportError:
+        _yaml_available = False
+        _warn("PyYAML がインストールされていません。YAML ファイルの内容検証をスキップします。")
+
+    for filename in _CONFIG_FILES:
+        path = _CONFIG_DIR / filename
+        if not path.exists():
+            _warn(
+                f"config/{filename} が見つかりません。"
+                " python scripts/generate_config.py で生成できます。"
+            )
+        elif _yaml_available:
+            try:
+                import yaml  # type: ignore[import]
+                with open(path, encoding="utf-8") as f:
+                    yaml.safe_load(f)
+                _info(f"config/{filename}: OK")
+            except Exception as e:
+                _error(f"config/{filename} のパースに失敗しました: {e}")
+
+
+def _check_live_guards() -> None:
+    """KABUSYS_ENV=live 時の追加チェック。"""
+    env = os.environ.get("KABUSYS_ENV", "development").lower()
+    if env != "live":
+        return
+
+    # LINE 通知の設定確認
+    if not os.environ.get("LINE_CHANNEL_ACCESS_TOKEN", ""):
+        _warn("本番環境で LINE_CHANNEL_ACCESS_TOKEN が未設定です。アラートが届きません。")
+    if not os.environ.get("LINE_USER_ID", ""):
+        _warn("本番環境で LINE_USER_ID が未設定です。アラートが届きません。")
+
+    # kill_flag_clear_on_start が 1 だと危険
+    if os.environ.get("KILL_FLAG_CLEAR_ON_START", "0") == "1":
+        _warn(
+            "本番環境で KILL_FLAG_CLEAR_ON_START=1 が設定されています。"
+            " Kill Switch が自動クリアされます。0 を推奨します。"
+        )
+
+
+# ---------------------------------------------------------------------------
+# エントリポイント
+# ---------------------------------------------------------------------------
+
+def validate() -> tuple[list[str], list[str], list[str]]:
+    """検証を実行し、(errors, warnings, infos) を返す。"""
+    _errors.clear()
+    _warnings.clear()
+    _infos.clear()
+
+    _check_required_env_vars()
+    _check_kabusys_env()
+    _check_log_level()
+    _check_db_paths()
+    _check_config_yaml_files()
+    _check_live_guards()
+
+    return list(_errors), list(_warnings), list(_infos)
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+    parser = argparse.ArgumentParser(
+        description="KabuSys 設定を検証する"
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="警告も FAIL として扱い exit(1) で終了する",
+    )
+    args = parser.parse_args(argv)
+
+    errors, warnings, infos = validate()
+
+    for msg in infos:
+        print(f"  INFO    {msg}")
+    for msg in warnings:
+        print(f"  WARNING {msg}")
+    for msg in errors:
+        print(f"  ERROR   {msg}")
+
+    if errors:
+        print(f"\n[FAIL] エラー {len(errors)} 件 / 警告 {len(warnings)} 件")
+        return 1
+    if warnings and args.strict:
+        print(f"\n[FAIL] 警告 {len(warnings)} 件（--strict モード）")
+        return 1
+    if warnings:
+        print(f"\n[OK] エラーなし / 警告 {len(warnings)} 件")
+    else:
+        print("\n[OK] すべての検証に合格しました。")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_config_setup.py
+++ b/tests/test_config_setup.py
@@ -1,0 +1,131 @@
+# tests/test_config_setup.py
+"""src/kabusys/config_setup.py の単体テスト"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+
+def test_read_env_parses_existing_file(tmp_path):
+    """_read_env が既存の .env ファイルを正しく読み込むこと。"""
+    from kabusys.config_setup import _read_env
+
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "# コメント\nJQUANTS_REFRESH_TOKEN=abc123\nKABUSYS_ENV=development\n",
+        encoding="utf-8",
+    )
+    result = _read_env(env_file)
+    assert result["JQUANTS_REFRESH_TOKEN"] == "abc123"
+    assert result["KABUSYS_ENV"] == "development"
+
+
+def test_read_env_returns_empty_for_missing_file(tmp_path):
+    """_read_env が存在しないファイルに対して空 dict を返すこと。"""
+    from kabusys.config_setup import _read_env
+
+    result = _read_env(tmp_path / ".env")
+    assert result == {}
+
+
+def test_write_env_creates_file(tmp_path):
+    """_write_env が .env ファイルを作成すること。"""
+    from kabusys.config_setup import _write_env
+
+    env_file = tmp_path / ".env"
+    values = {
+        "JQUANTS_REFRESH_TOKEN": "mytoken",
+        "KABU_API_PASSWORD": "mypass",
+        "KABUSYS_ENV": "development",
+    }
+    _write_env(env_file, values)
+
+    assert env_file.exists()
+    content = env_file.read_text(encoding="utf-8")
+    assert "JQUANTS_REFRESH_TOKEN=mytoken" in content
+    assert "KABU_API_PASSWORD=mypass" in content
+    assert "KABUSYS_ENV=development" in content
+
+
+def test_write_env_roundtrip(tmp_path):
+    """_write_env → _read_env でラウンドトリップできること。"""
+    from kabusys.config_setup import _read_env, _write_env
+
+    values = {
+        "JQUANTS_REFRESH_TOKEN": "tok",
+        "KABU_API_PASSWORD": "pass",
+        "KABUSYS_ENV": "paper_trading",
+        "LOG_LEVEL": "DEBUG",
+        "DUCKDB_PATH": "data/test.duckdb",
+        "SQLITE_PATH": "data/test.db",
+        "KABU_API_BASE_URL": "http://localhost:18080/kabusapi",
+        "LINE_CHANNEL_ACCESS_TOKEN": "",
+        "LINE_USER_ID": "",
+        "KILL_FLAG_CLEAR_ON_START": "0",
+    }
+    env_file = tmp_path / ".env"
+    _write_env(env_file, values)
+    read_back = _read_env(env_file)
+
+    assert read_back["KABUSYS_ENV"] == "paper_trading"
+    assert read_back["LOG_LEVEL"] == "DEBUG"
+    assert read_back["DUCKDB_PATH"] == "data/test.duckdb"
+
+
+def test_run_wizard_uses_existing_on_empty_input(tmp_path):
+    """Enter のみ（空入力）のとき既存値が使われること。"""
+    from kabusys.config_setup import run_wizard
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("KABUSYS_ENV=paper_trading\n", encoding="utf-8")
+
+    # すべての入力を空（Enter）にする
+    with patch("builtins.input", return_value=""):
+        result = run_wizard(env_path=env_file)
+
+    assert result["KABUSYS_ENV"] == "paper_trading"
+
+
+def test_run_wizard_accepts_new_value(tmp_path):
+    """ユーザーが新しい値を入力したとき、その値が使われること。"""
+    from kabusys.config_setup import run_wizard
+
+    env_file = tmp_path / ".env"
+    inputs = iter(
+        ["live"] + [""] * 100  # 最初の質問に "live"、残りは Enter
+    )
+    with patch("builtins.input", side_effect=inputs):
+        result = run_wizard(env_path=env_file)
+
+    assert result["KABUSYS_ENV"] == "live"
+
+
+def test_main_saves_file_on_y(tmp_path):
+    """main() でユーザーが y を入力したとき .env が保存されること。"""
+    from kabusys import config_setup
+
+    # _ITEMS は 10 項目 + 確認 1 回 = 11 回の input()
+    n_items = len(config_setup._ITEMS)
+    env_file = tmp_path / ".env"
+    inputs = iter(["development"] + [""] * (n_items - 1) + ["y"])
+    with patch("builtins.input", side_effect=inputs), \
+         patch.object(config_setup, "_ENV_PATH", env_file):
+        result = config_setup.main(["--env-file", str(env_file)])
+
+    assert result == 0
+    assert env_file.exists()
+
+
+def test_main_does_not_save_on_n(tmp_path):
+    """main() でユーザーが n を入力したとき .env が保存されないこと。"""
+    from kabusys import config_setup
+
+    n_items = len(config_setup._ITEMS)
+    env_file = tmp_path / ".env"
+    inputs = iter(["development"] + [""] * (n_items - 1) + ["n"])
+    with patch("builtins.input", side_effect=inputs), \
+         patch.object(config_setup, "_ENV_PATH", env_file):
+        result = config_setup.main(["--env-file", str(env_file)])
+
+    assert result == 0
+    assert not env_file.exists()

--- a/tests/test_generate_config.py
+++ b/tests/test_generate_config.py
@@ -1,0 +1,76 @@
+# tests/test_generate_config.py
+"""scripts/generate_config.py の単体テスト"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import generate_config
+
+
+def test_generate_creates_all_files(tmp_path):
+    """generate() が 6 つの YAML ファイルをすべて生成すること。"""
+    with patch.object(generate_config, "_CONFIG_DIR", tmp_path):
+        count = generate_config.generate()
+
+    files = list(tmp_path.glob("*.yaml"))
+    assert count == 6
+    assert len(files) == 6
+
+
+def test_generate_skips_existing_by_default(tmp_path):
+    """デフォルト動作では既存ファイルをスキップすること。"""
+    existing = tmp_path / "system_config.yaml"
+    existing.write_text("original", encoding="utf-8")
+
+    with patch.object(generate_config, "_CONFIG_DIR", tmp_path):
+        count = generate_config.generate(overwrite=False)
+
+    # 既存の 1 ファイルはスキップ、残り 5 ファイルが生成される
+    assert count == 5
+    assert existing.read_text(encoding="utf-8") == "original"
+
+
+def test_generate_overwrites_with_flag(tmp_path):
+    """--overwrite 時は既存ファイルを上書きすること。"""
+    existing = tmp_path / "system_config.yaml"
+    existing.write_text("original", encoding="utf-8")
+
+    with patch.object(generate_config, "_CONFIG_DIR", tmp_path):
+        count = generate_config.generate(overwrite=True)
+
+    assert count == 6
+    assert existing.read_text(encoding="utf-8") != "original"
+
+
+def test_generated_yaml_is_valid(tmp_path):
+    """生成された YAML ファイルが有効な YAML であること。"""
+    pytest.importorskip("yaml")
+    import yaml
+
+    with patch.object(generate_config, "_CONFIG_DIR", tmp_path):
+        generate_config.generate()
+
+    for yaml_file in tmp_path.glob("*.yaml"):
+        content = yaml_file.read_text(encoding="utf-8")
+        parsed = yaml.safe_load(content)
+        assert parsed is not None, f"{yaml_file.name} のパースに失敗"
+
+
+def test_risk_config_has_safe_defaults(tmp_path):
+    """risk_config.yaml の max_drawdown が安全側（0.15 以下）であること。"""
+    pytest.importorskip("yaml")
+    import yaml
+
+    with patch.object(generate_config, "_CONFIG_DIR", tmp_path):
+        generate_config.generate()
+
+    content = (tmp_path / "risk_config.yaml").read_text(encoding="utf-8")
+    data = yaml.safe_load(content)
+    assert data["risk"]["max_drawdown"] <= 0.15
+    assert data["risk"]["max_position_size"] <= 0.10

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -1,0 +1,147 @@
+# tests/test_validate_config.py
+"""src/kabusys/validate_config.py の単体テスト"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _run_validate(env_overrides: dict | None = None, config_dir: Path | None = None):
+    """validate() を実行するヘルパー。環境変数と config_dir をオーバーライド可能。"""
+    from kabusys import validate_config as vc
+
+    base_env = {
+        "JQUANTS_REFRESH_TOKEN": "test_token",
+        "KABU_API_PASSWORD": "test_pass",
+        "KABUSYS_ENV": "development",
+        "DUCKDB_PATH": "data/kabusys.duckdb",
+        "SQLITE_PATH": "data/monitoring.db",
+        "LOG_LEVEL": "INFO",
+    }
+    if env_overrides:
+        base_env.update(env_overrides)
+
+    patches = {k: v for k, v in base_env.items()}
+
+    with patch.dict(os.environ, patches, clear=False):
+        if config_dir is not None:
+            with patch.object(vc, "_CONFIG_DIR", config_dir):
+                return vc.validate()
+        else:
+            return vc.validate()
+
+
+def test_valid_config_returns_no_errors(tmp_path):
+    """必要な設定がすべて揃っているとき errors が空であること。"""
+    errors, warnings, _ = _run_validate(config_dir=tmp_path)
+    assert errors == []
+
+
+def test_missing_required_var_returns_error():
+    """必須環境変数が未設定のとき errors に含まれること。"""
+    errors, _, _ = _run_validate(
+        env_overrides={"JQUANTS_REFRESH_TOKEN": ""},
+        config_dir=Path("/nonexistent"),
+    )
+    assert any("JQUANTS_REFRESH_TOKEN" in e for e in errors)
+
+
+def test_placeholder_value_returns_warning():
+    """プレースホルダ値のとき warnings に含まれること。"""
+    _, warnings, _ = _run_validate(
+        env_overrides={"JQUANTS_REFRESH_TOKEN": "your_jquants_refresh_token_here"},
+        config_dir=Path("/nonexistent"),
+    )
+    assert any("JQUANTS_REFRESH_TOKEN" in w for w in warnings)
+
+
+def test_invalid_kabusys_env_returns_error():
+    """KABUSYS_ENV が無効値のとき errors に含まれること。"""
+    errors, _, _ = _run_validate(
+        env_overrides={"KABUSYS_ENV": "staging"},
+        config_dir=Path("/nonexistent"),
+    )
+    assert any("KABUSYS_ENV" in e for e in errors)
+
+
+def test_live_env_returns_warning():
+    """KABUSYS_ENV=live のとき warnings に含まれること。"""
+    _, warnings, _ = _run_validate(
+        env_overrides={"KABUSYS_ENV": "live"},
+        config_dir=Path("/nonexistent"),
+    )
+    assert any("live" in w for w in warnings)
+
+
+def test_invalid_log_level_returns_warning():
+    """LOG_LEVEL が無効値のとき warnings に含まれること。"""
+    _, warnings, _ = _run_validate(
+        env_overrides={"LOG_LEVEL": "VERBOSE"},
+        config_dir=Path("/nonexistent"),
+    )
+    assert any("LOG_LEVEL" in w for w in warnings)
+
+
+def test_missing_yaml_files_return_warnings(tmp_path):
+    """config/ に YAML がないとき warnings に含まれること。"""
+    _, warnings, _ = _run_validate(config_dir=tmp_path)
+    assert any("yaml" in w.lower() or ".yaml" in w for w in warnings)
+
+
+def test_valid_yaml_files_return_no_error(tmp_path):
+    """有効な YAML ファイルが揃っているとき errors が増えないこと。"""
+    pytest.importorskip("yaml")
+    sys_path = Path(__file__).resolve().parents[1] / "scripts"
+    import sys
+    sys.path.insert(0, str(sys_path))
+    import generate_config
+    with patch.object(generate_config, "_CONFIG_DIR", tmp_path):
+        generate_config.generate()
+
+    errors, _, _ = _run_validate(config_dir=tmp_path)
+    assert errors == []
+
+
+def test_main_returns_0_on_success(tmp_path):
+    """正常設定で main() が 0 を返すこと。"""
+    from kabusys import validate_config as vc
+
+    with patch.dict(os.environ, {
+        "JQUANTS_REFRESH_TOKEN": "tok",
+        "KABU_API_PASSWORD": "pass",
+        "KABUSYS_ENV": "development",
+        "LOG_LEVEL": "INFO",
+    }, clear=False), patch.object(vc, "_CONFIG_DIR", tmp_path):
+        result = vc.main([])
+    assert result == 0
+
+
+def test_main_returns_1_on_error():
+    """必須変数不足で main() が 1 を返すこと。"""
+    from kabusys import validate_config as vc
+
+    with patch.dict(os.environ, {
+        "JQUANTS_REFRESH_TOKEN": "",
+        "KABU_API_PASSWORD": "pass",
+    }, clear=False), patch.object(vc, "_CONFIG_DIR", Path("/nonexistent")):
+        result = vc.main([])
+    assert result == 1
+
+
+def test_strict_mode_fails_on_warning(tmp_path):
+    """--strict モードで警告があるとき main() が 1 を返すこと。"""
+    from kabusys import validate_config as vc
+
+    # config/ が空なので missing yaml warnings が出る
+    with patch.dict(os.environ, {
+        "JQUANTS_REFRESH_TOKEN": "tok",
+        "KABU_API_PASSWORD": "pass",
+        "KABUSYS_ENV": "development",
+        "LOG_LEVEL": "INFO",
+    }, clear=False), patch.object(vc, "_CONFIG_DIR", tmp_path):
+        result = vc.main(["--strict"])
+    # tmp_path には YAML がないので warning → strict では fail
+    assert result == 1


### PR DESCRIPTION
## Summary

Phase10 環境設定支援の4 Issues を一括対応。

| Issue | 対応内容 |
|-------|---------|
| #136 | `src/kabusys/config_setup.py` — 対話式ウィザード |
| #137 | `scripts/generate_config.py` + `config/*.yaml` — YAML テンプレート生成 |
| #138 | `src/kabusys/validate_config.py` — 設定検証 CLI |
| #139 | `README.md` — 初回セットアップ手順・環境使い分け表 |

## 各機能の説明

### 環境設定ウィザード（#136）
```cmd
python -m kabusys.config_setup
```
- `.env` の初期作成・更新を対話式で支援
- 既存値を表示して Enter で再利用可能
- `development / paper_trading / live` 選択肢付き
- 確認後に保存

### YAML テンプレート生成（#137）
```cmd
python scripts/generate_config.py          # 存在しないファイルのみ生成
python scripts/generate_config.py --overwrite  # 既存ファイルを上書き
```
- `config_schema.md` に準拠した安全側の初期値
- `risk_config.yaml`: `max_drawdown=0.15`, `max_position_size=0.05`

### 設定検証 CLI（#138）
```cmd
python -m kabusys.validate_config
python -m kabusys.validate_config --strict   # 警告も FAIL
```
- 必須環境変数の欠落チェック
- `KABUSYS_ENV` / `LOG_LEVEL` の値チェック
- DB パス親ディレクトリの存在確認
- `config/*.yaml` の存在・YAML 妥当性確認
- `live` 環境の追加警告

### README 更新（#139）
- ウィザード→YAML生成→検証の初回セットアップ手順を追記
- `development / paper_trading / live` の使い分け表を追加
- 必須環境変数テーブルを追加

## Test Plan

- [x] `test_generate_config.py` 5件（3 passed, 2 skipped due to missing PyYAML）
- [x] `test_validate_config.py` 11件（10 passed, 1 skipped）
- [x] `test_config_setup.py` 8件 全パス
- [x] フルテストスイート 724件パス

Closes #136
Closes #137
Closes #138
Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)