### PR TITLE
feat: ログローテーション機能の追加（Issue #55）

### DIFF
--- a/scripts/run_ai_analysis.py
+++ b/scripts/run_ai_analysis.py
@@ -18,8 +18,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 from kabusys.config import Settings
 from kabusys.ai.news_nlp import score_news
 from kabusys.ai.regime_detector import score_regime
+from kabusys.utils.logging_setup import setup_logging
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+setup_logging(app_name="ai_analysis")
 logger = logging.getLogger(__name__)
 
 

--- a/scripts/run_data_update.py
+++ b/scripts/run_data_update.py
@@ -15,8 +15,9 @@ import duckdb
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 from kabusys.config import Settings
 from kabusys.data.pipeline import run_daily_etl
+from kabusys.utils.logging_setup import setup_logging
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+setup_logging(app_name="data_update")
 logger = logging.getLogger(__name__)
 
 

--- a/scripts/run_feature_gen.py
+++ b/scripts/run_feature_gen.py
@@ -16,8 +16,9 @@ import duckdb
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 from kabusys.config import Settings
 from kabusys.strategy.feature_engineering import build_features
+from kabusys.utils.logging_setup import setup_logging
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+setup_logging(app_name="feature_gen")
 logger = logging.getLogger(__name__)
 
 

--- a/scripts/run_portfolio_construction.py
+++ b/scripts/run_portfolio_construction.py
@@ -24,8 +24,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 from kabusys.config import Settings
 from kabusys.portfolio.portfolio_builder import calc_score_weights, select_candidates
 from kabusys.portfolio.position_sizing import calc_position_sizes
+from kabusys.utils.logging_setup import setup_logging
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+setup_logging(app_name="portfolio_construction")
 logger = logging.getLogger(__name__)
 
 _DEFAULT_PORTFOLIO_VALUE = 10_000_000  # 1000万円

--- a/scripts/run_strategy_signal.py
+++ b/scripts/run_strategy_signal.py
@@ -16,8 +16,9 @@ import duckdb
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 from kabusys.config import Settings
 from kabusys.strategy.signal_generator import generate_signals
+from kabusys.utils.logging_setup import setup_logging
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+setup_logging(app_name="strategy_signal")
 logger = logging.getLogger(__name__)
 
 

--- a/scripts/start_system.py
+++ b/scripts/start_system.py
@@ -49,7 +49,9 @@ try:
 
     _setup_logging(app_name="start_system")
 except ImportError:
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+    )
 logger = logging.getLogger(__name__)
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent

--- a/scripts/start_system.py
+++ b/scripts/start_system.py
@@ -44,7 +44,12 @@ try:
 except ImportError:
     _DRY_RUN_DEPS_AVAILABLE = False
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+try:
+    from kabusys.utils.logging_setup import setup_logging as _setup_logging
+
+    _setup_logging(app_name="start_system")
+except ImportError:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -27,13 +27,14 @@ from kabusys.execution.order_repository import OrderRepository  # noqa: E402
 from kabusys.execution.reconciler import Reconciler  # noqa: E402
 from kabusys.execution.risk_manager import RiskConfig, RiskManager  # noqa: E402
 from kabusys.monitoring.monitoring_db import init_monitoring_db  # noqa: E402
+from kabusys.utils.logging_setup import setup_logging  # noqa: E402
 from kabusys.utils.process_priority import set_process_priority  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
 
 def main() -> None:
-    logging.basicConfig(level=logging.INFO)
+    setup_logging(app_name="execution")
     # 1. プロセス優先度を High に設定（最初に実行）
     set_process_priority("high")
 

--- a/src/kabusys/run_monitoring.py
+++ b/src/kabusys/run_monitoring.py
@@ -20,6 +20,7 @@ from kabusys.config import Settings
 _STOP_FLAG = Path(__file__).resolve().parents[2] / "data" / "stop_requested.flag"
 from kabusys.monitoring.monitoring_db import init_monitoring_db  # noqa: E402
 from kabusys.monitoring.system_monitor import SystemMonitor  # noqa: E402
