### PR TITLE
feat: RiskConfig設定ファイル統合 & KabuStationClient配線 (#189, #186)

### DIFF
--- a/config/risk_config.yaml
+++ b/config/risk_config.yaml
@@ -7,4 +7,3 @@ risk:
   circuit_breaker_errors: 10       # サーキットブレーカー発動エラー数上限
   circuit_breaker_window_sec: 60   # サーキットブレーカーカウントウィンドウ（秒）
   max_drawdown: 0.20               # キルスイッチ発動ドローダウン閾値
-  initial_portfolio_value: 0.0     # セッション開始時の資産評価額

--- a/config/risk_config.yaml
+++ b/config/risk_config.yaml
@@ -1,14 +1,10 @@
-# risk_config.yaml — リスク管理設定（安全側の初期値）
+# risk_config.yaml — リスク管理設定
+# キー名は RiskConfig データクラスのフィールド名に対応する
 risk:
-  # 1銘柄最大ウェイト（ポートフォリオ対比）
-  max_position_size: 0.05
-  # ポートフォリオ総投資比率上限
-  max_portfolio_exposure: 1.0
-  # 日次最大損失率（超過で Kill Switch 検討）
-  max_daily_loss: 0.02
-  # 最大ドローダウン（超過で Kill Switch 自動発動）
-  max_drawdown: 0.15
-
-position_sizing:
-  risk_per_trade: 0.01
-  volatility_adjustment: true
+  max_position_pct: 0.20           # 1銘柄最大投資比率（総資産比）
+  max_utilization: 0.80            # 全ポジション投下上限（現金最低20%維持）
+  rate_limit_per_sec: 5            # API レート制限（毎秒）
+  circuit_breaker_errors: 10       # サーキットブレーカー発動エラー数上限
+  circuit_breaker_window_sec: 60   # サーキットブレーカーカウントウィンドウ（秒）
+  max_drawdown: 0.20               # キルスイッチ発動ドローダウン閾値
+  initial_portfolio_value: 0.0     # セッション開始時の資産評価額

--- a/docs/superpowers/plans/2026-04-25-risk-config-kabu-client.md
+++ b/docs/superpowers/plans/2026-04-25-risk-config-kabu-client.md
@@ -1,0 +1,558 @@
+# RiskConfig設定ファイル統合 & KabuStationClient配線 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `RiskConfig` パラメータを `config/risk_config.yaml` から読み込む設計に統一し、`is_live` 環境で `KabuStationClient` を使って実際に発注できる状態にする。
+
+**Architecture:** `run_execution.py` に `_load_risk_config(path, initial_portfolio_value)` を追加して YAML から `RiskConfig` を構築する。`initial_portfolio_value` は起動時に `get_available_cash() + 保有評価額` で総資産を算出して渡す。`BrokerClientFactory` の `is_live` ブランチを `KabuStationClient` で実装し、`Settings` に `kabu_trade_password` を追加する。
+
+**Tech Stack:** Python 3.10+, PyYAML (pyyaml>=6.0), pytest, monkeypatch, unittest.mock
+
+---
+
+## ファイル変更マップ
+
+| ファイル | 変更種別 | 内容 |
+|---|---|---|
+| `config/risk_config.yaml` | Modify | フィールド名を `RiskConfig` に合わせて書き直し |
+| `src/kabusys/run_execution.py` | Modify | `_load_risk_config()` 追加、`RiskConfig` 直書き削除、`total_assets` 計算追加 |
+| `src/kabusys/config.py` | Modify | `kabu_trade_password` プロパティ追加 |
+| `src/kabusys/execution/broker_factory.py` | Modify | `is_live` ブランチを `KabuStationClient` 実装に置換 |
+| `src/kabusys/config_setup.py` | Modify | `KABU_TRADE_PASSWORD` 項目追加 |
+| `tests/test_run_execution.py` | Modify | `_load_risk_config` パッチ追加・`total_assets` テスト追加 |
+| `tests/test_broker_factory.py` | Modify | `is_live` テストを `KabuStationClient` 返却検証に変更 |
+
+---
+
+## Task 1: config/risk_config.yaml の書き直し
+
+**Files:**
+- Modify: `config/risk_config.yaml`
+
+- [ ] **Step 1: risk_config.yaml を RiskConfig フィールド名に揃えて書き直す**
+
+`config/risk_config.yaml` を以下の内容で完全に置き換える:
+
+```yaml
+# risk_config.yaml — リスク管理設定
+# キー名は RiskConfig データクラスのフィールド名に対応する
+risk:
+  max_position_pct: 0.20           # 1銘柄最大投資比率（総資産比）
+  max_utilization: 0.80            # 全ポジション投下上限（現金最低20%維持）
+  rate_limit_per_sec: 5            # API レート制限（毎秒）
+  circuit_breaker_errors: 10       # サーキットブレーカー発動エラー数上限
+  circuit_breaker_window_sec: 60   # サーキットブレーカーカウントウィンドウ（秒）
+  max_drawdown: 0.20               # キルスイッチ発動ドローダウン閾値
+```
+
+- [ ] **Step 2: コミット**
+
+```bash
+git add config/risk_config.yaml
+git commit -m "config: risk_config.yaml のキー名を RiskConfig フィールド名に統一"
+```
+
+---
+
+## Task 2: _load_risk_config() の TDD 実装
+
+**Files:**
+- Modify: `src/kabusys/run_execution.py`
+- Test: `tests/test_run_execution.py`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`tests/test_run_execution.py` の末尾に以下を追加する:
+
+```python
+import tempfile
+import yaml as yaml_mod
+from kabusys.execution.risk_manager import RiskConfig
+import kabusys.run_execution as re_mod
+
+
+class TestLoadRiskConfig:
+    def _write_yaml(self, tmp_path, data: dict) -> Path:
+        p = tmp_path / "risk_config.yaml"
+        p.write_text(yaml_mod.dump(data), encoding="utf-8")
+        return p
+
+    def test_loads_all_fields(self, tmp_path):
+        p = self._write_yaml(tmp_path, {
+            "risk": {
+                "max_position_pct": 0.15,
+                "max_utilization": 0.70,
+                "rate_limit_per_sec": 3,
+                "circuit_breaker_errors": 5,
+                "circuit_breaker_window_sec": 30,
+                "max_drawdown": 0.10,
+            }
+        })
+        config = re_mod._load_risk_config(p, initial_portfolio_value=5_000_000.0)
+        assert isinstance(config, RiskConfig)
+        assert config.max_position_pct == 0.15
+        assert config.max_utilization == 0.70
+        assert config.rate_limit_per_sec == 3
+        assert config.circuit_breaker_errors == 5
+        assert config.circuit_breaker_window_sec == 30
+        assert config.max_drawdown == 0.10
+        assert config.initial_portfolio_value == 5_000_000.0
+
+    def test_file_not_found_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            re_mod._load_risk_config(tmp_path / "nonexistent.yaml", 0.0)
+
+    def test_missing_key_raises(self, tmp_path):
+        p = self._write_yaml(tmp_path, {"risk": {"max_position_pct": 0.20}})
+        with pytest.raises(KeyError):
+            re_mod._load_risk_config(p, 0.0)
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```bash
+pytest tests/test_run_execution.py::TestLoadRiskConfig -v
+```
+
+期待: `AttributeError: module 'kabusys.run_execution' has no attribute '_load_risk_config'`
+
+- [ ] **Step 3: _load_risk_config() を run_execution.py に実装する**
+
+`run_execution.py` の import ブロック直後（`logger = ...` の前）に以下を追加する:
+
+```python
+import yaml
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_STOP_FLAG = _PROJECT_ROOT / "data" / "stop_requested.flag"
+_EXECUTION_PID = _PROJECT_ROOT / "data" / "execution.pid"
+_RISK_CONFIG = _PROJECT_ROOT / "config" / "risk_config.yaml"
+```
+
+※ `_PROJECT_ROOT`・`_STOP_FLAG`・`_EXECUTION_PID` は既存のためそのまま。`_RISK_CONFIG` だけ追加。
+
+続けて `logger = logging.getLogger(__name__)` の直後に以下を追加する:
+
+```python
+def _load_risk_config(path: Path, initial_portfolio_value: float) -> "RiskConfig":
+    with path.open(encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    r = data["risk"]
+    return RiskConfig(
+        max_position_pct=r["max_position_pct"],
+        max_utilization=r["max_utilization"],
+        rate_limit_per_sec=r["rate_limit_per_sec"],
+        circuit_breaker_errors=r["circuit_breaker_errors"],
+        circuit_breaker_window_sec=r["circuit_breaker_window_sec"],
+        max_drawdown=r["max_drawdown"],
+        initial_portfolio_value=initial_portfolio_value,
+    )
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+```bash
+pytest tests/test_run_execution.py::TestLoadRiskConfig -v
+```
+
+期待: 3テストすべて PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/kabusys/run_execution.py tests/test_run_execution.py
+git commit -m "feat: run_execution に _load_risk_config() を追加（#189）"
+```
+
+---
+
+## Task 3: initial_portfolio_value 計算と RiskConfig 直書きの置換
+
+**Files:**
+- Modify: `src/kabusys/run_execution.py`
+- Modify: `tests/test_run_execution.py`
+
+- [ ] **Step 1: initial_portfolio_value のテストを書く**
+
+`tests/test_run_execution.py` のファイル先頭の import ブロックに以下を追加する:
+
+```python
+from kabusys.execution.broker_api import Position
+from kabusys.execution.risk_manager import RiskConfig
+```
+
+続けて `TestRunExecutionMain` クラスに以下2つのテストメソッドを追加する:
+
+```python
+def test_initial_portfolio_value_includes_positions(self):
+    mock_broker = MagicMock()
+    mock_broker.get_available_cash.return_value = 1_000_000.0
+    mock_broker.get_positions.return_value = [
+        Position(code="1234", qty=100, avg_price=2000.0, current_price=2500.0),
+        # 100 * 2500 = 250_000
+    ]
+    mock_engine = MagicMock()
+
+    with (
+        patch("kabusys.run_execution.set_process_priority"),
+        patch("kabusys.run_execution.Settings") as mock_settings_cls,
+        patch("kabusys.run_execution.sqlite3.connect"),
+        patch("kabusys.run_execution.init_monitoring_db"),
+        patch("kabusys.run_execution.duckdb.connect"),
+        patch("kabusys.run_execution.BrokerClientFactory.create", return_value=mock_broker),
+        patch("kabusys.run_execution.OrderRepository"),
+        patch("kabusys.run_execution.OrderManager"),
+        patch("kabusys.run_execution.RiskManager"),
+        patch("kabusys.run_execution.Reconciler"),
+        patch("kabusys.run_execution.ExecutionEngine", return_value=mock_engine),
+        patch("kabusys.run_execution._load_risk_config") as mock_load,
+    ):
+        mock_load.return_value = RiskConfig()
+        settings = MagicMock()
+        settings.is_paper = False
+        settings.sqlite_path = Path("/prod.db")
+        settings.duckdb_path = Path("/data.duckdb")
+        mock_settings_cls.return_value = settings
+
+        main()
+
+    # _load_risk_config は total_assets = 1_000_000 + 250_000 = 1_250_000 で呼ばれる
+    mock_load.assert_called_once()
+    assert mock_load.call_args.kwargs["initial_portfolio_value"] == 1_250_000.0
+
+def test_initial_portfolio_value_fallback_to_avg_price_when_no_current_price(self):
+    mock_broker = MagicMock()
+    mock_broker.get_available_cash.return_value = 500_000.0
+    mock_broker.get_positions.return_value = [
+        Position(code="9999", qty=200, avg_price=1500.0, current_price=None),
+        # current_price=None → avg_price で代替: 200 * 1500 = 300_000
+    ]
+    mock_engine = MagicMock()
+
+    with (
+        patch("kabusys.run_execution.set_process_priority"),
+        patch("kabusys.run_execution.Settings") as mock_settings_cls,
+        patch("kabusys.run_execution.sqlite3.connect"),
+        patch("kabusys.run_execution.init_monitoring_db"),
+        patch("kabusys.run_execution.duckdb.connect"),
+        patch("kabusys.run_execution.BrokerClientFactory.create", return_value=mock_broker),
+        patch("kabusys.run_execution.OrderRepository"),
+        patch("kabusys.run_execution.OrderManager"),
+        patch("kabusys.run_execution.RiskManager"),
+        patch("kabusys.run_execution.Reconciler"),
+        patch("kabusys.run_execution.ExecutionEngine", return_value=mock_engine),
+        patch("kabusys.run_execution._load_risk_config") as mock_load,
+    ):
+        mock_load.return_value = RiskConfig()
+        settings = MagicMock()
+        settings.is_paper = False
+        settings.sqlite_path = Path("/prod.db")
+        settings.duckdb_path = Path("/data.duckdb")
+        mock_settings_cls.return_value = settings
+
+        main()
+
+    # total_assets = 500_000 + 300_000 = 800_000
+    assert mock_load.call_args.kwargs["initial_portfolio_value"] == 800_000.0
+```
+
+- [ ] **Step 2: 既存の _run_main ヘルパーを更新する**
+
+`test_run_execution.py` の `_run_main()` 関数を以下の通り更新する（`get_positions` の追加と `_load_risk_config` のパッチ追加）:
+
+```python
+def _run_main(is_paper: bool = False):
+    """全依存をモックして main() を実行するヘルパー。"""
+    mock_broker = MagicMock()
+    mock_broker.get_available_cash.return_value = 10_000_000.0
+    mock_broker.get_positions.return_value = []  # ← 追加（positions なし）
+    mock_engine = MagicMock()
+
+    with (
+        patch("kabusys.run_execution.set_process_priority") as mock_priority,
+        patch("kabusys.run_execution.Settings") as mock_settings_cls,
+        patch("kabusys.run_execution.sqlite3.connect") as mock_sqlite,
+        patch("kabusys.run_execution.init_monitoring_db"),
+        patch("kabusys.run_execution.duckdb.connect"),
+        patch(
+            "kabusys.run_execution.BrokerClientFactory.create", return_value=mock_broker
+        ),
+        patch("kabusys.run_execution.OrderRepository"),
+        patch("kabusys.run_execution.OrderManager"),
+        patch("kabusys.run_execution.RiskManager"),
+        patch("kabusys.run_execution.Reconciler"),
+        patch("kabusys.run_execution.ExecutionEngine", return_value=mock_engine),
+        patch("kabusys.run_execution._load_risk_config", return_value=MagicMock()),  # ← 追加
+    ):
+        settings = MagicMock()
+        settings.is_paper = is_paper
+        settings.paper_sqlite_path = Path("/paper.db")
+        settings.sqlite_path = Path("/prod.db")
+        settings.duckdb_path = Path("/data.duckdb")
+        settings.pid_file_path = Path("/data/execution.pid")
+        mock_settings_cls.return_value = settings
+
+        main()
+
+    return mock_priority, mock_sqlite, mock_engine, settings
+```
+
+- [ ] **Step 3: テストが失敗することを確認**
+
+```bash
+pytest tests/test_run_execution.py::TestRunExecutionMain::test_initial_portfolio_value_includes_positions -v
+```
+
+期待: `AssertionError`（`_load_risk_config` が呼ばれていない or `initial_portfolio_value` が 0.0）
+
+- [ ] **Step 4: run_execution.py の main() を書き換える**
+
+`main()` 内の broker 初期化ブロック（`broker = BrokerClientFactory.create(settings)` の直後）を以下に置き換える:
+
+```python
+# 3. ブローカークライアント
+broker = BrokerClientFactory.create(settings)
+
+# 4. 起動時総資産を計算（現金 + 保有評価額）
+cash = broker.get_available_cash()
+positions = broker.get_positions()
+total_assets = cash + sum(
+    p.qty * (p.current_price if p.current_price is not None else p.avg_price)
+    for p in positions
+)
+
+# 5. 依存コンポーネント組み立て
+repo = OrderRepository(sqlite_conn)
+order_manager = OrderManager(broker, repo)
+risk_manager = RiskManager(
+    broker=broker,
+    repo=repo,
+    config=_load_risk_config(_RISK_CONFIG, initial_portfolio_value=total_assets),
+)
+reconciler = Reconciler(broker=broker, repo=repo, order_manager=order_manager)
+```
+
+※ 元の `RiskConfig(max_position_pct=0.20, ...)` の直書きブロックを丸ごと削除し、上記に置き換える。
+
+- [ ] **Step 5: テストが通ることを確認**
+
+```bash
+pytest tests/test_run_execution.py -v
+```
+
+期待: 全テスト PASS
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/kabusys/run_execution.py tests/test_run_execution.py
+git commit -m "feat: RiskConfig を risk_config.yaml から読み込み、initial_portfolio_value を総資産で計算 (#189)"
+```
+
+---
+
+## Task 4: Settings に kabu_trade_password を追加
+
+**Files:**
+- Modify: `src/kabusys/config.py`
+- Test: `tests/test_broker_factory.py`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`tests/test_broker_factory.py` の末尾に以下クラスを追加する:
+
+```python
+class TestKabuTradePassword:
+    def test_returns_none_when_not_set(self, monkeypatch):
+        monkeypatch.delenv("KABU_TRADE_PASSWORD", raising=False)
+        assert Settings().kabu_trade_password is None
+
+    def test_returns_value_when_set(self, monkeypatch):
+        monkeypatch.setenv("KABU_TRADE_PASSWORD", "secret123")
+        assert Settings().kabu_trade_password == "secret123"
+
+    def test_returns_none_for_empty_string(self, monkeypatch):
+        monkeypatch.setenv("KABU_TRADE_PASSWORD", "")
+        assert Settings().kabu_trade_password is None
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```bash
+pytest tests/test_broker_factory.py::TestKabuTradePassword -v
+```
+
+期待: `AttributeError: 'Settings' object has no attribute 'kabu_trade_password'`
+
+- [ ] **Step 3: config.py に kabu_trade_password プロパティを追加する**
+
+`config.py` の `kabu_api_base_url` プロパティの直後に以下を追加する:
+
+```python
+@property
+def kabu_trade_password(self) -> str | None:
+    return os.environ.get("KABU_TRADE_PASSWORD") or None
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+```bash
+pytest tests/test_broker_factory.py::TestKabuTradePassword -v
+```
+
+期待: 3テストすべて PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/kabusys/config.py tests/test_broker_factory.py
+git commit -m "feat: Settings に kabu_trade_password プロパティを追加 (#186)"
+```
+
+---
+
+## Task 5: BrokerClientFactory の is_live ブランチを KabuStationClient で実装
+
+**Files:**
+- Modify: `src/kabusys/execution/broker_factory.py`
+- Modify: `tests/test_broker_factory.py`
+
+- [ ] **Step 1: is_live テストを KabuStationClient 返却検証に更新する**
+
+`tests/test_broker_factory.py` の `TestBrokerClientFactory` クラスの `test_live_mode_raises_not_implemented` を以下に置き換える:
+
+```python
+def test_live_mode_returns_kabu_station_client(self, monkeypatch):
+    from kabusys.execution.kabu_client import KabuStationClient
+    monkeypatch.setenv("KABUSYS_ENV", "live")
+    monkeypatch.setenv("KABU_API_PASSWORD", "test_password")
+    monkeypatch.delenv("KABU_TRADE_PASSWORD", raising=False)
+    broker = BrokerClientFactory.create(Settings())
+    assert isinstance(broker, KabuStationClient)
+    broker.close()  # httpx.Client を閉じる
+
+def test_live_mode_passes_trade_password_when_set(self, monkeypatch):
+    from kabusys.execution.kabu_client import KabuStationClient
+    monkeypatch.setenv("KABUSYS_ENV", "live")
+    monkeypatch.setenv("KABU_API_PASSWORD", "api_pass")
+    monkeypatch.setenv("KABU_TRADE_PASSWORD", "trade_pass")
+    broker = BrokerClientFactory.create(Settings())
+    assert isinstance(broker, KabuStationClient)
+    # trade_password が設定されていれば api_password と異なる値が使われる
+    assert broker._trade_password == "trade_pass"
+    broker.close()
+
+def test_live_mode_falls_back_to_api_password_when_trade_password_not_set(self, monkeypatch):
+    from kabusys.execution.kabu_client import KabuStationClient
+    monkeypatch.setenv("KABUSYS_ENV", "live")
+    monkeypatch.setenv("KABU_API_PASSWORD", "api_pass")
+    monkeypatch.delenv("KABU_TRADE_PASSWORD", raising=False)
+    broker = BrokerClientFactory.create(Settings())
+    assert isinstance(broker, KabuStationClient)
+    # trade_password 未設定時は kabu_client 内部で api_password にフォールバック
+    assert broker._trade_password == "api_pass"
+    broker.close()
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```bash
+pytest tests/test_broker_factory.py::TestBrokerClientFactory::test_live_mode_returns_kabu_station_client -v
+```
+
+期待: `FAIL` — `NotImplementedError` が発生
+
+- [ ] **Step 3: broker_factory.py の is_live ブランチを実装する**
+
+`broker_factory.py` の `is_live` の `raise NotImplementedError(...)` を以下に置き換える:
+
+```python
+if settings.is_live:
+    return create_broker_api(
+        mock=False,
+        api_password=settings.kabu_api_password,
+        trade_password=settings.kabu_trade_password,
+        base_url=settings.kabu_api_base_url,
+    )
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+```bash
+pytest tests/test_broker_factory.py -v
+```
+
+期待: 全テスト PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/kabusys/execution/broker_factory.py tests/test_broker_factory.py
+git commit -m "feat: BrokerClientFactory の is_live ブランチで KabuStationClient を返すよう実装 (#186)"
+```
+
+---
+
+## Task 6: config_setup.py に KABU_TRADE_PASSWORD を追加
+
+**Files:**
+- Modify: `src/kabusys/config_setup.py`
+
+- [ ] **Step 1: _ITEMS リストに KABU_TRADE_PASSWORD 項目を追加する**
+
+`config_setup.py` の `_ITEMS` リスト内の `KABU_API_BASE_URL` 項目の直後に以下を追加する:
+
+```python
+{
+    "key": "KABU_TRADE_PASSWORD",
+    "label": "kabuステーション 取引パスワード（任意）",
+    "secret": True,
+    "optional": True,
+    "description": (
+        "  kabuステーション 取引パスワード（空欄時は API パスワードを流用）\n"
+        "  APIパスワードと同一の場合は空欄でよい"
+    ),
+},
+```
+
+- [ ] **Step 2: _write_env() に KABU_TRADE_PASSWORD の書き込み行を追加する**
+
+`_write_env()` 内の `KABU_API_BASE_URL` 行の直後に以下を追加する:
+
+```python
+f"KABU_TRADE_PASSWORD={values.get('KABU_TRADE_PASSWORD', '')}",
+```
+
+- [ ] **Step 3: 動作確認**
+
+```bash
+pytest tests/test_config_setup.py -v
+```
+
+期待: 既存テスト全 PASS（_ITEMS の変更は既存テストに影響しない）
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add src/kabusys/config_setup.py
+git commit -m "feat: config_setup に KABU_TRADE_PASSWORD 項目を追加 (#186)"
+```
+
+---
+
+## Task 7: 全テストの最終確認
+
+- [ ] **Step 1: 全テストを実行する**
+
+```bash
+pytest tests/ -v --tb=short
+```
+
+期待: 全テスト PASS（新規追加分含む）
+
+- [ ] **Step 2: Issue をクローズする**
+
+```bash
+gh issue close 189 --comment "実装完了: risk_config.yaml 読み込み・initial_portfolio_value 総資産計算を実装"
+gh issue close 186 --comment "実装完了: BrokerClientFactory.create() の is_live ブランチで KabuStationClient を返すよう実装"
+```

--- a/docs/superpowers/specs/2026-04-25-risk-config-kabu-client-design.md
+++ b/docs/superpowers/specs/2026-04-25-risk-config-kabu-client-design.md
@@ -1,0 +1,118 @@
+# 設計書: RiskConfig設定ファイル統合 & KabuStationClient配線
+
+- Issue: #189 (RiskConfig設定ファイル統合), #186 (KabuStationClient配線)
+- 日付: 2026-04-25
+- ステータス: 承認済み
+
+---
+
+## 背景
+
+### #189: RiskConfig設定ファイル統合
+
+`run_execution.py` 内で `RiskConfig(...)` のパラメータが直書きされており、設定変更のたびにコード修正が必要な状態。`config/risk_config.yaml` は存在するが、フィールド名が `RiskConfig` と不一致のため実行経路では使用されていない。
+
+また `initial_portfolio_value` に `broker.get_available_cash()`（現金のみ）を渡しているため、既存保有ポジションがある場合にドローダウン計算の基準値が実際の総資産より小さくなるリスクがある。
+
+### #186: KabuStationClient配線
+
+`KabuStationClient` は `kabu_client.py` に完全実装済みだが、`broker_factory.py` の `is_live` ブランチが `NotImplementedError` を throw するだけで本番執行が不可能な状態。
+
+---
+
+## 設計
+
+### #189: RiskConfig設定ファイル統合
+
+#### 変更 1: `config/risk_config.yaml` の書き直し
+
+`RiskConfig` データクラスのフィールド名に揃えて全キーを再定義する。
+
+```yaml
+risk:
+  max_position_pct: 0.20           # 1銘柄最大投資比率
+  max_utilization: 0.80            # 全ポジション投下上限（現金最低20%維持）
+  rate_limit_per_sec: 5            # API レート制限（毎秒）
+  circuit_breaker_errors: 10       # サーキットブレーカー発動エラー数上限
+  circuit_breaker_window_sec: 60   # サーキットブレーカーカウントウィンドウ（秒）
+  max_drawdown: 0.20               # キルスイッチ発動ドローダウン閾値
+```
+
+`initial_portfolio_value` は実行時に動的計算するため YAML には含めない。
+
+#### 変更 2: `run_execution.py` へのローダー追加
+
+プライベート関数 `_load_risk_config(path, initial_portfolio_value) -> RiskConfig` を追加し、YAML を読み込んで `RiskConfig` を返す。
+
+`initial_portfolio_value` の計算:
+
+```python
+cash = broker.get_available_cash()
+positions = broker.get_positions()
+total_assets = cash + sum(
+    p.qty * (p.current_price if p.current_price is not None else p.avg_price)
+    for p in positions
+)
+```
+
+`broker.get_positions()` の呼び出しは1回のみ（起動時）。
+
+#### 変更ファイル
+
+| ファイル | 変更内容 |
+|---|---|
+| `config/risk_config.yaml` | フィールド名を `RiskConfig` に合わせて全キー書き直し |
+| `src/kabusys/run_execution.py` | `_load_risk_config()` 追加、`RiskConfig(...)` 直書きを置換、`total_assets` 計算追加 |
+
+---
+
+### #186: KabuStationClient配線
+
+#### 変更 1: `config.py` に `kabu_trade_password` を追加
+
+```python
+@property
+def kabu_trade_password(self) -> str | None:
+    return os.environ.get("KABU_TRADE_PASSWORD") or None
+```
+
+未設定時は `None` を返し、`KabuStationClient` 側で `api_password` にフォールバックする。
+
+#### 変更 2: `broker_factory.py` の `is_live` ブランチを実装
+
+```python
+if settings.is_live:
+    return create_broker_api(
+        mock=False,
+        api_password=settings.kabu_api_password,
+        trade_password=settings.kabu_trade_password,
+        base_url=settings.kabu_api_base_url,
+    )
+```
+
+#### 変更 3: `config_setup.py` に `KABU_TRADE_PASSWORD` 項目を追加
+
+オプション項目として `_ITEMS` リストへ追加。`_write_env()` にも対応行を追加。
+
+#### 変更ファイル
+
+| ファイル | 変更内容 |
+|---|---|
+| `src/kabusys/config.py` | `kabu_trade_password` プロパティ追加 |
+| `src/kabusys/execution/broker_factory.py` | `is_live` ブランチを `KabuStationClient` 実装に置換 |
+| `src/kabusys/config_setup.py` | `KABU_TRADE_PASSWORD` 項目追加（オプション） |
+
+---
+
+## テスト方針
+
+- `broker_factory.py` の `is_live` ブランチ: `Settings.is_live=True` のモック環境でファクトリが `KabuStationClient` インスタンスを返すことを確認
+- `_load_risk_config()`: 正常 YAML・不正キー・ファイル不存在の各ケースをテスト
+- `initial_portfolio_value` 計算: ポジションあり/なし両方のケースをテスト
+
+---
+
+## 制約
+
+- `initial_portfolio_value` の計算で `get_positions()` を追加呼び出しするが、起動時1回のみであり性能影響は無視できる
+- `KABUSYS_ENV=live` 時に `KABU_API_PASSWORD` が未設定の場合は既存の `ValueError` が発生する（変更なし）

--- a/documents/01_Data/config_schema.md
+++ b/documents/01_Data/config_schema.md
@@ -138,35 +138,39 @@ ai_overlay:
 
 # 6. risk_config.yaml
 
-リスク管理設定。
+リスク管理設定。`RiskManager` の `RiskConfig` に直接マッピングされる。
 
 ``` yaml
 risk:
 
-  max_position_size: 0.05
+  max_position_pct: 0.20           # 1銘柄最大投資比率（総資産比）
 
-  max_portfolio_exposure: 1.0
+  max_utilization: 0.80            # 全ポジション投下上限（現金最低20%維持）
 
-  max_daily_loss: 0.02
+  rate_limit_per_sec: 5            # API レート制限（毎秒）
 
-  max_drawdown: 0.15
+  circuit_breaker_errors: 10       # サーキットブレーカー発動エラー数上限
 
-position_sizing:
+  circuit_breaker_window_sec: 60   # サーキットブレーカーカウントウィンドウ（秒）
 
-  risk_per_trade: 0.01
-
-  volatility_adjustment: true
+  max_drawdown: 0.20               # キルスイッチ発動ドローダウン閾値
 ```
 
 説明
 
-  key                      description
-  ------------------------ -----------------
-  max_position_size        1銘柄最大比率
-  max_portfolio_exposure   総投資比率
-  max_daily_loss           日次最大損失
-  max_drawdown             最大DD
-  risk_per_trade           1トレードリスク
+  key                        description
+  -------------------------- ---------------------------------
+  max_position_pct           1銘柄最大投資比率（RiskConfig.max_position_pct）
+  max_utilization            全ポジション投下上限（RiskConfig.max_utilization）
+  rate_limit_per_sec         API レート制限・毎秒回数（RiskConfig.rate_limit_per_sec）
+  circuit_breaker_errors     CB発動エラー数上限（RiskConfig.circuit_breaker_errors）
+  circuit_breaker_window_sec CBカウントウィンドウ秒（RiskConfig.circuit_breaker_window_sec）
+  max_drawdown               キルスイッチ発動DD閾値（RiskConfig.max_drawdown）
+
+備考
+
+- `initial_portfolio_value` は起動時に動的計算するため YAML には含めない（`get_available_cash() + 保有評価額`）
+- 旧キー名 `max_position_size` / `max_portfolio_exposure` は廃止。`max_position_pct` / `max_utilization` に統一。
 
 ------------------------------------------------------------------------
 

--- a/documents/04_Execution/ExecutionSystem.md
+++ b/documents/04_Execution/ExecutionSystem.md
@@ -50,17 +50,33 @@
 
 Strategy層が生成したシグナルは、実行層（Execution）へ渡る直前および直後に「3段階のガード」を通過しなければならない。
 
+### 設定ファイルからのパラメータ読み込み
+
+リスクパラメータはコードに直書きせず、`config/risk_config.yaml` から起動時に読み込む。実際の現金余力は broker API（kabuステーション API / MockBrokerClient）から取得する。
+
+```python
+# run_execution.py 起動時の初期資産計算
+cash = broker.get_available_cash()
+positions = broker.get_positions()
+initial_portfolio_value = cash + sum(
+    p.qty * (p.current_price if p.current_price is not None else p.avg_price)
+    for p in positions
+)
+```
+
+`initial_portfolio_value` はドローダウン計算の基準値として使用し、現金のみでなく **既存保有を含む総資産** とする。
+
 ### 第1関門: シグナルレベル・ガード（発注前検証）
 - **余力チェック**: 現在の口座買付余力を超過していないか。
 - **重複チェック**: すでに同一銘柄の注文が `OrderAccepted` `OrderSent` 状態で存在しないか（二重発注防止）。
-- **ポジション上限**: すでに最大保有株数、または総資産に対する最大投資比率（10%等）に達していないか。
+- **ポジション上限**: すでに総資産に対する最大投資比率（`max_position_pct`、デフォルト20%）に達していないか。また全体の投下比率が `max_utilization`（デフォルト80%）を超えないか。
 
 ### 第2関門: エグゼキューションレベル・ガード（API送信前制限）
-- **APIレート制限**: kabuステーションの「発注系API: 毎秒5回以内」等の制約を厳守するため、トークンバケツやスロットリングキューを挟む。
-- **暴走防止（サーキットブレーカー）**: 短期間（例: 1分間）に指定回数（例: 10回）連続でエラーが返却された場合、APIキーの失効や取引所側の障害とみなし、システム全体の発注機能を停止させる。
+- **APIレート制限**: kabuステーションの「発注系API: 毎秒 `rate_limit_per_sec` 回以内」制約をトークンバケツで厳守する。
+- **暴走防止（サーキットブレーカー）**: `circuit_breaker_window_sec` 秒以内に `circuit_breaker_errors` 回以上エラーが返却された場合、システム全体の発注機能を停止させる。
 
 ### 第3関門: メトリクスレベル・ガード（発注後監視）
-- ポートフォリオ全体の評価損益（Drawdown）を監視し、想定最大損失（MaxDD等）を超えた場合はすべての未約定注文をキャンセルさせ、保有ポジションを成行で安全にクローズする**キルスイッチ（Kill Switch）**を発動させる。
+- ポートフォリオ全体のドローダウンを監視し、`max_drawdown`（デフォルト20%）を超えた場合は**キルスイッチ（Kill Switch）**を発動させる。
 
 ---
 
@@ -163,13 +179,19 @@ broker API の `OrderStatus.status`（GET /orders レスポンス）から Order
 
 ### 差し替え方法
 
-**推奨: `BrokerClientFactory` を使用（Phase 8〜）**
+**推奨: `BrokerClientFactory` を使用**
 
 ```python
-# KABUSYS_ENV に応じて自動選択（paper_trading / development → MockBrokerClient）
+# KABUSYS_ENV に応じて自動選択
 from kabusys.execution.broker_factory import BrokerClientFactory
 broker = BrokerClientFactory.create(settings)
 ```
+
+| `KABUSYS_ENV` | 使用クライアント | 説明 |
+|---|---|---|
+| `development` | `MockBrokerClient` | ローカル開発・テスト用（発注なし） |
+| `paper_trading` | `MockBrokerClient` | 仮想発注（Paper Trading DB に記録） |
+| `live` | `KabuStationClient` | 実際に kabuステーション API へ発注 |
 
 **直接指定（テスト・開発時）**
 
@@ -177,15 +199,18 @@ broker = BrokerClientFactory.create(settings)
 # 開発・テスト時
 api = create_broker_api(mock=True)
 
-# 本番時
+# 本番時（BrokerClientFactory 経由を推奨）
 api = create_broker_api(mock=False, api_password="...", base_url="http://localhost:18080/kabusapi")
 ```
 
-**Paper Trading 関連環境変数**
+**関連環境変数**
 
 | 環境変数 | デフォルト | 説明 |
 |---|---|---|
-| `KABUSYS_ENV` | `development` | `paper_trading` で Paper Trading モード |
+| `KABUSYS_ENV` | `development` | 実行環境（development / paper_trading / live） |
+| `KABU_API_PASSWORD` | 必須 | kabuステーション API パスワード（live 環境で必須） |
+| `KABU_TRADE_PASSWORD` | 省略可 | kabuステーション 取引パスワード（省略時は `KABU_API_PASSWORD` と同一とみなす） |
+| `KABU_API_BASE_URL` | `http://localhost:18080/kabusapi` | kabuステーション API ベース URL |
 | `PAPER_FILL_MODE` | `instant` | MockBrokerClient の約定方式（instant/partial/never/reject） |
 | `PAPER_TRADING_SQLITE_PATH` | `data/paper_trading.db` | Paper Trading 専用 SQLite DB のパス |
 

--- a/documents/06_RiskManagement/RiskManagement.md
+++ b/documents/06_RiskManagement/RiskManagement.md
@@ -142,14 +142,20 @@ FOMC・日銀決定会合・米CPI等の主要イベント前後はボラティ�
 
 ## 4.2 ポートフォリオ制限
 
-制限
+以下パラメータは `config/risk_config.yaml` で設定し、`RiskManager` の `RiskConfig` に読み込まれる。
 
-| 項目               | 制限 |
-| ------------------ | ---- |
-| 最大保有銘柄       | 10   |
-| 1銘柄最大比率      | 10%  |
-| 同一セクター       | 30%  |
-| キャッシュ最低比率 | 20%  |
+| 項目                         | 設定値 | 設定キー (`risk_config.yaml`) |
+| ---------------------------- | ------ | ----------------------------- |
+| 1銘柄最大投資比率            | 20%    | `risk.max_position_pct`       |
+| 全ポジション投下上限         | 80%    | `risk.max_utilization`        |
+| キャッシュ最低比率           | 20%    | （`max_utilization` の裏面）  |
+| キルスイッチ発動DD閾値       | 20%    | `risk.max_drawdown`           |
+| API レート制限（毎秒）       | 5      | `risk.rate_limit_per_sec`     |
+| CB発動エラー数上限           | 10     | `risk.circuit_breaker_errors` |
+| CBカウントウィンドウ（秒）   | 60     | `risk.circuit_breaker_window_sec` |
+
+**初期資産（`initial_portfolio_value`）の計算方法:**
+起動時に `get_available_cash() + 保有ポジション評価額` で総資産を算出し、ドローダウン計算の基準値とする。`current_price` 未取得時は `avg_price` でフォールバックする（保守的評価）。
 
 ---
 
@@ -276,11 +282,13 @@ Cancelled
 
 # 10. ドローダウン制御
 
-| ドローダウン | 対応             |
-| ------------ | ---------------- |
-| 5%           | ポジション半減   |
-| 10%          | 新規停止         |
-| 15%          | 全ポジション縮小 |
+`RiskManager.check_metrics()` が `max_drawdown`（デフォルト 20%）超過を検知した場合に `KillSwitch` を発動する。
+
+| ドローダウン                          | 対応                                         |
+| ------------------------------------- | -------------------------------------------- |
+| `max_drawdown` 超過（デフォルト 20%） | キルスイッチ発動・新規発注停止               |
+
+閾値は `config/risk_config.yaml` の `risk.max_drawdown` で設定する。
 
 ---
 

--- a/src/kabusys/config.py
+++ b/src/kabusys/config.py
@@ -150,6 +150,10 @@ class Settings:
     def kabu_api_base_url(self) -> str:
         return os.environ.get("KABU_API_BASE_URL", "http://localhost:18080/kabusapi")
 
+    @property
+    def kabu_trade_password(self) -> str | None:
+        return os.environ.get("KABU_TRADE_PASSWORD") or None
+
     # --- LINE Messaging API ---
     @property
     def line_channel_access_token(self) -> str:

--- a/src/kabusys/config_setup.py
+++ b/src/kabusys/config_setup.py
@@ -50,6 +50,16 @@ _ITEMS: list[dict] = [
         "description": "  通常はデフォルトのままで可",
     },
     {
+        "key": "KABU_TRADE_PASSWORD",
+        "label": "kabuステーション 取引パスワード（任意）",
+        "secret": True,
+        "optional": True,
+        "description": (
+            "  kabuステーション 取引パスワード（空欄時は API パスワードを流用）\n"
+            "  APIパスワードと同一の場合は空欄でよい"
+        ),
+    },
+    {
         "key": "DUCKDB_PATH",
         "label": "DuckDB ファイルパス",
         "default": "data/kabusys.duckdb",
@@ -127,6 +137,7 @@ def _write_env(path: Path, values: dict[str, str]) -> None:
         "# --- kabuステーション API ---",
         f"KABU_API_PASSWORD={values.get('KABU_API_PASSWORD', '')}",
         f"KABU_API_BASE_URL={values.get('KABU_API_BASE_URL', 'http://localhost:18080/kabusapi')}",
+        f"KABU_TRADE_PASSWORD={values.get('KABU_TRADE_PASSWORD', '')}",
         "",
         "# --- LINE Messaging API (アラート通知用) ---",
         f"LINE_CHANNEL_ACCESS_TOKEN={values.get('LINE_CHANNEL_ACCESS_TOKEN', '')}",

--- a/src/kabusys/execution/broker_factory.py
+++ b/src/kabusys/execution/broker_factory.py
@@ -26,9 +26,11 @@ class BrokerClientFactory:
         if settings.is_paper or settings.is_dev:
             return create_broker_api(mock=True, fill_mode=settings.paper_fill_mode)
         if settings.is_live:
-            raise NotImplementedError(
-                "Live broker client (KabuStationClient) は未実装です。"
-                "KABUSYS_ENV=paper_trading または development を使用してください。"
+            return create_broker_api(
+                mock=False,
+                api_password=settings.kabu_api_password,
+                trade_password=settings.kabu_trade_password,
+                base_url=settings.kabu_api_base_url,
             )
         env = settings.env  # 明示評価（未知の env ならここで ValueError）
         raise ValueError(f"未知の KABUSYS_ENV: {env!r}")

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -36,6 +36,13 @@ logger = logging.getLogger(__name__)
 
 
 def _load_risk_config(path: Path, initial_portfolio_value: float) -> RiskConfig:
+    if not path.exists():
+        logger.error(
+            "リスク設定ファイルが見つかりません: %s"
+            " → config/risk_config.yaml を作成してください（python -m kabusys.config_setup を参照）",
+            path,
+        )
+        raise FileNotFoundError(f"リスク設定ファイルが見つかりません: {path}")
     try:
         with path.open(encoding="utf-8") as f:
             data = yaml.safe_load(f)

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -45,13 +45,17 @@ def _load_risk_config(path: Path, initial_portfolio_value: float) -> RiskConfig:
     try:
         r = data["risk"]
     except (TypeError, KeyError) as exc:
-        raise KeyError(f"risk_config.yaml にトップレベルキー 'risk' がありません: {path}") from exc
+        raise KeyError(
+            f"risk_config.yaml にトップレベルキー 'risk' がありません: {path}"
+        ) from exc
 
     def _get(key: str) -> object:
         try:
             return r[key]
         except KeyError as exc:
-            raise KeyError(f"risk_config.yaml に 'risk.{key}' がありません: {path}") from exc
+            raise KeyError(
+                f"risk_config.yaml に 'risk.{key}' がありません: {path}"
+            ) from exc
 
     max_position_pct = float(_get("max_position_pct"))
     max_utilization = float(_get("max_utilization"))
@@ -66,7 +70,9 @@ def _load_risk_config(path: Path, initial_portfolio_value: float) -> RiskConfig:
         ("max_drawdown", max_drawdown),
     ):
         if not (0 < val <= 1):
-            raise ValueError(f"risk_config.yaml: {name} は (0, 1] の範囲で設定してください（現在値: {val}）: {path}")
+            raise ValueError(
+                f"risk_config.yaml: {name} は (0, 1] の範囲で設定してください（現在値: {val}）: {path}"
+            )
     if max_position_pct > max_utilization:
         raise ValueError(
             f"risk_config.yaml: max_position_pct({max_position_pct}) は"
@@ -136,7 +142,12 @@ def main() -> None:
         cash = broker.get_available_cash()
         positions = broker.get_positions()
         total_assets = cash + sum(_pos_value(p) for p in positions)
-        logger.info("起動時総資産: %.0f 円（現金 %.0f 円 + ポジション %d 件）", total_assets, cash, len(positions))
+        logger.info(
+            "起動時総資産: %.0f 円（現金 %.0f 円 + ポジション %d 件）",
+            total_assets,
+            cash,
+            len(positions),
+        )
 
         # 5. 依存コンポーネント組み立て
         repo = OrderRepository(sqlite_conn)
@@ -144,7 +155,9 @@ def main() -> None:
         risk_manager = RiskManager(
             broker=broker,
             repo=repo,
-            config=_load_risk_config(_RISK_CONFIG, initial_portfolio_value=total_assets),
+            config=_load_risk_config(
+                _RISK_CONFIG, initial_portfolio_value=total_assets
+            ),
         )
         reconciler = Reconciler(broker=broker, repo=repo, order_manager=order_manager)
 

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -14,12 +14,14 @@ from datetime import date
 from pathlib import Path
 
 import duckdb
+import yaml
 
 from kabusys.config import Settings
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 _STOP_FLAG = _PROJECT_ROOT / "data" / "stop_requested.flag"
 _EXECUTION_PID = _PROJECT_ROOT / "data" / "execution.pid"
+_RISK_CONFIG = _PROJECT_ROOT / "config" / "risk_config.yaml"
 from kabusys.execution.broker_factory import BrokerClientFactory  # noqa: E402
 from kabusys.execution.execution_engine import EngineConfig, ExecutionEngine  # noqa: E402
 from kabusys.execution.order_manager import OrderManager  # noqa: E402
@@ -31,6 +33,21 @@ from kabusys.utils.logging_setup import setup_logging  # noqa: E402
 from kabusys.utils.process_priority import set_process_priority  # noqa: E402
 
 logger = logging.getLogger(__name__)
+
+
+def _load_risk_config(path: Path, initial_portfolio_value: float) -> RiskConfig:
+    with path.open(encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    r = data["risk"]
+    return RiskConfig(
+        max_position_pct=r["max_position_pct"],
+        max_utilization=r["max_utilization"],
+        rate_limit_per_sec=r["rate_limit_per_sec"],
+        circuit_breaker_errors=r["circuit_breaker_errors"],
+        circuit_breaker_window_sec=r["circuit_breaker_window_sec"],
+        max_drawdown=r["max_drawdown"],
+        initial_portfolio_value=initial_portfolio_value,
+    )
 
 
 def main() -> None:

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -73,6 +73,7 @@ def main() -> None:
         # 4. 依存コンポーネント組み立て
         repo = OrderRepository(sqlite_conn)
         order_manager = OrderManager(broker, repo)
+        # TODO(#189 Task 3): replace inline RiskConfig with _load_risk_config(_RISK_CONFIG, total_assets)
         risk_manager = RiskManager(
             broker=broker,
             repo=repo,

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -36,18 +36,80 @@ logger = logging.getLogger(__name__)
 
 
 def _load_risk_config(path: Path, initial_portfolio_value: float) -> RiskConfig:
-    with path.open(encoding="utf-8") as f:
-        data = yaml.safe_load(f)
-    r = data["risk"]
-    return RiskConfig(
-        max_position_pct=r["max_position_pct"],
-        max_utilization=r["max_utilization"],
-        rate_limit_per_sec=r["rate_limit_per_sec"],
-        circuit_breaker_errors=r["circuit_breaker_errors"],
-        circuit_breaker_window_sec=r["circuit_breaker_window_sec"],
-        max_drawdown=r["max_drawdown"],
+    try:
+        with path.open(encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"risk_config.yaml のパース失敗: {path}") from exc
+
+    try:
+        r = data["risk"]
+    except (TypeError, KeyError) as exc:
+        raise KeyError(f"risk_config.yaml にトップレベルキー 'risk' がありません: {path}") from exc
+
+    def _get(key: str) -> object:
+        try:
+            return r[key]
+        except KeyError as exc:
+            raise KeyError(f"risk_config.yaml に 'risk.{key}' がありません: {path}") from exc
+
+    max_position_pct = float(_get("max_position_pct"))
+    max_utilization = float(_get("max_utilization"))
+    rate_limit_per_sec = int(_get("rate_limit_per_sec"))
+    circuit_breaker_errors = int(_get("circuit_breaker_errors"))
+    circuit_breaker_window_sec = int(_get("circuit_breaker_window_sec"))
+    max_drawdown = float(_get("max_drawdown"))
+
+    for name, val in (
+        ("max_position_pct", max_position_pct),
+        ("max_utilization", max_utilization),
+        ("max_drawdown", max_drawdown),
+    ):
+        if not (0 < val <= 1):
+            raise ValueError(f"risk_config.yaml: {name} は (0, 1] の範囲で設定してください（現在値: {val}）: {path}")
+    if max_position_pct > max_utilization:
+        raise ValueError(
+            f"risk_config.yaml: max_position_pct({max_position_pct}) は"
+            f" max_utilization({max_utilization}) 以下にしてください: {path}"
+        )
+
+    config = RiskConfig(
+        max_position_pct=max_position_pct,
+        max_utilization=max_utilization,
+        rate_limit_per_sec=rate_limit_per_sec,
+        circuit_breaker_errors=circuit_breaker_errors,
+        circuit_breaker_window_sec=circuit_breaker_window_sec,
+        max_drawdown=max_drawdown,
         initial_portfolio_value=initial_portfolio_value,
     )
+    logger.info(
+        "RiskConfig 読み込み完了: max_position_pct=%.0f%% max_utilization=%.0f%%"
+        " max_drawdown=%.0f%% rate_limit=%d/s CB_errors=%d CB_window=%ds",
+        max_position_pct * 100,
+        max_utilization * 100,
+        max_drawdown * 100,
+        rate_limit_per_sec,
+        circuit_breaker_errors,
+        circuit_breaker_window_sec,
+    )
+    return config
+
+
+def _pos_value(p: object) -> float:
+    price = (
+        p.current_price  # type: ignore[attr-defined]
+        if (p.current_price is not None and p.current_price > 0)  # type: ignore[attr-defined]
+        else p.avg_price  # type: ignore[attr-defined]
+    )
+    if price is None or price <= 0:
+        logger.warning(
+            "ポジション評価額を 0 として扱います: code=%s current_price=%s avg_price=%s",
+            getattr(p, "code", "?"),
+            getattr(p, "current_price", None),
+            getattr(p, "avg_price", None),
+        )
+        return 0.0
+    return float(p.qty) * float(price)  # type: ignore[attr-defined]
 
 
 def main() -> None:
@@ -73,10 +135,8 @@ def main() -> None:
         # 4. 起動時総資産を計算（現金 + 保有評価額）
         cash = broker.get_available_cash()
         positions = broker.get_positions()
-        total_assets = cash + sum(
-            p.qty * (p.current_price if p.current_price is not None else p.avg_price)
-            for p in positions
-        )
+        total_assets = cash + sum(_pos_value(p) for p in positions)
+        logger.info("起動時総資産: %.0f 円（現金 %.0f 円 + ポジション %d 件）", total_assets, cash, len(positions))
 
         # 5. 依存コンポーネント組み立て
         repo = OrderRepository(sqlite_conn)

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -70,22 +70,21 @@ def main() -> None:
         # 3. ブローカークライアント
         broker = BrokerClientFactory.create(settings)
 
-        # 4. 依存コンポーネント組み立て
+        # 4. 起動時総資産を計算（現金 + 保有評価額）
+        cash = broker.get_available_cash()
+        positions = broker.get_positions()
+        total_assets = cash + sum(
+            p.qty * (p.current_price if p.current_price is not None else p.avg_price)
+            for p in positions
+        )
+
+        # 5. 依存コンポーネント組み立て
         repo = OrderRepository(sqlite_conn)
         order_manager = OrderManager(broker, repo)
-        # TODO(#189 Task 3): replace inline RiskConfig with _load_risk_config(_RISK_CONFIG, total_assets)
         risk_manager = RiskManager(
             broker=broker,
             repo=repo,
-            config=RiskConfig(
-                max_position_pct=0.20,
-                max_utilization=0.80,
-                rate_limit_per_sec=5,
-                circuit_breaker_errors=10,
-                circuit_breaker_window_sec=60,
-                max_drawdown=0.20,
-                initial_portfolio_value=broker.get_available_cash(),
-            ),
+            config=_load_risk_config(_RISK_CONFIG, initial_portfolio_value=total_assets),
         )
         reconciler = Reconciler(broker=broker, repo=repo, order_manager=order_manager)
 

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -78,6 +78,15 @@ def _load_risk_config(path: Path, initial_portfolio_value: float) -> RiskConfig:
             f"risk_config.yaml: max_position_pct({max_position_pct}) は"
             f" max_utilization({max_utilization}) 以下にしてください: {path}"
         )
+    for name, val in (
+        ("rate_limit_per_sec", rate_limit_per_sec),
+        ("circuit_breaker_errors", circuit_breaker_errors),
+        ("circuit_breaker_window_sec", circuit_breaker_window_sec),
+    ):
+        if val < 1:
+            raise ValueError(
+                f"risk_config.yaml: {name} は 1 以上で設定してください（現在値: {val}）: {path}"
+            )
 
     config = RiskConfig(
         max_position_pct=max_position_pct,
@@ -142,7 +151,7 @@ def main() -> None:
         cash = broker.get_available_cash()
         positions = broker.get_positions()
         total_assets = cash + sum(_pos_value(p) for p in positions)
-        logger.info(
+        logger.debug(
             "起動時総資産: %.0f 円（現金 %.0f 円 + ポジション %d 件）",
             total_assets,
             cash,

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -39,7 +39,7 @@ def _load_risk_config(path: Path, initial_portfolio_value: float) -> RiskConfig:
     if not path.exists():
         logger.error(
             "リスク設定ファイルが見つかりません: %s"
-            " → config/risk_config.yaml を作成してください（python -m kabusys.config_setup を参照）",
+            " → git checkout config/risk_config.yaml で復元してください",
             path,
         )
         raise FileNotFoundError(f"リスク設定ファイルが見つかりません: {path}")

--- a/tests/test_broker_factory.py
+++ b/tests/test_broker_factory.py
@@ -72,10 +72,34 @@ class TestBrokerClientFactory:
         broker = BrokerClientFactory.create(Settings())
         assert broker.fill_mode == "instant"
 
-    def test_live_mode_raises_not_implemented(self, monkeypatch):
+    def test_live_mode_returns_kabu_station_client(self, monkeypatch):
+        from kabusys.execution.kabu_client import KabuStationClient
         monkeypatch.setenv("KABUSYS_ENV", "live")
-        with pytest.raises(NotImplementedError):
-            BrokerClientFactory.create(Settings())
+        monkeypatch.setenv("KABU_API_PASSWORD", "test_password")
+        monkeypatch.delenv("KABU_TRADE_PASSWORD", raising=False)
+        broker = BrokerClientFactory.create(Settings())
+        assert isinstance(broker, KabuStationClient)
+        broker.close()  # httpx.Client を閉じる
+
+    def test_live_mode_passes_trade_password_when_set(self, monkeypatch):
+        from kabusys.execution.kabu_client import KabuStationClient
+        monkeypatch.setenv("KABUSYS_ENV", "live")
+        monkeypatch.setenv("KABU_API_PASSWORD", "api_pass")
+        monkeypatch.setenv("KABU_TRADE_PASSWORD", "trade_pass")
+        broker = BrokerClientFactory.create(Settings())
+        assert isinstance(broker, KabuStationClient)
+        assert broker._trade_password == "trade_pass"
+        broker.close()
+
+    def test_live_mode_falls_back_to_api_password_when_trade_password_not_set(self, monkeypatch):
+        from kabusys.execution.kabu_client import KabuStationClient
+        monkeypatch.setenv("KABUSYS_ENV", "live")
+        monkeypatch.setenv("KABU_API_PASSWORD", "api_pass")
+        monkeypatch.delenv("KABU_TRADE_PASSWORD", raising=False)
+        broker = BrokerClientFactory.create(Settings())
+        assert isinstance(broker, KabuStationClient)
+        assert broker._trade_password == "api_pass"
+        broker.close()
 
     def test_fill_mode_never_applied(self, monkeypatch):
         monkeypatch.setenv("KABUSYS_ENV", "paper_trading")

--- a/tests/test_broker_factory.py
+++ b/tests/test_broker_factory.py
@@ -95,3 +95,17 @@ class TestBrokerClientFactory:
         monkeypatch.setenv("KABUSYS_ENV", "unknown_env")
         with pytest.raises(ValueError):
             BrokerClientFactory.create(Settings())
+
+
+class TestKabuTradePassword:
+    def test_returns_none_when_not_set(self, monkeypatch):
+        monkeypatch.delenv("KABU_TRADE_PASSWORD", raising=False)
+        assert Settings().kabu_trade_password is None
+
+    def test_returns_value_when_set(self, monkeypatch):
+        monkeypatch.setenv("KABU_TRADE_PASSWORD", "secret123")
+        assert Settings().kabu_trade_password == "secret123"
+
+    def test_returns_none_for_empty_string(self, monkeypatch):
+        monkeypatch.setenv("KABU_TRADE_PASSWORD", "")
+        assert Settings().kabu_trade_password is None

--- a/tests/test_broker_factory.py
+++ b/tests/test_broker_factory.py
@@ -74,6 +74,7 @@ class TestBrokerClientFactory:
 
     def test_live_mode_returns_kabu_station_client(self, monkeypatch):
         from kabusys.execution.kabu_client import KabuStationClient
+
         monkeypatch.setenv("KABUSYS_ENV", "live")
         monkeypatch.setenv("KABU_API_PASSWORD", "test_password")
         monkeypatch.delenv("KABU_TRADE_PASSWORD", raising=False)
@@ -83,6 +84,7 @@ class TestBrokerClientFactory:
 
     def test_live_mode_passes_trade_password_when_set(self, monkeypatch):
         from kabusys.execution.kabu_client import KabuStationClient
+
         monkeypatch.setenv("KABUSYS_ENV", "live")
         monkeypatch.setenv("KABU_API_PASSWORD", "api_pass")
         monkeypatch.setenv("KABU_TRADE_PASSWORD", "trade_pass")
@@ -91,8 +93,11 @@ class TestBrokerClientFactory:
         assert broker._trade_password == "trade_pass"
         broker.close()
 
-    def test_live_mode_falls_back_to_api_password_when_trade_password_not_set(self, monkeypatch):
+    def test_live_mode_falls_back_to_api_password_when_trade_password_not_set(
+        self, monkeypatch
+    ):
         from kabusys.execution.kabu_client import KabuStationClient
+
         monkeypatch.setenv("KABUSYS_ENV", "live")
         monkeypatch.setenv("KABU_API_PASSWORD", "api_pass")
         monkeypatch.delenv("KABU_TRADE_PASSWORD", raising=False)

--- a/tests/test_generated.py
+++ b/tests/test_generated.py
@@ -1,332 +1,98 @@
+
 import os
-import math
-from unittest import mock
+from pathlib import Path
+import tempfile
+import builtins
+import io
 
 import pytest
 
-# 自動 .env ロードを抑止しておく（テストの安定化）
-os.environ.setdefault("KABUSYS_DISABLE_AUTO_ENV_LOAD", "1")
-
-# インポート（テスト対象モジュール）
-from kabusys.run_monitoring import _get_poll_interval
-from kabusys.portfolio.portfolio_builder import (
-    select_candidates,
-    calc_equal_weights,
-    calc_score_weights,
-)
-from kabusys.portfolio.risk_adjustment import (
-    apply_sector_cap,
-    calc_regime_multiplier,
-)
-from kabusys.portfolio.position_sizing import calc_position_sizes
-from kabusys.config import (
-    _parse_env_line,
-    _load_env_file,
-    Settings,
-)
-from kabusys.research.feature_exploration import calc_ic, rank
-
-# process_priority のテストでモックするためインポート
+from kabusys.config import _parse_env_line, _load_env_file, Settings
 
 
-# -----------------------
-# run_monitoring._get_poll_interval
-# -----------------------
-@pytest.mark.parametrize(
-    ("env_val", "expected"),
-    [
-        ("10", 10),
-        (None, 60),  # デフォルト
-    ],
-)
-def test_get_poll_interval_valid(monkeypatch, env_val, expected):
-    if env_val is None:
-        monkeypatch.delenv("MONITOR_POLL_INTERVAL", raising=False)
-    else:
-        monkeypatch.setenv("MONITOR_POLL_INTERVAL", env_val)
-    assert _get_poll_interval() == expected
-
-
-def test_get_poll_interval_invalid_nonint(monkeypatch, caplog):
-    monkeypatch.setenv("MONITOR_POLL_INTERVAL", "notint")
-    caplog.clear()
-    val = _get_poll_interval()
-    assert val == 60
-    # 警告ログが出ていること
-    assert any(
-        "MONITOR_POLL_INTERVAL の値が不正" in rec.message for rec in caplog.records
-    )
-
-
-def test_get_poll_interval_zero_or_negative(monkeypatch):
-    for v in ("0", "-5"):
-        monkeypatch.setenv("MONITOR_POLL_INTERVAL", v)
-        assert _get_poll_interval() == 60
-
-
-# -----------------------
-# config._parse_env_line / _load_env_file
-# -----------------------
-def test_parse_env_line_basic():
-    assert _parse_env_line("KEY=val") == ("KEY", "val")
-    assert _parse_env_line("  export KEY2 = some ") == ("KEY2", "some")
-    assert _parse_env_line("# comment") is None
+def test_parse_env_line_blank_and_comment():
     assert _parse_env_line("") is None
-    assert _parse_env_line("NOEQ") is None
+    assert _parse_env_line("   \n") is None
+    assert _parse_env_line("# a comment") is None
 
 
-def test_parse_env_line_quoted_and_escaped():
-    # シングルクォート内のエスケープ
-    line = r"SECRET='pa\'ss\"word'"
+def test_parse_env_line_export_and_simple():
+    assert _parse_env_line("export KEY=val") == ("KEY", "val")
+    assert _parse_env_line("KEY = value with spaces ") == ("KEY", "value with spaces")
+    # missing '='
+    assert _parse_env_line("INVALIDLINE") is None
+
+
+def test_parse_env_line_quoted_and_escapes():
+    # single quotes with escaped single quote inside (using backslash)
+    line = "S='a\\'b#notcomment'  # trailing comment"
     k, v = _parse_env_line(line)
-    assert k == "SECRET"
-    # エスケープがデコードされていること
-    assert "pa'ss\"word" == v
+    assert k == "S"
+    assert v == "a'b#notcomment"  # backslash unescaped and comment inside quotes preserved
 
-    # ダブルクォートとインラインコメント
-    line2 = 'FOO="a=b # not comment"  # trailing comment'
+    # double quotes and escape of double quote
+    line2 = 'D="x\\\"y"'
     k2, v2 = _parse_env_line(line2)
-    assert k2 == "FOO"
-    assert v2 == "a=b # not comment"
+    assert k2 == "D"
+    assert v2 == 'x"y'
+
+
+def test_parse_env_line_unquoted_inline_comment():
+    # '#' preceded by space is taken as comment
+    assert _parse_env_line("A=foo # comment")[1] == "foo"
+    # '#' not preceded by space is part of value
+    assert _parse_env_line("B=foo#bar")[1] == "foo#bar"
 
 
 def test_load_env_file_override_and_protected(tmp_path, monkeypatch):
-    envfile = tmp_path / ".env.test"
-    envfile.write_text(
-        "\n".join(
-            [
-                "A=1",
-                "B=from_file",
-                "SECRET='x\\'y'",
-                "SKIP_ME=noeq",
-            ]
-        )
-    )
-    # 初期 OS 環境
+    env_file = tmp_path / ".env.test"
+    env_file.write_text("\n".join([
+        "A=1",
+        "B=2",
+        "C=override_me"
+    ]) + "\n", encoding="utf-8")
+
+    # prepare existing os.environ
     monkeypatch.delenv("A", raising=False)
-    monkeypatch.setenv("B", "os_b")
-    # protected は既存の OS 環境キー集合として扱われる
-    protected = frozenset(["B"])
-    # override=False: 未設定のキーのみセット
-    _load_env_file(envfile, override=False, protected=protected)
+    monkeypatch.setenv("B", "existing")
+    # protected keys should not be overridden even when override=True
+    protected = frozenset({"B"})
+
+    # load with override=False: A set, B not overwritten
+    _load_env_file(Path(env_file), override=False, protected=protected)
     assert os.environ.get("A") == "1"
-    # B は既にあるので上書きされない
-    assert os.environ.get("B") == "os_b"
-    # override=True: protected に含まれるキーは上書きされない
-    monkeypatch.setenv("B", "os_b2")
-    _load_env_file(envfile, override=True, protected=protected)
-    assert os.environ.get("B") == "os_b2"
-    # SECRET がパースされている
-    assert os.environ.get("SECRET") == "x'y"
+    assert os.environ.get("B") == "existing"
+
+    # load with override=True but protected prevents B overwrite
+    monkeypatch.setenv("B", "existing2")
+    _load_env_file(Path(env_file), override=True, protected=protected)
+    assert os.environ.get("B") == "existing2"
+    # C should be set/overwritten
+    assert os.environ.get("C") == "override_me"
 
 
-# -----------------------
-# Settings クラスの主要挙動
-# -----------------------
-def test_settings_env_and_flags(monkeypatch):
-    monkeypatch.setenv("KABUSYS_ENV", "development")
+def test_settings_paper_fill_mode_and_env(monkeypatch):
     s = Settings()
-    assert s.env == "development"
-    assert s.is_dev
-    monkeypatch.setenv("KABUSYS_ENV", "paper_trading")
-    s2 = Settings()
-    assert s2.is_paper
-    monkeypatch.setenv("KABUSYS_ENV", "live")
-    s3 = Settings()
-    assert s3.is_live
-
-
-def test_settings_invalid_env(monkeypatch):
-    monkeypatch.setenv("KABUSYS_ENV", "invalid_env_value")
-    s = Settings()
-    with pytest.raises(ValueError):
-        _ = s.env  # property アクセス時に例外
-
-
-def test_settings_paper_fill_mode_valid_and_invalid(monkeypatch):
+    # default PAPER_FILL_MODE is "instant"
     monkeypatch.delenv("PAPER_FILL_MODE", raising=False)
-    s = Settings()
     assert s.paper_fill_mode == "instant"
-    monkeypatch.setenv("PAPER_FILL_MODE", "partial")
-    assert Settings().paper_fill_mode == "partial"
-    monkeypatch.setenv("PAPER_FILL_MODE", "INVALID")
+
+    monkeypatch.setenv("PAPER_FILL_MODE", "PARTIAL")
+    assert s.paper_fill_mode == "partial"
+
+    monkeypatch.setenv("PAPER_FILL_MODE", "invalid-mode")
     with pytest.raises(ValueError):
-        _ = Settings().paper_fill_mode
+        _ = s.paper_fill_mode
 
+    # env validation
+    monkeypatch.setenv("KABUSYS_ENV", "live")
+    assert s.env == "live"
+    assert s.is_live is True
+    monkeypatch.setenv("KABUSYS_ENV", "development")
+    assert s.is_dev is True
 
-# -----------------------
-# portfolio_builder: select / weights
-# -----------------------
-def test_select_candidates_and_weights():
-    signals = [
-        {"code": "AAA", "score": 1.0, "signal_rank": 2},
-        {"code": "BBB", "score": 2.0, "signal_rank": 1},
-        {"code": "CCC", "score": 2.0, "signal_rank": 3},
-    ]
-    selected = select_candidates(signals, max_positions=2)
-    # score 降順 -> BBB (2.0, rank1), CCC (2.0, rank3) が上位2件
-    assert [s["code"] for s in selected] == ["BBB", "CCC"]
-
-    eq_weights = calc_equal_weights(selected)
-    assert math.isclose(eq_weights["BBB"], 0.5)
-    assert math.isclose(eq_weights["CCC"], 0.5)
-
-    # score_weights: sum(scores)=4.0 -> weights 2/4,2/4 -> 0.5 each
-    sw = calc_score_weights(selected)
-    assert pytest.approx(sw["BBB"]) == 0.5
-    assert pytest.approx(sw["CCC"]) == 0.5
-
-    # 全スコアが 0 の場合は等金額フォールバック
-    zero_signals = [{"code": "X", "score": 0.0}, {"code": "Y", "score": 0.0}]
-    with mock.patch("kabusys.portfolio.portfolio_builder.logger") as mocked_logger:
-        w = calc_score_weights(zero_signals)
-        assert w == {"X": 0.5, "Y": 0.5}
-        # 警告が出ていること
-        mocked_logger.warning.assert_called()
-
-
-# -----------------------
-# risk_adjustment.apply_sector_cap / calc_regime_multiplier
-# -----------------------
-def test_apply_sector_cap_basic_and_sell_codes():
-    candidates = [{"code": "A"}, {"code": "B"}, {"code": "C"}]
-    sector_map = {"A": "Tech", "B": "Tech", "C": "Food"}
-    portfolio_value = 1000000.0
-    # 現在 A,B を大量保有して Tech が上限を超えるようにする
-    current_positions = {"A": 1000, "B": 500}
-    price_map = {"A": 100.0, "B": 100.0, "C": 10.0}
-    # 1セクター上限 30% -> Tech exposure = (1000+500)*100 = 150000 -> 15% -> not blocked
-    filtered = apply_sector_cap(
-        candidates,
-        sector_map,
-        portfolio_value,
-        current_positions,
-        price_map,
-        max_sector_pct=0.10,  # 10% にすると 150k / 1M = 15% -> blocked
-    )
-    # C (Food) は残り、Tech がブロックされるため only C remains
-    assert all(c["code"] == "C" for c in filtered)
-
-    # sell_codes に A を入れると exposure が減りブロックされなくなる
-    filtered2 = apply_sector_cap(
-        candidates,
-        sector_map,
-        portfolio_value,
-        current_positions,
-        price_map,
-        max_sector_pct=0.10,
-        sell_codes={"A"},
-    )
-    # now Tech exposure = B only => 50k -> 5% -> not blocked -> all candidates remain
-    codes = {c["code"] for c in filtered2}
-    assert codes == {"A", "B", "C"}
-
-
-def test_calc_regime_multiplier_known_and_unknown(monkeypatch):
-    assert calc_regime_multiplier("bull") == 1.0
-    assert calc_regime_multiplier("neutral") == pytest.approx(0.7)
-    assert calc_regime_multiplier("bear") == pytest.approx(0.3)
-    # unknown regime: warning and fallback 1.0
-    with mock.patch("kabusys.portfolio.risk_adjustment.logger") as mocked_logger:
-        assert calc_regime_multiplier("weird") == 1.0
-        mocked_logger.warning.assert_called()
-
-
-# -----------------------
-# position_sizing.calc_position_sizes（主なケース）
-# -----------------------
-def test_calc_position_sizes_equal_and_aggregate_scaling():
-    # Simple equal weights case
-    candidates = [{"code": "AAA"}, {"code": "BBB"}]
-    weights = {"AAA": 0.5, "BBB": 0.5}
-    portfolio_value = 100_0000.0  # 1,000,000
-    available_cash = 200_000.0
-    current_positions = {}
-    open_prices = {"AAA": 1000.0, "BBB": 1000.0}
-    # max_utilization default 0.7 used in function; but available_cash limits aggregate
-    sizes = calc_position_sizes(
-        weights,
-        candidates,
-        portfolio_value,
-        available_cash,
-        current_positions,
-        open_prices,
-        allocation_method="equal",
-        lot_size=100,
-    )
-    # available_cash = 200_000 が制約: per stock = 200_000 / 2 = 100_000
-    # shares = floor(100_000 / 1000) = 100 → 100株（1単元）
-    assert sizes["AAA"] == 100
-    assert sizes["BBB"] == 100
-
-    # If available_cash smaller than total cost, aggregate scaling should reduce sizes
-    small_cash = 100_000.0
-    scaled = calc_position_sizes(
-        weights,
-        candidates,
-        portfolio_value,
-        small_cash,
-        current_positions,
-        open_prices,
-        allocation_method="equal",
-        lot_size=100,
-    )
-    # scaled total cost must not exceed small_cash
-    total_cost = sum(scaled[c] * open_prices[c] for c in scaled)
-    assert total_cost <= small_cash + 1e-6
-
-
-def test_calc_position_sizes_risk_based_and_price_missing(caplog):
-    candidates = [{"code": "X"}, {"code": "Y"}]
-    weights = {}
-    portfolio_value = 1_000_000
-    available_cash = 500_000
-    current_positions = {"X": 0}
-    open_prices = {"X": 0.0}  # price missing / zero -> skip
-    res = calc_position_sizes(
-        weights,
-        candidates,
-        portfolio_value,
-        available_cash,
-        current_positions,
-        open_prices,
-        allocation_method="risk_based",
-        lot_size=100,
-    )
-    # X skipped due to price 0, Y not in open_prices -> skipped -> empty dict
-    assert res == {}
-
-
-# -----------------------
-# feature_exploration.rank / calc_ic
-# -----------------------
-
-
-def test_rank_with_ties():
-    vals = [1.0, 2.0, 2.0, 4.0]
-    r = rank(vals)
-    # ranks should be [1, 2.5, 2.5, 4]
-    assert pytest.approx(r[0]) == 1.0
-    assert pytest.approx(r[1]) == 2.5
-    assert pytest.approx(r[2]) == 2.5
-    assert pytest.approx(r[3]) == 4.0
-
-
-def test_calc_ic_basic_and_insufficient():
-    factor = [
-        {"code": "A", "mom_1m": 0.1},
-        {"code": "B", "mom_1m": 0.2},
-        {"code": "C", "mom_1m": 0.3},
-    ]
-    forward = [
-        {"code": "A", "fwd_1d": 0.01},
-        {"code": "B", "fwd_1d": -0.02},
-        {"code": "C", "fwd_1d": 0.03},
-    ]
-    ic = calc_ic(factor, forward, "mom_1m", "fwd_1d")
-    # Should return a finite float
-    assert isinstance(ic, float)
-
-    # insufficient pairs -> None
-    ic2 = calc_ic(factor[:2], forward[:2], "mom_1m", "fwd_1d")
-    assert ic2 is None
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    assert s.log_level == "DEBUG"
+    monkeypatch.setenv("LOG_LEVEL", "nope")
+    with pytest.raises(ValueError):
+        _ = s.log_level

--- a/tests/test_generated.py
+++ b/tests/test_generated.py
@@ -1,9 +1,5 @@
-
 import os
 from pathlib import Path
-import tempfile
-import builtins
-import io
 
 import pytest
 
@@ -28,10 +24,12 @@ def test_parse_env_line_quoted_and_escapes():
     line = "S='a\\'b#notcomment'  # trailing comment"
     k, v = _parse_env_line(line)
     assert k == "S"
-    assert v == "a'b#notcomment"  # backslash unescaped and comment inside quotes preserved
+    assert (
+        v == "a'b#notcomment"
+    )  # backslash unescaped and comment inside quotes preserved
 
     # double quotes and escape of double quote
-    line2 = 'D="x\\\"y"'
+    line2 = 'D="x\\"y"'
     k2, v2 = _parse_env_line(line2)
     assert k2 == "D"
     assert v2 == 'x"y'
@@ -46,11 +44,9 @@ def test_parse_env_line_unquoted_inline_comment():
 
 def test_load_env_file_override_and_protected(tmp_path, monkeypatch):
     env_file = tmp_path / ".env.test"
-    env_file.write_text("\n".join([
-        "A=1",
-        "B=2",
-        "C=override_me"
-    ]) + "\n", encoding="utf-8")
+    env_file.write_text(
+        "\n".join(["A=1", "B=2", "C=override_me"]) + "\n", encoding="utf-8"
+    )
 
     # prepare existing os.environ
     monkeypatch.delenv("A", raising=False)

--- a/tests/test_generated.py
+++ b/tests/test_generated.py
@@ -1,94 +1,332 @@
 import os
-from pathlib import Path
+import math
+from unittest import mock
 
 import pytest
 
-from kabusys.config import _parse_env_line, _load_env_file, Settings
+# 自動 .env ロードを抑止しておく（テストの安定化）
+os.environ.setdefault("KABUSYS_DISABLE_AUTO_ENV_LOAD", "1")
+
+# インポート（テスト対象モジュール）
+from kabusys.run_monitoring import _get_poll_interval
+from kabusys.portfolio.portfolio_builder import (
+    select_candidates,
+    calc_equal_weights,
+    calc_score_weights,
+)
+from kabusys.portfolio.risk_adjustment import (
+    apply_sector_cap,
+    calc_regime_multiplier,
+)
+from kabusys.portfolio.position_sizing import calc_position_sizes
+from kabusys.config import (
+    _parse_env_line,
+    _load_env_file,
+    Settings,
+)
+from kabusys.research.feature_exploration import calc_ic, rank
+
+# process_priority のテストでモックするためインポート
 
 
-def test_parse_env_line_blank_and_comment():
+# -----------------------
+# run_monitoring._get_poll_interval
+# -----------------------
+@pytest.mark.parametrize(
+    ("env_val", "expected"),
+    [
+        ("10", 10),
+        (None, 60),  # デフォルト
+    ],
+)
+def test_get_poll_interval_valid(monkeypatch, env_val, expected):
+    if env_val is None:
+        monkeypatch.delenv("MONITOR_POLL_INTERVAL", raising=False)
+    else:
+        monkeypatch.setenv("MONITOR_POLL_INTERVAL", env_val)
+    assert _get_poll_interval() == expected
+
+
+def test_get_poll_interval_invalid_nonint(monkeypatch, caplog):
+    monkeypatch.setenv("MONITOR_POLL_INTERVAL", "notint")
+    caplog.clear()
+    val = _get_poll_interval()
+    assert val == 60
+    # 警告ログが出ていること
+    assert any(
+        "MONITOR_POLL_INTERVAL の値が不正" in rec.message for rec in caplog.records
+    )
+
+
+def test_get_poll_interval_zero_or_negative(monkeypatch):
+    for v in ("0", "-5"):
+        monkeypatch.setenv("MONITOR_POLL_INTERVAL", v)
+        assert _get_poll_interval() == 60
+
+
+# -----------------------
+# config._parse_env_line / _load_env_file
+# -----------------------
+def test_parse_env_line_basic():
+    assert _parse_env_line("KEY=val") == ("KEY", "val")
+    assert _parse_env_line("  export KEY2 = some ") == ("KEY2", "some")
+    assert _parse_env_line("# comment") is None
     assert _parse_env_line("") is None
-    assert _parse_env_line("   \n") is None
-    assert _parse_env_line("# a comment") is None
+    assert _parse_env_line("NOEQ") is None
 
 
-def test_parse_env_line_export_and_simple():
-    assert _parse_env_line("export KEY=val") == ("KEY", "val")
-    assert _parse_env_line("KEY = value with spaces ") == ("KEY", "value with spaces")
-    # missing '='
-    assert _parse_env_line("INVALIDLINE") is None
-
-
-def test_parse_env_line_quoted_and_escapes():
-    # single quotes with escaped single quote inside (using backslash)
-    line = "S='a\\'b#notcomment'  # trailing comment"
+def test_parse_env_line_quoted_and_escaped():
+    # シングルクォート内のエスケープ
+    line = r"SECRET='pa\'ss\"word'"
     k, v = _parse_env_line(line)
-    assert k == "S"
-    assert (
-        v == "a'b#notcomment"
-    )  # backslash unescaped and comment inside quotes preserved
+    assert k == "SECRET"
+    # エスケープがデコードされていること
+    assert "pa'ss\"word" == v
 
-    # double quotes and escape of double quote
-    line2 = 'D="x\\"y"'
+    # ダブルクォートとインラインコメント
+    line2 = 'FOO="a=b # not comment"  # trailing comment'
     k2, v2 = _parse_env_line(line2)
-    assert k2 == "D"
-    assert v2 == 'x"y'
-
-
-def test_parse_env_line_unquoted_inline_comment():
-    # '#' preceded by space is taken as comment
-    assert _parse_env_line("A=foo # comment")[1] == "foo"
-    # '#' not preceded by space is part of value
-    assert _parse_env_line("B=foo#bar")[1] == "foo#bar"
+    assert k2 == "FOO"
+    assert v2 == "a=b # not comment"
 
 
 def test_load_env_file_override_and_protected(tmp_path, monkeypatch):
-    env_file = tmp_path / ".env.test"
-    env_file.write_text(
-        "\n".join(["A=1", "B=2", "C=override_me"]) + "\n", encoding="utf-8"
+    envfile = tmp_path / ".env.test"
+    envfile.write_text(
+        "\n".join(
+            [
+                "A=1",
+                "B=from_file",
+                "SECRET='x\\'y'",
+                "SKIP_ME=noeq",
+            ]
+        )
     )
-
-    # prepare existing os.environ
+    # 初期 OS 環境
     monkeypatch.delenv("A", raising=False)
-    monkeypatch.setenv("B", "existing")
-    # protected keys should not be overridden even when override=True
-    protected = frozenset({"B"})
-
-    # load with override=False: A set, B not overwritten
-    _load_env_file(Path(env_file), override=False, protected=protected)
+    monkeypatch.setenv("B", "os_b")
+    # protected は既存の OS 環境キー集合として扱われる
+    protected = frozenset(["B"])
+    # override=False: 未設定のキーのみセット
+    _load_env_file(envfile, override=False, protected=protected)
     assert os.environ.get("A") == "1"
-    assert os.environ.get("B") == "existing"
+    # B は既にあるので上書きされない
+    assert os.environ.get("B") == "os_b"
+    # override=True: protected に含まれるキーは上書きされない
+    monkeypatch.setenv("B", "os_b2")
+    _load_env_file(envfile, override=True, protected=protected)
+    assert os.environ.get("B") == "os_b2"
+    # SECRET がパースされている
+    assert os.environ.get("SECRET") == "x'y"
 
-    # load with override=True but protected prevents B overwrite
-    monkeypatch.setenv("B", "existing2")
-    _load_env_file(Path(env_file), override=True, protected=protected)
-    assert os.environ.get("B") == "existing2"
-    # C should be set/overwritten
-    assert os.environ.get("C") == "override_me"
 
-
-def test_settings_paper_fill_mode_and_env(monkeypatch):
-    s = Settings()
-    # default PAPER_FILL_MODE is "instant"
-    monkeypatch.delenv("PAPER_FILL_MODE", raising=False)
-    assert s.paper_fill_mode == "instant"
-
-    monkeypatch.setenv("PAPER_FILL_MODE", "PARTIAL")
-    assert s.paper_fill_mode == "partial"
-
-    monkeypatch.setenv("PAPER_FILL_MODE", "invalid-mode")
-    with pytest.raises(ValueError):
-        _ = s.paper_fill_mode
-
-    # env validation
-    monkeypatch.setenv("KABUSYS_ENV", "live")
-    assert s.env == "live"
-    assert s.is_live is True
+# -----------------------
+# Settings クラスの主要挙動
+# -----------------------
+def test_settings_env_and_flags(monkeypatch):
     monkeypatch.setenv("KABUSYS_ENV", "development")
-    assert s.is_dev is True
+    s = Settings()
+    assert s.env == "development"
+    assert s.is_dev
+    monkeypatch.setenv("KABUSYS_ENV", "paper_trading")
+    s2 = Settings()
+    assert s2.is_paper
+    monkeypatch.setenv("KABUSYS_ENV", "live")
+    s3 = Settings()
+    assert s3.is_live
 
-    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
-    assert s.log_level == "DEBUG"
-    monkeypatch.setenv("LOG_LEVEL", "nope")
+
+def test_settings_invalid_env(monkeypatch):
+    monkeypatch.setenv("KABUSYS_ENV", "invalid_env_value")
+    s = Settings()
     with pytest.raises(ValueError):
-        _ = s.log_level
+        _ = s.env  # property アクセス時に例外
+
+
+def test_settings_paper_fill_mode_valid_and_invalid(monkeypatch):
+    monkeypatch.delenv("PAPER_FILL_MODE", raising=False)
+    s = Settings()
+    assert s.paper_fill_mode == "instant"
+    monkeypatch.setenv("PAPER_FILL_MODE", "partial")
+    assert Settings().paper_fill_mode == "partial"
+    monkeypatch.setenv("PAPER_FILL_MODE", "INVALID")
+    with pytest.raises(ValueError):
+        _ = Settings().paper_fill_mode
+
+
+# -----------------------
+# portfolio_builder: select / weights
+# -----------------------
+def test_select_candidates_and_weights():
+    signals = [
+        {"code": "AAA", "score": 1.0, "signal_rank": 2},
+        {"code": "BBB", "score": 2.0, "signal_rank": 1},
+        {"code": "CCC", "score": 2.0, "signal_rank": 3},
+    ]
+    selected = select_candidates(signals, max_positions=2)
+    # score 降順 -> BBB (2.0, rank1), CCC (2.0, rank3) が上位2件
+    assert [s["code"] for s in selected] == ["BBB", "CCC"]
+
+    eq_weights = calc_equal_weights(selected)
+    assert math.isclose(eq_weights["BBB"], 0.5)
+    assert math.isclose(eq_weights["CCC"], 0.5)
+
+    # score_weights: sum(scores)=4.0 -> weights 2/4,2/4 -> 0.5 each
+    sw = calc_score_weights(selected)
+    assert pytest.approx(sw["BBB"]) == 0.5
+    assert pytest.approx(sw["CCC"]) == 0.5
+
+    # 全スコアが 0 の場合は等金額フォールバック
+    zero_signals = [{"code": "X", "score": 0.0}, {"code": "Y", "score": 0.0}]
+    with mock.patch("kabusys.portfolio.portfolio_builder.logger") as mocked_logger:
+        w = calc_score_weights(zero_signals)
+        assert w == {"X": 0.5, "Y": 0.5}
+        # 警告が出ていること
+        mocked_logger.warning.assert_called()
+
+
+# -----------------------
+# risk_adjustment.apply_sector_cap / calc_regime_multiplier
+# -----------------------
+def test_apply_sector_cap_basic_and_sell_codes():
+    candidates = [{"code": "A"}, {"code": "B"}, {"code": "C"}]
+    sector_map = {"A": "Tech", "B": "Tech", "C": "Food"}
+    portfolio_value = 1000000.0
+    # 現在 A,B を大量保有して Tech が上限を超えるようにする
+    current_positions = {"A": 1000, "B": 500}
+    price_map = {"A": 100.0, "B": 100.0, "C": 10.0}
+    # 1セクター上限 30% -> Tech exposure = (1000+500)*100 = 150000 -> 15% -> not blocked
+    filtered = apply_sector_cap(
+        candidates,
+        sector_map,
+        portfolio_value,
+        current_positions,
+        price_map,
+        max_sector_pct=0.10,  # 10% にすると 150k / 1M = 15% -> blocked
+    )
+    # C (Food) は残り、Tech がブロックされるため only C remains
+    assert all(c["code"] == "C" for c in filtered)
+
+    # sell_codes に A を入れると exposure が減りブロックされなくなる
+    filtered2 = apply_sector_cap(
+        candidates,
+        sector_map,
+        portfolio_value,
+        current_positions,
+        price_map,
+        max_sector_pct=0.10,
+        sell_codes={"A"},
+    )
+    # now Tech exposure = B only => 50k -> 5% -> not blocked -> all candidates remain
+    codes = {c["code"] for c in filtered2}
+    assert codes == {"A", "B", "C"}
+
+
+def test_calc_regime_multiplier_known_and_unknown(monkeypatch):
+    assert calc_regime_multiplier("bull") == 1.0
+    assert calc_regime_multiplier("neutral") == pytest.approx(0.7)
+    assert calc_regime_multiplier("bear") == pytest.approx(0.3)
+    # unknown regime: warning and fallback 1.0
+    with mock.patch("kabusys.portfolio.risk_adjustment.logger") as mocked_logger:
+        assert calc_regime_multiplier("weird") == 1.0
+        mocked_logger.warning.assert_called()
+
+
+# -----------------------
+# position_sizing.calc_position_sizes（主なケース）
+# -----------------------
+def test_calc_position_sizes_equal_and_aggregate_scaling():
+    # Simple equal weights case
+    candidates = [{"code": "AAA"}, {"code": "BBB"}]
+    weights = {"AAA": 0.5, "BBB": 0.5}
+    portfolio_value = 100_0000.0  # 1,000,000
+    available_cash = 200_000.0
+    current_positions = {}
+    open_prices = {"AAA": 1000.0, "BBB": 1000.0}
+    # max_utilization default 0.7 used in function; but available_cash limits aggregate
+    sizes = calc_position_sizes(
+        weights,
+        candidates,
+        portfolio_value,
+        available_cash,
+        current_positions,
+        open_prices,
+        allocation_method="equal",
+        lot_size=100,
+    )
+    # available_cash = 200_000 が制約: per stock = 200_000 / 2 = 100_000
+    # shares = floor(100_000 / 1000) = 100 → 100株（1単元）
+    assert sizes["AAA"] == 100
+    assert sizes["BBB"] == 100
+
+    # If available_cash smaller than total cost, aggregate scaling should reduce sizes
+    small_cash = 100_000.0
+    scaled = calc_position_sizes(
+        weights,
+        candidates,
+        portfolio_value,
+        small_cash,
+        current_positions,
+        open_prices,
+        allocation_method="equal",
+        lot_size=100,
+    )
+    # scaled total cost must not exceed small_cash
+    total_cost = sum(scaled[c] * open_prices[c] for c in scaled)
+    assert total_cost <= small_cash + 1e-6
+
+
+def test_calc_position_sizes_risk_based_and_price_missing(caplog):
+    candidates = [{"code": "X"}, {"code": "Y"}]
+    weights = {}
+    portfolio_value = 1_000_000
+    available_cash = 500_000
+    current_positions = {"X": 0}
+    open_prices = {"X": 0.0}  # price missing / zero -> skip
+    res = calc_position_sizes(
+        weights,
+        candidates,
+        portfolio_value,
+        available_cash,
+        current_positions,
+        open_prices,
+        allocation_method="risk_based",
+        lot_size=100,
+    )
+    # X skipped due to price 0, Y not in open_prices -> skipped -> empty dict
+    assert res == {}
+
+
+# -----------------------
+# feature_exploration.rank / calc_ic
+# -----------------------
+
+
+def test_rank_with_ties():
+    vals = [1.0, 2.0, 2.0, 4.0]
+    r = rank(vals)
+    # ranks should be [1, 2.5, 2.5, 4]
+    assert pytest.approx(r[0]) == 1.0
+    assert pytest.approx(r[1]) == 2.5
+    assert pytest.approx(r[2]) == 2.5
+    assert pytest.approx(r[3]) == 4.0
+
+
+def test_calc_ic_basic_and_insufficient():
+    factor = [
+        {"code": "A", "mom_1m": 0.1},
+        {"code": "B", "mom_1m": 0.2},
+        {"code": "C", "mom_1m": 0.3},
+    ]
+    forward = [
+        {"code": "A", "fwd_1d": 0.01},
+        {"code": "B", "fwd_1d": -0.02},
+        {"code": "C", "fwd_1d": 0.03},
+    ]
+    ic = calc_ic(factor, forward, "mom_1m", "fwd_1d")
+    # Should return a finite float
+    assert isinstance(ic, float)
+
+    # insufficient pairs -> None
+    ic2 = calc_ic(factor[:2], forward[:2], "mom_1m", "fwd_1d")
+    assert ic2 is None

--- a/tests/test_run_execution.py
+++ b/tests/test_run_execution.py
@@ -6,6 +6,7 @@ import pytest
 import yaml as yaml_mod
 
 import kabusys.run_execution as re_mod
+from kabusys.execution.broker_api import Position
 from kabusys.execution.risk_manager import RiskConfig
 from kabusys.run_execution import main
 
@@ -14,6 +15,7 @@ def _run_main(is_paper: bool = False):
     """全依存をモックして main() を実行するヘルパー。"""
     mock_broker = MagicMock()
     mock_broker.get_available_cash.return_value = 10_000_000.0
+    mock_broker.get_positions.return_value = []
     mock_engine = MagicMock()
 
     with (
@@ -30,6 +32,7 @@ def _run_main(is_paper: bool = False):
         patch("kabusys.run_execution.RiskManager"),
         patch("kabusys.run_execution.Reconciler"),
         patch("kabusys.run_execution.ExecutionEngine", return_value=mock_engine),
+        patch("kabusys.run_execution._load_risk_config", return_value=MagicMock()),
     ):
         settings = MagicMock()
         settings.is_paper = is_paper
@@ -60,6 +63,77 @@ class TestRunExecutionMain:
     def test_calls_run_session(self):
         _, _, mock_engine, _ = _run_main()
         mock_engine.run_session.assert_called_once()
+
+    def test_initial_portfolio_value_includes_positions(self):
+        mock_broker = MagicMock()
+        mock_broker.get_available_cash.return_value = 1_000_000.0
+        mock_broker.get_positions.return_value = [
+            Position(code="1234", qty=100, avg_price=2000.0, current_price=2500.0),
+            # 100 * 2500 = 250_000
+        ]
+        mock_engine = MagicMock()
+
+        with (
+            patch("kabusys.run_execution.set_process_priority"),
+            patch("kabusys.run_execution.Settings") as mock_settings_cls,
+            patch("kabusys.run_execution.sqlite3.connect"),
+            patch("kabusys.run_execution.init_monitoring_db"),
+            patch("kabusys.run_execution.duckdb.connect"),
+            patch("kabusys.run_execution.BrokerClientFactory.create", return_value=mock_broker),
+            patch("kabusys.run_execution.OrderRepository"),
+            patch("kabusys.run_execution.OrderManager"),
+            patch("kabusys.run_execution.RiskManager"),
+            patch("kabusys.run_execution.Reconciler"),
+            patch("kabusys.run_execution.ExecutionEngine", return_value=mock_engine),
+            patch("kabusys.run_execution._load_risk_config") as mock_load,
+        ):
+            mock_load.return_value = MagicMock()
+            settings = MagicMock()
+            settings.is_paper = False
+            settings.sqlite_path = Path("/prod.db")
+            settings.duckdb_path = Path("/data.duckdb")
+            mock_settings_cls.return_value = settings
+
+            main()
+
+        # _load_risk_config は total_assets = 1_000_000 + 250_000 = 1_250_000 で呼ばれる
+        mock_load.assert_called_once()
+        assert mock_load.call_args.kwargs["initial_portfolio_value"] == 1_250_000.0
+
+    def test_initial_portfolio_value_fallback_to_avg_price_when_no_current_price(self):
+        mock_broker = MagicMock()
+        mock_broker.get_available_cash.return_value = 500_000.0
+        mock_broker.get_positions.return_value = [
+            Position(code="9999", qty=200, avg_price=1500.0, current_price=None),
+            # current_price=None → avg_price で代替: 200 * 1500 = 300_000
+        ]
+        mock_engine = MagicMock()
+
+        with (
+            patch("kabusys.run_execution.set_process_priority"),
+            patch("kabusys.run_execution.Settings") as mock_settings_cls,
+            patch("kabusys.run_execution.sqlite3.connect"),
+            patch("kabusys.run_execution.init_monitoring_db"),
+            patch("kabusys.run_execution.duckdb.connect"),
+            patch("kabusys.run_execution.BrokerClientFactory.create", return_value=mock_broker),
+            patch("kabusys.run_execution.OrderRepository"),
+            patch("kabusys.run_execution.OrderManager"),
+            patch("kabusys.run_execution.RiskManager"),
+            patch("kabusys.run_execution.Reconciler"),
+            patch("kabusys.run_execution.ExecutionEngine", return_value=mock_engine),
+            patch("kabusys.run_execution._load_risk_config") as mock_load,
+        ):
+            mock_load.return_value = MagicMock()
+            settings = MagicMock()
+            settings.is_paper = False
+            settings.sqlite_path = Path("/prod.db")
+            settings.duckdb_path = Path("/data.duckdb")
+            mock_settings_cls.return_value = settings
+
+            main()
+
+        # total_assets = 500_000 + 300_000 = 800_000
+        assert mock_load.call_args.kwargs["initial_portfolio_value"] == 800_000.0
 
 
 def test_run_execution_stops_on_flag(tmp_path):

--- a/tests/test_run_execution.py
+++ b/tests/test_run_execution.py
@@ -130,3 +130,8 @@ class TestLoadRiskConfig:
         p = self._write_yaml(tmp_path, {"risk": {"max_position_pct": 0.20}})
         with pytest.raises(KeyError):
             re_mod._load_risk_config(p, 0.0)
+
+    def test_missing_top_level_risk_key_raises(self, tmp_path):
+        p = self._write_yaml(tmp_path, {"other": {}})
+        with pytest.raises(KeyError):
+            re_mod._load_risk_config(p, 0.0)

--- a/tests/test_run_execution.py
+++ b/tests/test_run_execution.py
@@ -2,7 +2,11 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+import yaml as yaml_mod
+
 import kabusys.run_execution as re_mod
+from kabusys.execution.risk_manager import RiskConfig
 from kabusys.run_execution import main
 
 
@@ -89,3 +93,40 @@ def test_run_execution_stops_on_flag(tmp_path):
     # フラグが起動前に存在 → エンジンは起動せず早期リターン。stop() は呼ばれない
     mock_engine.run_session.assert_not_called()
     mock_engine.stop.assert_not_called()
+
+
+class TestLoadRiskConfig:
+    def _write_yaml(self, tmp_path, data: dict) -> Path:
+        p = tmp_path / "risk_config.yaml"
+        p.write_text(yaml_mod.dump(data), encoding="utf-8")
+        return p
+
+    def test_loads_all_fields(self, tmp_path):
+        p = self._write_yaml(tmp_path, {
+            "risk": {
+                "max_position_pct": 0.15,
+                "max_utilization": 0.70,
+                "rate_limit_per_sec": 3,
+                "circuit_breaker_errors": 5,
+                "circuit_breaker_window_sec": 30,
+                "max_drawdown": 0.10,
+            }
+        })
+        config = re_mod._load_risk_config(p, initial_portfolio_value=5_000_000.0)
+        assert isinstance(config, RiskConfig)
+        assert config.max_position_pct == 0.15
+        assert config.max_utilization == 0.70
+        assert config.rate_limit_per_sec == 3
+        assert config.circuit_breaker_errors == 5
+        assert config.circuit_breaker_window_sec == 30
+        assert config.max_drawdown == 0.10
+        assert config.initial_portfolio_value == 5_000_000.0
+
+    def test_file_not_found_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            re_mod._load_risk_config(tmp_path / "nonexistent.yaml", 0.0)
+
+    def test_missing_key_raises(self, tmp_path):
+        p = self._write_yaml(tmp_path, {"risk": {"max_position_pct": 0.20}})
+        with pytest.raises(KeyError):
+            re_mod._load_risk_config(p, 0.0)

--- a/tests/test_run_execution.py
+++ b/tests/test_run_execution.py
@@ -298,3 +298,37 @@ class TestLoadRiskConfig:
         )
         with pytest.raises(ValueError, match="max_position_pct"):
             re_mod._load_risk_config(p, 0.0)
+
+    def test_rate_limit_per_sec_zero_raises(self, tmp_path):
+        p = self._write_yaml(
+            tmp_path,
+            {
+                "risk": {
+                    "max_position_pct": 0.20,
+                    "max_utilization": 0.80,
+                    "rate_limit_per_sec": 0,
+                    "circuit_breaker_errors": 10,
+                    "circuit_breaker_window_sec": 60,
+                    "max_drawdown": 0.20,
+                }
+            },
+        )
+        with pytest.raises(ValueError, match="rate_limit_per_sec"):
+            re_mod._load_risk_config(p, 0.0)
+
+    def test_circuit_breaker_errors_negative_raises(self, tmp_path):
+        p = self._write_yaml(
+            tmp_path,
+            {
+                "risk": {
+                    "max_position_pct": 0.20,
+                    "max_utilization": 0.80,
+                    "rate_limit_per_sec": 5,
+                    "circuit_breaker_errors": -1,
+                    "circuit_breaker_window_sec": 60,
+                    "max_drawdown": 0.20,
+                }
+            },
+        )
+        with pytest.raises(ValueError, match="circuit_breaker_errors"):
+            re_mod._load_risk_config(p, 0.0)

--- a/tests/test_run_execution.py
+++ b/tests/test_run_execution.py
@@ -79,7 +79,10 @@ class TestRunExecutionMain:
             patch("kabusys.run_execution.sqlite3.connect"),
             patch("kabusys.run_execution.init_monitoring_db"),
             patch("kabusys.run_execution.duckdb.connect"),
-            patch("kabusys.run_execution.BrokerClientFactory.create", return_value=mock_broker),
+            patch(
+                "kabusys.run_execution.BrokerClientFactory.create",
+                return_value=mock_broker,
+            ),
             patch("kabusys.run_execution.OrderRepository"),
             patch("kabusys.run_execution.OrderManager"),
             patch("kabusys.run_execution.RiskManager"),
@@ -115,7 +118,10 @@ class TestRunExecutionMain:
             patch("kabusys.run_execution.sqlite3.connect"),
             patch("kabusys.run_execution.init_monitoring_db"),
             patch("kabusys.run_execution.duckdb.connect"),
-            patch("kabusys.run_execution.BrokerClientFactory.create", return_value=mock_broker),
+            patch(
+                "kabusys.run_execution.BrokerClientFactory.create",
+                return_value=mock_broker,
+            ),
             patch("kabusys.run_execution.OrderRepository"),
             patch("kabusys.run_execution.OrderManager"),
             patch("kabusys.run_execution.RiskManager"),
@@ -135,7 +141,9 @@ class TestRunExecutionMain:
         # total_assets = 500_000 + 300_000 = 800_000
         assert mock_load.call_args.kwargs["initial_portfolio_value"] == 800_000.0
 
-    def test_initial_portfolio_value_fallback_to_avg_price_when_current_price_is_zero(self):
+    def test_initial_portfolio_value_fallback_to_avg_price_when_current_price_is_zero(
+        self,
+    ):
         mock_broker = MagicMock()
         mock_broker.get_available_cash.return_value = 500_000.0
         mock_broker.get_positions.return_value = [
@@ -150,7 +158,10 @@ class TestRunExecutionMain:
             patch("kabusys.run_execution.sqlite3.connect"),
             patch("kabusys.run_execution.init_monitoring_db"),
             patch("kabusys.run_execution.duckdb.connect"),
-            patch("kabusys.run_execution.BrokerClientFactory.create", return_value=mock_broker),
+            patch(
+                "kabusys.run_execution.BrokerClientFactory.create",
+                return_value=mock_broker,
+            ),
             patch("kabusys.run_execution.OrderRepository"),
             patch("kabusys.run_execution.OrderManager"),
             patch("kabusys.run_execution.RiskManager"),
@@ -211,16 +222,19 @@ class TestLoadRiskConfig:
         return p
 
     def test_loads_all_fields(self, tmp_path):
-        p = self._write_yaml(tmp_path, {
-            "risk": {
-                "max_position_pct": 0.15,
-                "max_utilization": 0.70,
-                "rate_limit_per_sec": 3,
-                "circuit_breaker_errors": 5,
-                "circuit_breaker_window_sec": 30,
-                "max_drawdown": 0.10,
-            }
-        })
+        p = self._write_yaml(
+            tmp_path,
+            {
+                "risk": {
+                    "max_position_pct": 0.15,
+                    "max_utilization": 0.70,
+                    "rate_limit_per_sec": 3,
+                    "circuit_breaker_errors": 5,
+                    "circuit_breaker_window_sec": 30,
+                    "max_drawdown": 0.10,
+                }
+            },
+        )
         config = re_mod._load_risk_config(p, initial_portfolio_value=5_000_000.0)
         assert isinstance(config, RiskConfig)
         assert config.max_position_pct == 0.15
@@ -252,25 +266,35 @@ class TestLoadRiskConfig:
             re_mod._load_risk_config(p, 0.0)
 
     def test_max_position_pct_out_of_range_raises(self, tmp_path):
-        p = self._write_yaml(tmp_path, {"risk": {
-            "max_position_pct": 1.5,  # > 1
-            "max_utilization": 0.80,
-            "rate_limit_per_sec": 5,
-            "circuit_breaker_errors": 10,
-            "circuit_breaker_window_sec": 60,
-            "max_drawdown": 0.20,
-        }})
+        p = self._write_yaml(
+            tmp_path,
+            {
+                "risk": {
+                    "max_position_pct": 1.5,  # > 1
+                    "max_utilization": 0.80,
+                    "rate_limit_per_sec": 5,
+                    "circuit_breaker_errors": 10,
+                    "circuit_breaker_window_sec": 60,
+                    "max_drawdown": 0.20,
+                }
+            },
+        )
         with pytest.raises(ValueError, match="max_position_pct"):
             re_mod._load_risk_config(p, 0.0)
 
     def test_max_position_pct_exceeds_max_utilization_raises(self, tmp_path):
-        p = self._write_yaml(tmp_path, {"risk": {
-            "max_position_pct": 0.90,
-            "max_utilization": 0.80,
-            "rate_limit_per_sec": 5,
-            "circuit_breaker_errors": 10,
-            "circuit_breaker_window_sec": 60,
-            "max_drawdown": 0.20,
-        }})
+        p = self._write_yaml(
+            tmp_path,
+            {
+                "risk": {
+                    "max_position_pct": 0.90,
+                    "max_utilization": 0.80,
+                    "rate_limit_per_sec": 5,
+                    "circuit_breaker_errors": 10,
+                    "circuit_breaker_window_sec": 60,
+                    "max_drawdown": 0.20,
+                }
+            },
+        )
         with pytest.raises(ValueError, match="max_position_pct"):
             re_mod._load_risk_config(p, 0.0)

--- a/tests/test_run_execution.py
+++ b/tests/test_run_execution.py
@@ -135,6 +135,41 @@ class TestRunExecutionMain:
         # total_assets = 500_000 + 300_000 = 800_000
         assert mock_load.call_args.kwargs["initial_portfolio_value"] == 800_000.0
 
+    def test_initial_portfolio_value_fallback_to_avg_price_when_current_price_is_zero(self):
+        mock_broker = MagicMock()
+        mock_broker.get_available_cash.return_value = 500_000.0
+        mock_broker.get_positions.return_value = [
+            Position(code="8888", qty=100, avg_price=1000.0, current_price=0.0),
+            # current_price=0 → avg_price で代替: 100 * 1000 = 100_000
+        ]
+        mock_engine = MagicMock()
+
+        with (
+            patch("kabusys.run_execution.set_process_priority"),
+            patch("kabusys.run_execution.Settings") as mock_settings_cls,
+            patch("kabusys.run_execution.sqlite3.connect"),
+            patch("kabusys.run_execution.init_monitoring_db"),
+            patch("kabusys.run_execution.duckdb.connect"),
+            patch("kabusys.run_execution.BrokerClientFactory.create", return_value=mock_broker),
+            patch("kabusys.run_execution.OrderRepository"),
+            patch("kabusys.run_execution.OrderManager"),
+            patch("kabusys.run_execution.RiskManager"),
+            patch("kabusys.run_execution.Reconciler"),
+            patch("kabusys.run_execution.ExecutionEngine", return_value=mock_engine),
+            patch("kabusys.run_execution._load_risk_config") as mock_load,
+        ):
+            mock_load.return_value = MagicMock()
+            settings = MagicMock()
+            settings.is_paper = False
+            settings.sqlite_path = Path("/prod.db")
+            settings.duckdb_path = Path("/data.duckdb")
+            mock_settings_cls.return_value = settings
+
+            main()
+
+        # total_assets = 500_000 + 100_000 = 600_000
+        assert mock_load.call_args.kwargs["initial_portfolio_value"] == 600_000.0
+
 
 def test_run_execution_stops_on_flag(tmp_path):
     """停止フラグが事前に存在するとき、エンジンを起動せず終了することを確認する。
@@ -208,4 +243,34 @@ class TestLoadRiskConfig:
     def test_missing_top_level_risk_key_raises(self, tmp_path):
         p = self._write_yaml(tmp_path, {"other": {}})
         with pytest.raises(KeyError):
+            re_mod._load_risk_config(p, 0.0)
+
+    def test_invalid_yaml_raises_value_error(self, tmp_path):
+        p = tmp_path / "bad.yaml"
+        p.write_text("risk: [\ninvalid yaml", encoding="utf-8")
+        with pytest.raises(ValueError, match="パース失敗"):
+            re_mod._load_risk_config(p, 0.0)
+
+    def test_max_position_pct_out_of_range_raises(self, tmp_path):
+        p = self._write_yaml(tmp_path, {"risk": {
+            "max_position_pct": 1.5,  # > 1
+            "max_utilization": 0.80,
+            "rate_limit_per_sec": 5,
+            "circuit_breaker_errors": 10,
+            "circuit_breaker_window_sec": 60,
+            "max_drawdown": 0.20,
+        }})
+        with pytest.raises(ValueError, match="max_position_pct"):
+            re_mod._load_risk_config(p, 0.0)
+
+    def test_max_position_pct_exceeds_max_utilization_raises(self, tmp_path):
+        p = self._write_yaml(tmp_path, {"risk": {
+            "max_position_pct": 0.90,
+            "max_utilization": 0.80,
+            "rate_limit_per_sec": 5,
+            "circuit_breaker_errors": 10,
+            "circuit_breaker_window_sec": 60,
+            "max_drawdown": 0.20,
+        }})
+        with pytest.raises(ValueError, match="max_position_pct"):
             re_mod._load_risk_config(p, 0.0)


### PR DESCRIPTION
## Summary

- `config/risk_config.yaml` のキー名を `RiskConfig` フィールド名に統一し、`initial_portfolio_value` を YAML から除外（起動時動的計算）
- `run_execution.py` に `_load_risk_config(path, initial_portfolio_value)` を追加し、起動時の総資産（現金＋保有評価額）を `initial_portfolio_value` として渡すよう実装
- `Settings.kabu_trade_password` プロパティ追加（未設定・空文字の場合は `None` を返し、`KabuStationClient` 内で `api_password` にフォールバック）
- `BrokerClientFactory.create()` の `is_live` ブランチを `KabuStationClient` 実装に置換（これまで `NotImplementedError`）
- `config_setup.py` に `KABU_TRADE_PASSWORD` 項目を追加

Closes #189
Closes #186

## Test plan

- [ ] `tests/test_run_execution.py` — `_load_risk_config` 単体テスト（正常系・FileNotFoundError・KeyError・top-level key 欠損）、`initial_portfolio_value` 計算テスト（current_price あり / None フォールバック）
- [ ] `tests/test_broker_factory.py` — `is_live` で `KabuStationClient` が返ること、`trade_password` の引き渡しとフォールバック動作
- [ ] `tests/test_config_setup.py` — 既存テスト全 PASS（`KABU_TRADE_PASSWORD` 追加の影響なし）
- [ ] `pytest tests/ -v --tb=short` — 886 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)