### PR TITLE
feat: 決算・重要イベント回避 (#171)

### DIFF
--- a/src/kabusys/backtest/engine.py
+++ b/src/kabusys/backtest/engine.py
@@ -408,7 +408,9 @@ def run_backtest(
             simulator.mark_to_market(trading_day, close_prices)
 
             # Step 4: 翌日用シグナル生成（bt_conn の positions を読んで SELL 判定）
-            generate_signals(bt_conn, target_date=trading_day, event_dates=event_dates or {})
+            generate_signals(
+                bt_conn, target_date=trading_day, event_dates=event_dates or {}
+            )
 
             # Step 5: ポートフォリオ構築（Phase 5 モジュール使用）
             buy_signals, sell_signals = _read_day_signals(bt_conn, trading_day)
@@ -473,7 +475,9 @@ def run_backtest(
                 {
                     "code": code,
                     "side": "buy",
-                    "shares": max(0, (int(shares * sm_map.get(code, 1.0)) // lot_size) * lot_size),
+                    "shares": max(
+                        0, (int(shares * sm_map.get(code, 1.0)) // lot_size) * lot_size
+                    ),
                 }
                 for code, shares in sized.items()
                 if shares > 0 and code not in sell_codes

--- a/src/kabusys/data/event_calendar.py
+++ b/src/kabusys/data/event_calendar.py
@@ -46,11 +46,15 @@ def load_event_dates(md_path: str | Path) -> dict[date, str]:
                     logger.warning(
                         "load_event_dates: 日付 %s が複数イベントに登録されています "
                         "('%s' → '%s')。後者で上書きします。",
-                        d, result[d], current_event,
+                        d,
+                        result[d],
+                        current_event,
                     )
                 result[d] = current_event
             except ValueError:
-                logger.debug("load_event_dates: 不正な日付 '%s'—スキップ", m_date.group(1))
+                logger.debug(
+                    "load_event_dates: 不正な日付 '%s'—スキップ", m_date.group(1)
+                )
 
     logger.info("load_event_dates: %d 件のイベント日を読み込み: %s", len(result), path)
     return result

--- a/src/kabusys/data/jquants_client.py
+++ b/src/kabusys/data/jquants_client.py
@@ -362,7 +362,9 @@ def save_earnings_calendar(
         try:
             ann_date = date(int(date_str[:4]), int(date_str[4:6]), int(date_str[6:8]))
         except (ValueError, IndexError):
-            logger.warning("save_earnings_calendar: 不正な日付フォーマット '%s'—スキップ", date_str)
+            logger.warning(
+                "save_earnings_calendar: 不正な日付フォーマット '%s'—スキップ", date_str
+            )
             continue
         rows.append((code, ann_date))
 

--- a/src/kabusys/data/schema.py
+++ b/src/kabusys/data/schema.py
@@ -335,6 +335,16 @@ _INDEXES: list[str] = [
     "CREATE INDEX IF NOT EXISTS idx_news_symbols_code ON news_symbols(code)",
     "CREATE INDEX IF NOT EXISTS idx_raw_news_datetime ON raw_news(datetime)",
     "CREATE INDEX IF NOT EXISTS idx_position_entries_code_sell ON position_entries(code, sell_date)",
+    "CREATE INDEX IF NOT EXISTS idx_position_entries_code_entry ON position_entries(code, entry_date)",
+]
+
+# ---------------------------------------------------------------------------
+# スキーママイグレーション（既存 DB への後付けカラム追加）
+# ---------------------------------------------------------------------------
+
+_MIGRATIONS: list[str] = [
+    # v0.x → v0.y: signals に size_multiplier を追加
+    "ALTER TABLE signals ADD COLUMN size_multiplier DOUBLE NOT NULL DEFAULT 1.0",
 ]
 
 # ---------------------------------------------------------------------------
@@ -407,6 +417,15 @@ def init_schema(db_path: str | Path) -> duckdb.DuckDBPyConnection:
         except Exception as rb_exc:
             logger.warning("init_schema: ROLLBACK failed: %s", rb_exc)
         raise
+
+    # マイグレーション（既存 DB への後付けカラム追加）
+    # ALTER TABLE は IF NOT EXISTS 非サポートのため、失敗時は既存カラムとみなしてスキップ
+    for migration in _MIGRATIONS:
+        try:
+            conn.execute(migration)
+        except Exception:
+            pass
+
     return conn
 
 

--- a/src/kabusys/execution/execution_engine.py
+++ b/src/kabusys/execution/execution_engine.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import duckdb
 
+from kabusys.data.calendar_management import next_trading_day
 from kabusys.execution.broker_api import BrokerAPIProtocol, OrderSentPendingError
 
 # DuplicateOrderError は _process_signals() (Task 7) で使用
@@ -156,6 +157,7 @@ class ExecutionEngine:
             t0 = _time_module.perf_counter()
             latency_ms: float | None = None
             _order_sent = False
+            _order_pending = False
             try:
                 self._order_manager.send_order(record.client_order_id)
                 latency_ms = (_time_module.perf_counter() - t0) * 1000
@@ -170,14 +172,19 @@ class ExecutionEngine:
                 latency_ms = (_time_module.perf_counter() - t0) * 1000
                 self._risk_manager.record_api_success()
                 _order_sent = True
+                _order_pending = True
                 logger.info("発注保留（pending）: signal_id=%s", signal_id)
             except Exception as exc:
                 self._risk_manager.record_api_error()
                 logger.error("発注失敗: signal_id=%s: %s", signal_id, exc)
 
             # position_entries に約定を記録（最低保有日数・再エントリー制限用）
+            # fill_date: 発注当日の翌営業日（バックテストと整合させるため）
+            # BUY pending も記録する（発注確約済みとして扱う。キャンセル時はリコンシリエーションで回収）
+            # SELL pending は記録しない（保有中のポジションのクローズ確定前のため）
             if _order_sent:
                 try:
+                    fill_date = next_trading_day(self._duckdb_conn, self._config.target_date)
                     if side == "buy":
                         self._duckdb_conn.execute(
                             """
@@ -185,16 +192,22 @@ class ExecutionEngine:
                             VALUES (?, ?)
                             ON CONFLICT DO NOTHING
                             """,
-                            [code, self._config.target_date],
+                            [code, fill_date],
                         )
-                    elif side == "sell":
+                    elif side == "sell" and not _order_pending:
                         self._duckdb_conn.execute(
                             """
                             UPDATE position_entries
                             SET sell_date = ?
-                            WHERE code = ? AND sell_date IS NULL
+                            WHERE (code, entry_date) IN (
+                                SELECT code, entry_date
+                                FROM position_entries
+                                WHERE code = ? AND sell_date IS NULL
+                                ORDER BY entry_date ASC
+                                LIMIT 1
+                            )
                             """,
-                            [self._config.target_date, code],
+                            [fill_date, code],
                         )
                 except Exception as _pe_exc:
                     logger.warning(

--- a/src/kabusys/execution/execution_engine.py
+++ b/src/kabusys/execution/execution_engine.py
@@ -198,17 +198,8 @@ class ExecutionEngine:
                         )
                     elif side == "sell" and not _order_pending:
                         self._duckdb_conn.execute(
-                            """
-                            UPDATE position_entries
-                            SET sell_date = ?
-                            WHERE (code, entry_date) IN (
-                                SELECT code, entry_date
-                                FROM position_entries
-                                WHERE code = ? AND sell_date IS NULL
-                                ORDER BY entry_date ASC
-                                LIMIT 1
-                            )
-                            """,
+                            "UPDATE position_entries SET sell_date = ? "
+                            "WHERE code = ? AND sell_date IS NULL",
                             [fill_date, code],
                         )
                 except Exception as _pe_exc:

--- a/src/kabusys/execution/execution_engine.py
+++ b/src/kabusys/execution/execution_engine.py
@@ -184,7 +184,9 @@ class ExecutionEngine:
             # SELL pending は記録しない（保有中のポジションのクローズ確定前のため）
             if _order_sent:
                 try:
-                    fill_date = next_trading_day(self._duckdb_conn, self._config.target_date)
+                    fill_date = next_trading_day(
+                        self._duckdb_conn, self._config.target_date
+                    )
                     if side == "buy":
                         self._duckdb_conn.execute(
                             """

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -62,8 +62,10 @@ _GAP_DOWN_THRESHOLD: float = -0.03  # gap_ratio <= -0.03 → BUY 抑制（境界
 _GAP_THRESHOLD_EPSILON: float = 1e-9
 _SECTOR_BOOST: float = 0.03  # 上位 _SECTOR_QUARTILE セクター銘柄への final_score 加算量
 _SECTOR_QUARTILE: float = 0.25  # 上位・下位の区切り割合（各 ceil(N×0.25) セクター）
-_MIN_HOLDING_DAYS: int = 5   # BUY 後この営業日数を経過するまで非ストップロス SELL を抑制
-_REENTRY_COOLDOWN_DAYS: int = 5  # SELL 後この営業日数を経過するまで同一銘柄の BUY を禁止
+_MIN_HOLDING_DAYS: int = 5  # BUY 後この営業日数を経過するまで非ストップロス SELL を抑制
+_REENTRY_COOLDOWN_DAYS: int = (
+    5  # SELL 後この営業日数を経過するまで同一銘柄の BUY を禁止
+)
 
 
 # ---------------------------------------------------------------------------
@@ -707,9 +709,7 @@ def generate_signals(
                 continue
             # 再エントリー制限チェック
             if _is_reentry_blocked(conn, r["code"], target_date):
-                logger.debug(
-                    "reentry blocked: %s — date=%s", r["code"], target_date
-                )
+                logger.debug("reentry blocked: %s — date=%s", r["code"], target_date)
                 reentry_suppressed += 1
                 continue
             # 決算回避フィルタ（翌営業日が決算日の銘柄は BUY 抑制）

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -316,6 +316,8 @@ def _held_days(
     if row is None:
         return None
     entry_date = row[0] if isinstance(row[0], date) else date.fromisoformat(str(row[0]))
+    if entry_date > target_date:
+        return 0
     days = get_trading_days(conn, entry_date, target_date)
     return len(days) - 1  # 0 = entry 当日、5 = 5営業日後
 

--- a/tests/integration/test_paper_trading.py
+++ b/tests/integration/test_paper_trading.py
@@ -44,7 +44,8 @@ def mon_conn():
 
 def _sig(conn, code: str, side: str = "buy"):
     conn.execute(
-        "INSERT INTO signals (date, code, side, score, signal_rank) VALUES (?, ?, ?, ?, ?)", [TARGET_DATE, code, side, 0.8, 1]
+        "INSERT INTO signals (date, code, side, score, signal_rank) VALUES (?, ?, ?, ?, ?)",
+        [TARGET_DATE, code, side, 0.8, 1],
     )
 
 

--- a/tests/test_backtest_framework.py
+++ b/tests/test_backtest_framework.py
@@ -935,9 +935,7 @@ def test_position_entries_sell_date_updated(conn):
     bt_conn = init_schema(":memory:")
 
     # まず BUY
-    buy_trades = [
-        TradeRecord(date(2026, 4, 1), "1001", "buy", 100, 1000.0, 55.0, None)
-    ]
+    buy_trades = [TradeRecord(date(2026, 4, 1), "1001", "buy", 100, 1000.0, 55.0, None)]
     _write_position_entries(bt_conn, buy_trades, date(2026, 4, 1))
 
     # 次に SELL

--- a/tests/test_execution_engine.py
+++ b/tests/test_execution_engine.py
@@ -18,6 +18,7 @@ from kabusys.monitoring.monitoring_db import MonitoringDB
 
 
 TARGET_DATE = date(2026, 3, 29)
+FILL_DATE = date(2026, 3, 30)  # next_trading_day(TARGET_DATE) — 月曜
 
 
 def _make_engine(
@@ -435,7 +436,7 @@ class TestPositionEntriesOnFill:
             "SELECT entry_date FROM position_entries WHERE code = '9999'"
         ).fetchone()
         assert row is not None, "BUY 発注後に position_entries が挿入されるべき"
-        assert row[0] == TARGET_DATE
+        assert row[0] == FILL_DATE, "entry_date は約定日（翌営業日）であるべき"
 
     def test_buy_signal_pending_inserts_position_entry(self, sqlite_conn, duckdb_conn):
         """BUY 発注保留（OrderSentPendingError）でも position_entries に entry_date が挿入される。"""
@@ -450,7 +451,7 @@ class TestPositionEntriesOnFill:
             "SELECT entry_date FROM position_entries WHERE code = '8888'"
         ).fetchone()
         assert row is not None, "発注保留（pending）後も position_entries が挿入されるべき"
-        assert row[0] == TARGET_DATE
+        assert row[0] == FILL_DATE, "entry_date は約定日（翌営業日）であるべき"
 
     def test_buy_signal_idempotent(self, sqlite_conn, duckdb_conn):
         """同一 code/date の BUY を2回処理しても position_entries は1行のみ（冪等性）。"""
@@ -484,7 +485,26 @@ class TestPositionEntriesOnFill:
             "SELECT sell_date FROM position_entries WHERE code = '6666'"
         ).fetchone()
         assert row is not None
-        assert row[0] == TARGET_DATE, "SELL 発注後に sell_date が設定されるべき"
+        assert row[0] == FILL_DATE, "sell_date は約定日（翌営業日）であるべき"
+
+    def test_sell_signal_pending_does_not_update_sell_date(self, sqlite_conn, duckdb_conn):
+        """SELL 発注保留（pending）では sell_date を書かない（ポジションはまだ保有中）。"""
+        duckdb_conn.execute(
+            "INSERT INTO position_entries (code, entry_date) VALUES ('5555', ?)",
+            [TARGET_DATE],
+        )
+        _insert_signal(duckdb_conn, "5555", side="sell")
+        _insert_target(duckdb_conn, "5555", qty=100, price=1000.0)
+        broker = MockBrokerClient(available_cash=5_000_000.0, fill_mode="never")
+        engine = _make_engine(broker, sqlite_conn, duckdb_conn)
+
+        engine._process_signals()
+
+        row = duckdb_conn.execute(
+            "SELECT sell_date FROM position_entries WHERE code = '5555'"
+        ).fetchone()
+        assert row is not None
+        assert row[0] is None, "SELL pending では sell_date は NULL のままであるべき"
 
     def test_size_multiplier_applied_to_buy_qty(self, sqlite_conn, duckdb_conn):
         """size_multiplier=0.5 のシグナルは発注数量が半減する。"""

--- a/tests/test_execution_engine.py
+++ b/tests/test_execution_engine.py
@@ -450,7 +450,9 @@ class TestPositionEntriesOnFill:
         row = duckdb_conn.execute(
             "SELECT entry_date FROM position_entries WHERE code = '8888'"
         ).fetchone()
-        assert row is not None, "発注保留（pending）後も position_entries が挿入されるべき"
+        assert row is not None, (
+            "発注保留（pending）後も position_entries が挿入されるべき"
+        )
         assert row[0] == FILL_DATE, "entry_date は約定日（翌営業日）であるべき"
 
     def test_buy_signal_idempotent(self, sqlite_conn, duckdb_conn):
@@ -487,7 +489,9 @@ class TestPositionEntriesOnFill:
         assert row is not None
         assert row[0] == FILL_DATE, "sell_date は約定日（翌営業日）であるべき"
 
-    def test_sell_signal_pending_does_not_update_sell_date(self, sqlite_conn, duckdb_conn):
+    def test_sell_signal_pending_does_not_update_sell_date(
+        self, sqlite_conn, duckdb_conn
+    ):
         """SELL 発注保留（pending）では sell_date を書かない（ポジションはまだ保有中）。"""
         duckdb_conn.execute(
             "INSERT INTO position_entries (code, entry_date) VALUES ('5555', ?)",
@@ -522,7 +526,9 @@ class TestPositionEntriesOnFill:
         # 発注された注文の qty が 100 (= 200 * 0.5) であること
         orders = engine._repo.list_active()
         assert len(orders) == 1, "発注が1件あるべき"
-        assert orders[0].qty == 100, f"size_multiplier=0.5 適用後 qty=100 であるべき、実際={orders[0].qty}"
+        assert orders[0].qty == 100, (
+            f"size_multiplier=0.5 適用後 qty=100 であるべき、実際={orders[0].qty}"
+        )
 
     def test_size_multiplier_fractional_floors_to_lot(self, sqlite_conn, duckdb_conn):
         """size_multiplier 適用後に端数が切り捨てられ、ロット単位に丸められる。"""
@@ -540,7 +546,9 @@ class TestPositionEntriesOnFill:
         # 発注された注文の qty が 100 (= floor(250 * 0.5 / 100) * 100) であること
         orders = engine._repo.list_active()
         assert len(orders) == 1, "発注が1件あるべき"
-        assert orders[0].qty == 100, f"端数切り捨て後 qty=100 であるべき、実際={orders[0].qty}"
+        assert orders[0].qty == 100, (
+            f"端数切り捨て後 qty=100 であるべき、実際={orders[0].qty}"
+        )
 
     def test_size_multiplier_zero_skips_order(self, sqlite_conn, duckdb_conn):
         """size_multiplier 適用後 qty=0 の場合は発注をスキップする。"""

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -170,6 +170,7 @@ def test_breadth_stop_bear_regime_both_block_buy(conn):
 # Task 2: 最低保有日数 / 再エントリー制限
 # ---------------------------------------------------------------------------
 
+
 def _insert_position(conn, code: str, d: date, avg_price: float = 1000.0) -> None:
     conn.execute(
         "INSERT INTO positions (date, code, position_size, avg_price) VALUES (?, ?, 100, ?)",
@@ -177,16 +178,16 @@ def _insert_position(conn, code: str, d: date, avg_price: float = 1000.0) -> Non
     )
 
 
-def _insert_position_entry(
-    conn, code: str, entry_date: date, sell_date=None
-) -> None:
+def _insert_position_entry(conn, code: str, entry_date: date, sell_date=None) -> None:
     conn.execute(
         "INSERT INTO position_entries (code, entry_date, sell_date) VALUES (?, ?, ?)",
         [code, entry_date, sell_date],
     )
 
 
-def _insert_price(conn, code: str, d: date, close: float = 1000.0, open_: float = 1000.0) -> None:
+def _insert_price(
+    conn, code: str, d: date, close: float = 1000.0, open_: float = 1000.0
+) -> None:
     conn.execute(
         "INSERT INTO prices_daily (date, code, open, high, low, close, volume) "
         "VALUES (?, ?, ?, ?, ?, ?, 1000000)",
@@ -244,7 +245,7 @@ class TestMinHoldingDays:
         biz_days = [base + timedelta(days=i) for i in range(7)]
         _insert_calendar_days(conn, biz_days)
 
-        entry_date = biz_days[0]   # 4/1
+        entry_date = biz_days[0]  # 4/1
         target_date = biz_days[5]  # 4/6 (5営業日後)
 
         code = "1002"
@@ -321,7 +322,7 @@ class TestReentryRestriction:
         biz_days = [base + timedelta(days=i) for i in range(5)]
         _insert_calendar_days(conn, biz_days)
 
-        sell_date = biz_days[0]   # 4/1 に SELL
+        sell_date = biz_days[0]  # 4/1 に SELL
         target_date = biz_days[3]  # 4/4 (3営業日後)
 
         code = "2001"


### PR DESCRIPTION
## 概要

Issue #171 の実装。決算カレンダー・イベントカレンダーを使った BUY抑制・SELL強制・発注サイズ縮小を追加。PR-A (#174 Part 1) の上に積み上げる形。

## 変更内容

- `src/kabusys/data/schema.py` — `earnings_calendar` テーブル + `signals.size_multiplier` カラム追加
- `src/kabusys/data/jquants_client.py` — J-Quants 決算カレンダー取得・保存
- `src/kabusys/data/pipeline.py` — daily ETL に決算カレンダー取得ステップ追加
- `src/kabusys/data/event_calendar.py` — Markdown イベントカレンダーパーサー（新規）
- `config/event_calendar.md` — FOMC・日銀決定会合・米CPI の日程（2026年分）（新規）
- `src/kabusys/strategy/signal_generator.py` — 決算回避BUY抑制 / 決算前SELL強制 / イベント前 size_multiplier=0.5
- `src/kabusys/backtest/engine.py` — earnings_calendar コピー + size_multiplier 適用
- `src/kabusys/execution/execution_engine.py` — size_multiplier を発注サイズに適用

## テスト計画

- [x] `TestEarningsAvoidance` — 翌日決算はBUY抑制・SELL強制、なければ通常
- [x] `TestEventSizeMultiplier` — イベント当日は size_multiplier=0.5、それ以外は 1.0
- [x] `TestEarningsCalendarPipeline` — 冪等性・不正日付スキップ
- [x] `test_event_calendar.py` — 5テスト（パース・欠損ファイル・不正行・重複日付）
- [x] `test_size_multiplier_applied_to_buy_qty` / `test_size_multiplier_zero_skips_order` / `test_size_multiplier_fractional_floors_to_lot`

871テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)