+from kabusys.utils.logging_setup import setup_logging  # noqa: E402
 from kabusys.utils.process_priority import set_process_priority  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -48,7 +49,7 @@ def _get_poll_interval() -> int:
 
 
 def main() -> None:
-    logging.basicConfig(level=logging.INFO)
+    setup_logging(app_name="monitoring")
     # 1. プロセス優先度を High に設定（最初に実行）
     set_process_priority("high")
 

--- a/src/kabusys/utils/logging_setup.py
+++ b/src/kabusys/utils/logging_setup.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 def setup_logging(
     app_name: str = "kabusys",
     log_dir: Path | None = None,
-    level: str | None = None,
+    level: str | int | None = None,
 ) -> None:
     """ロギングを設定する。
 
@@ -52,14 +52,17 @@ def setup_logging(
     Args:
         app_name: ログファイル名のプレフィックス（例: ``"execution"`` → ``logs/execution.log``）。
         log_dir:  ログファイルの保存ディレクトリ。None の場合は上記解決順を使用。
-        level:    ログレベル文字列（"DEBUG"/"INFO"/"WARNING"/"ERROR"/"CRITICAL"）。
-                  None の場合は上記解決順を使用。
+        level:    ログレベル文字列（"DEBUG"/"INFO"/"WARNING"/"ERROR"/"CRITICAL"）または
+                  整数値（例: ``logging.DEBUG``）。None の場合は上記解決順を使用。
     """
-    # ログレベル解決
-    resolved_level_str = (
-        level or os.environ.get("LOG_LEVEL", _DEFAULT_LOG_LEVEL)
-    ).upper()
-    numeric_level = getattr(logging, resolved_level_str, logging.INFO)
+    # ログレベル解決（int / str の両形式を受け入れる）
+    if isinstance(level, int):
+        numeric_level = level
+    else:
+        resolved_level_str = (
+            level or os.environ.get("LOG_LEVEL", _DEFAULT_LOG_LEVEL)
+        ).upper()
+        numeric_level = getattr(logging, resolved_level_str, logging.INFO)
 
     # ログディレクトリ解決・作成
     resolved_dir = log_dir or Path(os.environ.get("LOG_DIR", str(_DEFAULT_LOG_DIR)))
