### PR TITLE
docs: 最近の実装変更を documents/ に反映

### DIFF
--- a/documents/00_Architecture/ImplementationRoadmap.md
+++ b/documents/00_Architecture/ImplementationRoadmap.md
@@ -34,6 +34,7 @@
     Phase 7  Monitoring
     Phase 8  Paper Trading
     Phase 9  Live Trading
+    Phase 10 Environment Setup & Operations
 
 ------------------------------------------------------------------------
 
@@ -276,6 +277,44 @@
   7      Monitoring
   8      Paper Trading
   9      Live Trading
+
+------------------------------------------------------------------------
+
+------------------------------------------------------------------------
+
+# Phase 10 --- Environment Setup & Operations
+
+目的: 初期セットアップ支援・設定管理・運用補助ツールの整備
+
+実装項目:
+
+-   対話式 `.env` 設定ウィザード（`config_setup.py`）
+-   `config/*.yaml` テンプレート自動生成（`generate_config.py`）
+-   設定事前検証 CLI（`validate_config.py`）
+-   起動前状態確認モード（`start_system.py --dry-run`）
+-   初回セットアップ手順ドキュメント整備（`README.md`, `DeploymentArchitecture.md`）
+
+作成モジュール・スクリプト
+
+    src/kabusys/
+        config_setup.py         — .env 対話式ウィザード
+        validate_config.py      — 設定検証 CLI
+    scripts/
+        generate_config.py      — config/*.yaml テンプレート生成
+    config/
+        system_config.yaml
+        data_config.yaml
+        strategy_config.yaml
+        risk_config.yaml
+        execution_config.yaml
+        monitoring_config.yaml
+
+成果物:
+
+-   `python -m kabusys.config_setup` で .env を対話式に作成・更新できる
+-   `python scripts/generate_config.py` で config/*.yaml を生成できる
+-   `python -m kabusys.validate_config` で設定不備を起動前に検出できる
+-   `python scripts/start_system.py --dry-run` で発注なしの状態確認ができる
 
 ------------------------------------------------------------------------
 

--- a/documents/01_Data/DataSchema.md
+++ b/documents/01_Data/DataSchema.md
@@ -243,15 +243,23 @@ Executionへ引き渡すための冪等な発注指示キュー。
 
     pending
     processing
-    executed
+    filled
     cancelled
     error
+    failed
+
+- `pending`    : 発注待ち（初期状態）
+- `processing` : 発注処理中（ExecutionEngine がロック中）
+- `filled`     : 約定済み
+- `cancelled`  : キャンセル済み
+- `error`      : システムエラーによる失敗
+- `failed`     : 手動で失敗マーク（`mark_signal_failed.py` で設定）
 
 Executionの処理フロー:
 1. `SELECT * FROM signal_queue WHERE status = 'pending'`
 2. `UPDATE ... SET status = 'processing' WHERE signal_id = ? (Lock)`
 3. broker API へ発注
-4. `UPDATE ... SET status = 'executed'`
+4. 約定確認後 `UPDATE ... SET status = 'filled'`
 
 ------------------------------------------------------------------------
 

--- a/documents/08_Operations/FailureRecovery.md
+++ b/documents/08_Operations/FailureRecovery.md
@@ -96,12 +96,17 @@ python scripts\stop_system.py
 3. 10 秒以内に終了しない場合は `psutil.Process(pid).kill()` で強制終了
 4. PID ファイル（`data/execution.pid`, `data/monitoring.pid`）を削除
 
+> **PID 再利用チェック**: PID ファイルには PID と起動時刻（`create_time`）が記録されている。
+> 停止時に実プロセスの `create_time` と照合し、不一致の場合は別プロセスへの誤 kill を防ぐためスキップする。
+
 ### 4.3 Kill Switch 発動後の確認
 
 ```
 1. kabuステーション画面でポジション・未約定注文を直接確認
 2. ログで発動原因を特定（ERROR / CRITICAL メッセージ）
-3. 原因が解消したら §9「Kill Switch 発動後の復旧」に従う
+3. --dry-run で DB 状態を確認（発注なし）
+   python scripts\start_system.py --dry-run
+4. 原因が解消したら §9「Kill Switch 発動後の復旧」に従う
 ```
 
 ---

--- a/documents/09_Deployment/DeploymentArchitecture.md
+++ b/documents/09_Deployment/DeploymentArchitecture.md
@@ -274,23 +274,41 @@ Windows Task Scheduler により以下を自動実行する。
 
 **初期セットアップ（初回のみ）:**
 
-    powershell -File scripts\setup_task_scheduler.ps1
+```cmd
+:: 1. 環境変数設定（.env ウィザード）
+python -m kabusys.config_setup
+
+:: 2. config/*.yaml テンプレート生成
+python scripts\generate_config.py
+
+:: 3. 設定検証
+python -m kabusys.validate_config
+
+:: 4. Task Scheduler 登録
+powershell -File scripts\setup_task_scheduler.ps1
+```
 
 **手動起動・停止:**
 
-  操作          コマンド
-  ------------- -----------------------------------------------
-  全体起動      python scripts\start_system.py
-  全体停止      python scripts\stop_system.py
-  実行系のみ起動  python scripts\start_system.py --component execution
-  監視系のみ起動  python scripts\start_system.py --component monitoring
+  操作                   コマンド
+  ---------------------- -----------------------------------------------
+  全体起動               python scripts\start_system.py
+  全体停止               python scripts\stop_system.py
+  実行系のみ起動         python scripts\start_system.py --component execution
+  監視系のみ起動         python scripts\start_system.py --component monitoring
+  状態確認（発注なし）   python scripts\start_system.py --dry-run
+  停止フラグ解除＋起動   python scripts\start_system.py --clear-stop-flag
 
 **保守スクリプト:**
 
-  スクリプト                     用途
-  ------------------------------ ----------------------------------------
-  scripts\rebuild_features.py    特徴量を手動再計算（データ確認付き）
-  scripts\reset_signals.py       signal_queue をクリア
+  スクリプト                        用途
+  --------------------------------- -------------------------------------------------
+  scripts\rebuild_features.py       特徴量を手動再計算（データ確認付き）
+  scripts\reset_signals.py          signal_queue をクリア（取引時間外のみ）
+  scripts\mark_signal_failed.py     指定シグナルを status='failed' に手動更新
+  scripts\generate_config.py        config/*.yaml テンプレートを生成
+  python -m kabusys.config_setup    .env を対話式で作成・更新
+  python -m kabusys.validate_config 設定の事前検証（必須変数・YAML・live 警告）
 
 詳細: `documents/10_Runtime/RuntimeJobSchedule.md`
 


### PR DESCRIPTION
## Summary

最近のPR群（#159〜#164）で実装された内容を4つの設計ドキュメントに反映。

| ファイル | 変更内容 |
|---------|---------|
| `DataSchema.md` | `signal_queue` ステータス値を実装に合わせて修正（`executed`→`filled`、`failed` 追加） |
| `DeploymentArchitecture.md` | Phase10 初期セットアップ手順・保守スクリプト一覧を追加 |
| `FailureRecovery.md` | PID create_time 再利用保護の注記、`--dry-run` ステップを §4.3 に追加 |
| `ImplementationRoadmap.md` | Phase10 をフェーズ一覧と詳細セクションに追加 |

## 変更の背景

- `signal_queue.status` の CHECK 制約は `('pending','processing','filled','cancelled','error','failed')` だが、ドキュメントは `executed` という存在しない値を記載していた
- Phase10（#136〜#139）で追加されたツール群がデプロイ手順に未記載だった
- `stop_system.py` の PID 再利用保護（PR #159）が FailureRecovery.md に未反映だった
- ImplementationRoadmap.md に Phase10 が未記載だった

🤖 Generated with [Claude Code](https://claude.com/claude-code)