@@ -82,6 +85,8 @@ def setup_logging(
     formatter = logging.Formatter(_LOG_FORMAT, datefmt=_DATE_FORMAT)
 
     # StreamHandler（コンソール stdout 出力）
+    # stderr ではなく stdout を使用: Task Scheduler/cron から起動する際に
+    # stdout/stderr を一本化してリダイレクトするため
     stream_handler = logging.StreamHandler(sys.stdout)
     stream_handler.setLevel(numeric_level)
     stream_handler.setFormatter(formatter)
@@ -107,6 +112,6 @@ def setup_logging(
 
     logger.debug(
         "ロギングを設定しました: level=%s, log_file=%s",
-        resolved_level_str,
+        logging.getLevelName(numeric_level),
         log_file,
     )

--- a/src/kabusys/utils/logging_setup.py
+++ b/src/kabusys/utils/logging_setup.py
@@ -1,7 +1,7 @@
 # src/kabusys/utils/logging_setup.py
 """logging_setup.py — ログ設定ユーティリティ。
 
-StreamHandler（コンソール）と TimedRotatingFileHandler（日次ローテーション）を
+StreamHandler（コンソール stdout）と TimedRotatingFileHandler（日次ローテーション）を
 ルートロガーに設定する。全起動スクリプトから呼び出して統一的なログ管理を実現する。
 
 使い方:
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
 
@@ -64,30 +65,45 @@ def setup_logging(
     resolved_dir = log_dir or Path(os.environ.get("LOG_DIR", str(_DEFAULT_LOG_DIR)))
     resolved_dir.mkdir(parents=True, exist_ok=True)
 
-    # ルートロガーにレベルを設定（既存ハンドラをクリア）
+    # ルートロガーにレベルを設定（既存ハンドラを flush/close してから削除）
     root = logging.getLogger()
     root.setLevel(numeric_level)
-    root.handlers.clear()
+    for h in list(root.handlers):
+        try:
+            h.flush()
+        except Exception:
+            pass
+        try:
+            h.close()
+        except Exception:
+            pass
+        root.removeHandler(h)
 
     formatter = logging.Formatter(_LOG_FORMAT, datefmt=_DATE_FORMAT)
 
-    # StreamHandler（コンソール出力）
-    stream_handler = logging.StreamHandler()
+    # StreamHandler（コンソール stdout 出力）
+    stream_handler = logging.StreamHandler(sys.stdout)
     stream_handler.setLevel(numeric_level)
     stream_handler.setFormatter(formatter)
     root.addHandler(stream_handler)
 
     # TimedRotatingFileHandler（日次ローテーション・30日保持）
+    # ファイル作成に失敗した場合は StreamHandler のみで継続する
     log_file = resolved_dir / f"{app_name}.log"
-    file_handler = TimedRotatingFileHandler(
-        log_file,
-        when="midnight",
-        backupCount=_BACKUP_COUNT,
-        encoding="utf-8",
-    )
-    file_handler.setLevel(numeric_level)
-    file_handler.setFormatter(formatter)
-    root.addHandler(file_handler)
+    try:
+        file_handler = TimedRotatingFileHandler(
+            log_file,
+            when="midnight",
+            backupCount=_BACKUP_COUNT,
+            encoding="utf-8",
+        )
+        file_handler.setLevel(numeric_level)
+        file_handler.setFormatter(formatter)
+        root.addHandler(file_handler)
+    except Exception as e:
+        logger.warning(
+            "ファイルハンドラの作成に失敗しました。コンソール出力のみ有効です: %s", e
+        )
 
     logger.debug(
         "ロギングを設定しました: level=%s, log_file=%s",

--- a/src/kabusys/utils/logging_setup.py
+++ b/src/kabusys/utils/logging_setup.py
@@ -65,8 +65,18 @@ def setup_logging(
         numeric_level = getattr(logging, resolved_level_str, logging.INFO)
 
     # ログディレクトリ解決・作成
+    # 作成失敗時は FileHandler をスキップして StreamHandler のみで継続する
     resolved_dir = log_dir or Path(os.environ.get("LOG_DIR", str(_DEFAULT_LOG_DIR)))
-    resolved_dir.mkdir(parents=True, exist_ok=True)
+    _dir_ok = True
+    try:
+        resolved_dir.mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        _dir_ok = False
+        # ルートロガー未設定のため print で警告を出す
+        print(
+            f"WARNING: ログディレクトリの作成に失敗しました。ファイル出力を無効化します: {e}",
+            file=sys.stderr,
+        )
 
     # ルートロガーにレベルを設定（既存ハンドラを flush/close してから削除）
     root = logging.getLogger()
@@ -93,22 +103,24 @@ def setup_logging(
     root.addHandler(stream_handler)
 
     # TimedRotatingFileHandler（日次ローテーション・30日保持）
-    # ファイル作成に失敗した場合は StreamHandler のみで継続する
+    # ディレクトリ作成またはファイル作成に失敗した場合は StreamHandler のみで継続する
     log_file = resolved_dir / f"{app_name}.log"
-    try:
-        file_handler = TimedRotatingFileHandler(
-            log_file,
-            when="midnight",
-            backupCount=_BACKUP_COUNT,
-            encoding="utf-8",
-        )
-        file_handler.setLevel(numeric_level)
-        file_handler.setFormatter(formatter)
-        root.addHandler(file_handler)
-    except Exception as e:
-        logger.warning(
-            "ファイルハンドラの作成に失敗しました。コンソール出力のみ有効です: %s", e
-        )
+    if _dir_ok:
+        try:
+            file_handler = TimedRotatingFileHandler(
+                log_file,
+                when="midnight",
+                backupCount=_BACKUP_COUNT,
+                encoding="utf-8",
+            )
+            file_handler.setLevel(numeric_level)
+            file_handler.setFormatter(formatter)
+            root.addHandler(file_handler)
+        except Exception as e:
+            logger.warning(
+                "ファイルハンドラの作成に失敗しました。コンソール出力のみ有効です: %s",
+                e,
+            )
 
     logger.debug(
         "ロギングを設定しました: level=%s, log_file=%s",

--- a/src/kabusys/utils/logging_setup.py
+++ b/src/kabusys/utils/logging_setup.py
@@ -55,7 +55,9 @@ def setup_logging(
                   None の場合は上記解決順を使用。
     """
     # ログレベル解決
-    resolved_level_str = (level or os.environ.get("LOG_LEVEL", _DEFAULT_LOG_LEVEL)).upper()
+    resolved_level_str = (
+        level or os.environ.get("LOG_LEVEL", _DEFAULT_LOG_LEVEL)
+    ).upper()
     numeric_level = getattr(logging, resolved_level_str, logging.INFO)
 
     # ログディレクトリ解決・作成

--- a/src/kabusys/utils/logging_setup.py
+++ b/src/kabusys/utils/logging_setup.py
@@ -1,0 +1,94 @@
+# src/kabusys/utils/logging_setup.py
+"""logging_setup.py — ログ設定ユーティリティ。
+
+StreamHandler（コンソール）と TimedRotatingFileHandler（日次ローテーション）を
+ルートロガーに設定する。全起動スクリプトから呼び出して統一的なログ管理を実現する。
+
+使い方:
+    from kabusys.utils.logging_setup import setup_logging
+    setup_logging(app_name="execution")
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
+
+_LOG_FORMAT = "%(asctime)s %(levelname)-8s %(name)s: %(message)s"
+_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
+_DEFAULT_LOG_DIR = Path("logs")
+_DEFAULT_LOG_LEVEL = "INFO"
+_BACKUP_COUNT = 30  # 日次ローテーション・30日分保持
+
+logger = logging.getLogger(__name__)
+
+
+def setup_logging(
+    app_name: str = "kabusys",
+    log_dir: Path | None = None,
+    level: str | None = None,
+) -> None:
+    """ロギングを設定する。
+
+    ルートロガーに以下の2ハンドラを設定する:
+      - StreamHandler: コンソール（stdout）出力
+      - TimedRotatingFileHandler: ``<log_dir>/<app_name>.log`` への日次ローテーション出力
+
+    既にハンドラが設定されている場合は一度クリアしてから再設定する（二重設定防止）。
+
+    ログレベルの解決順:
+      1. 引数 ``level``
+      2. 環境変数 ``LOG_LEVEL``
+      3. デフォルト ``"INFO"``
+
+    ログディレクトリの解決順:
+      1. 引数 ``log_dir``
+      2. 環境変数 ``LOG_DIR``
+      3. デフォルト ``"logs/"``
+
+    Args:
+        app_name: ログファイル名のプレフィックス（例: ``"execution"`` → ``logs/execution.log``）。
+        log_dir:  ログファイルの保存ディレクトリ。None の場合は上記解決順を使用。
+        level:    ログレベル文字列（"DEBUG"/"INFO"/"WARNING"/"ERROR"/"CRITICAL"）。
+                  None の場合は上記解決順を使用。
+    """
+    # ログレベル解決
+    resolved_level_str = (level or os.environ.get("LOG_LEVEL", _DEFAULT_LOG_LEVEL)).upper()
+    numeric_level = getattr(logging, resolved_level_str, logging.INFO)
+
+    # ログディレクトリ解決・作成
+    resolved_dir = log_dir or Path(os.environ.get("LOG_DIR", str(_DEFAULT_LOG_DIR)))
+    resolved_dir.mkdir(parents=True, exist_ok=True)
+
+    # ルートロガーにレベルを設定（既存ハンドラをクリア）
+    root = logging.getLogger()
+    root.setLevel(numeric_level)
+    root.handlers.clear()
+
+    formatter = logging.Formatter(_LOG_FORMAT, datefmt=_DATE_FORMAT)
+
+    # StreamHandler（コンソール出力）
+    stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(numeric_level)
+    stream_handler.setFormatter(formatter)
+    root.addHandler(stream_handler)
+
+    # TimedRotatingFileHandler（日次ローテーション・30日保持）
+    log_file = resolved_dir / f"{app_name}.log"
+    file_handler = TimedRotatingFileHandler(
+        log_file,
+        when="midnight",
+        backupCount=_BACKUP_COUNT,
+        encoding="utf-8",
+    )
+    file_handler.setLevel(numeric_level)
+    file_handler.setFormatter(formatter)
+    root.addHandler(file_handler)
+
+    logger.debug(
+        "ロギングを設定しました: level=%s, log_file=%s",
+        resolved_level_str,
+        log_file,
+    )

--- a/tests/test_generated.py
+++ b/tests/test_generated.py
@@ -1,0 +1,88 @@
+
+import io
+import json
+import logging
+import math
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+# --- config._parse_env_line, Settings, _load_env_file, _require tests ---
+from kabusys.config import (
+    _parse_env_line,
+    _load_env_file,
+    Settings,
+    _require,
+)
+
+
+def test_parse_env_line_basic_and_comments():
+    assert _parse_env_line("") is None
+    assert _parse_env_line("   # comment") is None
+    assert _parse_env_line("KEYWITHOUTEQ") is None
+
+    assert _parse_env_line("export FOO=bar") == ("FOO", "bar")
+    assert _parse_env_line("KEY= value  ") == ("KEY", "value")
+    # inline comment is trimmed only if preceded by space/tab
+    assert _parse_env_line("K=val #comment") == ("K", "val")
+    assert _parse_env_line("K=val#notcomment") == ("K", "val#notcomment")
+
+
+def test_parse_env_line_quoted_and_escaped():
+    # single quotes with escaped quote
+    assert _parse_env_line("A='a\\'b'") == ("A", "a'b")
+    # double quotes with escape
+    assert _parse_env_line('B="x\\\"y"') == ("B", 'x"y')
+    # empty value in quotes
+    assert _parse_env_line("C=''") == ("C", "")
+    # quoted with trailing comment ignored
+    assert _parse_env_line("D='foo'  # comment") == ("D", "foo")
+
+
+def test_load_env_file_override_and_protected(tmp_path, monkeypatch):
+    p = tmp_path / ".env.test"
+    p.write_text("A=1\nB=2\nC=3\n", encoding="utf-8")
+
+    # ensure environment starts empty for these keys
+    monkeypatch.delenv("A", raising=False)
+    monkeypatch.delenv("B", raising=False)
+    monkeypatch.delenv("C", raising=False)
+
+    # load without override -> set missing keys only
+    _load_env_file(p, override=False, protected=frozenset())
+    assert os.environ.get("A") == "1"
+    assert os.environ.get("B") == "2"
+
+    # set B to something else, then load with override but protected contains B
+    os.environ["B"] = "orig"
+    _load_env_file(p, override=True, protected=frozenset({"B"}))
+    # B should remain orig because it's protected
+    assert os.environ["B"] == "orig"
+
+
+def test_require_raises_when_missing(monkeypatch):
+    monkeypatch.delenv("SOME_NONEXISTENT_KEY", raising=False)
+    with pytest.raises(ValueError):
+        _require("SOME_NONEXISTENT_KEY")
+
+
+def test_settings_env_and_fill_mode(monkeypatch):
+    s = Settings()
+    # default env is development
+    monkeypatch.setenv("KABUSYS_ENV", "development")
+    assert s.env == "development"
+    # invalid env should raise
+    monkeypatch.setenv("KABUSYS_ENV", "invalid_env_value")
+    with pytest.raises(ValueError):
+        _ = s.env
+
+    # PAPER_FILL_MODE valid/invalid
+    monkeypatch.setenv("PAPER_FILL_MODE", "instant")
+    assert s.paper_fill_mode == "instant"
+    monkeypatch.setenv("PAPER_FILL_MODE", "PARTIAL")
+    assert s.paper_fill_mode == "partial"
+    monkeypatch.setenv("PAPER_FILL_MODE", "invalid_mode")
+    with pytest.raises(ValueError):
+        _ = s.paper_fill_mode

--- a/tests/test_generated.py
+++ b/tests/test_generated.py
@@ -1,11 +1,4 @@
-
-import io
-import json
-import logging
-import math
 import os
-from pathlib import Path
-from unittest import mock
 
 import pytest
 
@@ -34,7 +27,7 @@ def test_parse_env_line_quoted_and_escaped():
     # single quotes with escaped quote
     assert _parse_env_line("A='a\\'b'") == ("A", "a'b")
     # double quotes with escape
-    assert _parse_env_line('B="x\\\"y"') == ("B", 'x"y')
+    assert _parse_env_line('B="x\\"y"') == ("B", 'x"y')
     # empty value in quotes
     assert _parse_env_line("C=''") == ("C", "")
     # quoted with trailing comment ignored

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -86,7 +86,9 @@ class TestSetupLogging:
         """TimedRotatingFileHandler が midnight/30日保持で設定される。"""
         setup_logging(app_name="test", log_dir=tmp_path)
         root = logging.getLogger()
-        file_handlers = [h for h in root.handlers if isinstance(h, TimedRotatingFileHandler)]
+        file_handlers = [
+            h for h in root.handlers if isinstance(h, TimedRotatingFileHandler)
+        ]
         assert len(file_handlers) == 1
         fh = file_handlers[0]
         assert fh.when == "MIDNIGHT"

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -4,10 +4,7 @@
 from __future__ import annotations
 
 import logging
-import os
 from logging.handlers import TimedRotatingFileHandler
-from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,0 +1,108 @@
+# tests/test_logging_setup.py
+"""logging_setup モジュールのユニットテスト（Issue #55）"""
+
+from __future__ import annotations
+
+import logging
+import os
+from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kabusys.utils.logging_setup import setup_logging
+
+
+@pytest.fixture(autouse=True)
+def reset_root_logger():
+    """各テスト後にルートロガーのハンドラをリセットする。"""
+    yield
+    root = logging.getLogger()
+    for h in list(root.handlers):
+        h.close()
+        root.removeHandler(h)
+
+
+class TestSetupLogging:
+    def test_creates_log_file(self, tmp_path):
+        """setup_logging() でログファイルが作成される。"""
+        setup_logging(app_name="test_app", log_dir=tmp_path)
+        assert (tmp_path / "test_app.log").exists()
+
+    def test_creates_log_dir_if_missing(self, tmp_path):
+        """存在しないディレクトリは自動作成される。"""
+        log_dir = tmp_path / "subdir" / "logs"
+        setup_logging(app_name="test", log_dir=log_dir)
+        assert log_dir.exists()
+        assert (log_dir / "test.log").exists()
+
+    def test_stream_and_file_handlers_added(self, tmp_path):
+        """StreamHandler と TimedRotatingFileHandler の2つが追加される。"""
+        setup_logging(app_name="test", log_dir=tmp_path)
+        root = logging.getLogger()
+        handler_types = {type(h) for h in root.handlers}
+        assert logging.StreamHandler in handler_types
+        assert TimedRotatingFileHandler in handler_types
+
+    def test_handler_count_is_two(self, tmp_path):
+        """ハンドラ数がちょうど2（stream + file）。"""
+        setup_logging(app_name="test", log_dir=tmp_path)
+        assert len(logging.getLogger().handlers) == 2
+
+    def test_no_duplicate_handlers_on_second_call(self, tmp_path):
+        """2回呼んでもハンドラが重複しない。"""
+        setup_logging(app_name="test", log_dir=tmp_path)
+        setup_logging(app_name="test", log_dir=tmp_path)
+        assert len(logging.getLogger().handlers) == 2
+
+    def test_log_level_from_argument(self, tmp_path):
+        """引数 level が反映される。"""
+        setup_logging(app_name="test", log_dir=tmp_path, level="DEBUG")
+        assert logging.getLogger().level == logging.DEBUG
+
+    def test_log_level_from_env(self, tmp_path, monkeypatch):
+        """環境変数 LOG_LEVEL が反映される。"""
+        monkeypatch.setenv("LOG_LEVEL", "WARNING")
+        setup_logging(app_name="test", log_dir=tmp_path)
+        assert logging.getLogger().level == logging.WARNING
+
+    def test_arg_level_takes_precedence_over_env(self, tmp_path, monkeypatch):
+        """引数 level が環境変数より優先される。"""
+        monkeypatch.setenv("LOG_LEVEL", "WARNING")
+        setup_logging(app_name="test", log_dir=tmp_path, level="ERROR")
+        assert logging.getLogger().level == logging.ERROR
+
+    def test_default_level_is_info(self, tmp_path, monkeypatch):
+        """LOG_LEVEL 未設定時のデフォルトは INFO。"""
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        setup_logging(app_name="test", log_dir=tmp_path)
+        assert logging.getLogger().level == logging.INFO
+
+    def test_log_dir_from_env(self, tmp_path, monkeypatch):
+        """環境変数 LOG_DIR が反映される。"""
+        monkeypatch.setenv("LOG_DIR", str(tmp_path))
+        setup_logging(app_name="env_test")
+        assert (tmp_path / "env_test.log").exists()
+
+    def test_file_handler_rotation_config(self, tmp_path):
+        """TimedRotatingFileHandler が midnight/30日保持で設定される。"""
+        setup_logging(app_name="test", log_dir=tmp_path)
+        root = logging.getLogger()
+        file_handlers = [h for h in root.handlers if isinstance(h, TimedRotatingFileHandler)]
+        assert len(file_handlers) == 1
+        fh = file_handlers[0]
+        assert fh.when == "MIDNIGHT"
+        assert fh.backupCount == 30
+
+    def test_invalid_log_level_falls_back_to_info(self, tmp_path, monkeypatch):
+        """無効なログレベルは INFO にフォールバックされる。"""
+        monkeypatch.setenv("LOG_LEVEL", "INVALID_LEVEL")
+        setup_logging(app_name="test", log_dir=tmp_path)
+        assert logging.getLogger().level == logging.INFO
+
+    def test_app_name_used_as_filename(self, tmp_path):
+        """app_name がファイル名 "<app_name>.log" に使われる。"""
+        setup_logging(app_name="my_service", log_dir=tmp_path)
+        assert (tmp_path / "my_service.log").exists()
+        assert not (tmp_path / "kabusys.log").exists()

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import logging
+import sys
 from logging.handlers import TimedRotatingFileHandler
+from unittest.mock import patch
 
 import pytest
 
@@ -41,6 +43,14 @@ class TestSetupLogging:
         handler_types = {type(h) for h in root.handlers}
         assert logging.StreamHandler in handler_types
         assert TimedRotatingFileHandler in handler_types
+
+    def test_stream_handler_uses_stdout(self, tmp_path):
+        """StreamHandler が sys.stdout を使用する。"""
+        setup_logging(app_name="test", log_dir=tmp_path)
+        root = logging.getLogger()
+        stream_handlers = [h for h in root.handlers if type(h) is logging.StreamHandler]
+        assert len(stream_handlers) == 1
+        assert stream_handlers[0].stream is sys.stdout
 
     def test_handler_count_is_two(self, tmp_path):
         """ハンドラ数がちょうど2（stream + file）。"""
@@ -105,3 +115,39 @@ class TestSetupLogging:
         setup_logging(app_name="my_service", log_dir=tmp_path)
         assert (tmp_path / "my_service.log").exists()
         assert not (tmp_path / "kabusys.log").exists()
+
+    def test_file_handler_failure_falls_back_to_stream_only(self, tmp_path):
+        """FileHandler 作成失敗時も StreamHandler のみで継続する。"""
+        with patch(
+            "kabusys.utils.logging_setup.TimedRotatingFileHandler",
+            side_effect=OSError("permission denied"),
+        ):
+            setup_logging(app_name="test", log_dir=tmp_path)
+        root = logging.getLogger()
+        assert len(root.handlers) == 1
+        assert type(root.handlers[0]) is logging.StreamHandler
+
+    def test_existing_handlers_closed_before_setup(self, tmp_path):
+        """2回目の呼び出しで既存ハンドラが close される（ spy で検証）。"""
+        setup_logging(app_name="test", log_dir=tmp_path)
+        root = logging.getLogger()
+        first_handlers = list(root.handlers)
+
+        closed = []
+
+        # 既存ハンドラの close をラップして呼び出しを追跡する
+        for h in first_handlers:
+            original = h.close
+
+            def make_spy(orig, handler):
+                def spy():
+                    closed.append(handler)
+                    orig()
+
+                return spy
+
+            h.close = make_spy(original, h)
+
+        setup_logging(app_name="test", log_dir=tmp_path)
+
+        assert len(closed) == len(first_handlers)

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -133,6 +133,16 @@ class TestSetupLogging:
         assert len(root.handlers) == 1
         assert type(root.handlers[0]) is logging.StreamHandler
 
+    def test_mkdir_failure_falls_back_to_stream_only(self, tmp_path):
+        """ログディレクトリ作成失敗時も StreamHandler のみで継続する。"""
+        with patch.object(
+            type(tmp_path), "mkdir", side_effect=PermissionError("permission denied")
+        ):
+            setup_logging(app_name="test", log_dir=tmp_path)
+        root = logging.getLogger()
+        assert len(root.handlers) == 1
+        assert type(root.handlers[0]) is logging.StreamHandler
+
     def test_existing_handlers_closed_before_setup(self, tmp_path):
         """2回目の呼び出しで既存ハンドラが close される（ spy で検証）。"""
         setup_logging(app_name="test", log_dir=tmp_path)

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -15,12 +15,13 @@ from kabusys.utils.logging_setup import setup_logging
 
 @pytest.fixture(autouse=True)
 def reset_root_logger():
-    """各テスト後にルートロガーのハンドラをリセットする。"""
+    """各テスト後にルートロガーのハンドラとレベルをリセットしてテスト間の独立性を保つ。"""
     yield
     root = logging.getLogger()
     for h in list(root.handlers):
         h.close()
         root.removeHandler(h)
+    root.setLevel(logging.WARNING)
 
 
 class TestSetupLogging:
@@ -66,6 +67,11 @@ class TestSetupLogging:
     def test_log_level_from_argument(self, tmp_path):
         """引数 level が反映される。"""
         setup_logging(app_name="test", log_dir=tmp_path, level="DEBUG")
+        assert logging.getLogger().level == logging.DEBUG
+
+    def test_log_level_as_int(self, tmp_path):
+        """引数 level に int（例: logging.DEBUG）を渡しても正しく設定される。"""
+        setup_logging(app_name="test", log_dir=tmp_path, level=logging.DEBUG)
         assert logging.getLogger().level == logging.DEBUG
 
     def test_log_level_from_env(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Issue #55「統合ログ・トレーサビリティシステム構築」のログローテーションタスクを実装。

- `src/kabusys/utils/logging_setup.py` を新規追加
  - `TimedRotatingFileHandler`（日次ローテーション・30日保持）と `StreamHandler` を統一設定
  - ログレベル: 引数 → `LOG_LEVEL` 環境変数 → デフォルト `INFO` の優先順
  - ログディレクトリ: 引数 → `LOG_DIR` 環境変数 → デフォルト `logs/` の優先順
  - 2回呼んでもハンドラが重複しない設計
- 全 run スクリプトの `logging.basicConfig()` を `setup_logging()` に置き換え
  - `run_execution.py`、`run_monitoring.py`（デーモンプロセス）
  - `scripts/run_*.py`、`scripts/start_system.py`（バッチスクリプト）
- `tests/test_logging_setup.py` を追加（13テスト）

**Issue #55 の残りタスク状況:**
- ✅ ログレベル設定 — `LOG_LEVEL` 環境変数で既に制御済み
- ✅ ログローテーション — 今回実装
- ✅ UUID 連鎖トレース（シグナル→発注→約定）— `audit.py` で実装済み

## Test plan

- [ ] `tests/test_logging_setup.py` 13件パスを確認
- [ ] 既存ユニットテスト 727件パス（リグレッションなし）を確認
- [ ] `logs/` が `.gitignore` 済みであることを確認