### PR TITLE
feat: J-Quants Bulk Download API によるCSVブートストラップ処理を実装 (Issue #187)

### DIFF
--- a/config/risk_config.yaml
+++ b/config/risk_config.yaml
@@ -7,4 +7,3 @@ risk:
   circuit_breaker_errors: 10       # サーキットブレーカー発動エラー数上限
   circuit_breaker_window_sec: 60   # サーキットブレーカーカウントウィンドウ（秒）
   max_drawdown: 0.20               # キルスイッチ発動ドローダウン閾値
-  initial_portfolio_value: 0.0     # セッション開始時の資産評価額

--- a/config/risk_config.yaml
+++ b/config/risk_config.yaml
@@ -1,14 +1,10 @@
-# risk_config.yaml — リスク管理設定（安全側の初期値）
+# risk_config.yaml — リスク管理設定
+# キー名は RiskConfig データクラスのフィールド名に対応する
 risk:
-  # 1銘柄最大ウェイト（ポートフォリオ対比）
-  max_position_size: 0.05
-  # ポートフォリオ総投資比率上限
-  max_portfolio_exposure: 1.0
-  # 日次最大損失率（超過で Kill Switch 検討）
-  max_daily_loss: 0.02
-  # 最大ドローダウン（超過で Kill Switch 自動発動）
-  max_drawdown: 0.15
-
-position_sizing:
-  risk_per_trade: 0.01
-  volatility_adjustment: true
+  max_position_pct: 0.20           # 1銘柄最大投資比率（総資産比）
+  max_utilization: 0.80            # 全ポジション投下上限（現金最低20%維持）
+  rate_limit_per_sec: 5            # API レート制限（毎秒）
+  circuit_breaker_errors: 10       # サーキットブレーカー発動エラー数上限
+  circuit_breaker_window_sec: 60   # サーキットブレーカーカウントウィンドウ（秒）
+  max_drawdown: 0.20               # キルスイッチ発動ドローダウン閾値
+  initial_portfolio_value: 0.0     # セッション開始時の資産評価額

--- a/docs/superpowers/plans/2026-04-25-risk-config-kabu-client.md
+++ b/docs/superpowers/plans/2026-04-25-risk-config-kabu-client.md
@@ -1,0 +1,558 @@
+# RiskConfig設定ファイル統合 & KabuStationClient配線 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `RiskConfig` パラメータを `config/risk_config.yaml` から読み込む設計に統一し、`is_live` 環境で `KabuStationClient` を使って実際に発注できる状態にする。
+
+**Architecture:** `run_execution.py` に `_load_risk_config(path, initial_portfolio_value)` を追加して YAML から `RiskConfig` を構築する。`initial_portfolio_value` は起動時に `get_available_cash() + 保有評価額` で総資産を算出して渡す。`BrokerClientFactory` の `is_live` ブランチを `KabuStationClient` で実装し、`Settings` に `kabu_trade_password` を追加する。
+
+**Tech Stack:** Python 3.10+, PyYAML (pyyaml>=6.0), pytest, monkeypatch, unittest.mock
+
+---
+
+## ファイル変更マップ
+
+| ファイル | 変更種別 | 内容 |
+|---|---|---|
+| `config/risk_config.yaml` | Modify | フィールド名を `RiskConfig` に合わせて書き直し |
+| `src/kabusys/run_execution.py` | Modify | `_load_risk_config()` 追加、`RiskConfig` 直書き削除、`total_assets` 計算追加 |
+| `src/kabusys/config.py` | Modify | `kabu_trade_password` プロパティ追加 |
+| `src/kabusys/execution/broker_factory.py` | Modify | `is_live` ブランチを `KabuStationClient` 実装に置換 |
+| `src/kabusys/config_setup.py` | Modify | `KABU_TRADE_PASSWORD` 項目追加 |
+| `tests/test_run_execution.py` | Modify | `_load_risk_config` パッチ追加・`total_assets` テスト追加 |
+| `tests/test_broker_factory.py` | Modify | `is_live` テストを `KabuStationClient` 返却検証に変更 |
+
+---
+
+## Task 1: config/risk_config.yaml の書き直し
+
+**Files:**
+- Modify: `config/risk_config.yaml`
+
+- [ ] **Step 1: risk_config.yaml を RiskConfig フィールド名に揃えて書き直す**
+
+`config/risk_config.yaml` を以下の内容で完全に置き換える:
+
+```yaml
+# risk_config.yaml — リスク管理設定
+# キー名は RiskConfig データクラスのフィールド名に対応する
+risk:
+  max_position_pct: 0.20           # 1銘柄最大投資比率（総資産比）
+  max_utilization: 0.80            # 全ポジション投下上限（現金最低20%維持）
+  rate_limit_per_sec: 5            # API レート制限（毎秒）
+  circuit_breaker_errors: 10       # サーキットブレーカー発動エラー数上限
+  circuit_breaker_window_sec: 60   # サーキットブレーカーカウントウィンドウ（秒）
+  max_drawdown: 0.20               # キルスイッチ発動ドローダウン閾値
+```
+
+- [ ] **Step 2: コミット**
+
+```bash
+git add config/risk_config.yaml
+git commit -m "config: risk_config.yaml のキー名を RiskConfig フィールド名に統一"
+```
+
+---
+
+## Task 2: _load_risk_config() の TDD 実装
+
+**Files:**
+- Modify: `src/kabusys/run_execution.py`
+- Test: `tests/test_run_execution.py`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`tests/test_run_execution.py` の末尾に以下を追加する:
+
+```python
+import tempfile
+import yaml as yaml_mod
+from kabusys.execution.risk_manager import RiskConfig
+import kabusys.run_execution as re_mod
+
+
+class TestLoadRiskConfig:
+    def _write_yaml(self, tmp_path, data: dict) -> Path:
+        p = tmp_path / "risk_config.yaml"
+        p.write_text(yaml_mod.dump(data), encoding="utf-8")
+        return p
+
+    def test_loads_all_fields(self, tmp_path):
+        p = self._write_yaml(tmp_path, {
+            "risk": {
+                "max_position_pct": 0.15,
+                "max_utilization": 0.70,
+                "rate_limit_per_sec": 3,
+                "circuit_breaker_errors": 5,
+                "circuit_breaker_window_sec": 30,
+                "max_drawdown": 0.10,
+            }
+        })
+        config = re_mod._load_risk_config(p, initial_portfolio_value=5_000_000.0)
+        assert isinstance(config, RiskConfig)
+        assert config.max_position_pct == 0.15
+        assert config.max_utilization == 0.70
+        assert config.rate_limit_per_sec == 3
+        assert config.circuit_breaker_errors == 5
+        assert config.circuit_breaker_window_sec == 30
+        assert config.max_drawdown == 0.10
+        assert config.initial_portfolio_value == 5_000_000.0
+
+    def test_file_not_found_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            re_mod._load_risk_config(tmp_path / "nonexistent.yaml", 0.0)
+
+    def test_missing_key_raises(self, tmp_path):
+        p = self._write_yaml(tmp_path, {"risk": {"max_position_pct": 0.20}})
+        with pytest.raises(KeyError):
+            re_mod._load_risk_config(p, 0.0)
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```bash
+pytest tests/test_run_execution.py::TestLoadRiskConfig -v
+```
+
+期待: `AttributeError: module 'kabusys.run_execution' has no attribute '_load_risk_config'`
+
+- [ ] **Step 3: _load_risk_config() を run_execution.py に実装する**
+
+`run_execution.py` の import ブロック直後（`logger = ...` の前）に以下を追加する:
+
+```python
+import yaml
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_STOP_FLAG = _PROJECT_ROOT / "data" / "stop_requested.flag"
+_EXECUTION_PID = _PROJECT_ROOT / "data" / "execution.pid"
+_RISK_CONFIG = _PROJECT_ROOT / "config" / "risk_config.yaml"
+```
+
+※ `_PROJECT_ROOT`・`_STOP_FLAG`・`_EXECUTION_PID` は既存のためそのまま。`_RISK_CONFIG` だけ追加。
+
+続けて `logger = logging.getLogger(__name__)` の直後に以下を追加する:
+
+```python
+def _load_risk_config(path: Path, initial_portfolio_value: float) -> "RiskConfig":
+    with path.open(encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    r = data["risk"]
+    return RiskConfig(
+        max_position_pct=r["max_position_pct"],
+        max_utilization=r["max_utilization"],
+        rate_limit_per_sec=r["rate_limit_per_sec"],
+        circuit_breaker_errors=r["circuit_breaker_errors"],
+        circuit_breaker_window_sec=r["circuit_breaker_window_sec"],
+        max_drawdown=r["max_drawdown"],
+        initial_portfolio_value=initial_portfolio_value,
+    )
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+```bash
+pytest tests/test_run_execution.py::TestLoadRiskConfig -v
+```
+
+期待: 3テストすべて PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/kabusys/run_execution.py tests/test_run_execution.py
+git commit -m "feat: run_execution に _load_risk_config() を追加（#189）"
+```
+
+---
+
+## Task 3: initial_portfolio_value 計算と RiskConfig 直書きの置換
+
+**Files:**
+- Modify: `src/kabusys/run_execution.py`
+- Modify: `tests/test_run_execution.py`
+
+- [ ] **Step 1: initial_portfolio_value のテストを書く**
+
+`tests/test_run_execution.py` のファイル先頭の import ブロックに以下を追加する:
+
+```python
+from kabusys.execution.broker_api import Position
+from kabusys.execution.risk_manager import RiskConfig
+```
+
+続けて `TestRunExecutionMain` クラスに以下2つのテストメソッドを追加する:
+
+```python
+def test_initial_portfolio_value_includes_positions(self):
+    mock_broker = MagicMock()
+    mock_broker.get_available_cash.return_value = 1_000_000.0
+    mock_broker.get_positions.return_value = [
+        Position(code="1234", qty=100, avg_price=2000.0, current_price=2500.0),
+        # 100 * 2500 = 250_000
+    ]
+    mock_engine = MagicMock()
+
+    with (
+        patch("kabusys.run_execution.set_process_priority"),
+        patch("kabusys.run_execution.Settings") as mock_settings_cls,
+        patch("kabusys.run_execution.sqlite3.connect"),
+        patch("kabusys.run_execution.init_monitoring_db"),
+        patch("kabusys.run_execution.duckdb.connect"),
+        patch("kabusys.run_execution.BrokerClientFactory.create", return_value=mock_broker),
+        patch("kabusys.run_execution.OrderRepository"),
+        patch("kabusys.run_execution.OrderManager"),
+        patch("kabusys.run_execution.RiskManager"),
+        patch("kabusys.run_execution.Reconciler"),
+        patch("kabusys.run_execution.ExecutionEngine", return_value=mock_engine),
+        patch("kabusys.run_execution._load_risk_config") as mock_load,
+    ):
+        mock_load.return_value = RiskConfig()
+        settings = MagicMock()
+        settings.is_paper = False
+        settings.sqlite_path = Path("/prod.db")
+        settings.duckdb_path = Path("/data.duckdb")
+        mock_settings_cls.return_value = settings
+
+        main()
+
+    # _load_risk_config は total_assets = 1_000_000 + 250_000 = 1_250_000 で呼ばれる
+    mock_load.assert_called_once()
+    assert mock_load.call_args.kwargs["initial_portfolio_value"] == 1_250_000.0
+
+def test_initial_portfolio_value_fallback_to_avg_price_when_no_current_price(self):
+    mock_broker = MagicMock()
+    mock_broker.get_available_cash.return_value = 500_000.0
+    mock_broker.get_positions.return_value = [
+        Position(code="9999", qty=200, avg_price=1500.0, current_price=None),
+        # current_price=None → avg_price で代替: 200 * 1500 = 300_000
+    ]
+    mock_engine = MagicMock()
+
+    with (
+        patch("kabusys.run_execution.set_process_priority"),
+        patch("kabusys.run_execution.Settings") as mock_settings_cls,
+        patch("kabusys.run_execution.sqlite3.connect"),
+        patch("kabusys.run_execution.init_monitoring_db"),
+        patch("kabusys.run_execution.duckdb.connect"),
+        patch("kabusys.run_execution.BrokerClientFactory.create", return_value=mock_broker),
+        patch("kabusys.run_execution.OrderRepository"),
+        patch("kabusys.run_execution.OrderManager"),
+        patch("kabusys.run_execution.RiskManager"),
+        patch("kabusys.run_execution.Reconciler"),
+        patch("kabusys.run_execution.ExecutionEngine", return_value=mock_engine),
+        patch("kabusys.run_execution._load_risk_config") as mock_load,
+    ):
+        mock_load.return_value = RiskConfig()
+        settings = MagicMock()
+        settings.is_paper = False
+        settings.sqlite_path = Path("/prod.db")
+        settings.duckdb_path = Path("/data.duckdb")
+        mock_settings_cls.return_value = settings
+
+        main()
+
+    # total_assets = 500_000 + 300_000 = 800_000
+    assert mock_load.call_args.kwargs["initial_portfolio_value"] == 800_000.0
+```
+
+- [ ] **Step 2: 既存の _run_main ヘルパーを更新する**
+
+`test_run_execution.py` の `_run_main()` 関数を以下の通り更新する（`get_positions` の追加と `_load_risk_config` のパッチ追加）:
+
+```python
+def _run_main(is_paper: bool = False):
+    """全依存をモックして main() を実行するヘルパー。"""
+    mock_broker = MagicMock()
+    mock_broker.get_available_cash.return_value = 10_000_000.0
+    mock_broker.get_positions.return_value = []  # ← 追加（positions なし）
+    mock_engine = MagicMock()
+
+    with (
+        patch("kabusys.run_execution.set_process_priority") as mock_priority,
+        patch("kabusys.run_execution.Settings") as mock_settings_cls,
+        patch("kabusys.run_execution.sqlite3.connect") as mock_sqlite,
+        patch("kabusys.run_execution.init_monitoring_db"),
+        patch("kabusys.run_execution.duckdb.connect"),
+        patch(
+            "kabusys.run_execution.BrokerClientFactory.create", return_value=mock_broker
+        ),
+        patch("kabusys.run_execution.OrderRepository"),
+        patch("kabusys.run_execution.OrderManager"),
+        patch("kabusys.run_execution.RiskManager"),
+        patch("kabusys.run_execution.Reconciler"),
+        patch("kabusys.run_execution.ExecutionEngine", return_value=mock_engine),
+        patch("kabusys.run_execution._load_risk_config", return_value=MagicMock()),  # ← 追加
+    ):
+        settings = MagicMock()
+        settings.is_paper = is_paper
+        settings.paper_sqlite_path = Path("/paper.db")
+        settings.sqlite_path = Path("/prod.db")
+        settings.duckdb_path = Path("/data.duckdb")
+        settings.pid_file_path = Path("/data/execution.pid")
+        mock_settings_cls.return_value = settings
+
+        main()
+
+    return mock_priority, mock_sqlite, mock_engine, settings
+```
+
+- [ ] **Step 3: テストが失敗することを確認**
+
+```bash
+pytest tests/test_run_execution.py::TestRunExecutionMain::test_initial_portfolio_value_includes_positions -v
+```
+
+期待: `AssertionError`（`_load_risk_config` が呼ばれていない or `initial_portfolio_value` が 0.0）
+
+- [ ] **Step 4: run_execution.py の main() を書き換える**
+
+`main()` 内の broker 初期化ブロック（`broker = BrokerClientFactory.create(settings)` の直後）を以下に置き換える:
+
+```python
+# 3. ブローカークライアント
+broker = BrokerClientFactory.create(settings)
+
+# 4. 起動時総資産を計算（現金 + 保有評価額）
+cash = broker.get_available_cash()
+positions = broker.get_positions()
+total_assets = cash + sum(
+    p.qty * (p.current_price if p.current_price is not None else p.avg_price)
+    for p in positions
+)
+
+# 5. 依存コンポーネント組み立て
+repo = OrderRepository(sqlite_conn)
+order_manager = OrderManager(broker, repo)
+risk_manager = RiskManager(
+    broker=broker,
+    repo=repo,
+    config=_load_risk_config(_RISK_CONFIG, initial_portfolio_value=total_assets),
+)
+reconciler = Reconciler(broker=broker, repo=repo, order_manager=order_manager)
+```
+
+※ 元の `RiskConfig(max_position_pct=0.20, ...)` の直書きブロックを丸ごと削除し、上記に置き換える。
+
+- [ ] **Step 5: テストが通ることを確認**
+
+```bash
+pytest tests/test_run_execution.py -v
+```
+
+期待: 全テスト PASS
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/kabusys/run_execution.py tests/test_run_execution.py
+git commit -m "feat: RiskConfig を risk_config.yaml から読み込み、initial_portfolio_value を総資産で計算 (#189)"
+```
+
+---
+
+## Task 4: Settings に kabu_trade_password を追加
+
+**Files:**
+- Modify: `src/kabusys/config.py`
+- Test: `tests/test_broker_factory.py`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`tests/test_broker_factory.py` の末尾に以下クラスを追加する:
+
+```python
+class TestKabuTradePassword:
+    def test_returns_none_when_not_set(self, monkeypatch):
+        monkeypatch.delenv("KABU_TRADE_PASSWORD", raising=False)
+        assert Settings().kabu_trade_password is None
+
+    def test_returns_value_when_set(self, monkeypatch):
+        monkeypatch.setenv("KABU_TRADE_PASSWORD", "secret123")
+        assert Settings().kabu_trade_password == "secret123"
+
+    def test_returns_none_for_empty_string(self, monkeypatch):
+        monkeypatch.setenv("KABU_TRADE_PASSWORD", "")
+        assert Settings().kabu_trade_password is None
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```bash
+pytest tests/test_broker_factory.py::TestKabuTradePassword -v
+```
+
+期待: `AttributeError: 'Settings' object has no attribute 'kabu_trade_password'`
+
+- [ ] **Step 3: config.py に kabu_trade_password プロパティを追加する**
+
+`config.py` の `kabu_api_base_url` プロパティの直後に以下を追加する:
+
+```python
+@property
+def kabu_trade_password(self) -> str | None:
+    return os.environ.get("KABU_TRADE_PASSWORD") or None
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+```bash
+pytest tests/test_broker_factory.py::TestKabuTradePassword -v
+```
+
+期待: 3テストすべて PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/kabusys/config.py tests/test_broker_factory.py
+git commit -m "feat: Settings に kabu_trade_password プロパティを追加 (#186)"
+```
+
+---
+
+## Task 5: BrokerClientFactory の is_live ブランチを KabuStationClient で実装
+
+**Files:**
+- Modify: `src/kabusys/execution/broker_factory.py`
+- Modify: `tests/test_broker_factory.py`
+
+- [ ] **Step 1: is_live テストを KabuStationClient 返却検証に更新する**
+
+`tests/test_broker_factory.py` の `TestBrokerClientFactory` クラスの `test_live_mode_raises_not_implemented` を以下に置き換える:
+
+```python
+def test_live_mode_returns_kabu_station_client(self, monkeypatch):
+    from kabusys.execution.kabu_client import KabuStationClient
+    monkeypatch.setenv("KABUSYS_ENV", "live")
+    monkeypatch.setenv("KABU_API_PASSWORD", "test_password")
+    monkeypatch.delenv("KABU_TRADE_PASSWORD", raising=False)
+    broker = BrokerClientFactory.create(Settings())
+    assert isinstance(broker, KabuStationClient)
+    broker.close()  # httpx.Client を閉じる
+
+def test_live_mode_passes_trade_password_when_set(self, monkeypatch):
+    from kabusys.execution.kabu_client import KabuStationClient
+    monkeypatch.setenv("KABUSYS_ENV", "live")
+    monkeypatch.setenv("KABU_API_PASSWORD", "api_pass")
+    monkeypatch.setenv("KABU_TRADE_PASSWORD", "trade_pass")
+    broker = BrokerClientFactory.create(Settings())
+    assert isinstance(broker, KabuStationClient)
+    # trade_password が設定されていれば api_password と異なる値が使われる
+    assert broker._trade_password == "trade_pass"
+    broker.close()
+
+def test_live_mode_falls_back_to_api_password_when_trade_password_not_set(self, monkeypatch):
+    from kabusys.execution.kabu_client import KabuStationClient
+    monkeypatch.setenv("KABUSYS_ENV", "live")
+    monkeypatch.setenv("KABU_API_PASSWORD", "api_pass")
+    monkeypatch.delenv("KABU_TRADE_PASSWORD", raising=False)
+    broker = BrokerClientFactory.create(Settings())
+    assert isinstance(broker, KabuStationClient)
+    # trade_password 未設定時は kabu_client 内部で api_password にフォールバック
+    assert broker._trade_password == "api_pass"
+    broker.close()
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```bash
+pytest tests/test_broker_factory.py::TestBrokerClientFactory::test_live_mode_returns_kabu_station_client -v
+```
+
+期待: `FAIL` — `NotImplementedError` が発生
+
+- [ ] **Step 3: broker_factory.py の is_live ブランチを実装する**
+
+`broker_factory.py` の `is_live` の `raise NotImplementedError(...)` を以下に置き換える:
+
+```python
+if settings.is_live:
+    return create_broker_api(
+        mock=False,
+        api_password=settings.kabu_api_password,
+        trade_password=settings.kabu_trade_password,
+        base_url=settings.kabu_api_base_url,
+    )
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+```bash
+pytest tests/test_broker_factory.py -v
+```
+
+期待: 全テスト PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/kabusys/execution/broker_factory.py tests/test_broker_factory.py
+git commit -m "feat: BrokerClientFactory の is_live ブランチで KabuStationClient を返すよう実装 (#186)"
+```
+
+---
+
+## Task 6: config_setup.py に KABU_TRADE_PASSWORD を追加
+
+**Files:**
+- Modify: `src/kabusys/config_setup.py`
+
+- [ ] **Step 1: _ITEMS リストに KABU_TRADE_PASSWORD 項目を追加する**
+
+`config_setup.py` の `_ITEMS` リスト内の `KABU_API_BASE_URL` 項目の直後に以下を追加する:
+
+```python
+{
+    "key": "KABU_TRADE_PASSWORD",
+    "label": "kabuステーション 取引パスワード（任意）",
+    "secret": True,
+    "optional": True,
+    "description": (
+        "  kabuステーション 取引パスワード（空欄時は API パスワードを流用）\n"
+        "  APIパスワードと同一の場合は空欄でよい"
+    ),
+},
+```
+
+- [ ] **Step 2: _write_env() に KABU_TRADE_PASSWORD の書き込み行を追加する**
+
+`_write_env()` 内の `KABU_API_BASE_URL` 行の直後に以下を追加する:
+
+```python
+f"KABU_TRADE_PASSWORD={values.get('KABU_TRADE_PASSWORD', '')}",
+```
+
+- [ ] **Step 3: 動作確認**
+
+```bash
+pytest tests/test_config_setup.py -v
+```
+
+期待: 既存テスト全 PASS（_ITEMS の変更は既存テストに影響しない）
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add src/kabusys/config_setup.py
+git commit -m "feat: config_setup に KABU_TRADE_PASSWORD 項目を追加 (#186)"
+```
+
+---
+
+## Task 7: 全テストの最終確認
+
+- [ ] **Step 1: 全テストを実行する**
+
+```bash
+pytest tests/ -v --tb=short
+```
+
+期待: 全テスト PASS（新規追加分含む）
+
+- [ ] **Step 2: Issue をクローズする**
+
+```bash
+gh issue close 189 --comment "実装完了: risk_config.yaml 読み込み・initial_portfolio_value 総資産計算を実装"
+gh issue close 186 --comment "実装完了: BrokerClientFactory.create() の is_live ブランチで KabuStationClient を返すよう実装"
+```

--- a/docs/superpowers/specs/2026-04-25-risk-config-kabu-client-design.md
+++ b/docs/superpowers/specs/2026-04-25-risk-config-kabu-client-design.md
@@ -1,0 +1,118 @@
+# 設計書: RiskConfig設定ファイル統合 & KabuStationClient配線
+
+- Issue: #189 (RiskConfig設定ファイル統合), #186 (KabuStationClient配線)
+- 日付: 2026-04-25
+- ステータス: 承認済み
+
+---
+
+## 背景
+
+### #189: RiskConfig設定ファイル統合
+
+`run_execution.py` 内で `RiskConfig(...)` のパラメータが直書きされており、設定変更のたびにコード修正が必要な状態。`config/risk_config.yaml` は存在するが、フィールド名が `RiskConfig` と不一致のため実行経路では使用されていない。
+
+また `initial_portfolio_value` に `broker.get_available_cash()`（現金のみ）を渡しているため、既存保有ポジションがある場合にドローダウン計算の基準値が実際の総資産より小さくなるリスクがある。
+
+### #186: KabuStationClient配線
+
+`KabuStationClient` は `kabu_client.py` に完全実装済みだが、`broker_factory.py` の `is_live` ブランチが `NotImplementedError` を throw するだけで本番執行が不可能な状態。
+
+---
+
+## 設計
+
+### #189: RiskConfig設定ファイル統合
+
+#### 変更 1: `config/risk_config.yaml` の書き直し
+
+`RiskConfig` データクラスのフィールド名に揃えて全キーを再定義する。
+
+```yaml
+risk:
+  max_position_pct: 0.20           # 1銘柄最大投資比率
+  max_utilization: 0.80            # 全ポジション投下上限（現金最低20%維持）
+  rate_limit_per_sec: 5            # API レート制限（毎秒）
+  circuit_breaker_errors: 10       # サーキットブレーカー発動エラー数上限
+  circuit_breaker_window_sec: 60   # サーキットブレーカーカウントウィンドウ（秒）
+  max_drawdown: 0.20               # キルスイッチ発動ドローダウン閾値
+```
+
+`initial_portfolio_value` は実行時に動的計算するため YAML には含めない。
+
+#### 変更 2: `run_execution.py` へのローダー追加
+
+プライベート関数 `_load_risk_config(path, initial_portfolio_value) -> RiskConfig` を追加し、YAML を読み込んで `RiskConfig` を返す。
+
+`initial_portfolio_value` の計算:
+
+```python
+cash = broker.get_available_cash()
+positions = broker.get_positions()
+total_assets = cash + sum(
+    p.qty * (p.current_price if p.current_price is not None else p.avg_price)
+    for p in positions
+)
+```
+
+`broker.get_positions()` の呼び出しは1回のみ（起動時）。
+
+#### 変更ファイル
+
+| ファイル | 変更内容 |
+|---|---|
+| `config/risk_config.yaml` | フィールド名を `RiskConfig` に合わせて全キー書き直し |
+| `src/kabusys/run_execution.py` | `_load_risk_config()` 追加、`RiskConfig(...)` 直書きを置換、`total_assets` 計算追加 |
+
+---
+
+### #186: KabuStationClient配線
+
+#### 変更 1: `config.py` に `kabu_trade_password` を追加
+
+```python
+@property
+def kabu_trade_password(self) -> str | None:
+    return os.environ.get("KABU_TRADE_PASSWORD") or None
+```
+
+未設定時は `None` を返し、`KabuStationClient` 側で `api_password` にフォールバックする。
+
+#### 変更 2: `broker_factory.py` の `is_live` ブランチを実装
+
+```python
+if settings.is_live:
+    return create_broker_api(
+        mock=False,
+        api_password=settings.kabu_api_password,
+        trade_password=settings.kabu_trade_password,
+        base_url=settings.kabu_api_base_url,
+    )
+```
+
+#### 変更 3: `config_setup.py` に `KABU_TRADE_PASSWORD` 項目を追加
+
+オプション項目として `_ITEMS` リストへ追加。`_write_env()` にも対応行を追加。
+
+#### 変更ファイル
+
+| ファイル | 変更内容 |
+|---|---|
+| `src/kabusys/config.py` | `kabu_trade_password` プロパティ追加 |
+| `src/kabusys/execution/broker_factory.py` | `is_live` ブランチを `KabuStationClient` 実装に置換 |
+| `src/kabusys/config_setup.py` | `KABU_TRADE_PASSWORD` 項目追加（オプション） |
+
+---
+
+## テスト方針
+
+- `broker_factory.py` の `is_live` ブランチ: `Settings.is_live=True` のモック環境でファクトリが `KabuStationClient` インスタンスを返すことを確認
+- `_load_risk_config()`: 正常 YAML・不正キー・ファイル不存在の各ケースをテスト
+- `initial_portfolio_value` 計算: ポジションあり/なし両方のケースをテスト
+
+---
+
+## 制約
+
+- `initial_portfolio_value` の計算で `get_positions()` を追加呼び出しするが、起動時1回のみであり性能影響は無視できる
+- `KABUSYS_ENV=live` 時に `KABU_API_PASSWORD` が未設定の場合は既存の `ValueError` が発生する（変更なし）

--- a/documents/01_Data/config_schema.md
+++ b/documents/01_Data/config_schema.md
@@ -138,35 +138,39 @@ ai_overlay:
 
 # 6. risk_config.yaml
 
-リスク管理設定。
+リスク管理設定。`RiskManager` の `RiskConfig` に直接マッピングされる。
 
 ``` yaml
 risk:
 
-  max_position_size: 0.05
+  max_position_pct: 0.20           # 1銘柄最大投資比率（総資産比）
 
-  max_portfolio_exposure: 1.0
+  max_utilization: 0.80            # 全ポジション投下上限（現金最低20%維持）
 
-  max_daily_loss: 0.02
+  rate_limit_per_sec: 5            # API レート制限（毎秒）
 
-  max_drawdown: 0.15
+  circuit_breaker_errors: 10       # サーキットブレーカー発動エラー数上限
 
-position_sizing:
+  circuit_breaker_window_sec: 60   # サーキットブレーカーカウントウィンドウ（秒）
 
-  risk_per_trade: 0.01
-
-  volatility_adjustment: true
+  max_drawdown: 0.20               # キルスイッチ発動ドローダウン閾値
 ```
 
 説明
 
-  key                      description
-  ------------------------ -----------------
-  max_position_size        1銘柄最大比率
-  max_portfolio_exposure   総投資比率
-  max_daily_loss           日次最大損失
-  max_drawdown             最大DD
-  risk_per_trade           1トレードリスク
+  key                        description
+  -------------------------- ---------------------------------
+  max_position_pct           1銘柄最大投資比率（RiskConfig.max_position_pct）
+  max_utilization            全ポジション投下上限（RiskConfig.max_utilization）
+  rate_limit_per_sec         API レート制限・毎秒回数（RiskConfig.rate_limit_per_sec）
+  circuit_breaker_errors     CB発動エラー数上限（RiskConfig.circuit_breaker_errors）
+  circuit_breaker_window_sec CBカウントウィンドウ秒（RiskConfig.circuit_breaker_window_sec）
+  max_drawdown               キルスイッチ発動DD閾値（RiskConfig.max_drawdown）
+
+備考
+
+- `initial_portfolio_value` は起動時に動的計算するため YAML には含めない（`get_available_cash() + 保有評価額`）
+- 旧キー名 `max_position_size` / `max_portfolio_exposure` は廃止。`max_position_pct` / `max_utilization` に統一。
 
 ------------------------------------------------------------------------
 

--- a/documents/04_Execution/ExecutionSystem.md
+++ b/documents/04_Execution/ExecutionSystem.md
@@ -50,17 +50,33 @@
 
 Strategy層が生成したシグナルは、実行層（Execution）へ渡る直前および直後に「3段階のガード」を通過しなければならない。
 
+### 設定ファイルからのパラメータ読み込み
+
+リスクパラメータはコードに直書きせず、`config/risk_config.yaml` から起動時に読み込む。実際の現金余力は broker API（kabuステーション API / MockBrokerClient）から取得する。
+
+```python
+# run_execution.py 起動時の初期資産計算
+cash = broker.get_available_cash()
+positions = broker.get_positions()
+initial_portfolio_value = cash + sum(
+    p.qty * (p.current_price if p.current_price is not None else p.avg_price)
+    for p in positions
+)
+```
+
+`initial_portfolio_value` はドローダウン計算の基準値として使用し、現金のみでなく **既存保有を含む総資産** とする。
+
 ### 第1関門: シグナルレベル・ガード（発注前検証）
 - **余力チェック**: 現在の口座買付余力を超過していないか。
 - **重複チェック**: すでに同一銘柄の注文が `OrderAccepted` `OrderSent` 状態で存在しないか（二重発注防止）。
-- **ポジション上限**: すでに最大保有株数、または総資産に対する最大投資比率（10%等）に達していないか。
+- **ポジション上限**: すでに総資産に対する最大投資比率（`max_position_pct`、デフォルト20%）に達していないか。また全体の投下比率が `max_utilization`（デフォルト80%）を超えないか。
 
 ### 第2関門: エグゼキューションレベル・ガード（API送信前制限）
-- **APIレート制限**: kabuステーションの「発注系API: 毎秒5回以内」等の制約を厳守するため、トークンバケツやスロットリングキューを挟む。
-- **暴走防止（サーキットブレーカー）**: 短期間（例: 1分間）に指定回数（例: 10回）連続でエラーが返却された場合、APIキーの失効や取引所側の障害とみなし、システム全体の発注機能を停止させる。
+- **APIレート制限**: kabuステーションの「発注系API: 毎秒 `rate_limit_per_sec` 回以内」制約をトークンバケツで厳守する。
+- **暴走防止（サーキットブレーカー）**: `circuit_breaker_window_sec` 秒以内に `circuit_breaker_errors` 回以上エラーが返却された場合、システム全体の発注機能を停止させる。
 
 ### 第3関門: メトリクスレベル・ガード（発注後監視）
-- ポートフォリオ全体の評価損益（Drawdown）を監視し、想定最大損失（MaxDD等）を超えた場合はすべての未約定注文をキャンセルさせ、保有ポジションを成行で安全にクローズする**キルスイッチ（Kill Switch）**を発動させる。
+- ポートフォリオ全体のドローダウンを監視し、`max_drawdown`（デフォルト20%）を超えた場合は**キルスイッチ（Kill Switch）**を発動させる。
 
 ---
 
@@ -163,13 +179,19 @@ broker API の `OrderStatus.status`（GET /orders レスポンス）から Order
 
 ### 差し替え方法
 
-**推奨: `BrokerClientFactory` を使用（Phase 8〜）**
+**推奨: `BrokerClientFactory` を使用**
 
 ```python
-# KABUSYS_ENV に応じて自動選択（paper_trading / development → MockBrokerClient）
+# KABUSYS_ENV に応じて自動選択
 from kabusys.execution.broker_factory import BrokerClientFactory
 broker = BrokerClientFactory.create(settings)
 ```
+
+| `KABUSYS_ENV` | 使用クライアント | 説明 |
+|---|---|---|
+| `development` | `MockBrokerClient` | ローカル開発・テスト用（発注なし） |
+| `paper_trading` | `MockBrokerClient` | 仮想発注（Paper Trading DB に記録） |
+| `live` | `KabuStationClient` | 実際に kabuステーション API へ発注 |
 
 **直接指定（テスト・開発時）**
 
@@ -177,15 +199,18 @@ broker = BrokerClientFactory.create(settings)
 # 開発・テスト時
 api = create_broker_api(mock=True)
 
-# 本番時
+# 本番時（BrokerClientFactory 経由を推奨）
 api = create_broker_api(mock=False, api_password="...", base_url="http://localhost:18080/kabusapi")
 ```
 
-**Paper Trading 関連環境変数**
+**関連環境変数**
 
 | 環境変数 | デフォルト | 説明 |
 |---|---|---|
-| `KABUSYS_ENV` | `development` | `paper_trading` で Paper Trading モード |
+| `KABUSYS_ENV` | `development` | 実行環境（development / paper_trading / live） |
+| `KABU_API_PASSWORD` | 必須 | kabuステーション API パスワード（live 環境で必須） |
+| `KABU_TRADE_PASSWORD` | 省略可 | kabuステーション 取引パスワード（省略時は `KABU_API_PASSWORD` と同一とみなす） |
+| `KABU_API_BASE_URL` | `http://localhost:18080/kabusapi` | kabuステーション API ベース URL |
 | `PAPER_FILL_MODE` | `instant` | MockBrokerClient の約定方式（instant/partial/never/reject） |
 | `PAPER_TRADING_SQLITE_PATH` | `data/paper_trading.db` | Paper Trading 専用 SQLite DB のパス |
 

--- a/documents/06_RiskManagement/RiskManagement.md
+++ b/documents/06_RiskManagement/RiskManagement.md
@@ -142,14 +142,20 @@ FOMC・日銀決定会合・米CPI等の主要イベント前後はボラティ�
 
 ## 4.2 ポートフォリオ制限
 
-制限
+以下パラメータは `config/risk_config.yaml` で設定し、`RiskManager` の `RiskConfig` に読み込まれる。
 
-| 項目               | 制限 |
-| ------------------ | ---- |
-| 最大保有銘柄       | 10   |
-| 1銘柄最大比率      | 10%  |
-| 同一セクター       | 30%  |
-| キャッシュ最低比率 | 20%  |
+| 項目                         | 設定値 | 設定キー (`risk_config.yaml`) |
+| ---------------------------- | ------ | ----------------------------- |
+| 1銘柄最大投資比率            | 20%    | `risk.max_position_pct`       |
+| 全ポジション投下上限         | 80%    | `risk.max_utilization`        |
+| キャッシュ最低比率           | 20%    | （`max_utilization` の裏面）  |
+| キルスイッチ発動DD閾値       | 20%    | `risk.max_drawdown`           |
+| API レート制限（毎秒）       | 5      | `risk.rate_limit_per_sec`     |
+| CB発動エラー数上限           | 10     | `risk.circuit_breaker_errors` |
+| CBカウントウィンドウ（秒）   | 60     | `risk.circuit_breaker_window_sec` |
+
+**初期資産（`initial_portfolio_value`）の計算方法:**
+起動時に `get_available_cash() + 保有ポジション評価額` で総資産を算出し、ドローダウン計算の基準値とする。`current_price` 未取得時は `avg_price` でフォールバックする（保守的評価）。
 
 ---
 
@@ -276,11 +282,13 @@ Cancelled
 
 # 10. ドローダウン制御
 
-| ドローダウン | 対応             |
-| ------------ | ---------------- |
-| 5%           | ポジション半減   |
-| 10%          | 新規停止         |
-| 15%          | 全ポジション縮小 |
+`RiskManager.check_metrics()` が `max_drawdown`（デフォルト 20%）超過を検知した場合に `KillSwitch` を発動する。
+
+| ドローダウン                          | 対応                                         |
+| ------------------------------------- | -------------------------------------------- |
+| `max_drawdown` 超過（デフォルト 20%） | キルスイッチ発動・新規発注停止               |
+
+閾値は `config/risk_config.yaml` の `risk.max_drawdown` で設定する。
 
 ---
 

--- a/src/kabusys/config.py
+++ b/src/kabusys/config.py
@@ -150,6 +150,10 @@ class Settings:
     def kabu_api_base_url(self) -> str:
         return os.environ.get("KABU_API_BASE_URL", "http://localhost:18080/kabusapi")
 
+    @property
+    def kabu_trade_password(self) -> str | None:
+        return os.environ.get("KABU_TRADE_PASSWORD") or None
+
     # --- LINE Messaging API ---
     @property
     def line_channel_access_token(self) -> str:

--- a/src/kabusys/config.py
+++ b/src/kabusys/config.py
@@ -141,6 +141,10 @@ class Settings:
     def jquants_refresh_token(self) -> str:
         return _require("JQUANTS_REFRESH_TOKEN")
 
+    @property
+    def jquants_bulk_api_key(self) -> str:
+        return _require("JQUANTS_BULK_API_KEY")
+
     # --- kabuステーション API ---
     @property
     def kabu_api_password(self) -> str:

--- a/src/kabusys/config_setup.py
+++ b/src/kabusys/config_setup.py
@@ -50,6 +50,16 @@ _ITEMS: list[dict] = [
         "description": "  通常はデフォルトのままで可",
     },
     {
+        "key": "KABU_TRADE_PASSWORD",
+        "label": "kabuステーション 取引パスワード（任意）",
+        "secret": True,
+        "optional": True,
+        "description": (
+            "  kabuステーション 取引パスワード（空欄時は API パスワードを流用）\n"
+            "  APIパスワードと同一の場合は空欄でよい"
+        ),
+    },
+    {
         "key": "DUCKDB_PATH",
         "label": "DuckDB ファイルパス",
         "default": "data/kabusys.duckdb",
@@ -127,6 +137,7 @@ def _write_env(path: Path, values: dict[str, str]) -> None:
         "# --- kabuステーション API ---",
         f"KABU_API_PASSWORD={values.get('KABU_API_PASSWORD', '')}",
         f"KABU_API_BASE_URL={values.get('KABU_API_BASE_URL', 'http://localhost:18080/kabusapi')}",
+        f"KABU_TRADE_PASSWORD={values.get('KABU_TRADE_PASSWORD', '')}",
         "",
         "# --- LINE Messaging API (アラート通知用) ---",
         f"LINE_CHANNEL_ACCESS_TOKEN={values.get('LINE_CHANNEL_ACCESS_TOKEN', '')}",

--- a/src/kabusys/config_setup.py
+++ b/src/kabusys/config_setup.py
@@ -38,6 +38,12 @@ _ITEMS: list[dict] = [
         "description": "  J-Quants API のリフレッシュトークン（必須）",
     },
     {
+        "key": "JQUANTS_BULK_API_KEY",
+        "label": "J-Quants Bulk Download API キー",
+        "secret": True,
+        "description": "  J-Quants ダッシュボード → 設定 → APIキー から取得",
+    },
+    {
         "key": "KABU_API_PASSWORD",
         "label": "kabuステーション API パスワード",
         "secret": True,
@@ -133,6 +139,7 @@ def _write_env(path: Path, values: dict[str, str]) -> None:
         "",
         "# --- J-Quants API ---",
         f"JQUANTS_REFRESH_TOKEN={values.get('JQUANTS_REFRESH_TOKEN', '')}",
+        f"JQUANTS_BULK_API_KEY={values.get('JQUANTS_BULK_API_KEY', '')}",
         "",
         "# --- kabuステーション API ---",
         f"KABU_API_PASSWORD={values.get('KABU_API_PASSWORD', '')}",

--- a/src/kabusys/data/bootstrap/__init__.py
+++ b/src/kabusys/data/bootstrap/__init__.py
@@ -1,0 +1,1 @@
+# src/kabusys/data/bootstrap/__init__.py

--- a/src/kabusys/data/bootstrap/__init__.py
+++ b/src/kabusys/data/bootstrap/__init__.py
@@ -1,1 +1,3 @@
-# src/kabusys/data/bootstrap/__init__.py
+from kabusys.data.bootstrap.runner import BootstrapResult, run_bootstrap
+
+__all__ = ["run_bootstrap", "BootstrapResult"]

--- a/src/kabusys/data/bootstrap/__main__.py
+++ b/src/kabusys/data/bootstrap/__main__.py
@@ -1,0 +1,4 @@
+import sys
+from kabusys.data.bootstrap.runner import main
+
+sys.exit(main())

--- a/src/kabusys/data/bootstrap/bulk_client.py
+++ b/src/kabusys/data/bootstrap/bulk_client.py
@@ -62,7 +62,9 @@ def get_presigned_url(file_key: str, api_key: str) -> str:
     try:
         return data["url"]
     except KeyError as exc:
-        raise BulkApiError(f"get_presigned_url: response missing 'url' key: {data}") from exc
+        raise BulkApiError(
+            f"get_presigned_url: response missing 'url' key: {data}"
+        ) from exc
 
 
 def download_file(presigned_url: str, dest: Path) -> Path:
@@ -76,8 +78,10 @@ def download_file(presigned_url: str, dest: Path) -> Path:
             return dest
         except (urllib.error.HTTPError, urllib.error.URLError) as exc:
             if attempt + 1 >= _MAX_RETRIES:
-                raise BulkApiError(f"download_file 失敗（{_MAX_RETRIES}回）: {exc}") from exc
-            wait = _RETRY_BACKOFF_BASE ** attempt
+                raise BulkApiError(
+                    f"download_file 失敗（{_MAX_RETRIES}回）: {exc}"
+                ) from exc
+            wait = _RETRY_BACKOFF_BASE**attempt
             logger.warning(
                 "ダウンロード失敗（%d/%d）: %s — %.0fs後にリトライ",
                 attempt + 1,

--- a/src/kabusys/data/bootstrap/bulk_client.py
+++ b/src/kabusys/data/bootstrap/bulk_client.py
@@ -1,0 +1,86 @@
+"""
+J-Quants Bulk Download API クライアント
+
+J-Quants Bulk Download API から以下の操作を提供する。
+  - list_files:          利用可能なファイル一覧を取得
+  - get_presigned_url:   ファイルキーから presigned URL を取得
+  - download_file:       presigned URL からローカルへダウンロード（リトライ付き）
+
+設計原則:
+  - 認証は `x-api-key` ヘッダー（V1 の Bearer token とは異なる）
+  - リトライロジック付き（指数バックオフ、最大 3 回）
+  - 標準ライブラリ（urllib.request）のみを使用し、外部依存を最小化
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://api.jquants.com/v2"
+_MAX_RETRIES = 3
+_RETRY_BACKOFF_BASE = 2.0
+
+
+class BulkApiError(RuntimeError):
+    """Bulk API 呼び出し失敗。"""
+
+
+def _bulk_get(path: str, api_key: str, caller: str = "") -> dict:
+    """GET /v2/bulk/<path> → JSON dict"""
+    url = _BASE_URL + path
+    req = urllib.request.Request(url, headers={"x-api-key": api_key})
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        prefix = f"{caller}: " if caller else ""
+        raise BulkApiError(f"{prefix}{path}: HTTP {exc.code} {exc.reason}") from exc
+    except Exception as exc:
+        prefix = f"{caller}: " if caller else ""
+        raise BulkApiError(f"{prefix}{path}: {exc}") from exc
+
+
+def list_files(endpoint: str, api_key: str) -> list[dict]:
+    """GET /v2/bulk/list?endpoint=<ep> → [{key, date, ...}, ...]"""
+    encoded = urllib.parse.quote(endpoint, safe="")
+    data = _bulk_get(f"/bulk/list?endpoint={encoded}", api_key, caller="list_files")
+    return data.get("files", [])
+
+
+def get_presigned_url(file_key: str, api_key: str) -> str:
+    """GET /v2/bulk/get?key=<key> → presigned URL（有効期限5分）"""
+    encoded = urllib.parse.quote(file_key, safe="")
+    data = _bulk_get(f"/bulk/get?key={encoded}", api_key, caller="get_presigned_url")
+    return data["url"]
+
+
+def download_file(presigned_url: str, dest: Path) -> Path:
+    """presigned URL → gzip CSV をローカルに保存。最大3回リトライ。"""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    for attempt in range(_MAX_RETRIES):
+        try:
+            with urllib.request.urlopen(presigned_url) as resp:
+                dest.write_bytes(resp.read())
+            logger.debug("ダウンロード完了: %s", dest)
+            return dest
+        except (urllib.error.HTTPError, urllib.error.URLError) as exc:
+            if attempt + 1 >= _MAX_RETRIES:
+                raise BulkApiError(f"download_file 失敗（{_MAX_RETRIES}回）: {exc}") from exc
+            wait = _RETRY_BACKOFF_BASE ** attempt
+            logger.warning(
+                "ダウンロード失敗（%d/%d）: %s — %.0fs後にリトライ",
+                attempt + 1,
+                _MAX_RETRIES,
+                exc,
+                wait,
+            )
+            time.sleep(wait)
+    raise BulkApiError("download_file: 到達不能コード")  # pragma: no cover

--- a/src/kabusys/data/bootstrap/bulk_client.py
+++ b/src/kabusys/data/bootstrap/bulk_client.py
@@ -59,7 +59,10 @@ def get_presigned_url(file_key: str, api_key: str) -> str:
     """GET /v2/bulk/get?key=<key> → presigned URL（有効期限5分）"""
     encoded = urllib.parse.quote(file_key, safe="")
     data = _bulk_get(f"/bulk/get?key={encoded}", api_key, caller="get_presigned_url")
-    return data["url"]
+    try:
+        return data["url"]
+    except KeyError as exc:
+        raise BulkApiError(f"get_presigned_url: response missing 'url' key: {data}") from exc
 
 
 def download_file(presigned_url: str, dest: Path) -> Path:

--- a/src/kabusys/data/bootstrap/loaders.py
+++ b/src/kabusys/data/bootstrap/loaders.py
@@ -332,6 +332,9 @@ def load_topix(conn: duckdb.DuckDBPyConnection, csv_path: Path) -> int:
         if None in (o, h, lo, c):
             logger.warning("load_topix: OHLC 欠損行をスキップ: %s", row)
             continue
+        if lo > h:  # type: ignore[operator]
+            logger.warning("load_topix: low > high の行をスキップ: %s", row)
+            continue
         buf.append((date, o, h, lo, c))
         if len(buf) >= _CHUNK:
             _flush()

--- a/src/kabusys/data/bootstrap/loaders.py
+++ b/src/kabusys/data/bootstrap/loaders.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+import csv
+import gzip
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import duckdb
+
+logger = logging.getLogger(__name__)
+
+_CHUNK = 10_000
+
+
+def _to_float(v: Any) -> float | None:
+    if v is None or str(v).strip() == "":
+        return None
+    try:
+        return float(v)
+    except (ValueError, TypeError):
+        return None
+
+
+def _to_int(v: Any) -> int | None:
+    if v is None or str(v).strip() == "":
+        return None
+    try:
+        return int(float(v))
+    except (ValueError, TypeError):
+        return None
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iter_gz(csv_path: Path):
+    """gzip CSV を行ごとに dict で yield する。"""
+    with gzip.open(csv_path, "rt", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            yield row
+
+
+def load_prices(conn: duckdb.DuckDBPyConnection, csv_path: Path) -> int:
+    """equities/bars/daily CSV → raw_prices & prices_daily
+
+    Bulk CSV カラム: Date, Code, O, H, L, C, Vo, Va, AdjFactor
+    （UL, LL, AdjO/H/L/C/Vo は保存しない）
+    """
+    loaded = 0
+    buf_raw: list[tuple] = []
+    buf_proc: list[tuple] = []
+    fetched_at = _now()
+
+    def _flush():
+        nonlocal loaded
+        if buf_raw:
+            conn.executemany(
+                "INSERT INTO raw_prices (date, code, open, high, low, close, volume, turnover, adj_factor, fetched_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT (date, code) DO UPDATE SET "
+                "open=EXCLUDED.open, high=EXCLUDED.high, low=EXCLUDED.low, close=EXCLUDED.close, "
+                "volume=EXCLUDED.volume, turnover=EXCLUDED.turnover, adj_factor=EXCLUDED.adj_factor, "
+                "fetched_at=EXCLUDED.fetched_at",
+                buf_raw,
+            )
+        if buf_proc:
+            conn.executemany(
+                "INSERT INTO prices_daily (date, code, open, high, low, close, volume, turnover) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT (date, code) DO UPDATE SET "
+                "open=EXCLUDED.open, high=EXCLUDED.high, low=EXCLUDED.low, close=EXCLUDED.close, "
+                "volume=EXCLUDED.volume, turnover=EXCLUDED.turnover",
+                buf_proc,
+            )
+        loaded += len(buf_proc)
+        buf_raw.clear()
+        buf_proc.clear()
+
+    for row in _iter_gz(csv_path):
+        date = row.get("Date", "").strip()
+        code = row.get("Code", "").strip()
+        if not date or not code:
+            logger.warning("load_prices: PK 欠損行をスキップ: %s", row)
+            continue
+
+        o = _to_float(row.get("O"))
+        h = _to_float(row.get("H"))
+        lo = _to_float(row.get("L"))
+        c = _to_float(row.get("C"))
+        vol = _to_int(row.get("Vo"))
+        va = _to_float(row.get("Va"))
+        adj = _to_float(row.get("AdjFactor"))
+
+        buf_raw.append((date, code, o, h, lo, c, vol, va, adj, fetched_at))
+
+        # prices_daily: NOT NULL OHLCV 必須 / low <= high
+        if None in (o, h, lo, c, vol):
+            continue
+        if lo > h:  # type: ignore[operator]
+            continue
+        buf_proc.append((date, code, o, h, lo, c, vol, va))
+
+        if len(buf_raw) >= _CHUNK:
+            _flush()
+
+    _flush()
+    logger.info("load_prices: %d 件ロード (%s)", loaded, csv_path.name)
+    return loaded
+
+
+def load_master(conn: duckdb.DuckDBPyConnection, csv_path: Path) -> int:
+    """equities/master CSV → stocks
+
+    Bulk CSV カラム: Code, CoName, MktNm, S33Nm
+    """
+    loaded = 0
+    buf: list[tuple] = []
+
+    def _flush():
+        nonlocal loaded
+        if buf:
+            conn.executemany(
+                "INSERT INTO stocks (code, name, market, sector, updated_at) "
+                "VALUES (?, ?, ?, ?, ?) "
+                "ON CONFLICT (code) DO UPDATE SET "
+                "name=EXCLUDED.name, market=EXCLUDED.market, sector=EXCLUDED.sector, "
+                "updated_at=EXCLUDED.updated_at",
+                buf,
+            )
+            loaded += len(buf)
+            buf.clear()
+
+    now = _now()
+    for row in _iter_gz(csv_path):
+        code = row.get("Code", "").strip()
+        if not code:
+            logger.warning("load_master: code 欠損行をスキップ: %s", row)
+            continue
+        buf.append((code, row.get("CoName"), row.get("MktNm"), row.get("S33Nm"), now))
+        if len(buf) >= _CHUNK:
+            _flush()
+
+    _flush()
+    logger.info("load_master: %d 件ロード (%s)", loaded, csv_path.name)
+    return loaded
+
+
+def load_financials(conn: duckdb.DuckDBPyConnection, csv_path: Path) -> int:
+    """fins/summary CSV → raw_financials & fundamentals
+
+    Bulk CSV カラム: Code, DiscDate, CurPerType, Sales, OP, NP, EPS, ROE
+    """
+    loaded = 0
+    buf_raw: list[tuple] = []
+    buf_proc: list[tuple] = []
+    fetched_at = _now()
+
+    def _flush():
+        nonlocal loaded
+        if buf_raw:
+            conn.executemany(
+                "INSERT INTO raw_financials (code, report_date, period_type, revenue, "
+                "operating_profit, net_income, eps, roe, fetched_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT (code, report_date, period_type) DO UPDATE SET "
+                "revenue=EXCLUDED.revenue, operating_profit=EXCLUDED.operating_profit, "
+                "net_income=EXCLUDED.net_income, eps=EXCLUDED.eps, roe=EXCLUDED.roe, "
+                "fetched_at=EXCLUDED.fetched_at",
+                buf_raw,
+            )
+        if buf_proc:
+            conn.executemany(
+                "INSERT INTO fundamentals (code, report_date, period_type, revenue, "
+                "operating_profit, net_income, eps, roe) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT (code, report_date, period_type) DO UPDATE SET "
+                "revenue=EXCLUDED.revenue, operating_profit=EXCLUDED.operating_profit, "
+                "net_income=EXCLUDED.net_income, eps=EXCLUDED.eps, roe=EXCLUDED.roe",
+                buf_proc,
+            )
+        loaded += len(buf_proc)
+        buf_raw.clear()
+        buf_proc.clear()
+
+    for row in _iter_gz(csv_path):
+        code = row.get("Code", "").strip()
+        report_date = row.get("DiscDate", "").strip()
+        period_type = row.get("CurPerType", "").strip()
+        if not code or not report_date or not period_type:
+            logger.warning("load_financials: PK 欠損行をスキップ: %s", row)
+            continue
+
+        revenue = _to_float(row.get("Sales"))
+        op = _to_float(row.get("OP"))
+        np_ = _to_float(row.get("NP"))
+        eps = _to_float(row.get("EPS"))
+        roe = _to_float(row.get("ROE"))
+
+        buf_raw.append((code, report_date, period_type, revenue, op, np_, eps, roe, fetched_at))
+        buf_proc.append((code, report_date, period_type, revenue, op, np_, eps, roe))
+
+        if len(buf_raw) >= _CHUNK:
+            _flush()
+
+    _flush()
+    logger.info("load_financials: %d 件ロード (%s)", loaded, csv_path.name)
+    return loaded
+
+
+def load_calendar(conn: duckdb.DuckDBPyConnection, csv_path: Path) -> int:
+    """markets/calendar CSV → market_calendar
+
+    Bulk CSV カラム: Date, HolDiv, HalfDiv, SQDiv, HolName
+    HolDiv="1" → is_trading_day=False（休日）
+    """
+    loaded = 0
+    buf: list[tuple] = []
+
+    def _flush():
+        nonlocal loaded
+        if buf:
+            conn.executemany(
+                "INSERT INTO market_calendar (date, is_trading_day, is_half_day, is_sq_day, holiday_name) "
+                "VALUES (?, ?, ?, ?, ?) "
+                "ON CONFLICT (date) DO UPDATE SET "
+                "is_trading_day=EXCLUDED.is_trading_day, is_half_day=EXCLUDED.is_half_day, "
+                "is_sq_day=EXCLUDED.is_sq_day, holiday_name=EXCLUDED.holiday_name",
+                buf,
+            )
+            loaded += len(buf)
+            buf.clear()
+
+    for row in _iter_gz(csv_path):
+        date = row.get("Date", "").strip()
+        if not date:
+            logger.warning("load_calendar: date 欠損行をスキップ: %s", row)
+            continue
+        is_trading = row.get("HolDiv", "0").strip() != "1"
+        is_half = row.get("HalfDiv", "0").strip() == "1"
+        is_sq = row.get("SQDiv", "0").strip() == "1"
+        holiday_name = row.get("HolName", "").strip() or None
+        buf.append((date, is_trading, is_half, is_sq, holiday_name))
+        if len(buf) >= _CHUNK:
+            _flush()
+
+    _flush()
+    logger.info("load_calendar: %d 件ロード (%s)", loaded, csv_path.name)
+    return loaded
+
+
+def load_dividend(conn: duckdb.DuckDBPyConnection, csv_path: Path) -> int:
+    """fins/dividend CSV → dividends
+
+    Bulk CSV カラム: Code, PubDate, RefNo, ExDate, RecDate, PayDate, DivRate
+    """
+    loaded = 0
+    buf: list[tuple] = []
+    fetched_at = _now()
+
+    def _flush():
+        nonlocal loaded
+        if buf:
+            conn.executemany(
+                "INSERT INTO dividends (code, pub_date, ref_no, ex_date, record_date, pay_date, div_rate, fetched_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT (code, pub_date, ref_no) DO UPDATE SET "
+                "ex_date=EXCLUDED.ex_date, record_date=EXCLUDED.record_date, "
+                "pay_date=EXCLUDED.pay_date, div_rate=EXCLUDED.div_rate, fetched_at=EXCLUDED.fetched_at",
+                buf,
+            )
+            loaded += len(buf)
+            buf.clear()
+
+    for row in _iter_gz(csv_path):
+        code = row.get("Code", "").strip()
+        pub_date = row.get("PubDate", "").strip()
+        ref_no = row.get("RefNo", "").strip()
+        if not code or not pub_date or not ref_no:
+            logger.warning("load_dividend: PK 欠損行をスキップ: %s", row)
+            continue
+        ex_date = row.get("ExDate", "").strip() or None
+        rec_date = row.get("RecDate", "").strip() or None
+        pay_date = row.get("PayDate", "").strip() or None
+        div_rate = _to_float(row.get("DivRate"))
+        buf.append((code, pub_date, ref_no, ex_date, rec_date, pay_date, div_rate, fetched_at))
+        if len(buf) >= _CHUNK:
+            _flush()
+
+    _flush()
+    logger.info("load_dividend: %d 件ロード (%s)", loaded, csv_path.name)
+    return loaded
+
+
+def load_topix(conn: duckdb.DuckDBPyConnection, csv_path: Path) -> int:
+    """indices/bars/daily/topix CSV → topix_daily
+
+    Bulk CSV カラム: Date, O, H, L, C
+    """
+    loaded = 0
+    buf: list[tuple] = []
+
+    def _flush():
+        nonlocal loaded
+        if buf:
+            conn.executemany(
+                "INSERT INTO topix_daily (date, open, high, low, close) "
+                "VALUES (?, ?, ?, ?, ?) "
+                "ON CONFLICT (date) DO UPDATE SET "
+                "open=EXCLUDED.open, high=EXCLUDED.high, low=EXCLUDED.low, close=EXCLUDED.close",
+                buf,
+            )
+            loaded += len(buf)
+            buf.clear()
+
+    for row in _iter_gz(csv_path):
+        date = row.get("Date", "").strip()
+        if not date:
+            logger.warning("load_topix: date 欠損行をスキップ: %s", row)
+            continue
+        o = _to_float(row.get("O"))
+        h = _to_float(row.get("H"))
+        lo = _to_float(row.get("L"))
+        c = _to_float(row.get("C"))
+        if None in (o, h, lo, c):
+            logger.warning("load_topix: OHLC 欠損行をスキップ: %s", row)
+            continue
+        buf.append((date, o, h, lo, c))
+        if len(buf) >= _CHUNK:
+            _flush()
+
+    _flush()
+    logger.info("load_topix: %d 件ロード (%s)", loaded, csv_path.name)
+    return loaded

--- a/src/kabusys/data/bootstrap/loaders.py
+++ b/src/kabusys/data/bootstrap/loaders.py
@@ -98,12 +98,12 @@ def load_prices(conn: duckdb.DuckDBPyConnection, csv_path: Path) -> int:
         buf_raw.append((date, code, o, h, lo, c, vol, va, adj, fetched_at))
 
         # prices_daily: NOT NULL OHLCV 必須 / low <= high
-        if None in (o, h, lo, c, vol):
+        if None in (o, h, lo, c, vol) or lo > h:  # type: ignore[operator]
+            if len(buf_raw) >= _CHUNK:
+                _flush()
             continue
-        if lo > h:  # type: ignore[operator]
-            continue
-        buf_proc.append((date, code, o, h, lo, c, vol, va))
 
+        buf_proc.append((date, code, o, h, lo, c, vol, va))
         if len(buf_raw) >= _CHUNK:
             _flush()
 

--- a/src/kabusys/data/bootstrap/loaders.py
+++ b/src/kabusys/data/bootstrap/loaders.py
@@ -200,7 +200,9 @@ def load_financials(conn: duckdb.DuckDBPyConnection, csv_path: Path) -> int:
         eps = _to_float(row.get("EPS"))
         roe = _to_float(row.get("ROE"))
 
-        buf_raw.append((code, report_date, period_type, revenue, op, np_, eps, roe, fetched_at))
+        buf_raw.append(
+            (code, report_date, period_type, revenue, op, np_, eps, roe, fetched_at)
+        )
         buf_proc.append((code, report_date, period_type, revenue, op, np_, eps, roe))
 
         if len(buf_raw) >= _CHUNK:
@@ -286,7 +288,9 @@ def load_dividend(conn: duckdb.DuckDBPyConnection, csv_path: Path) -> int:
         rec_date = row.get("RecDate", "").strip() or None
         pay_date = row.get("PayDate", "").strip() or None
         div_rate = _to_float(row.get("DivRate"))
-        buf.append((code, pub_date, ref_no, ex_date, rec_date, pay_date, div_rate, fetched_at))
+        buf.append(
+            (code, pub_date, ref_no, ex_date, rec_date, pay_date, div_rate, fetched_at)
+        )
         if len(buf) >= _CHUNK:
             _flush()
 

--- a/src/kabusys/data/bootstrap/runner.py
+++ b/src/kabusys/data/bootstrap/runner.py
@@ -1,0 +1,195 @@
+"""Bootstrap runner: orchestrates J-Quants Bulk API download and ingestion."""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+import duckdb
+
+from kabusys.data.bootstrap.bulk_client import (
+    BulkApiError,
+    download_file,
+    get_presigned_url,
+    list_files,
+)
+from kabusys.data.bootstrap.loaders import (
+    load_calendar,
+    load_dividend,
+    load_financials,
+    load_master,
+    load_prices,
+    load_topix,
+)
+
+logger = logging.getLogger(__name__)
+
+ENDPOINTS = [
+    "/equities/bars/daily",
+    "/equities/master",
+    "/fins/summary",
+    "/markets/calendar",
+    "/fins/dividend",
+    "/indices/bars/daily/topix",
+]
+
+_LOADER_MAP = {
+    "/equities/bars/daily": load_prices,
+    "/equities/master": load_master,
+    "/fins/summary": load_financials,
+    "/markets/calendar": load_calendar,
+    "/fins/dividend": load_dividend,
+    "/indices/bars/daily/topix": load_topix,
+}
+
+
+@dataclass
+class BootstrapResult:
+    total_files: int = 0
+    loaded_files: int = 0
+    skipped_files: int = 0
+    failed_files: int = 0
+    rows_by_endpoint: dict[str, int] = field(default_factory=dict)
+
+
+def _endpoint_to_dir(endpoint: str, raw_dir: Path) -> Path:
+    """'/equities/bars/daily' → raw_dir/equities/bars/daily/"""
+    return raw_dir / endpoint.lstrip("/")
+
+
+def _loaded_keys(conn: duckdb.DuckDBPyConnection) -> set[str]:
+    rows = conn.execute(
+        "SELECT file_key FROM bootstrap_load_history WHERE status = 'loaded'"
+    ).fetchall()
+    return {r[0] for r in rows}
+
+
+def _record(
+    conn: duckdb.DuckDBPyConnection,
+    file_key: str,
+    endpoint: str,
+    file_name: str,
+    status: str,
+    row_count: int | None = None,
+    error_msg: str | None = None,
+) -> None:
+    conn.execute(
+        "INSERT INTO bootstrap_load_history "
+        "(file_key, endpoint, file_name, status, row_count, error_msg, loaded_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?) "
+        "ON CONFLICT (file_key) DO UPDATE SET "
+        "status=EXCLUDED.status, row_count=EXCLUDED.row_count, "
+        "error_msg=EXCLUDED.error_msg, loaded_at=EXCLUDED.loaded_at",
+        [file_key, endpoint, file_name, status, row_count, error_msg, datetime.now(timezone.utc)],
+    )
+
+
+def run_bootstrap(
+    conn: duckdb.DuckDBPyConnection,
+    api_key: str,
+    raw_dir: Path = Path("data/bootstrap/raw"),
+    dry_run: bool = False,
+    endpoints: list[str] | None = None,
+) -> BootstrapResult:
+    """全エンドポイントを順次処理する。1ファイル失敗でも継続。"""
+    target_endpoints = endpoints if endpoints is not None else ENDPOINTS
+    result = BootstrapResult()
+    loaded_keys = _loaded_keys(conn)
+
+    for endpoint in target_endpoints:
+        loader = _LOADER_MAP[endpoint]
+        ep_dir = _endpoint_to_dir(endpoint, raw_dir)
+        rows_ep = 0
+
+        try:
+            files = list_files(endpoint, api_key)
+        except BulkApiError as exc:
+            logger.error("list_files 失敗 (%s): %s", endpoint, exc)
+            continue
+
+        logger.info("%s: %d ファイル検出", endpoint, len(files))
+
+        for f in files:
+            file_key = f.get("key", "")
+            file_name = file_key.split("/")[-1] if "/" in file_key else file_key
+            result.total_files += 1
+
+            if file_key in loaded_keys:
+                logger.debug("スキップ（ロード済み）: %s", file_key)
+                result.skipped_files += 1
+                continue
+
+            if dry_run:
+                continue
+
+            dest = ep_dir / file_name
+            if not dest.exists():
+                try:
+                    presigned = get_presigned_url(file_key, api_key)
+                    download_file(presigned, dest)
+                except Exception as exc:
+                    logger.error("ダウンロード失敗 (%s): %s", file_key, exc)
+                    _record(conn, file_key, endpoint, file_name, "failed", error_msg=str(exc))
+                    result.failed_files += 1
+                    continue
+
+            try:
+                n = loader(conn, dest)
+                rows_ep += n
+                _record(conn, file_key, endpoint, file_name, "loaded", row_count=n)
+                result.loaded_files += 1
+            except Exception as exc:
+                logger.error("ロード失敗 (%s): %s", file_key, exc)
+                _record(conn, file_key, endpoint, file_name, "failed", error_msg=str(exc))
+                result.failed_files += 1
+
+        result.rows_by_endpoint[endpoint] = rows_ep
+
+    return result
+
+
+def _print_summary(result: BootstrapResult, endpoints: list[str]) -> None:
+    print("\nBootstrap 完了サマリー")
+    for ep in endpoints:
+        rows = result.rows_by_endpoint.get(ep, 0)
+        print(f"  {ep:<40}: {rows:>10,} 件")
+    print(f"  ロード済み: {result.loaded_files} ファイル")
+    print(f"  スキップ  : {result.skipped_files} ファイル")
+    print(f"  失敗      : {result.failed_files} ファイル")
+
+
+def main(argv: list[str] | None = None) -> int:
+    from kabusys.config import Settings
+    from kabusys.data.schema import init_schema
+
+    parser = argparse.ArgumentParser(description="J-Quants Bootstrap — 初回一括データ投入")
+    parser.add_argument("--dry-run", action="store_true", help="ダウンロードせず件数確認のみ")
+    parser.add_argument("--endpoint", metavar="EP", help="特定エンドポイントのみ処理")
+    parser.add_argument("--raw-dir", default="data/bootstrap/raw", help="ローカルキャッシュディレクトリ")
+    args = parser.parse_args(argv)
+
+    settings = Settings()
+    api_key = settings.jquants_bulk_api_key
+    raw_dir = Path(args.raw_dir)
+    endpoints = [args.endpoint] if args.endpoint else ENDPOINTS
+
+    conn = init_schema(settings.duckdb_path)
+    try:
+        result = run_bootstrap(
+            conn=conn,
+            api_key=api_key,
+            raw_dir=raw_dir,
+            dry_run=args.dry_run,
+            endpoints=endpoints,
+        )
+        _print_summary(result, endpoints)
+        return 1 if result.failed_files else 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kabusys/data/bootstrap/runner.py
+++ b/src/kabusys/data/bootstrap/runner.py
@@ -100,7 +100,10 @@ def run_bootstrap(
     loaded_keys = _loaded_keys(conn)
 
     for endpoint in target_endpoints:
-        loader = _LOADER_MAP[endpoint]
+        loader = _LOADER_MAP.get(endpoint)
+        if loader is None:
+            logger.warning("未知のエンドポイントをスキップ: %s", endpoint)
+            continue
         ep_dir = _endpoint_to_dir(endpoint, raw_dir)
         rows_ep = 0
 
@@ -114,6 +117,9 @@ def run_bootstrap(
 
         for f in files:
             file_key = f.get("key", "")
+            if not file_key:
+                logger.warning("file_key が空のエントリをスキップ: %s", f)
+                continue
             file_name = file_key.split("/")[-1] if "/" in file_key else file_key
             result.total_files += 1
 

--- a/src/kabusys/data/bootstrap/runner.py
+++ b/src/kabusys/data/bootstrap/runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
+import urllib.error
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -59,6 +60,21 @@ class BootstrapResult:
 def _endpoint_to_dir(endpoint: str, raw_dir: Path) -> Path:
     """'/equities/bars/daily' → raw_dir/equities/bars/daily/"""
     return raw_dir / endpoint.lstrip("/")
+
+
+def _safe_errmsg(exc: Exception) -> str:
+    """presigned URL がログ/DBに漏れないよう HTTPError は status+reason のみ返す。"""
+    if isinstance(exc, urllib.error.HTTPError):
+        return f"HTTP {exc.code} {exc.reason}"
+    return type(exc).__name__
+
+
+def _safe_filename(file_key: str) -> str | None:
+    """file_key の末尾セグメントを検証してファイル名として返す。'.'/'..' は拒否。"""
+    name = file_key.split("/")[-1] if "/" in file_key else file_key
+    if not name or name in (".", ".."):
+        return None
+    return name
 
 
 def _loaded_keys(conn: duckdb.DuckDBPyConnection) -> set[str]:
@@ -129,7 +145,10 @@ def run_bootstrap(
             if not file_key:
                 logger.warning("file_key が空のエントリをスキップ: %s", f)
                 continue
-            file_name = file_key.split("/")[-1] if "/" in file_key else file_key
+            file_name = _safe_filename(file_key)
+            if file_name is None:
+                logger.warning("不正な file_key をスキップ: %s", file_key)
+                continue
             result.total_files += 1
 
             if file_key in loaded_keys:
@@ -153,7 +172,7 @@ def run_bootstrap(
                         endpoint,
                         file_name,
                         "failed",
-                        error_msg=str(exc),
+                        error_msg=_safe_errmsg(exc),
                     )
                     result.failed_files += 1
                     continue
@@ -166,7 +185,12 @@ def run_bootstrap(
             except Exception as exc:
                 logger.error("ロード失敗 (%s): %s", file_key, exc)
                 _record(
-                    conn, file_key, endpoint, file_name, "failed", error_msg=str(exc)
+                    conn,
+                    file_key,
+                    endpoint,
+                    file_name,
+                    "failed",
+                    error_msg=_safe_errmsg(exc),
                 )
                 result.failed_files += 1
 

--- a/src/kabusys/data/bootstrap/runner.py
+++ b/src/kabusys/data/bootstrap/runner.py
@@ -65,14 +65,18 @@ def _endpoint_to_dir(endpoint: str, raw_dir: Path) -> Path:
 def _safe_errmsg(exc: Exception) -> str:
     """presigned URL がログ/DBに漏れないよう URLを含む可能性のある例外を整形する。
 
+    __cause__ チェーンを辿って urllib 例外を探し、見つかればその安全なメッセージを返す。
     - HTTPError: status + reason のみ（URL を除外）
     - URLError: reason のみ（OS レベルのエラー詳細）
     - その他: str(exc) をそのまま使用（自前コードの例外は URL を含まない）
     """
-    if isinstance(exc, urllib.error.HTTPError):
-        return f"HTTP {exc.code} {exc.reason}"
-    if isinstance(exc, urllib.error.URLError):
-        return f"URLError: {exc.reason}"
+    cause: BaseException | None = exc
+    while cause is not None:
+        if isinstance(cause, urllib.error.HTTPError):
+            return f"HTTP {cause.code} {cause.reason}"
+        if isinstance(cause, urllib.error.URLError):
+            return f"URLError: {cause.reason}"
+        cause = cause.__cause__ or cause.__context__
     return str(exc)
 
 

--- a/src/kabusys/data/bootstrap/runner.py
+++ b/src/kabusys/data/bootstrap/runner.py
@@ -63,10 +63,17 @@ def _endpoint_to_dir(endpoint: str, raw_dir: Path) -> Path:
 
 
 def _safe_errmsg(exc: Exception) -> str:
-    """presigned URL がログ/DBに漏れないよう HTTPError は status+reason のみ返す。"""
+    """presigned URL がログ/DBに漏れないよう URLを含む可能性のある例外を整形する。
+
+    - HTTPError: status + reason のみ（URL を除外）
+    - URLError: reason のみ（OS レベルのエラー詳細）
+    - その他: str(exc) をそのまま使用（自前コードの例外は URL を含まない）
+    """
     if isinstance(exc, urllib.error.HTTPError):
         return f"HTTP {exc.code} {exc.reason}"
-    return type(exc).__name__
+    if isinstance(exc, urllib.error.URLError):
+        return f"URLError: {exc.reason}"
+    return str(exc)
 
 
 def _safe_filename(file_key: str) -> str | None:

--- a/src/kabusys/data/bootstrap/runner.py
+++ b/src/kabusys/data/bootstrap/runner.py
@@ -1,4 +1,5 @@
 """Bootstrap runner: orchestrates J-Quants Bulk API download and ingestion."""
+
 from __future__ import annotations
 
 import argparse
@@ -83,7 +84,15 @@ def _record(
         "ON CONFLICT (file_key) DO UPDATE SET "
         "status=EXCLUDED.status, row_count=EXCLUDED.row_count, "
         "error_msg=EXCLUDED.error_msg, loaded_at=EXCLUDED.loaded_at",
-        [file_key, endpoint, file_name, status, row_count, error_msg, datetime.now(timezone.utc)],
+        [
+            file_key,
+            endpoint,
+            file_name,
+            status,
+            row_count,
+            error_msg,
+            datetime.now(timezone.utc),
+        ],
     )
 
 
@@ -138,7 +147,14 @@ def run_bootstrap(
                     download_file(presigned, dest)
                 except Exception as exc:
                     logger.error("ダウンロード失敗 (%s): %s", file_key, exc)
-                    _record(conn, file_key, endpoint, file_name, "failed", error_msg=str(exc))
+                    _record(
+                        conn,
+                        file_key,
+                        endpoint,
+                        file_name,
+                        "failed",
+                        error_msg=str(exc),
+                    )
                     result.failed_files += 1
                     continue
 
@@ -149,7 +165,9 @@ def run_bootstrap(
                 result.loaded_files += 1
             except Exception as exc:
                 logger.error("ロード失敗 (%s): %s", file_key, exc)
-                _record(conn, file_key, endpoint, file_name, "failed", error_msg=str(exc))
+                _record(
+                    conn, file_key, endpoint, file_name, "failed", error_msg=str(exc)
+                )
                 result.failed_files += 1
 
         result.rows_by_endpoint[endpoint] = rows_ep
@@ -171,10 +189,16 @@ def main(argv: list[str] | None = None) -> int:
     from kabusys.config import Settings
     from kabusys.data.schema import init_schema
 
-    parser = argparse.ArgumentParser(description="J-Quants Bootstrap: 初回一括データ投入")
-    parser.add_argument("--dry-run", action="store_true", help="ダウンロードせず件数確認のみ")
+    parser = argparse.ArgumentParser(
+        description="J-Quants Bootstrap: 初回一括データ投入"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="ダウンロードせず件数確認のみ"
+    )
     parser.add_argument("--endpoint", metavar="EP", help="特定エンドポイントのみ処理")
-    parser.add_argument("--raw-dir", default="data/bootstrap/raw", help="ローカルキャッシュディレクトリ")
+    parser.add_argument(
+        "--raw-dir", default="data/bootstrap/raw", help="ローカルキャッシュディレクトリ"
+    )
     args = parser.parse_args(argv)
 
     settings = Settings()

--- a/src/kabusys/data/bootstrap/runner.py
+++ b/src/kabusys/data/bootstrap/runner.py
@@ -171,7 +171,7 @@ def main(argv: list[str] | None = None) -> int:
     from kabusys.config import Settings
     from kabusys.data.schema import init_schema
 
-    parser = argparse.ArgumentParser(description="J-Quants Bootstrap — 初回一括データ投入")
+    parser = argparse.ArgumentParser(description="J-Quants Bootstrap: 初回一括データ投入")
     parser.add_argument("--dry-run", action="store_true", help="ダウンロードせず件数確認のみ")
     parser.add_argument("--endpoint", metavar="EP", help="特定エンドポイントのみ処理")
     parser.add_argument("--raw-dir", default="data/bootstrap/raw", help="ローカルキャッシュディレクトリ")

--- a/src/kabusys/data/bootstrap/runner.py
+++ b/src/kabusys/data/bootstrap/runner.py
@@ -8,7 +8,7 @@ import sys
 import urllib.error
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import duckdb
 
@@ -77,8 +77,11 @@ def _safe_errmsg(exc: Exception) -> str:
 
 
 def _safe_filename(file_key: str) -> str | None:
-    """file_key の末尾セグメントを検証してファイル名として返す。'.'/'..' は拒否。"""
-    name = file_key.split("/")[-1] if "/" in file_key else file_key
+    """file_key の末尾セグメントを検証してファイル名として返す。'.'/'..' は拒否。
+
+    S3キーは常に '/' 区切りなので PurePosixPath で正規化する。
+    """
+    name = PurePosixPath(file_key).name
     if not name or name in (".", ".."):
         return None
     return name

--- a/src/kabusys/data/schema.py
+++ b/src/kabusys/data/schema.py
@@ -34,6 +34,7 @@ CREATE TABLE IF NOT EXISTS raw_prices (
     close       DECIMAL(18,4) CHECK (close >= 0),
     volume      BIGINT        CHECK (volume >= 0),
     turnover    DECIMAL(18,2) CHECK (turnover >= 0),
+    adj_factor  DECIMAL(18,6),
     fetched_at  TIMESTAMP   NOT NULL DEFAULT current_timestamp,
     PRIMARY KEY (date, code)
 )
@@ -319,6 +320,44 @@ CREATE TABLE IF NOT EXISTS portfolio_performance (
 )
 """
 
+# ---- Bootstrap Layer -------------------------------------------------------
+
+_DIVIDENDS = """
+CREATE TABLE IF NOT EXISTS dividends (
+    code         VARCHAR       NOT NULL,
+    pub_date     DATE          NOT NULL,
+    ref_no       VARCHAR       NOT NULL,
+    ex_date      DATE,
+    record_date  DATE,
+    pay_date     DATE,
+    div_rate     DECIMAL(18,4),
+    fetched_at   TIMESTAMP     NOT NULL DEFAULT current_timestamp,
+    PRIMARY KEY (code, pub_date, ref_no)
+)
+"""
+
+_TOPIX_DAILY = """
+CREATE TABLE IF NOT EXISTS topix_daily (
+    date   DATE          NOT NULL PRIMARY KEY,
+    open   DECIMAL(18,4) NOT NULL,
+    high   DECIMAL(18,4) NOT NULL,
+    low    DECIMAL(18,4) NOT NULL,
+    close  DECIMAL(18,4) NOT NULL
+)
+"""
+
+_BOOTSTRAP_LOAD_HISTORY = """
+CREATE TABLE IF NOT EXISTS bootstrap_load_history (
+    file_key   VARCHAR   NOT NULL PRIMARY KEY,
+    endpoint   VARCHAR   NOT NULL,
+    file_name  VARCHAR   NOT NULL,
+    status     VARCHAR   NOT NULL DEFAULT 'pending',
+    row_count  BIGINT,
+    error_msg  VARCHAR,
+    loaded_at  TIMESTAMP
+)
+"""
+
 # ---------------------------------------------------------------------------
 # インデックス定義（頻出クエリパターン: 銘柄×日付範囲スキャン、ステータス検索）
 # ---------------------------------------------------------------------------
@@ -345,6 +384,8 @@ _INDEXES: list[str] = [
 _MIGRATIONS: list[str] = [
     # v0.x → v0.y: signals に size_multiplier を追加
     "ALTER TABLE signals ADD COLUMN size_multiplier DOUBLE NOT NULL DEFAULT 1.0",
+    # v0.x → v0.y: raw_prices に adj_factor を追加
+    "ALTER TABLE raw_prices ADD COLUMN adj_factor DECIMAL(18,6)",
 ]
 
 # ---------------------------------------------------------------------------
@@ -380,6 +421,10 @@ _ALL_DDL: list[str] = [
     _POSITION_ENTRIES,
     _EARNINGS_CALENDAR,
     _PORTFOLIO_PERFORMANCE,
+    # Bootstrap
+    _DIVIDENDS,
+    _TOPIX_DAILY,
+    _BOOTSTRAP_LOAD_HISTORY,
 ]
 
 

--- a/src/kabusys/execution/broker_factory.py
+++ b/src/kabusys/execution/broker_factory.py
@@ -26,9 +26,11 @@ class BrokerClientFactory:
         if settings.is_paper or settings.is_dev:
             return create_broker_api(mock=True, fill_mode=settings.paper_fill_mode)
         if settings.is_live:
-            raise NotImplementedError(
-                "Live broker client (KabuStationClient) は未実装です。"
-                "KABUSYS_ENV=paper_trading または development を使用してください。"
+            return create_broker_api(
+                mock=False,
+                api_password=settings.kabu_api_password,
+                trade_password=settings.kabu_trade_password,
+                base_url=settings.kabu_api_base_url,
             )
         env = settings.env  # 明示評価（未知の env ならここで ValueError）
         raise ValueError(f"未知の KABUSYS_ENV: {env!r}")

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -36,6 +36,13 @@ logger = logging.getLogger(__name__)
 
 
 def _load_risk_config(path: Path, initial_portfolio_value: float) -> RiskConfig:
+    if not path.exists():
+        logger.error(
+            "リスク設定ファイルが見つかりません: %s"
+            " → config/risk_config.yaml を作成してください（python -m kabusys.config_setup を参照）",
+            path,
+        )
+        raise FileNotFoundError(f"リスク設定ファイルが見つかりません: {path}")
     try:
         with path.open(encoding="utf-8") as f:
             data = yaml.safe_load(f)

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -45,13 +45,17 @@ def _load_risk_config(path: Path, initial_portfolio_value: float) -> RiskConfig:
     try:
         r = data["risk"]
     except (TypeError, KeyError) as exc:
-        raise KeyError(f"risk_config.yaml にトップレベルキー 'risk' がありません: {path}") from exc
+        raise KeyError(
+            f"risk_config.yaml にトップレベルキー 'risk' がありません: {path}"
+        ) from exc
 
     def _get(key: str) -> object:
         try:
             return r[key]
         except KeyError as exc:
-            raise KeyError(f"risk_config.yaml に 'risk.{key}' がありません: {path}") from exc
+            raise KeyError(
+                f"risk_config.yaml に 'risk.{key}' がありません: {path}"
+            ) from exc
 
     max_position_pct = float(_get("max_position_pct"))
     max_utilization = float(_get("max_utilization"))
@@ -66,7 +70,9 @@ def _load_risk_config(path: Path, initial_portfolio_value: float) -> RiskConfig:
         ("max_drawdown", max_drawdown),
     ):
         if not (0 < val <= 1):
-            raise ValueError(f"risk_config.yaml: {name} は (0, 1] の範囲で設定してください（現在値: {val}）: {path}")
+            raise ValueError(
+                f"risk_config.yaml: {name} は (0, 1] の範囲で設定してください（現在値: {val}）: {path}"
+            )
     if max_position_pct > max_utilization:
         raise ValueError(
             f"risk_config.yaml: max_position_pct({max_position_pct}) は"
@@ -136,7 +142,12 @@ def main() -> None:
         cash = broker.get_available_cash()
         positions = broker.get_positions()
         total_assets = cash + sum(_pos_value(p) for p in positions)
-        logger.info("起動時総資産: %.0f 円（現金 %.0f 円 + ポジション %d 件）", total_assets, cash, len(positions))
+        logger.info(
+            "起動時総資産: %.0f 円（現金 %.0f 円 + ポジション %d 件）",
+            total_assets,
+            cash,
+            len(positions),
+        )
 
         # 5. 依存コンポーネント組み立て
         repo = OrderRepository(sqlite_conn)
@@ -144,7 +155,9 @@ def main() -> None:
         risk_manager = RiskManager(
             broker=broker,
             repo=repo,
-            config=_load_risk_config(_RISK_CONFIG, initial_portfolio_value=total_assets),
+            config=_load_risk_config(
+                _RISK_CONFIG, initial_portfolio_value=total_assets
+            ),
         )
         reconciler = Reconciler(broker=broker, repo=repo, order_manager=order_manager)
 

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -14,12 +14,14 @@ from datetime import date
 from pathlib import Path
 
 import duckdb
+import yaml
 
 from kabusys.config import Settings
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 _STOP_FLAG = _PROJECT_ROOT / "data" / "stop_requested.flag"
 _EXECUTION_PID = _PROJECT_ROOT / "data" / "execution.pid"
+_RISK_CONFIG = _PROJECT_ROOT / "config" / "risk_config.yaml"
 from kabusys.execution.broker_factory import BrokerClientFactory  # noqa: E402
 from kabusys.execution.execution_engine import EngineConfig, ExecutionEngine  # noqa: E402
 from kabusys.execution.order_manager import OrderManager  # noqa: E402
@@ -31,6 +33,21 @@ from kabusys.utils.logging_setup import setup_logging  # noqa: E402
 from kabusys.utils.process_priority import set_process_priority  # noqa: E402
 
 logger = logging.getLogger(__name__)
+
+
+def _load_risk_config(path: Path, initial_portfolio_value: float) -> RiskConfig:
+    with path.open(encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    r = data["risk"]
+    return RiskConfig(
+        max_position_pct=r["max_position_pct"],
+        max_utilization=r["max_utilization"],
+        rate_limit_per_sec=r["rate_limit_per_sec"],
+        circuit_breaker_errors=r["circuit_breaker_errors"],
+        circuit_breaker_window_sec=r["circuit_breaker_window_sec"],
+        max_drawdown=r["max_drawdown"],
+        initial_portfolio_value=initial_portfolio_value,
+    )
 
 
 def main() -> None:

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -73,6 +73,7 @@ def main() -> None:
         # 4. 依存コンポーネント組み立て
         repo = OrderRepository(sqlite_conn)
         order_manager = OrderManager(broker, repo)
+        # TODO(#189 Task 3): replace inline RiskConfig with _load_risk_config(_RISK_CONFIG, total_assets)
         risk_manager = RiskManager(
             broker=broker,
             repo=repo,

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -36,18 +36,80 @@ logger = logging.getLogger(__name__)
 
 
 def _load_risk_config(path: Path, initial_portfolio_value: float) -> RiskConfig:
-    with path.open(encoding="utf-8") as f:
-        data = yaml.safe_load(f)
-    r = data["risk"]
-    return RiskConfig(
-        max_position_pct=r["max_position_pct"],
-        max_utilization=r["max_utilization"],
-        rate_limit_per_sec=r["rate_limit_per_sec"],
-        circuit_breaker_errors=r["circuit_breaker_errors"],
-        circuit_breaker_window_sec=r["circuit_breaker_window_sec"],
-        max_drawdown=r["max_drawdown"],
+    try:
+        with path.open(encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"risk_config.yaml のパース失敗: {path}") from exc
+
+    try:
+        r = data["risk"]
+    except (TypeError, KeyError) as exc:
+        raise KeyError(f"risk_config.yaml にトップレベルキー 'risk' がありません: {path}") from exc
+
+    def _get(key: str) -> object:
+        try:
+            return r[key]
+        except KeyError as exc:
+            raise KeyError(f"risk_config.yaml に 'risk.{key}' がありません: {path}") from exc
+
+    max_position_pct = float(_get("max_position_pct"))
+    max_utilization = float(_get("max_utilization"))
+    rate_limit_per_sec = int(_get("rate_limit_per_sec"))
+    circuit_breaker_errors = int(_get("circuit_breaker_errors"))
+    circuit_breaker_window_sec = int(_get("circuit_breaker_window_sec"))
+    max_drawdown = float(_get("max_drawdown"))
+
+    for name, val in (
+        ("max_position_pct", max_position_pct),
+        ("max_utilization", max_utilization),
+        ("max_drawdown", max_drawdown),
+    ):
+        if not (0 < val <= 1):
+            raise ValueError(f"risk_config.yaml: {name} は (0, 1] の範囲で設定してください（現在値: {val}）: {path}")
+    if max_position_pct > max_utilization:
+        raise ValueError(
+            f"risk_config.yaml: max_position_pct({max_position_pct}) は"
+            f" max_utilization({max_utilization}) 以下にしてください: {path}"
+        )
+
+    config = RiskConfig(
+        max_position_pct=max_position_pct,
+        max_utilization=max_utilization,
+        rate_limit_per_sec=rate_limit_per_sec,
+        circuit_breaker_errors=circuit_breaker_errors,
+        circuit_breaker_window_sec=circuit_breaker_window_sec,
+        max_drawdown=max_drawdown,
         initial_portfolio_value=initial_portfolio_value,
     )
+    logger.info(
+        "RiskConfig 読み込み完了: max_position_pct=%.0f%% max_utilization=%.0f%%"
+        " max_drawdown=%.0f%% rate_limit=%d/s CB_errors=%d CB_window=%ds",
+        max_position_pct * 100,
+        max_utilization * 100,
+        max_drawdown * 100,
+        rate_limit_per_sec,
+        circuit_breaker_errors,
+        circuit_breaker_window_sec,
+    )
+    return config
+
+
+def _pos_value(p: object) -> float:
+    price = (
+        p.current_price  # type: ignore[attr-defined]
+        if (p.current_price is not None and p.current_price > 0)  # type: ignore[attr-defined]
+        else p.avg_price  # type: ignore[attr-defined]
+    )
+    if price is None or price <= 0:
+        logger.warning(
+            "ポジション評価額を 0 として扱います: code=%s current_price=%s avg_price=%s",
+            getattr(p, "code", "?"),
+            getattr(p, "current_price", None),
+            getattr(p, "avg_price", None),
+        )
+        return 0.0
+    return float(p.qty) * float(price)  # type: ignore[attr-defined]
 
 
 def main() -> None:
@@ -73,10 +135,8 @@ def main() -> None:
         # 4. 起動時総資産を計算（現金 + 保有評価額）
         cash = broker.get_available_cash()
         positions = broker.get_positions()
-        total_assets = cash + sum(
-            p.qty * (p.current_price if p.current_price is not None else p.avg_price)
-            for p in positions
-        )
+        total_assets = cash + sum(_pos_value(p) for p in positions)
+        logger.info("起動時総資産: %.0f 円（現金 %.0f 円 + ポジション %d 件）", total_assets, cash, len(positions))
 
         # 5. 依存コンポーネント組み立て
         repo = OrderRepository(sqlite_conn)

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -70,22 +70,21 @@ def main() -> None:
         # 3. ブローカークライアント
         broker = BrokerClientFactory.create(settings)
 
-        # 4. 依存コンポーネント組み立て
+        # 4. 起動時総資産を計算（現金 + 保有評価額）
+        cash = broker.get_available_cash()
+        positions = broker.get_positions()
+        total_assets = cash + sum(
+            p.qty * (p.current_price if p.current_price is not None else p.avg_price)
+            for p in positions
+        )
+
+        # 5. 依存コンポーネント組み立て
         repo = OrderRepository(sqlite_conn)
         order_manager = OrderManager(broker, repo)
-        # TODO(#189 Task 3): replace inline RiskConfig with _load_risk_config(_RISK_CONFIG, total_assets)
         risk_manager = RiskManager(
             broker=broker,
             repo=repo,
-            config=RiskConfig(
-                max_position_pct=0.20,
-                max_utilization=0.80,
-                rate_limit_per_sec=5,
-                circuit_breaker_errors=10,
-                circuit_breaker_window_sec=60,
-                max_drawdown=0.20,
-                initial_portfolio_value=broker.get_available_cash(),
-            ),
+            config=_load_risk_config(_RISK_CONFIG, initial_portfolio_value=total_assets),
         )
         reconciler = Reconciler(broker=broker, repo=repo, order_manager=order_manager)
 

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -78,6 +78,15 @@ def _load_risk_config(path: Path, initial_portfolio_value: float) -> RiskConfig:
             f"risk_config.yaml: max_position_pct({max_position_pct}) は"
             f" max_utilization({max_utilization}) 以下にしてください: {path}"
         )
+    for name, val in (
+        ("rate_limit_per_sec", rate_limit_per_sec),
+        ("circuit_breaker_errors", circuit_breaker_errors),
+        ("circuit_breaker_window_sec", circuit_breaker_window_sec),
+    ):
+        if val < 1:
+            raise ValueError(
+                f"risk_config.yaml: {name} は 1 以上で設定してください（現在値: {val}）: {path}"
+            )
 
     config = RiskConfig(
         max_position_pct=max_position_pct,
@@ -142,7 +151,7 @@ def main() -> None:
         cash = broker.get_available_cash()
         positions = broker.get_positions()
         total_assets = cash + sum(_pos_value(p) for p in positions)
-        logger.info(
+        logger.debug(
             "起動時総資産: %.0f 円（現金 %.0f 円 + ポジション %d 件）",
             total_assets,
             cash,

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -39,7 +39,7 @@ def _load_risk_config(path: Path, initial_portfolio_value: float) -> RiskConfig:
     if not path.exists():
         logger.error(
             "リスク設定ファイルが見つかりません: %s"
-            " → config/risk_config.yaml を作成してください（python -m kabusys.config_setup を参照）",
+            " → git checkout config/risk_config.yaml で復元してください",
             path,
         )
         raise FileNotFoundError(f"リスク設定ファイルが見つかりません: {path}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ MINIMAL_DDL = [
         close       DECIMAL(18,4),
         volume      BIGINT,
         turnover    DECIMAL(18,2),
+        adj_factor  DECIMAL(18,6),
         fetched_at  TIMESTAMP     NOT NULL DEFAULT current_timestamp,
         PRIMARY KEY (date, code)
     )""",

--- a/tests/test_bootstrap_client.py
+++ b/tests/test_bootstrap_client.py
@@ -64,6 +64,14 @@ def test_download_file_saves_to_dest(tmp_path):
     assert dest.read_bytes() == content
 
 
+def test_get_presigned_url_raises_on_missing_url_key():
+    payload = json.dumps({"error": "not found"}).encode()
+    with patch("urllib.request.urlopen") as mock_open:
+        mock_open.return_value = _make_response(payload)
+        with pytest.raises(BulkApiError, match="missing 'url' key"):
+            get_presigned_url("some_key", "my_api_key")
+
+
 def test_download_file_retries_on_error(tmp_path):
     content = gzip.compress(b"Date,Code,O\n2024-01-01,7203,2800\n")
     dest = tmp_path / "output.csv.gz"

--- a/tests/test_bootstrap_client.py
+++ b/tests/test_bootstrap_client.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import gzip
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+import urllib.error
+
+import pytest
+
+from kabusys.data.bootstrap.bulk_client import (
+    list_files,
+    get_presigned_url,
+    download_file,
+    BulkApiError,
+)
+
+
+def _make_response(body: bytes, status: int = 200):
+    resp = MagicMock()
+    resp.status = status
+    resp.read.return_value = body
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+def test_list_files_returns_list():
+    payload = json.dumps({"files": [{"key": "k1", "date": "2024-01-01"}, {"key": "k2", "date": "2024-01-02"}]}).encode()
+    with patch("urllib.request.urlopen") as mock_open:
+        mock_open.return_value = _make_response(payload)
+        result = list_files("/equities/bars/daily", "my_api_key")
+    assert result == [{"key": "k1", "date": "2024-01-01"}, {"key": "k2", "date": "2024-01-02"}]
+    req = mock_open.call_args[0][0]
+    assert req.get_header("X-api-key") == "my_api_key"
+
+
+def test_list_files_raises_on_http_error():
+    with patch("urllib.request.urlopen") as mock_open:
+        mock_open.side_effect = urllib.error.HTTPError(
+            url="", code=500, msg="Internal Server Error", hdrs=None, fp=None
+        )
+        with pytest.raises(BulkApiError, match="list_files"):
+            list_files("/equities/bars/daily", "key")
+
+
+def test_get_presigned_url_returns_url():
+    payload = json.dumps({"url": "https://s3.example.com/presigned?token=abc"}).encode()
+    with patch("urllib.request.urlopen") as mock_open:
+        mock_open.return_value = _make_response(payload)
+        url = get_presigned_url("some_file_key", "my_api_key")
+    assert url == "https://s3.example.com/presigned?token=abc"
+
+
+def test_download_file_saves_to_dest(tmp_path):
+    content = gzip.compress(b"Date,Code,O\n2024-01-01,7203,2800\n")
+    with patch("urllib.request.urlopen") as mock_open:
+        mock_open.return_value = _make_response(content)
+        dest = tmp_path / "output.csv.gz"
+        result = download_file("https://s3.example.com/presigned", dest)
+    assert result == dest
+    assert dest.exists()
+    assert dest.read_bytes() == content
+
+
+def test_download_file_retries_on_error(tmp_path):
+    content = gzip.compress(b"Date,Code,O\n2024-01-01,7203,2800\n")
+    dest = tmp_path / "output.csv.gz"
+    responses = [
+        urllib.error.HTTPError(url="", code=500, msg="err", hdrs=None, fp=None),
+        _make_response(content),
+    ]
+    with patch("urllib.request.urlopen", side_effect=responses):
+        with patch("time.sleep"):  # sleepをスキップ
+            result = download_file("https://s3.example.com/presigned", dest)
+    assert result == dest

--- a/tests/test_bootstrap_client.py
+++ b/tests/test_bootstrap_client.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 import gzip
 import json
-import tempfile
-from pathlib import Path
-from unittest.mock import MagicMock, patch, call
 import urllib.error
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -27,11 +25,21 @@ def _make_response(body: bytes, status: int = 200):
 
 
 def test_list_files_returns_list():
-    payload = json.dumps({"files": [{"key": "k1", "date": "2024-01-01"}, {"key": "k2", "date": "2024-01-02"}]}).encode()
+    payload = json.dumps(
+        {
+            "files": [
+                {"key": "k1", "date": "2024-01-01"},
+                {"key": "k2", "date": "2024-01-02"},
+            ]
+        }
+    ).encode()
     with patch("urllib.request.urlopen") as mock_open:
         mock_open.return_value = _make_response(payload)
         result = list_files("/equities/bars/daily", "my_api_key")
-    assert result == [{"key": "k1", "date": "2024-01-01"}, {"key": "k2", "date": "2024-01-02"}]
+    assert result == [
+        {"key": "k1", "date": "2024-01-01"},
+        {"key": "k2", "date": "2024-01-02"},
+    ]
     req = mock_open.call_args[0][0]
     assert req.get_header("X-api-key") == "my_api_key"
 

--- a/tests/test_bootstrap_loaders.py
+++ b/tests/test_bootstrap_loaders.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import csv
+import gzip
+import io
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from kabusys.data.bootstrap.loaders import (
+    load_prices,
+    load_master,
+    load_financials,
+    load_calendar,
+    load_dividend,
+    load_topix,
+)
+
+# ---------------------------------------------------------------------------
+# テスト用 DB フィクスチャ
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def conn():
+    c = duckdb.connect(":memory:")
+    c.execute("""
+        CREATE TABLE raw_prices (
+            date DATE NOT NULL, code VARCHAR NOT NULL,
+            open DECIMAL(18,4), high DECIMAL(18,4),
+            low DECIMAL(18,4), close DECIMAL(18,4),
+            volume BIGINT, turnover DECIMAL(18,2),
+            adj_factor DECIMAL(18,6),
+            fetched_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+            PRIMARY KEY (date, code)
+        )
+    """)
+    c.execute("""
+        CREATE TABLE prices_daily (
+            date DATE NOT NULL, code VARCHAR NOT NULL,
+            open DECIMAL(18,4) NOT NULL, high DECIMAL(18,4) NOT NULL,
+            low DECIMAL(18,4) NOT NULL CHECK (low <= high),
+            close DECIMAL(18,4) NOT NULL, volume BIGINT NOT NULL,
+            turnover DECIMAL(18,2),
+            PRIMARY KEY (date, code)
+        )
+    """)
+    c.execute("""
+        CREATE TABLE stocks (
+            code VARCHAR NOT NULL PRIMARY KEY,
+            name VARCHAR, market VARCHAR, sector VARCHAR,
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+    """)
+    c.execute("""
+        CREATE TABLE raw_financials (
+            code VARCHAR NOT NULL, report_date DATE NOT NULL,
+            period_type VARCHAR NOT NULL,
+            revenue DECIMAL(20,4), operating_profit DECIMAL(20,4),
+            net_income DECIMAL(20,4), eps DECIMAL(18,4), roe DECIMAL(10,6),
+            fetched_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+            PRIMARY KEY (code, report_date, period_type)
+        )
+    """)
+    c.execute("""
+        CREATE TABLE fundamentals (
+            code VARCHAR NOT NULL, report_date DATE NOT NULL,
+            period_type VARCHAR NOT NULL,
+            revenue DECIMAL(20,4), operating_profit DECIMAL(20,4),
+            net_income DECIMAL(20,4), eps DECIMAL(18,4), roe DECIMAL(10,6),
+            PRIMARY KEY (code, report_date, period_type)
+        )
+    """)
+    c.execute("""
+        CREATE TABLE market_calendar (
+            date DATE NOT NULL PRIMARY KEY,
+            is_trading_day BOOLEAN NOT NULL,
+            is_half_day BOOLEAN NOT NULL DEFAULT false,
+            is_sq_day BOOLEAN NOT NULL DEFAULT false,
+            holiday_name VARCHAR
+        )
+    """)
+    c.execute("""
+        CREATE TABLE dividends (
+            code VARCHAR NOT NULL, pub_date DATE NOT NULL,
+            ref_no VARCHAR NOT NULL,
+            ex_date DATE, record_date DATE, pay_date DATE,
+            div_rate DECIMAL(18,4),
+            fetched_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+            PRIMARY KEY (code, pub_date, ref_no)
+        )
+    """)
+    c.execute("""
+        CREATE TABLE topix_daily (
+            date DATE NOT NULL PRIMARY KEY,
+            open DECIMAL(18,4) NOT NULL, high DECIMAL(18,4) NOT NULL,
+            low DECIMAL(18,4) NOT NULL, close DECIMAL(18,4) NOT NULL
+        )
+    """)
+    yield c
+    c.close()
+
+
+def _gz(rows: list[dict], tmp_path: Path, name: str) -> Path:
+    """rows を gzip CSV として tmp_path に保存してパスを返す。"""
+    p = tmp_path / name
+    buf = io.StringIO()
+    if rows:
+        writer = csv.DictWriter(buf, fieldnames=rows[0].keys())
+        writer.writeheader()
+        writer.writerows(rows)
+    p.write_bytes(gzip.compress(buf.getvalue().encode("utf-8")))
+    return p
+
+
+# ---------------------------------------------------------------------------
+# load_prices
+# ---------------------------------------------------------------------------
+
+def test_load_prices_inserts_raw_and_processed(conn, tmp_path):
+    rows = [{"Date": "2024-01-10", "Code": "7203", "O": "2800", "H": "2850",
+              "L": "2780", "C": "2830", "Vo": "1000000", "Va": "2830000000", "AdjFactor": "1.0"}]
+    path = _gz(rows, tmp_path, "prices.csv.gz")
+    count = load_prices(conn, path)
+    assert count == 1
+    assert conn.execute("SELECT COUNT(*) FROM raw_prices").fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM prices_daily").fetchone()[0] == 1
+
+
+def test_load_prices_skips_invalid_rows(conn, tmp_path):
+    rows = [
+        {"Date": "2024-01-10", "Code": "7203", "O": "2800", "H": "2850",
+         "L": "2780", "C": "2830", "Vo": "1000000", "Va": "", "AdjFactor": "1.0"},
+        {"Date": "2024-01-11", "Code": "", "O": "100", "H": "110",
+         "L": "90", "C": "105", "Vo": "500", "Va": "", "AdjFactor": "1.0"},  # code 欠損
+    ]
+    path = _gz(rows, tmp_path, "prices_skip.csv.gz")
+    count = load_prices(conn, path)
+    assert count == 1  # code 欠損行はスキップ
+
+
+def test_load_prices_idempotent(conn, tmp_path):
+    rows = [{"Date": "2024-01-10", "Code": "7203", "O": "2800", "H": "2850",
+              "L": "2780", "C": "2830", "Vo": "1000000", "Va": "", "AdjFactor": "1.0"}]
+    path = _gz(rows, tmp_path, "prices_idem.csv.gz")
+    load_prices(conn, path)
+    count = load_prices(conn, path)
+    assert conn.execute("SELECT COUNT(*) FROM raw_prices").fetchone()[0] == 1
+
+
+# ---------------------------------------------------------------------------
+# load_master
+# ---------------------------------------------------------------------------
+
+def test_load_master_inserts_stocks(conn, tmp_path):
+    rows = [{"Code": "7203", "CoName": "トヨタ自動車", "MktNm": "Prime", "S33Nm": "輸送用機器"}]
+    path = _gz(rows, tmp_path, "master.csv.gz")
+    count = load_master(conn, path)
+    assert count == 1
+    row = conn.execute("SELECT name, market, sector FROM stocks WHERE code='7203'").fetchone()
+    assert row == ("トヨタ自動車", "Prime", "輸送用機器")
+
+
+# ---------------------------------------------------------------------------
+# load_financials
+# ---------------------------------------------------------------------------
+
+def test_load_financials_inserts_raw_and_processed(conn, tmp_path):
+    rows = [{"Code": "7203", "DiscDate": "2024-01-10", "CurPerType": "FY",
+              "Sales": "10000000", "OP": "1000000", "NP": "800000",
+              "EPS": "120.5", "ROE": "0.12"}]
+    path = _gz(rows, tmp_path, "fins.csv.gz")
+    count = load_financials(conn, path)
+    assert count == 1
+    assert conn.execute("SELECT COUNT(*) FROM raw_financials").fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM fundamentals").fetchone()[0] == 1
+
+
+# ---------------------------------------------------------------------------
+# load_calendar
+# ---------------------------------------------------------------------------
+
+def test_load_calendar_inserts_market_calendar(conn, tmp_path):
+    rows = [
+        {"Date": "2024-01-04", "HolDiv": "0", "HalfDiv": "0", "SQDiv": "0", "HolName": ""},
+        {"Date": "2024-01-08", "HolDiv": "1", "HalfDiv": "0", "SQDiv": "0", "HolName": "成人の日"},
+    ]
+    path = _gz(rows, tmp_path, "cal.csv.gz")
+    count = load_calendar(conn, path)
+    assert count == 2
+    row = conn.execute(
+        "SELECT is_trading_day, holiday_name FROM market_calendar WHERE date='2024-01-08'"
+    ).fetchone()
+    assert row[0] is False
+    assert row[1] == "成人の日"
+
+
+# ---------------------------------------------------------------------------
+# load_dividend
+# ---------------------------------------------------------------------------
+
+def test_load_dividend_inserts_dividends(conn, tmp_path):
+    rows = [{"Code": "7203", "PubDate": "2024-01-15", "RefNo": "001",
+              "ExDate": "2024-03-27", "RecDate": "2024-03-31",
+              "PayDate": "2024-06-05", "DivRate": "30.0"}]
+    path = _gz(rows, tmp_path, "div.csv.gz")
+    count = load_dividend(conn, path)
+    assert count == 1
+    row = conn.execute("SELECT div_rate FROM dividends WHERE code='7203'").fetchone()
+    assert float(row[0]) == 30.0
+
+
+# ---------------------------------------------------------------------------
+# load_topix
+# ---------------------------------------------------------------------------
+
+def test_load_topix_inserts_topix_daily(conn, tmp_path):
+    rows = [{"Date": "2024-01-04", "O": "2500.5", "H": "2510.0", "L": "2490.0", "C": "2505.0"}]
+    path = _gz(rows, tmp_path, "topix.csv.gz")
+    count = load_topix(conn, path)
+    assert count == 1
+    row = conn.execute("SELECT close FROM topix_daily WHERE date='2024-01-04'").fetchone()
+    assert float(row[0]) == 2505.0

--- a/tests/test_bootstrap_loaders.py
+++ b/tests/test_bootstrap_loaders.py
@@ -146,6 +146,8 @@ def test_load_prices_idempotent(conn, tmp_path):
     load_prices(conn, path)
     count = load_prices(conn, path)
     assert conn.execute("SELECT COUNT(*) FROM raw_prices").fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM prices_daily").fetchone()[0] == 1
+    assert count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bootstrap_loaders.py
+++ b/tests/test_bootstrap_loaders.py
@@ -318,3 +318,14 @@ def test_load_topix_inserts_topix_daily(conn, tmp_path):
         "SELECT close FROM topix_daily WHERE date='2024-01-04'"
     ).fetchone()
     assert float(row[0]) == 2505.0
+
+
+def test_load_topix_skips_low_gt_high(conn, tmp_path):
+    rows = [
+        {"Date": "2024-01-05", "O": "100.0", "H": "90.0", "L": "110.0", "C": "95.0"},
+        {"Date": "2024-01-06", "O": "100.0", "H": "110.0", "L": "90.0", "C": "105.0"},
+    ]
+    path = _gz(rows, tmp_path, "topix_bad.csv.gz")
+    count = load_topix(conn, path)
+    assert count == 1
+    assert conn.execute("SELECT COUNT(*) FROM topix_daily").fetchone()[0] == 1

--- a/tests/test_bootstrap_loaders.py
+++ b/tests/test_bootstrap_loaders.py
@@ -21,6 +21,7 @@ from kabusys.data.bootstrap.loaders import (
 # テスト用 DB フィクスチャ
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def conn():
     c = duckdb.connect(":memory:")
@@ -117,9 +118,21 @@ def _gz(rows: list[dict], tmp_path: Path, name: str) -> Path:
 # load_prices
 # ---------------------------------------------------------------------------
 
+
 def test_load_prices_inserts_raw_and_processed(conn, tmp_path):
-    rows = [{"Date": "2024-01-10", "Code": "7203", "O": "2800", "H": "2850",
-              "L": "2780", "C": "2830", "Vo": "1000000", "Va": "2830000000", "AdjFactor": "1.0"}]
+    rows = [
+        {
+            "Date": "2024-01-10",
+            "Code": "7203",
+            "O": "2800",
+            "H": "2850",
+            "L": "2780",
+            "C": "2830",
+            "Vo": "1000000",
+            "Va": "2830000000",
+            "AdjFactor": "1.0",
+        }
+    ]
     path = _gz(rows, tmp_path, "prices.csv.gz")
     count = load_prices(conn, path)
     assert count == 1
@@ -129,10 +142,28 @@ def test_load_prices_inserts_raw_and_processed(conn, tmp_path):
 
 def test_load_prices_skips_invalid_rows(conn, tmp_path):
     rows = [
-        {"Date": "2024-01-10", "Code": "7203", "O": "2800", "H": "2850",
-         "L": "2780", "C": "2830", "Vo": "1000000", "Va": "", "AdjFactor": "1.0"},
-        {"Date": "2024-01-11", "Code": "", "O": "100", "H": "110",
-         "L": "90", "C": "105", "Vo": "500", "Va": "", "AdjFactor": "1.0"},  # code 欠損
+        {
+            "Date": "2024-01-10",
+            "Code": "7203",
+            "O": "2800",
+            "H": "2850",
+            "L": "2780",
+            "C": "2830",
+            "Vo": "1000000",
+            "Va": "",
+            "AdjFactor": "1.0",
+        },
+        {
+            "Date": "2024-01-11",
+            "Code": "",
+            "O": "100",
+            "H": "110",
+            "L": "90",
+            "C": "105",
+            "Vo": "500",
+            "Va": "",
+            "AdjFactor": "1.0",
+        },  # code 欠損
     ]
     path = _gz(rows, tmp_path, "prices_skip.csv.gz")
     count = load_prices(conn, path)
@@ -140,8 +171,19 @@ def test_load_prices_skips_invalid_rows(conn, tmp_path):
 
 
 def test_load_prices_idempotent(conn, tmp_path):
-    rows = [{"Date": "2024-01-10", "Code": "7203", "O": "2800", "H": "2850",
-              "L": "2780", "C": "2830", "Vo": "1000000", "Va": "", "AdjFactor": "1.0"}]
+    rows = [
+        {
+            "Date": "2024-01-10",
+            "Code": "7203",
+            "O": "2800",
+            "H": "2850",
+            "L": "2780",
+            "C": "2830",
+            "Vo": "1000000",
+            "Va": "",
+            "AdjFactor": "1.0",
+        }
+    ]
     path = _gz(rows, tmp_path, "prices_idem.csv.gz")
     load_prices(conn, path)
     count = load_prices(conn, path)
@@ -154,12 +196,22 @@ def test_load_prices_idempotent(conn, tmp_path):
 # load_master
 # ---------------------------------------------------------------------------
 
+
 def test_load_master_inserts_stocks(conn, tmp_path):
-    rows = [{"Code": "7203", "CoName": "トヨタ自動車", "MktNm": "Prime", "S33Nm": "輸送用機器"}]
+    rows = [
+        {
+            "Code": "7203",
+            "CoName": "トヨタ自動車",
+            "MktNm": "Prime",
+            "S33Nm": "輸送用機器",
+        }
+    ]
     path = _gz(rows, tmp_path, "master.csv.gz")
     count = load_master(conn, path)
     assert count == 1
-    row = conn.execute("SELECT name, market, sector FROM stocks WHERE code='7203'").fetchone()
+    row = conn.execute(
+        "SELECT name, market, sector FROM stocks WHERE code='7203'"
+    ).fetchone()
     assert row == ("トヨタ自動車", "Prime", "輸送用機器")
 
 
@@ -167,10 +219,20 @@ def test_load_master_inserts_stocks(conn, tmp_path):
 # load_financials
 # ---------------------------------------------------------------------------
 
+
 def test_load_financials_inserts_raw_and_processed(conn, tmp_path):
-    rows = [{"Code": "7203", "DiscDate": "2024-01-10", "CurPerType": "FY",
-              "Sales": "10000000", "OP": "1000000", "NP": "800000",
-              "EPS": "120.5", "ROE": "0.12"}]
+    rows = [
+        {
+            "Code": "7203",
+            "DiscDate": "2024-01-10",
+            "CurPerType": "FY",
+            "Sales": "10000000",
+            "OP": "1000000",
+            "NP": "800000",
+            "EPS": "120.5",
+            "ROE": "0.12",
+        }
+    ]
     path = _gz(rows, tmp_path, "fins.csv.gz")
     count = load_financials(conn, path)
     assert count == 1
@@ -182,10 +244,23 @@ def test_load_financials_inserts_raw_and_processed(conn, tmp_path):
 # load_calendar
 # ---------------------------------------------------------------------------
 
+
 def test_load_calendar_inserts_market_calendar(conn, tmp_path):
     rows = [
-        {"Date": "2024-01-04", "HolDiv": "0", "HalfDiv": "0", "SQDiv": "0", "HolName": ""},
-        {"Date": "2024-01-08", "HolDiv": "1", "HalfDiv": "0", "SQDiv": "0", "HolName": "成人の日"},
+        {
+            "Date": "2024-01-04",
+            "HolDiv": "0",
+            "HalfDiv": "0",
+            "SQDiv": "0",
+            "HolName": "",
+        },
+        {
+            "Date": "2024-01-08",
+            "HolDiv": "1",
+            "HalfDiv": "0",
+            "SQDiv": "0",
+            "HolName": "成人の日",
+        },
     ]
     path = _gz(rows, tmp_path, "cal.csv.gz")
     count = load_calendar(conn, path)
@@ -201,10 +276,19 @@ def test_load_calendar_inserts_market_calendar(conn, tmp_path):
 # load_dividend
 # ---------------------------------------------------------------------------
 
+
 def test_load_dividend_inserts_dividends(conn, tmp_path):
-    rows = [{"Code": "7203", "PubDate": "2024-01-15", "RefNo": "001",
-              "ExDate": "2024-03-27", "RecDate": "2024-03-31",
-              "PayDate": "2024-06-05", "DivRate": "30.0"}]
+    rows = [
+        {
+            "Code": "7203",
+            "PubDate": "2024-01-15",
+            "RefNo": "001",
+            "ExDate": "2024-03-27",
+            "RecDate": "2024-03-31",
+            "PayDate": "2024-06-05",
+            "DivRate": "30.0",
+        }
+    ]
     path = _gz(rows, tmp_path, "div.csv.gz")
     count = load_dividend(conn, path)
     assert count == 1
@@ -216,10 +300,21 @@ def test_load_dividend_inserts_dividends(conn, tmp_path):
 # load_topix
 # ---------------------------------------------------------------------------
 
+
 def test_load_topix_inserts_topix_daily(conn, tmp_path):
-    rows = [{"Date": "2024-01-04", "O": "2500.5", "H": "2510.0", "L": "2490.0", "C": "2505.0"}]
+    rows = [
+        {
+            "Date": "2024-01-04",
+            "O": "2500.5",
+            "H": "2510.0",
+            "L": "2490.0",
+            "C": "2505.0",
+        }
+    ]
     path = _gz(rows, tmp_path, "topix.csv.gz")
     count = load_topix(conn, path)
     assert count == 1
-    row = conn.execute("SELECT close FROM topix_daily WHERE date='2024-01-04'").fetchone()
+    row = conn.execute(
+        "SELECT close FROM topix_daily WHERE date='2024-01-04'"
+    ).fetchone()
     assert float(row[0]) == 2505.0

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -291,3 +291,23 @@ def test_safe_errmsg_url_error_shows_reason():
 def test_safe_errmsg_generic_exception_shows_message():
     msg = _safe_errmsg(ValueError("some detail"))
     assert msg == "some detail"
+
+
+def test_safe_errmsg_unwraps_cause_chain():
+    """BulkApiError でラップされた HTTPError でも URL が漏れないことを確認。"""
+    import urllib.error
+
+    http_exc = urllib.error.HTTPError(
+        url="https://s3.amazonaws.com/?X-Amz-Signature=secret",
+        code=403,
+        msg="Forbidden",
+        hdrs=None,
+        fp=None,
+    )
+    wrapped = RuntimeError("download failed")
+    wrapped.__cause__ = http_exc
+
+    msg = _safe_errmsg(wrapped)
+    assert "403" in msg
+    assert "Forbidden" in msg
+    assert "secret" not in msg

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import gzip
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import duckdb
+import pytest
+
+from kabusys.data.bootstrap.runner import run_bootstrap, BootstrapResult
+
+
+# ---------------------------------------------------------------------------
+# テスト用 DB フィクスチャ（最小スキーマ）
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def conn():
+    c = duckdb.connect(":memory:")
+    c.execute("""
+        CREATE TABLE bootstrap_load_history (
+            file_key VARCHAR NOT NULL PRIMARY KEY,
+            endpoint VARCHAR NOT NULL,
+            file_name VARCHAR NOT NULL,
+            status VARCHAR NOT NULL DEFAULT 'pending',
+            row_count BIGINT,
+            error_msg VARCHAR,
+            loaded_at TIMESTAMP
+        )
+    """)
+    c.execute("""
+        CREATE TABLE raw_prices (
+            date DATE NOT NULL, code VARCHAR NOT NULL,
+            open DECIMAL(18,4), high DECIMAL(18,4),
+            low DECIMAL(18,4), close DECIMAL(18,4),
+            volume BIGINT, turnover DECIMAL(18,2),
+            adj_factor DECIMAL(18,6),
+            fetched_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+            PRIMARY KEY (date, code)
+        )
+    """)
+    c.execute("""
+        CREATE TABLE prices_daily (
+            date DATE NOT NULL, code VARCHAR NOT NULL,
+            open DECIMAL(18,4) NOT NULL, high DECIMAL(18,4) NOT NULL,
+            low DECIMAL(18,4) NOT NULL CHECK (low <= high),
+            close DECIMAL(18,4) NOT NULL, volume BIGINT NOT NULL,
+            turnover DECIMAL(18,2),
+            PRIMARY KEY (date, code)
+        )
+    """)
+    c.execute("""
+        CREATE TABLE stocks (
+            code VARCHAR NOT NULL PRIMARY KEY,
+            name VARCHAR, market VARCHAR, sector VARCHAR,
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+    """)
+    c.execute("""
+        CREATE TABLE raw_financials (
+            code VARCHAR NOT NULL, report_date DATE NOT NULL,
+            period_type VARCHAR NOT NULL,
+            revenue DECIMAL(20,4), operating_profit DECIMAL(20,4),
+            net_income DECIMAL(20,4), eps DECIMAL(18,4), roe DECIMAL(10,6),
+            fetched_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+            PRIMARY KEY (code, report_date, period_type)
+        )
+    """)
+    c.execute("""
+        CREATE TABLE fundamentals (
+            code VARCHAR NOT NULL, report_date DATE NOT NULL,
+            period_type VARCHAR NOT NULL,
+            revenue DECIMAL(20,4), operating_profit DECIMAL(20,4),
+            net_income DECIMAL(20,4), eps DECIMAL(18,4), roe DECIMAL(10,6),
+            PRIMARY KEY (code, report_date, period_type)
+        )
+    """)
+    c.execute("""
+        CREATE TABLE market_calendar (
+            date DATE NOT NULL PRIMARY KEY,
+            is_trading_day BOOLEAN NOT NULL,
+            is_half_day BOOLEAN NOT NULL DEFAULT false,
+            is_sq_day BOOLEAN NOT NULL DEFAULT false,
+            holiday_name VARCHAR
+        )
+    """)
+    c.execute("""
+        CREATE TABLE dividends (
+            code VARCHAR NOT NULL, pub_date DATE NOT NULL,
+            ref_no VARCHAR NOT NULL,
+            ex_date DATE, record_date DATE, pay_date DATE,
+            div_rate DECIMAL(18,4),
+            fetched_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+            PRIMARY KEY (code, pub_date, ref_no)
+        )
+    """)
+    c.execute("""
+        CREATE TABLE topix_daily (
+            date DATE NOT NULL PRIMARY KEY,
+            open DECIMAL(18,4) NOT NULL, high DECIMAL(18,4) NOT NULL,
+            low DECIMAL(18,4) NOT NULL, close DECIMAL(18,4) NOT NULL
+        )
+    """)
+    yield c
+    c.close()
+
+
+def _gz_prices(tmp_path: Path) -> bytes:
+    import csv, io
+    buf = io.StringIO()
+    w = csv.DictWriter(buf, fieldnames=["Date","Code","O","H","L","C","Vo","Va","AdjFactor"])
+    w.writeheader()
+    w.writerow({"Date":"2024-01-10","Code":"7203","O":"2800","H":"2850","L":"2780","C":"2830","Vo":"1000000","Va":"","AdjFactor":"1.0"})
+    return gzip.compress(buf.getvalue().encode())
+
+
+# ---------------------------------------------------------------------------
+# テスト
+# ---------------------------------------------------------------------------
+
+def test_run_bootstrap_dry_run_returns_result(conn, tmp_path):
+    file_list = [{"key": "prices_2024_01.csv.gz", "date": "2024-01"}]
+    with patch("kabusys.data.bootstrap.runner.list_files", return_value=file_list), \
+         patch("kabusys.data.bootstrap.runner.get_presigned_url", return_value="https://s3/f"), \
+         patch("kabusys.data.bootstrap.runner.download_file") as mock_dl:
+        result = run_bootstrap(
+            conn=conn,
+            api_key="test_key",
+            raw_dir=tmp_path,
+            dry_run=True,
+            endpoints=["/equities/bars/daily"],
+        )
+    mock_dl.assert_not_called()
+    assert isinstance(result, BootstrapResult)
+    assert result.total_files == 1
+
+
+def test_run_bootstrap_skips_loaded_files(conn, tmp_path):
+    conn.execute(
+        "INSERT INTO bootstrap_load_history (file_key, endpoint, file_name, status, row_count) "
+        "VALUES ('prices_2024_01.csv.gz', '/equities/bars/daily', 'prices_2024_01.csv.gz', 'loaded', 100)"
+    )
+    file_list = [{"key": "prices_2024_01.csv.gz", "date": "2024-01"}]
+    with patch("kabusys.data.bootstrap.runner.list_files", return_value=file_list), \
+         patch("kabusys.data.bootstrap.runner.download_file") as mock_dl:
+        result = run_bootstrap(
+            conn=conn,
+            api_key="test_key",
+            raw_dir=tmp_path,
+            endpoints=["/equities/bars/daily"],
+        )
+    mock_dl.assert_not_called()
+    assert result.skipped_files == 1
+
+
+def test_run_bootstrap_records_loaded_status(conn, tmp_path):
+    ep_dir = tmp_path / "equities" / "bars" / "daily"
+    ep_dir.mkdir(parents=True)
+    gz_path = ep_dir / "prices_2024_01.csv.gz"
+    gz_path.write_bytes(_gz_prices(tmp_path))
+
+    file_list = [{"key": "prices_2024_01.csv.gz", "date": "2024-01"}]
+    with patch("kabusys.data.bootstrap.runner.list_files", return_value=file_list), \
+         patch("kabusys.data.bootstrap.runner.get_presigned_url", return_value="https://s3/f"), \
+         patch("kabusys.data.bootstrap.runner.download_file", return_value=gz_path):
+        result = run_bootstrap(
+            conn=conn,
+            api_key="test_key",
+            raw_dir=tmp_path,
+            endpoints=["/equities/bars/daily"],
+        )
+
+    row = conn.execute(
+        "SELECT status, row_count FROM bootstrap_load_history WHERE file_key='prices_2024_01.csv.gz'"
+    ).fetchone()
+    assert row[0] == "loaded"
+    assert row[1] == 1
+    assert result.failed_files == 0
+
+
+def test_run_bootstrap_continues_on_single_file_failure(conn, tmp_path):
+    file_list = [
+        {"key": "prices_2024_01.csv.gz", "date": "2024-01"},
+        {"key": "prices_2024_02.csv.gz", "date": "2024-02"},
+    ]
+    ep_dir = tmp_path / "equities" / "bars" / "daily"
+    ep_dir.mkdir(parents=True)
+    good_gz = ep_dir / "prices_2024_02.csv.gz"
+    good_gz.write_bytes(_gz_prices(tmp_path))
+
+    def _side_effect(url, dest):
+        if "2024_01" in str(dest):
+            raise RuntimeError("download failed")
+        dest.write_bytes(_gz_prices(tmp_path))
+        return dest
+
+    with patch("kabusys.data.bootstrap.runner.list_files", return_value=file_list), \
+         patch("kabusys.data.bootstrap.runner.get_presigned_url", return_value="https://s3/f"), \
+         patch("kabusys.data.bootstrap.runner.download_file", side_effect=_side_effect):
+        result = run_bootstrap(
+            conn=conn,
+            api_key="test_key",
+            raw_dir=tmp_path,
+            endpoints=["/equities/bars/daily"],
+        )
+
+    assert result.failed_files == 1
+    assert result.loaded_files == 1
+    failed_row = conn.execute(
+        "SELECT status FROM bootstrap_load_history WHERE file_key='prices_2024_01.csv.gz'"
+    ).fetchone()
+    assert failed_row[0] == "failed"

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -277,6 +277,15 @@ def test_safe_errmsg_masks_http_error():
     assert "s3.amazonaws.com" not in msg
 
 
-def test_safe_errmsg_generic_exception():
+def test_safe_errmsg_url_error_shows_reason():
+    import urllib.error
+
+    exc = urllib.error.URLError(reason="Connection refused")
+    msg = _safe_errmsg(exc)
+    assert "Connection refused" in msg
+    assert "URLError" in msg
+
+
+def test_safe_errmsg_generic_exception_shows_message():
     msg = _safe_errmsg(ValueError("some detail"))
-    assert msg == "ValueError"
+    assert msg == "some detail"

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -255,7 +255,9 @@ def test_run_bootstrap_continues_on_single_file_failure(conn, tmp_path):
 def test_safe_filename_rejects_dot_and_dotdot():
     assert _safe_filename("path/to/file.csv.gz") == "file.csv.gz"
     assert _safe_filename("file.csv.gz") == "file.csv.gz"
-    assert _safe_filename("path/.") is None
+    # PurePosixPath は "path/." を "path" に正規化するため None にはならない
+    # 重要なのは ".." を含むパス横断を防ぐこと
+    assert _safe_filename("path/..") is None
     assert _safe_filename("..") is None
     assert _safe_filename("") is None
 

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -7,7 +7,12 @@ from unittest.mock import patch
 import duckdb
 import pytest
 
-from kabusys.data.bootstrap.runner import run_bootstrap, BootstrapResult
+from kabusys.data.bootstrap.runner import (
+    run_bootstrap,
+    BootstrapResult,
+    _safe_filename,
+    _safe_errmsg,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -245,3 +250,33 @@ def test_run_bootstrap_continues_on_single_file_failure(conn, tmp_path):
         "SELECT status FROM bootstrap_load_history WHERE file_key='prices_2024_01.csv.gz'"
     ).fetchone()
     assert failed_row[0] == "failed"
+
+
+def test_safe_filename_rejects_dot_and_dotdot():
+    assert _safe_filename("path/to/file.csv.gz") == "file.csv.gz"
+    assert _safe_filename("file.csv.gz") == "file.csv.gz"
+    assert _safe_filename("path/.") is None
+    assert _safe_filename("..") is None
+    assert _safe_filename("") is None
+
+
+def test_safe_errmsg_masks_http_error():
+    import urllib.error
+
+    exc = urllib.error.HTTPError(
+        url="https://s3.amazonaws.com/bucket/key?X-Amz-Signature=secret",
+        code=403,
+        msg="Forbidden",
+        hdrs=None,
+        fp=None,
+    )
+    msg = _safe_errmsg(exc)
+    assert "403" in msg
+    assert "Forbidden" in msg
+    assert "secret" not in msg
+    assert "s3.amazonaws.com" not in msg
+
+
+def test_safe_errmsg_generic_exception():
+    msg = _safe_errmsg(ValueError("some detail"))
+    assert msg == "ValueError"

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import gzip
-import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import patch
 
 import duckdb
 import pytest
@@ -14,6 +13,7 @@ from kabusys.data.bootstrap.runner import run_bootstrap, BootstrapResult
 # ---------------------------------------------------------------------------
 # テスト用 DB フィクスチャ（最小スキーマ）
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def conn():
@@ -107,11 +107,27 @@ def conn():
 
 
 def _gz_prices(tmp_path: Path) -> bytes:
-    import csv, io
+    import csv
+    import io
+
     buf = io.StringIO()
-    w = csv.DictWriter(buf, fieldnames=["Date","Code","O","H","L","C","Vo","Va","AdjFactor"])
+    w = csv.DictWriter(
+        buf, fieldnames=["Date", "Code", "O", "H", "L", "C", "Vo", "Va", "AdjFactor"]
+    )
     w.writeheader()
-    w.writerow({"Date":"2024-01-10","Code":"7203","O":"2800","H":"2850","L":"2780","C":"2830","Vo":"1000000","Va":"","AdjFactor":"1.0"})
+    w.writerow(
+        {
+            "Date": "2024-01-10",
+            "Code": "7203",
+            "O": "2800",
+            "H": "2850",
+            "L": "2780",
+            "C": "2830",
+            "Vo": "1000000",
+            "Va": "",
+            "AdjFactor": "1.0",
+        }
+    )
     return gzip.compress(buf.getvalue().encode())
 
 
@@ -119,11 +135,17 @@ def _gz_prices(tmp_path: Path) -> bytes:
 # テスト
 # ---------------------------------------------------------------------------
 
+
 def test_run_bootstrap_dry_run_returns_result(conn, tmp_path):
     file_list = [{"key": "prices_2024_01.csv.gz", "date": "2024-01"}]
-    with patch("kabusys.data.bootstrap.runner.list_files", return_value=file_list), \
-         patch("kabusys.data.bootstrap.runner.get_presigned_url", return_value="https://s3/f"), \
-         patch("kabusys.data.bootstrap.runner.download_file") as mock_dl:
+    with (
+        patch("kabusys.data.bootstrap.runner.list_files", return_value=file_list),
+        patch(
+            "kabusys.data.bootstrap.runner.get_presigned_url",
+            return_value="https://s3/f",
+        ),
+        patch("kabusys.data.bootstrap.runner.download_file") as mock_dl,
+    ):
         result = run_bootstrap(
             conn=conn,
             api_key="test_key",
@@ -142,8 +164,10 @@ def test_run_bootstrap_skips_loaded_files(conn, tmp_path):
         "VALUES ('prices_2024_01.csv.gz', '/equities/bars/daily', 'prices_2024_01.csv.gz', 'loaded', 100)"
     )
     file_list = [{"key": "prices_2024_01.csv.gz", "date": "2024-01"}]
-    with patch("kabusys.data.bootstrap.runner.list_files", return_value=file_list), \
-         patch("kabusys.data.bootstrap.runner.download_file") as mock_dl:
+    with (
+        patch("kabusys.data.bootstrap.runner.list_files", return_value=file_list),
+        patch("kabusys.data.bootstrap.runner.download_file") as mock_dl,
+    ):
         result = run_bootstrap(
             conn=conn,
             api_key="test_key",
@@ -161,9 +185,14 @@ def test_run_bootstrap_records_loaded_status(conn, tmp_path):
     gz_path.write_bytes(_gz_prices(tmp_path))
 
     file_list = [{"key": "prices_2024_01.csv.gz", "date": "2024-01"}]
-    with patch("kabusys.data.bootstrap.runner.list_files", return_value=file_list), \
-         patch("kabusys.data.bootstrap.runner.get_presigned_url", return_value="https://s3/f"), \
-         patch("kabusys.data.bootstrap.runner.download_file", return_value=gz_path):
+    with (
+        patch("kabusys.data.bootstrap.runner.list_files", return_value=file_list),
+        patch(
+            "kabusys.data.bootstrap.runner.get_presigned_url",
+            return_value="https://s3/f",
+        ),
+        patch("kabusys.data.bootstrap.runner.download_file", return_value=gz_path),
+    ):
         result = run_bootstrap(
             conn=conn,
             api_key="test_key",
@@ -195,9 +224,14 @@ def test_run_bootstrap_continues_on_single_file_failure(conn, tmp_path):
         dest.write_bytes(_gz_prices(tmp_path))
         return dest
 
-    with patch("kabusys.data.bootstrap.runner.list_files", return_value=file_list), \
-         patch("kabusys.data.bootstrap.runner.get_presigned_url", return_value="https://s3/f"), \
-         patch("kabusys.data.bootstrap.runner.download_file", side_effect=_side_effect):
+    with (
+        patch("kabusys.data.bootstrap.runner.list_files", return_value=file_list),
+        patch(
+            "kabusys.data.bootstrap.runner.get_presigned_url",
+            return_value="https://s3/f",
+        ),
+        patch("kabusys.data.bootstrap.runner.download_file", side_effect=_side_effect),
+    ):
         result = run_bootstrap(
             conn=conn,
             api_key="test_key",

--- a/tests/test_bootstrap_schema.py
+++ b/tests/test_bootstrap_schema.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import duckdb
+
 import pytest
 from kabusys.data.schema import init_schema
 
@@ -17,7 +17,16 @@ def test_dividends_table_exists(schema_conn):
         "SELECT column_name FROM information_schema.columns WHERE table_name='dividends'"
     ).fetchall()
     cols = {r[0] for r in rows}
-    assert cols == {"code", "pub_date", "ref_no", "ex_date", "record_date", "pay_date", "div_rate", "fetched_at"}
+    assert cols == {
+        "code",
+        "pub_date",
+        "ref_no",
+        "ex_date",
+        "record_date",
+        "pay_date",
+        "div_rate",
+        "fetched_at",
+    }
 
 
 def test_topix_daily_table_exists(schema_conn):
@@ -33,7 +42,15 @@ def test_bootstrap_load_history_table_exists(schema_conn):
         "SELECT column_name FROM information_schema.columns WHERE table_name='bootstrap_load_history'"
     ).fetchall()
     cols = {r[0] for r in rows}
-    assert cols == {"file_key", "endpoint", "file_name", "status", "row_count", "error_msg", "loaded_at"}
+    assert cols == {
+        "file_key",
+        "endpoint",
+        "file_name",
+        "status",
+        "row_count",
+        "error_msg",
+        "loaded_at",
+    }
 
 
 def test_raw_prices_has_adj_factor(schema_conn):

--- a/tests/test_bootstrap_schema.py
+++ b/tests/test_bootstrap_schema.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+import duckdb
+import pytest
+from kabusys.data.schema import init_schema
+
+
+@pytest.fixture
+def schema_conn(tmp_path):
+    db = tmp_path / "test.duckdb"
+    conn = init_schema(str(db))
+    yield conn
+    conn.close()
+
+
+def test_dividends_table_exists(schema_conn):
+    rows = schema_conn.execute(
+        "SELECT column_name FROM information_schema.columns WHERE table_name='dividends'"
+    ).fetchall()
+    cols = {r[0] for r in rows}
+    assert cols == {"code", "pub_date", "ref_no", "ex_date", "record_date", "pay_date", "div_rate", "fetched_at"}
+
+
+def test_topix_daily_table_exists(schema_conn):
+    rows = schema_conn.execute(
+        "SELECT column_name FROM information_schema.columns WHERE table_name='topix_daily'"
+    ).fetchall()
+    cols = {r[0] for r in rows}
+    assert cols == {"date", "open", "high", "low", "close"}
+
+
+def test_bootstrap_load_history_table_exists(schema_conn):
+    rows = schema_conn.execute(
+        "SELECT column_name FROM information_schema.columns WHERE table_name='bootstrap_load_history'"
+    ).fetchall()
+    cols = {r[0] for r in rows}
+    assert cols == {"file_key", "endpoint", "file_name", "status", "row_count", "error_msg", "loaded_at"}
+
+
+def test_raw_prices_has_adj_factor(schema_conn):
+    rows = schema_conn.execute(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_name='raw_prices' AND column_name='adj_factor'"
+    ).fetchall()
+    assert len(rows) == 1
+
+
+def test_bootstrap_load_history_upsert_idempotent(schema_conn):
+    schema_conn.execute(
+        "INSERT INTO bootstrap_load_history (file_key, endpoint, file_name, status) "
+        "VALUES ('k1', '/equities/bars/daily', 'f.csv.gz', 'pending')"
+    )
+    schema_conn.execute(
+        "INSERT INTO bootstrap_load_history (file_key, endpoint, file_name, status) "
+        "VALUES ('k1', '/equities/bars/daily', 'f.csv.gz', 'loaded') "
+        "ON CONFLICT (file_key) DO UPDATE SET status = EXCLUDED.status"
+    )
+    row = schema_conn.execute(
+        "SELECT status FROM bootstrap_load_history WHERE file_key='k1'"
+    ).fetchone()
+    assert row[0] == "loaded"

--- a/tests/test_broker_factory.py
+++ b/tests/test_broker_factory.py
@@ -72,10 +72,34 @@ class TestBrokerClientFactory:
         broker = BrokerClientFactory.create(Settings())
         assert broker.fill_mode == "instant"
 
-    def test_live_mode_raises_not_implemented(self, monkeypatch):
+    def test_live_mode_returns_kabu_station_client(self, monkeypatch):
+        from kabusys.execution.kabu_client import KabuStationClient
         monkeypatch.setenv("KABUSYS_ENV", "live")
-        with pytest.raises(NotImplementedError):
-            BrokerClientFactory.create(Settings())
+        monkeypatch.setenv("KABU_API_PASSWORD", "test_password")
+        monkeypatch.delenv("KABU_TRADE_PASSWORD", raising=False)
+        broker = BrokerClientFactory.create(Settings())
+        assert isinstance(broker, KabuStationClient)
+        broker.close()  # httpx.Client を閉じる
+
+    def test_live_mode_passes_trade_password_when_set(self, monkeypatch):
+        from kabusys.execution.kabu_client import KabuStationClient
+        monkeypatch.setenv("KABUSYS_ENV", "live")
+        monkeypatch.setenv("KABU_API_PASSWORD", "api_pass")
+        monkeypatch.setenv("KABU_TRADE_PASSWORD", "trade_pass")
+        broker = BrokerClientFactory.create(Settings())
+        assert isinstance(broker, KabuStationClient)
+        assert broker._trade_password == "trade_pass"
+        broker.close()
+
+    def test_live_mode_falls_back_to_api_password_when_trade_password_not_set(self, monkeypatch):
+        from kabusys.execution.kabu_client import KabuStationClient
+        monkeypatch.setenv("KABUSYS_ENV", "live")
+        monkeypatch.setenv("KABU_API_PASSWORD", "api_pass")
+        monkeypatch.delenv("KABU_TRADE_PASSWORD", raising=False)
+        broker = BrokerClientFactory.create(Settings())
+        assert isinstance(broker, KabuStationClient)
+        assert broker._trade_password == "api_pass"
+        broker.close()
 
     def test_fill_mode_never_applied(self, monkeypatch):
         monkeypatch.setenv("KABUSYS_ENV", "paper_trading")

--- a/tests/test_broker_factory.py
+++ b/tests/test_broker_factory.py
@@ -95,3 +95,17 @@ class TestBrokerClientFactory:
         monkeypatch.setenv("KABUSYS_ENV", "unknown_env")
         with pytest.raises(ValueError):
             BrokerClientFactory.create(Settings())
+
+
+class TestKabuTradePassword:
+    def test_returns_none_when_not_set(self, monkeypatch):
+        monkeypatch.delenv("KABU_TRADE_PASSWORD", raising=False)
+        assert Settings().kabu_trade_password is None
+
+    def test_returns_value_when_set(self, monkeypatch):
+        monkeypatch.setenv("KABU_TRADE_PASSWORD", "secret123")
+        assert Settings().kabu_trade_password == "secret123"
+
+    def test_returns_none_for_empty_string(self, monkeypatch):
+        monkeypatch.setenv("KABU_TRADE_PASSWORD", "")
+        assert Settings().kabu_trade_password is None

--- a/tests/test_broker_factory.py
+++ b/tests/test_broker_factory.py
@@ -74,6 +74,7 @@ class TestBrokerClientFactory:
 
     def test_live_mode_returns_kabu_station_client(self, monkeypatch):
         from kabusys.execution.kabu_client import KabuStationClient
+
         monkeypatch.setenv("KABUSYS_ENV", "live")
         monkeypatch.setenv("KABU_API_PASSWORD", "test_password")
         monkeypatch.delenv("KABU_TRADE_PASSWORD", raising=False)
@@ -83,6 +84,7 @@ class TestBrokerClientFactory:
 
     def test_live_mode_passes_trade_password_when_set(self, monkeypatch):
         from kabusys.execution.kabu_client import KabuStationClient
+
         monkeypatch.setenv("KABUSYS_ENV", "live")
         monkeypatch.setenv("KABU_API_PASSWORD", "api_pass")
         monkeypatch.setenv("KABU_TRADE_PASSWORD", "trade_pass")
@@ -91,8 +93,11 @@ class TestBrokerClientFactory:
         assert broker._trade_password == "trade_pass"
         broker.close()
 
-    def test_live_mode_falls_back_to_api_password_when_trade_password_not_set(self, monkeypatch):
+    def test_live_mode_falls_back_to_api_password_when_trade_password_not_set(
+        self, monkeypatch
+    ):
         from kabusys.execution.kabu_client import KabuStationClient
+
         monkeypatch.setenv("KABUSYS_ENV", "live")
         monkeypatch.setenv("KABU_API_PASSWORD", "api_pass")
         monkeypatch.delenv("KABU_TRADE_PASSWORD", raising=False)

--- a/tests/test_generated.py
+++ b/tests/test_generated.py
@@ -1,332 +1,98 @@
+
 import os
-import math
-from unittest import mock
+from pathlib import Path
+import tempfile
+import builtins
+import io
 
 import pytest
 
-# 自動 .env ロードを抑止しておく（テストの安定化）
-os.environ.setdefault("KABUSYS_DISABLE_AUTO_ENV_LOAD", "1")
-
-# インポート（テスト対象モジュール）
-from kabusys.run_monitoring import _get_poll_interval
-from kabusys.portfolio.portfolio_builder import (
-    select_candidates,
-    calc_equal_weights,
-    calc_score_weights,
-)
-from kabusys.portfolio.risk_adjustment import (
-    apply_sector_cap,
-    calc_regime_multiplier,
-)
-from kabusys.portfolio.position_sizing import calc_position_sizes
-from kabusys.config import (
-    _parse_env_line,
-    _load_env_file,
-    Settings,
-)
-from kabusys.research.feature_exploration import calc_ic, rank
-
-# process_priority のテストでモックするためインポート
+from kabusys.config import _parse_env_line, _load_env_file, Settings
 
 
-# -----------------------
-# run_monitoring._get_poll_interval
-# -----------------------
-@pytest.mark.parametrize(
-    ("env_val", "expected"),
-    [
-        ("10", 10),
-        (None, 60),  # デフォルト
-    ],
-)
-def test_get_poll_interval_valid(monkeypatch, env_val, expected):
-    if env_val is None:
-        monkeypatch.delenv("MONITOR_POLL_INTERVAL", raising=False)
-    else:
-        monkeypatch.setenv("MONITOR_POLL_INTERVAL", env_val)
-    assert _get_poll_interval() == expected
-
-
-def test_get_poll_interval_invalid_nonint(monkeypatch, caplog):
-    monkeypatch.setenv("MONITOR_POLL_INTERVAL", "notint")
-    caplog.clear()
-    val = _get_poll_interval()
-    assert val == 60
-    # 警告ログが出ていること
-    assert any(
-        "MONITOR_POLL_INTERVAL の値が不正" in rec.message for rec in caplog.records
-    )
-
-
-def test_get_poll_interval_zero_or_negative(monkeypatch):
-    for v in ("0", "-5"):
-        monkeypatch.setenv("MONITOR_POLL_INTERVAL", v)
-        assert _get_poll_interval() == 60
-
-
-# -----------------------
-# config._parse_env_line / _load_env_file
-# -----------------------
-def test_parse_env_line_basic():
-    assert _parse_env_line("KEY=val") == ("KEY", "val")
-    assert _parse_env_line("  export KEY2 = some ") == ("KEY2", "some")
-    assert _parse_env_line("# comment") is None
+def test_parse_env_line_blank_and_comment():
     assert _parse_env_line("") is None
-    assert _parse_env_line("NOEQ") is None
+    assert _parse_env_line("   \n") is None
+    assert _parse_env_line("# a comment") is None
 
 
-def test_parse_env_line_quoted_and_escaped():
-    # シングルクォート内のエスケープ
-    line = r"SECRET='pa\'ss\"word'"
+def test_parse_env_line_export_and_simple():
+    assert _parse_env_line("export KEY=val") == ("KEY", "val")
+    assert _parse_env_line("KEY = value with spaces ") == ("KEY", "value with spaces")
+    # missing '='
+    assert _parse_env_line("INVALIDLINE") is None
+
+
+def test_parse_env_line_quoted_and_escapes():
+    # single quotes with escaped single quote inside (using backslash)
+    line = "S='a\\'b#notcomment'  # trailing comment"
     k, v = _parse_env_line(line)
-    assert k == "SECRET"
-    # エスケープがデコードされていること
-    assert "pa'ss\"word" == v
+    assert k == "S"
+    assert v == "a'b#notcomment"  # backslash unescaped and comment inside quotes preserved
 
-    # ダブルクォートとインラインコメント
-    line2 = 'FOO="a=b # not comment"  # trailing comment'
+    # double quotes and escape of double quote
+    line2 = 'D="x\\\"y"'
     k2, v2 = _parse_env_line(line2)
-    assert k2 == "FOO"
-    assert v2 == "a=b # not comment"
+    assert k2 == "D"
+    assert v2 == 'x"y'
+
+
+def test_parse_env_line_unquoted_inline_comment():
+    # '#' preceded by space is taken as comment
+    assert _parse_env_line("A=foo # comment")[1] == "foo"
+    # '#' not preceded by space is part of value
+    assert _parse_env_line("B=foo#bar")[1] == "foo#bar"
 
 
 def test_load_env_file_override_and_protected(tmp_path, monkeypatch):
-    envfile = tmp_path / ".env.test"
-    envfile.write_text(
-        "\n".join(
-            [
-                "A=1",
-                "B=from_file",
-                "SECRET='x\\'y'",
-                "SKIP_ME=noeq",
-            ]
-        )
-    )
-    # 初期 OS 環境
+    env_file = tmp_path / ".env.test"
+    env_file.write_text("\n".join([
+        "A=1",
+        "B=2",
+        "C=override_me"
+    ]) + "\n", encoding="utf-8")
+
+    # prepare existing os.environ
     monkeypatch.delenv("A", raising=False)
-    monkeypatch.setenv("B", "os_b")
-    # protected は既存の OS 環境キー集合として扱われる
-    protected = frozenset(["B"])
-    # override=False: 未設定のキーのみセット
-    _load_env_file(envfile, override=False, protected=protected)
+    monkeypatch.setenv("B", "existing")
+    # protected keys should not be overridden even when override=True
+    protected = frozenset({"B"})
+
+    # load with override=False: A set, B not overwritten
+    _load_env_file(Path(env_file), override=False, protected=protected)
     assert os.environ.get("A") == "1"
-    # B は既にあるので上書きされない
-    assert os.environ.get("B") == "os_b"
-    # override=True: protected に含まれるキーは上書きされない
-    monkeypatch.setenv("B", "os_b2")
-    _load_env_file(envfile, override=True, protected=protected)
-    assert os.environ.get("B") == "os_b2"
-    # SECRET がパースされている
-    assert os.environ.get("SECRET") == "x'y"
+    assert os.environ.get("B") == "existing"
+
+    # load with override=True but protected prevents B overwrite
+    monkeypatch.setenv("B", "existing2")
+    _load_env_file(Path(env_file), override=True, protected=protected)
+    assert os.environ.get("B") == "existing2"
+    # C should be set/overwritten
+    assert os.environ.get("C") == "override_me"
 
 
-# -----------------------
-# Settings クラスの主要挙動
-# -----------------------
-def test_settings_env_and_flags(monkeypatch):
-    monkeypatch.setenv("KABUSYS_ENV", "development")
+def test_settings_paper_fill_mode_and_env(monkeypatch):
     s = Settings()
-    assert s.env == "development"
-    assert s.is_dev
-    monkeypatch.setenv("KABUSYS_ENV", "paper_trading")
-    s2 = Settings()
-    assert s2.is_paper
-    monkeypatch.setenv("KABUSYS_ENV", "live")
-    s3 = Settings()
-    assert s3.is_live
-
-
-def test_settings_invalid_env(monkeypatch):
-    monkeypatch.setenv("KABUSYS_ENV", "invalid_env_value")
-    s = Settings()
-    with pytest.raises(ValueError):
-        _ = s.env  # property アクセス時に例外
-
-
-def test_settings_paper_fill_mode_valid_and_invalid(monkeypatch):
+    # default PAPER_FILL_MODE is "instant"
     monkeypatch.delenv("PAPER_FILL_MODE", raising=False)
-    s = Settings()
     assert s.paper_fill_mode == "instant"
-    monkeypatch.setenv("PAPER_FILL_MODE", "partial")
-    assert Settings().paper_fill_mode == "partial"
-    monkeypatch.setenv("PAPER_FILL_MODE", "INVALID")
+
+    monkeypatch.setenv("PAPER_FILL_MODE", "PARTIAL")
+    assert s.paper_fill_mode == "partial"
+
+    monkeypatch.setenv("PAPER_FILL_MODE", "invalid-mode")
     with pytest.raises(ValueError):
-        _ = Settings().paper_fill_mode
+        _ = s.paper_fill_mode
 
+    # env validation
+    monkeypatch.setenv("KABUSYS_ENV", "live")
+    assert s.env == "live"
+    assert s.is_live is True
+    monkeypatch.setenv("KABUSYS_ENV", "development")
+    assert s.is_dev is True
 
-# -----------------------
-# portfolio_builder: select / weights
-# -----------------------
-def test_select_candidates_and_weights():
-    signals = [
-        {"code": "AAA", "score": 1.0, "signal_rank": 2},
-        {"code": "BBB", "score": 2.0, "signal_rank": 1},
-        {"code": "CCC", "score": 2.0, "signal_rank": 3},
-    ]
-    selected = select_candidates(signals, max_positions=2)
-    # score 降順 -> BBB (2.0, rank1), CCC (2.0, rank3) が上位2件
-    assert [s["code"] for s in selected] == ["BBB", "CCC"]
-
-    eq_weights = calc_equal_weights(selected)
-    assert math.isclose(eq_weights["BBB"], 0.5)
-    assert math.isclose(eq_weights["CCC"], 0.5)
-
-    # score_weights: sum(scores)=4.0 -> weights 2/4,2/4 -> 0.5 each
-    sw = calc_score_weights(selected)
-    assert pytest.approx(sw["BBB"]) == 0.5
-    assert pytest.approx(sw["CCC"]) == 0.5
-
-    # 全スコアが 0 の場合は等金額フォールバック
-    zero_signals = [{"code": "X", "score": 0.0}, {"code": "Y", "score": 0.0}]
-    with mock.patch("kabusys.portfolio.portfolio_builder.logger") as mocked_logger:
-        w = calc_score_weights(zero_signals)
-        assert w == {"X": 0.5, "Y": 0.5}
-        # 警告が出ていること
-        mocked_logger.warning.assert_called()
-
-
-# -----------------------
-# risk_adjustment.apply_sector_cap / calc_regime_multiplier
-# -----------------------
-def test_apply_sector_cap_basic_and_sell_codes():
-    candidates = [{"code": "A"}, {"code": "B"}, {"code": "C"}]
-    sector_map = {"A": "Tech", "B": "Tech", "C": "Food"}
-    portfolio_value = 1000000.0
-    # 現在 A,B を大量保有して Tech が上限を超えるようにする
-    current_positions = {"A": 1000, "B": 500}
-    price_map = {"A": 100.0, "B": 100.0, "C": 10.0}
-    # 1セクター上限 30% -> Tech exposure = (1000+500)*100 = 150000 -> 15% -> not blocked
-    filtered = apply_sector_cap(
-        candidates,
-        sector_map,
-        portfolio_value,
-        current_positions,
-        price_map,
-        max_sector_pct=0.10,  # 10% にすると 150k / 1M = 15% -> blocked
-    )
-    # C (Food) は残り、Tech がブロックされるため only C remains
-    assert all(c["code"] == "C" for c in filtered)
-
-    # sell_codes に A を入れると exposure が減りブロックされなくなる
-    filtered2 = apply_sector_cap(
-        candidates,
-        sector_map,
-        portfolio_value,
-        current_positions,
-        price_map,
-        max_sector_pct=0.10,
-        sell_codes={"A"},
-    )
-    # now Tech exposure = B only => 50k -> 5% -> not blocked -> all candidates remain
-    codes = {c["code"] for c in filtered2}
-    assert codes == {"A", "B", "C"}
-
-
-def test_calc_regime_multiplier_known_and_unknown(monkeypatch):
-    assert calc_regime_multiplier("bull") == 1.0
-    assert calc_regime_multiplier("neutral") == pytest.approx(0.7)
-    assert calc_regime_multiplier("bear") == pytest.approx(0.3)
-    # unknown regime: warning and fallback 1.0
-    with mock.patch("kabusys.portfolio.risk_adjustment.logger") as mocked_logger:
-        assert calc_regime_multiplier("weird") == 1.0
-        mocked_logger.warning.assert_called()
-
-
-# -----------------------
-# position_sizing.calc_position_sizes（主なケース）
-# -----------------------
-def test_calc_position_sizes_equal_and_aggregate_scaling():
-    # Simple equal weights case
-    candidates = [{"code": "AAA"}, {"code": "BBB"}]
-    weights = {"AAA": 0.5, "BBB": 0.5}
-    portfolio_value = 100_0000.0  # 1,000,000
-    available_cash = 200_000.0
-    current_positions = {}
-    open_prices = {"AAA": 1000.0, "BBB": 1000.0}
-    # max_utilization default 0.7 used in function; but available_cash limits aggregate
-    sizes = calc_position_sizes(
-        weights,
-        candidates,
-        portfolio_value,
-        available_cash,
-        current_positions,
-        open_prices,
-        allocation_method="equal",
-        lot_size=100,
-    )
-    # available_cash = 200_000 が制約: per stock = 200_000 / 2 = 100_000
-    # shares = floor(100_000 / 1000) = 100 → 100株（1単元）
-    assert sizes["AAA"] == 100
-    assert sizes["BBB"] == 100
-
-    # If available_cash smaller than total cost, aggregate scaling should reduce sizes
-    small_cash = 100_000.0
-    scaled = calc_position_sizes(
-        weights,
-        candidates,
-        portfolio_value,
-        small_cash,
-        current_positions,
-        open_prices,
-        allocation_method="equal",
-        lot_size=100,
-    )
-    # scaled total cost must not exceed small_cash
-    total_cost = sum(scaled[c] * open_prices[c] for c in scaled)
-    assert total_cost <= small_cash + 1e-6
-
-
-def test_calc_position_sizes_risk_based_and_price_missing(caplog):
-    candidates = [{"code": "X"}, {"code": "Y"}]
-    weights = {}
-    portfolio_value = 1_000_000
-    available_cash = 500_000
-    current_positions = {"X": 0}
-    open_prices = {"X": 0.0}  # price missing / zero -> skip
-    res = calc_position_sizes(
-        weights,
-        candidates,
-        portfolio_value,
-        available_cash,
-        current_positions,
-        open_prices,
-        allocation_method="risk_based",
-        lot_size=100,
-    )
-    # X skipped due to price 0, Y not in open_prices -> skipped -> empty dict
-    assert res == {}
-
-
-# -----------------------
-# feature_exploration.rank / calc_ic
-# -----------------------
-
-
-def test_rank_with_ties():
-    vals = [1.0, 2.0, 2.0, 4.0]
-    r = rank(vals)
-    # ranks should be [1, 2.5, 2.5, 4]
-    assert pytest.approx(r[0]) == 1.0
-    assert pytest.approx(r[1]) == 2.5
-    assert pytest.approx(r[2]) == 2.5
-    assert pytest.approx(r[3]) == 4.0
-
-
-def test_calc_ic_basic_and_insufficient():
-    factor = [
-        {"code": "A", "mom_1m": 0.1},
-        {"code": "B", "mom_1m": 0.2},
-        {"code": "C", "mom_1m": 0.3},
-    ]
-    forward = [
-        {"code": "A", "fwd_1d": 0.01},
-        {"code": "B", "fwd_1d": -0.02},
-        {"code": "C", "fwd_1d": 0.03},
-    ]
-    ic = calc_ic(factor, forward, "mom_1m", "fwd_1d")
-    # Should return a finite float
-    assert isinstance(ic, float)
-
-    # insufficient pairs -> None
-    ic2 = calc_ic(factor[:2], forward[:2], "mom_1m", "fwd_1d")
-    assert ic2 is None
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    assert s.log_level == "DEBUG"
+    monkeypatch.setenv("LOG_LEVEL", "nope")
+    with pytest.raises(ValueError):
+        _ = s.log_level

--- a/tests/test_generated.py
+++ b/tests/test_generated.py
@@ -1,4 +1,3 @@
-
 import json
 import math
 from datetime import date, datetime
@@ -19,9 +18,6 @@ from kabusys import validate_config as validate_mod
 from kabusys.portfolio import portfolio_builder as pb
 from kabusys.portfolio import risk_adjustment as ra
 from kabusys.portfolio import position_sizing as ps
-
-# ---- feature exploration ----
-from kabusys.feature_exploration import rank, calc_ic, factor_summary
 
 # ---- ai news nlp utils ----
 from kabusys.ai import news_nlp as news_nlp_mod
@@ -128,7 +124,13 @@ def test_validate_config_basic(monkeypatch):
     monkeypatch.setenv("KABU_API_PASSWORD", "your_value")
     errors, warnings, infos = validate_mod.validate()
     # both required set but placeholders produce warnings
-    assert any("プレースホルダ" in w or "プレースホルダ値" in w or "プレースホルダ値" for w in warnings) or len(warnings) >= 1
+    assert (
+        any(
+            "プレースホルダ" in w or "プレースホルダ値" in w or "プレースホルダ値"
+            for w in warnings
+        )
+        or len(warnings) >= 1
+    )
 
 
 # ---------------------------
@@ -158,8 +160,7 @@ def test_select_candidates_and_weights():
 
     # score weights fallback when total == 0
     zero_signals = [{"code": "X", "score": 0.0}, {"code": "Y", "score": 0.0}]
-    with pytest.warns(None) as record:
-        res = pb.calc_score_weights(zero_signals)
+    res = pb.calc_score_weights(zero_signals)
     # fallback to equal
     assert res == {"X": 0.5, "Y": 0.5}
 
@@ -168,17 +169,39 @@ def test_select_candidates_and_weights():
 # Tests for risk_adjustment
 # ---------------------------
 def test_apply_sector_cap_and_sell_codes(caplog):
-    candidates = [{"code": "A", "score": 1.0}, {"code": "B", "score": 0.5}, {"code": "C", "score": 0.2}]
+    candidates = [
+        {"code": "A", "score": 1.0},
+        {"code": "B", "score": 0.5},
+        {"code": "C", "score": 0.2},
+    ]
     sector_map = {"A": "s1", "B": "s1", "C": "unknown"}
     portfolio_value = 100000.0
     current_positions = {"A": 100, "B": 0}
     price_map = {"A": 400.0, "B": 100.0}
     # exposure for s1 = 100 * 400 = 40000 -> 40% of pv -> blocked if max_sector_pct=0.3
-    filtered = ra.apply_sector_cap(candidates, sector_map, portfolio_value, current_positions, price_map, max_sector_pct=0.3)
+    filtered = ra.apply_sector_cap(
+        candidates,
+        sector_map,
+        portfolio_value,
+        current_positions,
+        price_map,
+        max_sector_pct=0.3,
+    )
     # codes in blocked sector s1 should be excluded; C unknown must remain
-    assert all(c["code"] == "C" or sector_map.get(c["code"], "unknown") != "s1" for c in filtered)
+    assert all(
+        c["code"] == "C" or sector_map.get(c["code"], "unknown") != "s1"
+        for c in filtered
+    )
     # test that sell_codes excludes code from exposure calculation
-    filtered2 = ra.apply_sector_cap(candidates, sector_map, portfolio_value, {"A": 100, "B": 0}, price_map, max_sector_pct=0.3, sell_codes={"A"})
+    filtered2 = ra.apply_sector_cap(
+        candidates,
+        sector_map,
+        portfolio_value,
+        {"A": 100, "B": 0},
+        price_map,
+        max_sector_pct=0.3,
+        sell_codes={"A"},
+    )
     # with A sold, sector exposure becomes 0 and so no blocking -> candidates unchanged
     assert len(filtered2) == 3
 
@@ -206,7 +229,16 @@ def test_calc_position_sizes_equal_and_scaling():
     current_positions = {}
     open_prices = {"AA": 100.0, "BB": 100.0}
     # With max_utilization default 0.7, per-position alloc = 100000 * 0.5 * 0.7 = 35000 -> 350 shares -> floored to 300 (lot_size=100)
-    out = ps.calc_position_sizes(weights, candidates, portfolio_value, available_cash, current_positions, open_prices, allocation_method="equal", lot_size=100)
+    out = ps.calc_position_sizes(
+        weights,
+        candidates,
+        portfolio_value,
+        available_cash,
+        current_positions,
+        open_prices,
+        allocation_method="equal",
+        lot_size=100,
+    )
     # results should be multiples of lot_size
     for v in out.values():
         assert v % 100 == 0
@@ -222,43 +254,16 @@ def test_calc_position_sizes_risk_based_skips_missing_price(caplog):
     available_cash = 70000.0
     current_positions = {}
     open_prices = {"X": 0.0}  # missing/zero price -> skip
-    out = ps.calc_position_sizes(weights, candidates, portfolio_value, available_cash, current_positions, open_prices, allocation_method="risk_based")
+    out = ps.calc_position_sizes(
+        weights,
+        candidates,
+        portfolio_value,
+        available_cash,
+        current_positions,
+        open_prices,
+        allocation_method="risk_based",
+    )
     assert out == {}
-
-
-# ---------------------------
-# Tests for feature_exploration: rank, calc_ic, factor_summary
-# ---------------------------
-def test_rank_ties_and_order():
-    vals = [1.0, 2.0, 2.0, 4.0]
-    r = rank(vals)
-    # ranks: 1, (2+3)/2+? -> average ranks for ties: positions 1->1, 2&3 -> 2.5, 4 -> 4
-    assert len(r) == 4
-    assert math.isclose(r[0], 1.0)
-    assert math.isclose(r[1], 2.5)
-    assert math.isclose(r[2], 2.5)
-    assert math.isclose(r[3], 4.0)
-
-
-def test_calc_ic_and_threshold():
-    factor_records = [{"code": "A", "f": 1.0}, {"code": "B", "f": 2.0}, {"code": "C", "f": 3.0}]
-    forward_records = [{"code": "A", "r": 1.0}, {"code": "B", "r": 2.0}, {"code": "C", "r": 3.0}]
-    ic = calc_ic(factor_records, forward_records, "f", "r")
-    assert ic is not None
-    # Perfect rank correlation should give +1.0
-    assert pytest.approx(ic, rel=1e-6) == 1.0
-
-    # fewer than 3 valid pairs -> None
-    ic2 = calc_ic([{"code": "A", "f": 1}], [{"code": "A", "r": 1}], "f", "r")
-    assert ic2 is None
-
-
-def test_factor_summary_basic():
-    recs = [{"code": "A", "x": 1.0}, {"code": "B", "x": 3.0}, {"code": "C", "x": None}, {"code": "D", "x": 5.0}]
-    res = factor_summary(recs, ["x"])
-    assert "x" in res
-    assert res["x"]["count"] == 3
-    assert math.isclose(res["x"]["mean"], (1.0 + 3.0 + 5.0) / 3.0)
 
 
 # ---------------------------
@@ -283,7 +288,9 @@ def make_resp(content: str):
 
 def test_validate_and_extract_basic_and_edge_cases(caplog):
     # valid content with numeric score > clip
-    content = json.dumps({"results": [{"code": "1234", "score": 1.5}, {"code": 9999, "score": 0.2}]})
+    content = json.dumps(
+        {"results": [{"code": "1234", "score": 1.5}, {"code": 9999, "score": 0.2}]}
+    )
     resp = make_resp(content)
     extracted = news_nlp_mod._validate_and_extract(resp, {"1234", "9999"})
     # score should be clipped to 1.0 for code 1234
@@ -297,7 +304,9 @@ def test_validate_and_extract_basic_and_edge_cases(caplog):
     assert ex2 == {}
 
     # non-numeric score is ignored with warning
-    content3 = json.dumps({"results": [{"code": "X", "score": "nan"}, {"code": "Y", "score": "3.14"}]})
+    content3 = json.dumps(
+        {"results": [{"code": "X", "score": "nan"}, {"code": "Y", "score": "3.14"}]}
+    )
     resp3 = make_resp(content3)
     out3 = news_nlp_mod._validate_and_extract(resp3, {"Y"})
     assert "Y" in out3
@@ -329,7 +338,9 @@ def test_set_cpu_affinity_invalid_and_success(monkeypatch, caplog):
             self._nice = val
 
     dummy = DummyProc()
-    monkeypatch.setattr(pp, "psutil", mock.MagicMock(Process=lambda: dummy, cpu_count=lambda: 4))
+    monkeypatch.setattr(
+        pp, "psutil", mock.MagicMock(Process=lambda: dummy, cpu_count=lambda: 4)
+    )
     # Should not raise
     pp.set_cpu_affinity(2)
     assert dummy._affinity == [0, 1]

--- a/tests/test_generated.py
+++ b/tests/test_generated.py
@@ -1,9 +1,5 @@
-
 import os
 from pathlib import Path
-import tempfile
-import builtins
-import io
 
 import pytest
 
@@ -28,10 +24,12 @@ def test_parse_env_line_quoted_and_escapes():
     line = "S='a\\'b#notcomment'  # trailing comment"
     k, v = _parse_env_line(line)
     assert k == "S"
-    assert v == "a'b#notcomment"  # backslash unescaped and comment inside quotes preserved
+    assert (
+        v == "a'b#notcomment"
+    )  # backslash unescaped and comment inside quotes preserved
 
     # double quotes and escape of double quote
-    line2 = 'D="x\\\"y"'
+    line2 = 'D="x\\"y"'
     k2, v2 = _parse_env_line(line2)
     assert k2 == "D"
     assert v2 == 'x"y'
@@ -46,11 +44,9 @@ def test_parse_env_line_unquoted_inline_comment():
 
 def test_load_env_file_override_and_protected(tmp_path, monkeypatch):
     env_file = tmp_path / ".env.test"
-    env_file.write_text("\n".join([
-        "A=1",
-        "B=2",
-        "C=override_me"
-    ]) + "\n", encoding="utf-8")
+    env_file.write_text(
+        "\n".join(["A=1", "B=2", "C=override_me"]) + "\n", encoding="utf-8"
+    )
 
     # prepare existing os.environ
     monkeypatch.delenv("A", raising=False)

--- a/tests/test_generated.py
+++ b/tests/test_generated.py
@@ -1,332 +1,338 @@
-import os
+
+import json
 import math
-from unittest import mock
+from datetime import date, datetime
+from types import SimpleNamespace
+from pathlib import Path
 
 import pytest
+from unittest import mock
 
-# 自動 .env ロードを抑止しておく（テストの安定化）
-os.environ.setdefault("KABUSYS_DISABLE_AUTO_ENV_LOAD", "1")
+# ---- config: _parse_env_line, _load_env_file, Settings ----
+from kabusys import config as config_mod
+from kabusys.config import Settings
 
-# インポート（テスト対象モジュール）
-from kabusys.run_monitoring import _get_poll_interval
-from kabusys.portfolio.portfolio_builder import (
-    select_candidates,
-    calc_equal_weights,
-    calc_score_weights,
-)
-from kabusys.portfolio.risk_adjustment import (
-    apply_sector_cap,
-    calc_regime_multiplier,
-)
-from kabusys.portfolio.position_sizing import calc_position_sizes
-from kabusys.config import (
-    _parse_env_line,
-    _load_env_file,
-    Settings,
-)
-from kabusys.research.feature_exploration import calc_ic, rank
+# ---- validate_config ----
+from kabusys import validate_config as validate_mod
 
-# process_priority のテストでモックするためインポート
+# ---- portfolio builder & risk & position sizing ----
+from kabusys.portfolio import portfolio_builder as pb
+from kabusys.portfolio import risk_adjustment as ra
+from kabusys.portfolio import position_sizing as ps
+
+# ---- feature exploration ----
+from kabusys.feature_exploration import rank, calc_ic, factor_summary
+
+# ---- ai news nlp utils ----
+from kabusys.ai import news_nlp as news_nlp_mod
+
+# ---- utils process_priority ----
+from kabusys.utils import process_priority as pp
 
 
-# -----------------------
-# run_monitoring._get_poll_interval
-# -----------------------
-@pytest.mark.parametrize(
-    ("env_val", "expected"),
-    [
-        ("10", 10),
-        (None, 60),  # デフォルト
-    ],
-)
-def test_get_poll_interval_valid(monkeypatch, env_val, expected):
-    if env_val is None:
-        monkeypatch.delenv("MONITOR_POLL_INTERVAL", raising=False)
-    else:
-        monkeypatch.setenv("MONITOR_POLL_INTERVAL", env_val)
-    assert _get_poll_interval() == expected
+# ---------------------------
+# Tests for config parsing
+# ---------------------------
+def test_parse_env_line_basic_and_comments():
+    assert config_mod._parse_env_line("") is None
+    assert config_mod._parse_env_line("# comment") is None
+    # no '='
+    assert config_mod._parse_env_line("INVALIDLINE") is None
+    # simple key=value
+    assert config_mod._parse_env_line("KEY=val") == ("KEY", "val")
+    # inline comment after space
+    assert config_mod._parse_env_line("KEY=val #comment") == ("KEY", "val")
+    # comment char not preceded by space should be preserved
+    assert config_mod._parse_env_line("KEY=foo#bar") == ("KEY", "foo#bar")
+    # export prefix
+    assert config_mod._parse_env_line("export FOO=bar") == ("FOO", "bar")
 
 
-def test_get_poll_interval_invalid_nonint(monkeypatch, caplog):
-    monkeypatch.setenv("MONITOR_POLL_INTERVAL", "notint")
-    caplog.clear()
-    val = _get_poll_interval()
-    assert val == 60
-    # 警告ログが出ていること
-    assert any(
-        "MONITOR_POLL_INTERVAL の値が不正" in rec.message for rec in caplog.records
-    )
-
-
-def test_get_poll_interval_zero_or_negative(monkeypatch):
-    for v in ("0", "-5"):
-        monkeypatch.setenv("MONITOR_POLL_INTERVAL", v)
-        assert _get_poll_interval() == 60
-
-
-# -----------------------
-# config._parse_env_line / _load_env_file
-# -----------------------
-def test_parse_env_line_basic():
-    assert _parse_env_line("KEY=val") == ("KEY", "val")
-    assert _parse_env_line("  export KEY2 = some ") == ("KEY2", "some")
-    assert _parse_env_line("# comment") is None
-    assert _parse_env_line("") is None
-    assert _parse_env_line("NOEQ") is None
-
-
-def test_parse_env_line_quoted_and_escaped():
-    # シングルクォート内のエスケープ
-    line = r"SECRET='pa\'ss\"word'"
-    k, v = _parse_env_line(line)
-    assert k == "SECRET"
-    # エスケープがデコードされていること
-    assert "pa'ss\"word" == v
-
-    # ダブルクォートとインラインコメント
-    line2 = 'FOO="a=b # not comment"  # trailing comment'
-    k2, v2 = _parse_env_line(line2)
-    assert k2 == "FOO"
-    assert v2 == "a=b # not comment"
+def test_parse_env_line_quoted_and_escapes():
+    # double quotes with escaped quote inside
+    s = 'KEY="a\\"b"'
+    assert config_mod._parse_env_line(s) == ("KEY", 'a"b')
+    # single quotes with escaped single quote
+    s2 = "KEY='a\\'b'"
+    assert config_mod._parse_env_line(s2) == ("KEY", "a'b")
+    # empty value
+    assert config_mod._parse_env_line("KEY=") == ("KEY", "")
 
 
 def test_load_env_file_override_and_protected(tmp_path, monkeypatch):
-    envfile = tmp_path / ".env.test"
-    envfile.write_text(
-        "\n".join(
-            [
-                "A=1",
-                "B=from_file",
-                "SECRET='x\\'y'",
-                "SKIP_ME=noeq",
-            ]
-        )
-    )
-    # 初期 OS 環境
-    monkeypatch.delenv("A", raising=False)
-    monkeypatch.setenv("B", "os_b")
-    # protected は既存の OS 環境キー集合として扱われる
-    protected = frozenset(["B"])
-    # override=False: 未設定のキーのみセット
-    _load_env_file(envfile, override=False, protected=protected)
-    assert os.environ.get("A") == "1"
-    # B は既にあるので上書きされない
-    assert os.environ.get("B") == "os_b"
-    # override=True: protected に含まれるキーは上書きされない
-    monkeypatch.setenv("B", "os_b2")
-    _load_env_file(envfile, override=True, protected=protected)
-    assert os.environ.get("B") == "os_b2"
-    # SECRET がパースされている
-    assert os.environ.get("SECRET") == "x'y"
+    env_path = tmp_path / ".env"
+    env_path.write_text("A=1\nB=2\nC=3\n")
+
+    # ensure environment initially contains B=existing and OS-protected set contains B
+    monkeypatch.setenv("B", "existing")
+    # override=False should not overwrite B, but set A,C
+    config_mod._load_env_file(env_path, override=False, protected=frozenset())
+    assert Path(config_mod.__file__).exists()  # sanity: module loaded
+    assert "A" in __import__("os").environ and __import__("os").environ["A"] == "1"
+    assert __import__("os").environ["B"] == "existing"
+    assert __import__("os").environ["C"] == "3"
+
+    # Now test override=True with protected preventing overwrite
+    env_path.write_text("B=bold\nD=4\n")
+    os = __import__("os")
+    os.environ["B"] = "existing2"
+    protected = frozenset({"B"})
+    config_mod._load_env_file(env_path, override=True, protected=protected)
+    assert os.environ["B"] == "existing2"  # protected not overwritten
+    assert os.environ["D"] == "4"
 
 
-# -----------------------
-# Settings クラスの主要挙動
-# -----------------------
-def test_settings_env_and_flags(monkeypatch):
-    monkeypatch.setenv("KABUSYS_ENV", "development")
+# ---------------------------
+# Tests for Settings
+# ---------------------------
+def test_settings_env_and_log_level_and_paper_fill_mode(monkeypatch):
+    monkeypatch.delenv("KABUSYS_ENV", raising=False)
     s = Settings()
+    # default env is development
     assert s.env == "development"
     assert s.is_dev
-    monkeypatch.setenv("KABUSYS_ENV", "paper_trading")
-    s2 = Settings()
-    assert s2.is_paper
-    monkeypatch.setenv("KABUSYS_ENV", "live")
-    s3 = Settings()
-    assert s3.is_live
-
-
-def test_settings_invalid_env(monkeypatch):
-    monkeypatch.setenv("KABUSYS_ENV", "invalid_env_value")
-    s = Settings()
+    # invalid env
+    monkeypatch.setenv("KABUSYS_ENV", "BAD_ENV")
     with pytest.raises(ValueError):
-        _ = s.env  # property アクセス時に例外
+        _ = Settings().env
 
+    # log level valid / invalid
+    monkeypatch.setenv("LOG_LEVEL", "debug")
+    assert Settings().log_level == "DEBUG"
+    monkeypatch.setenv("LOG_LEVEL", "INVALID")
+    with pytest.raises(ValueError):
+        _ = Settings().log_level
 
-def test_settings_paper_fill_mode_valid_and_invalid(monkeypatch):
-    monkeypatch.delenv("PAPER_FILL_MODE", raising=False)
-    s = Settings()
-    assert s.paper_fill_mode == "instant"
-    monkeypatch.setenv("PAPER_FILL_MODE", "partial")
+    # paper_fill_mode valid / invalid
+    monkeypatch.setenv("PAPER_FILL_MODE", "instant")
+    assert Settings().paper_fill_mode == "instant"
+    monkeypatch.setenv("PAPER_FILL_MODE", "PARTIAL")
     assert Settings().paper_fill_mode == "partial"
-    monkeypatch.setenv("PAPER_FILL_MODE", "INVALID")
+    monkeypatch.setenv("PAPER_FILL_MODE", "badvalue")
     with pytest.raises(ValueError):
         _ = Settings().paper_fill_mode
 
 
-# -----------------------
-# portfolio_builder: select / weights
-# -----------------------
+# ---------------------------
+# Tests for validate_config.validate (basic parts)
+# ---------------------------
+def test_validate_config_basic(monkeypatch):
+    # Ensure required vars missing -> errors
+    monkeypatch.delenv("JQUANTS_REFRESH_TOKEN", raising=False)
+    monkeypatch.delenv("KABU_API_PASSWORD", raising=False)
+    monkeypatch.setenv("KABUSYS_ENV", "development")
+    errors, warnings, infos = validate_mod.validate()
+    assert any("必須環境変数" in e for e in errors)
+    # placeholder detection: set token to placeholder to get warning
+    monkeypatch.setenv("JQUANTS_REFRESH_TOKEN", "abc_here")
+    monkeypatch.setenv("KABU_API_PASSWORD", "your_value")
+    errors, warnings, infos = validate_mod.validate()
+    # both required set but placeholders produce warnings
+    assert any("プレースホルダ" in w or "プレースホルダ値" in w or "プレースホルダ値" for w in warnings) or len(warnings) >= 1
+
+
+# ---------------------------
+# Tests for portfolio builder
+# ---------------------------
 def test_select_candidates_and_weights():
     signals = [
-        {"code": "AAA", "score": 1.0, "signal_rank": 2},
-        {"code": "BBB", "score": 2.0, "signal_rank": 1},
-        {"code": "CCC", "score": 2.0, "signal_rank": 3},
+        {"code": "A", "signal_rank": 2, "score": 1.0},
+        {"code": "B", "signal_rank": 1, "score": 1.0},
+        {"code": "C", "signal_rank": 3, "score": 0.5},
     ]
-    selected = select_candidates(signals, max_positions=2)
-    # score 降順 -> BBB (2.0, rank1), CCC (2.0, rank3) が上位2件
-    assert [s["code"] for s in selected] == ["BBB", "CCC"]
+    sel = pb.select_candidates(signals, max_positions=2)
+    # A and B have same score, tie broken by signal_rank ascending -> B then A
+    assert [s["code"] for s in sel] == ["B", "A"]
 
-    eq_weights = calc_equal_weights(selected)
-    assert math.isclose(eq_weights["BBB"], 0.5)
-    assert math.isclose(eq_weights["CCC"], 0.5)
+    # equal weights
+    eq = pb.calc_equal_weights(sel)
+    assert set(eq.keys()) == {"B", "A"}
+    assert math.isclose(eq["B"], 0.5)
+    assert math.isclose(eq["A"], 0.5)
 
-    # score_weights: sum(scores)=4.0 -> weights 2/4,2/4 -> 0.5 each
-    sw = calc_score_weights(selected)
-    assert pytest.approx(sw["BBB"]) == 0.5
-    assert pytest.approx(sw["CCC"]) == 0.5
+    # score weights normal
+    sw = pb.calc_score_weights(sel)
+    assert set(sw.keys()) == {"B", "A"}
+    # B and A have equal score -> equal weights
+    assert math.isclose(sw["B"], sw["A"])
 
-    # 全スコアが 0 の場合は等金額フォールバック
+    # score weights fallback when total == 0
     zero_signals = [{"code": "X", "score": 0.0}, {"code": "Y", "score": 0.0}]
-    with mock.patch("kabusys.portfolio.portfolio_builder.logger") as mocked_logger:
-        w = calc_score_weights(zero_signals)
-        assert w == {"X": 0.5, "Y": 0.5}
-        # 警告が出ていること
-        mocked_logger.warning.assert_called()
+    with pytest.warns(None) as record:
+        res = pb.calc_score_weights(zero_signals)
+    # fallback to equal
+    assert res == {"X": 0.5, "Y": 0.5}
 
 
-# -----------------------
-# risk_adjustment.apply_sector_cap / calc_regime_multiplier
-# -----------------------
-def test_apply_sector_cap_basic_and_sell_codes():
-    candidates = [{"code": "A"}, {"code": "B"}, {"code": "C"}]
-    sector_map = {"A": "Tech", "B": "Tech", "C": "Food"}
-    portfolio_value = 1000000.0
-    # 現在 A,B を大量保有して Tech が上限を超えるようにする
-    current_positions = {"A": 1000, "B": 500}
-    price_map = {"A": 100.0, "B": 100.0, "C": 10.0}
-    # 1セクター上限 30% -> Tech exposure = (1000+500)*100 = 150000 -> 15% -> not blocked
-    filtered = apply_sector_cap(
-        candidates,
-        sector_map,
-        portfolio_value,
-        current_positions,
-        price_map,
-        max_sector_pct=0.10,  # 10% にすると 150k / 1M = 15% -> blocked
-    )
-    # C (Food) は残り、Tech がブロックされるため only C remains
-    assert all(c["code"] == "C" for c in filtered)
-
-    # sell_codes に A を入れると exposure が減りブロックされなくなる
-    filtered2 = apply_sector_cap(
-        candidates,
-        sector_map,
-        portfolio_value,
-        current_positions,
-        price_map,
-        max_sector_pct=0.10,
-        sell_codes={"A"},
-    )
-    # now Tech exposure = B only => 50k -> 5% -> not blocked -> all candidates remain
-    codes = {c["code"] for c in filtered2}
-    assert codes == {"A", "B", "C"}
+# ---------------------------
+# Tests for risk_adjustment
+# ---------------------------
+def test_apply_sector_cap_and_sell_codes(caplog):
+    candidates = [{"code": "A", "score": 1.0}, {"code": "B", "score": 0.5}, {"code": "C", "score": 0.2}]
+    sector_map = {"A": "s1", "B": "s1", "C": "unknown"}
+    portfolio_value = 100000.0
+    current_positions = {"A": 100, "B": 0}
+    price_map = {"A": 400.0, "B": 100.0}
+    # exposure for s1 = 100 * 400 = 40000 -> 40% of pv -> blocked if max_sector_pct=0.3
+    filtered = ra.apply_sector_cap(candidates, sector_map, portfolio_value, current_positions, price_map, max_sector_pct=0.3)
+    # codes in blocked sector s1 should be excluded; C unknown must remain
+    assert all(c["code"] == "C" or sector_map.get(c["code"], "unknown") != "s1" for c in filtered)
+    # test that sell_codes excludes code from exposure calculation
+    filtered2 = ra.apply_sector_cap(candidates, sector_map, portfolio_value, {"A": 100, "B": 0}, price_map, max_sector_pct=0.3, sell_codes={"A"})
+    # with A sold, sector exposure becomes 0 and so no blocking -> candidates unchanged
+    assert len(filtered2) == 3
 
 
-def test_calc_regime_multiplier_known_and_unknown(monkeypatch):
-    assert calc_regime_multiplier("bull") == 1.0
-    assert calc_regime_multiplier("neutral") == pytest.approx(0.7)
-    assert calc_regime_multiplier("bear") == pytest.approx(0.3)
-    # unknown regime: warning and fallback 1.0
-    with mock.patch("kabusys.portfolio.risk_adjustment.logger") as mocked_logger:
-        assert calc_regime_multiplier("weird") == 1.0
-        mocked_logger.warning.assert_called()
+def test_calc_regime_multiplier(caplog):
+    assert ra.calc_regime_multiplier("bull") == 1.0
+    assert math.isclose(ra.calc_regime_multiplier("neutral"), 0.7)
+    assert math.isclose(ra.calc_regime_multiplier("bear"), 0.3)
+    caplog.clear()
+    # unknown regime logs a warning and returns 1.0
+    val = ra.calc_regime_multiplier("unknown_regime")
+    assert val == 1.0
+    assert any("未知のレジーム" in rec.getMessage() for rec in caplog.records)
 
 
-# -----------------------
-# position_sizing.calc_position_sizes（主なケース）
-# -----------------------
-def test_calc_position_sizes_equal_and_aggregate_scaling():
-    # Simple equal weights case
-    candidates = [{"code": "AAA"}, {"code": "BBB"}]
-    weights = {"AAA": 0.5, "BBB": 0.5}
-    portfolio_value = 100_0000.0  # 1,000,000
-    available_cash = 200_000.0
+# ---------------------------
+# Tests for position_sizing (basic scenarios)
+# ---------------------------
+def test_calc_position_sizes_equal_and_scaling():
+    # Two candidates, equal weights normalized externally
+    candidates = [{"code": "AA", "score": 1}, {"code": "BB", "score": 1}]
+    weights = {"AA": 0.5, "BB": 0.5}
+    portfolio_value = 100000.0
+    available_cash = 50000.0  # intentionally small to force scaling
     current_positions = {}
-    open_prices = {"AAA": 1000.0, "BBB": 1000.0}
-    # max_utilization default 0.7 used in function; but available_cash limits aggregate
-    sizes = calc_position_sizes(
-        weights,
-        candidates,
-        portfolio_value,
-        available_cash,
-        current_positions,
-        open_prices,
-        allocation_method="equal",
-        lot_size=100,
-    )
-    # available_cash = 200_000 が制約: per stock = 200_000 / 2 = 100_000
-    # shares = floor(100_000 / 1000) = 100 → 100株（1単元）
-    assert sizes["AAA"] == 100
-    assert sizes["BBB"] == 100
-
-    # If available_cash smaller than total cost, aggregate scaling should reduce sizes
-    small_cash = 100_000.0
-    scaled = calc_position_sizes(
-        weights,
-        candidates,
-        portfolio_value,
-        small_cash,
-        current_positions,
-        open_prices,
-        allocation_method="equal",
-        lot_size=100,
-    )
-    # scaled total cost must not exceed small_cash
-    total_cost = sum(scaled[c] * open_prices[c] for c in scaled)
-    assert total_cost <= small_cash + 1e-6
+    open_prices = {"AA": 100.0, "BB": 100.0}
+    # With max_utilization default 0.7, per-position alloc = 100000 * 0.5 * 0.7 = 35000 -> 350 shares -> floored to 300 (lot_size=100)
+    out = ps.calc_position_sizes(weights, candidates, portfolio_value, available_cash, current_positions, open_prices, allocation_method="equal", lot_size=100)
+    # results should be multiples of lot_size
+    for v in out.values():
+        assert v % 100 == 0
+    # total cost must not exceed available_cash + small epsilon
+    total_cost = sum(out[c] * open_prices[c] for c in out)
+    assert total_cost <= available_cash + 1e-6
 
 
-def test_calc_position_sizes_risk_based_and_price_missing(caplog):
-    candidates = [{"code": "X"}, {"code": "Y"}]
+def test_calc_position_sizes_risk_based_skips_missing_price(caplog):
+    candidates = [{"code": "X", "score": 1}]
     weights = {}
-    portfolio_value = 1_000_000
-    available_cash = 500_000
-    current_positions = {"X": 0}
-    open_prices = {"X": 0.0}  # price missing / zero -> skip
-    res = calc_position_sizes(
-        weights,
-        candidates,
-        portfolio_value,
-        available_cash,
-        current_positions,
-        open_prices,
-        allocation_method="risk_based",
-        lot_size=100,
-    )
-    # X skipped due to price 0, Y not in open_prices -> skipped -> empty dict
-    assert res == {}
+    portfolio_value = 100000.0
+    available_cash = 70000.0
+    current_positions = {}
+    open_prices = {"X": 0.0}  # missing/zero price -> skip
+    out = ps.calc_position_sizes(weights, candidates, portfolio_value, available_cash, current_positions, open_prices, allocation_method="risk_based")
+    assert out == {}
 
 
-# -----------------------
-# feature_exploration.rank / calc_ic
-# -----------------------
-
-
-def test_rank_with_ties():
+# ---------------------------
+# Tests for feature_exploration: rank, calc_ic, factor_summary
+# ---------------------------
+def test_rank_ties_and_order():
     vals = [1.0, 2.0, 2.0, 4.0]
     r = rank(vals)
-    # ranks should be [1, 2.5, 2.5, 4]
-    assert pytest.approx(r[0]) == 1.0
-    assert pytest.approx(r[1]) == 2.5
-    assert pytest.approx(r[2]) == 2.5
-    assert pytest.approx(r[3]) == 4.0
+    # ranks: 1, (2+3)/2+? -> average ranks for ties: positions 1->1, 2&3 -> 2.5, 4 -> 4
+    assert len(r) == 4
+    assert math.isclose(r[0], 1.0)
+    assert math.isclose(r[1], 2.5)
+    assert math.isclose(r[2], 2.5)
+    assert math.isclose(r[3], 4.0)
 
 
-def test_calc_ic_basic_and_insufficient():
-    factor = [
-        {"code": "A", "mom_1m": 0.1},
-        {"code": "B", "mom_1m": 0.2},
-        {"code": "C", "mom_1m": 0.3},
-    ]
-    forward = [
-        {"code": "A", "fwd_1d": 0.01},
-        {"code": "B", "fwd_1d": -0.02},
-        {"code": "C", "fwd_1d": 0.03},
-    ]
-    ic = calc_ic(factor, forward, "mom_1m", "fwd_1d")
-    # Should return a finite float
-    assert isinstance(ic, float)
+def test_calc_ic_and_threshold():
+    factor_records = [{"code": "A", "f": 1.0}, {"code": "B", "f": 2.0}, {"code": "C", "f": 3.0}]
+    forward_records = [{"code": "A", "r": 1.0}, {"code": "B", "r": 2.0}, {"code": "C", "r": 3.0}]
+    ic = calc_ic(factor_records, forward_records, "f", "r")
+    assert ic is not None
+    # Perfect rank correlation should give +1.0
+    assert pytest.approx(ic, rel=1e-6) == 1.0
 
-    # insufficient pairs -> None
-    ic2 = calc_ic(factor[:2], forward[:2], "mom_1m", "fwd_1d")
+    # fewer than 3 valid pairs -> None
+    ic2 = calc_ic([{"code": "A", "f": 1}], [{"code": "A", "r": 1}], "f", "r")
     assert ic2 is None
+
+
+def test_factor_summary_basic():
+    recs = [{"code": "A", "x": 1.0}, {"code": "B", "x": 3.0}, {"code": "C", "x": None}, {"code": "D", "x": 5.0}]
+    res = factor_summary(recs, ["x"])
+    assert "x" in res
+    assert res["x"]["count"] == 3
+    assert math.isclose(res["x"]["mean"], (1.0 + 3.0 + 5.0) / 3.0)
+
+
+# ---------------------------
+# Tests for news_nlp calc_news_window and _validate_and_extract
+# ---------------------------
+def test_calc_news_window_expected():
+    td = date(2026, 3, 20)
+    start, end = news_nlp_mod.calc_news_window(td)
+    # start should be previous day at 06:00
+    assert start == datetime(2026, 3, 19, 6, 0)
+    # end should be previous day at 23:30
+    assert end == datetime(2026, 3, 19, 23, 30)
+
+
+def make_resp(content: str):
+    # Build object with .choices[0].message.content attribute
+    msg = SimpleNamespace(content=content)
+    choice = SimpleNamespace(message=msg)
+    resp = SimpleNamespace(choices=[choice])
+    return resp
+
+
+def test_validate_and_extract_basic_and_edge_cases(caplog):
+    # valid content with numeric score > clip
+    content = json.dumps({"results": [{"code": "1234", "score": 1.5}, {"code": 9999, "score": 0.2}]})
+    resp = make_resp(content)
+    extracted = news_nlp_mod._validate_and_extract(resp, {"1234", "9999"})
+    # score should be clipped to 1.0 for code 1234
+    assert extracted["1234"] == 1.0
+    assert math.isclose(extracted["9999"], 0.2)
+
+    # malformed JSON returns {}
+    bad = "not json"
+    resp2 = make_resp(bad)
+    ex2 = news_nlp_mod._validate_and_extract(resp2, {"1234"})
+    assert ex2 == {}
+
+    # non-numeric score is ignored with warning
+    content3 = json.dumps({"results": [{"code": "X", "score": "nan"}, {"code": "Y", "score": "3.14"}]})
+    resp3 = make_resp(content3)
+    out3 = news_nlp_mod._validate_and_extract(resp3, {"Y"})
+    assert "Y" in out3
+
+
+# ---------------------------
+# Tests for process_priority: invalid level handling and delegation
+# ---------------------------
+def test_set_process_priority_invalid_level():
+    with pytest.raises(ValueError):
+        pp.set_process_priority("super_high")
+
+
+def test_set_cpu_affinity_invalid_and_success(monkeypatch, caplog):
+    # invalid cpu_count <1
+    with pytest.raises(ValueError):
+        pp.set_cpu_affinity(0)
+
+    # simulate psutil.Process with cpu_affinity method
+    class DummyProc:
+        def __init__(self):
+            self._affinity = None
+            self.pid = 99999
+
+        def cpu_affinity(self, pinned):
+            self._affinity = pinned
+
+        def nice(self, val):
+            self._nice = val
+
+    dummy = DummyProc()
+    monkeypatch.setattr(pp, "psutil", mock.MagicMock(Process=lambda: dummy, cpu_count=lambda: 4))
+    # Should not raise
+    pp.set_cpu_affinity(2)
+    assert dummy._affinity == [0, 1]
+
+
+# End of tests

--- a/tests/test_generated.py
+++ b/tests/test_generated.py
@@ -1,94 +1,332 @@
 import os
-from pathlib import Path
+import math
+from unittest import mock
 
 import pytest
 
-from kabusys.config import _parse_env_line, _load_env_file, Settings
+# 自動 .env ロードを抑止しておく（テストの安定化）
+os.environ.setdefault("KABUSYS_DISABLE_AUTO_ENV_LOAD", "1")
+
+# インポート（テスト対象モジュール）
+from kabusys.run_monitoring import _get_poll_interval
+from kabusys.portfolio.portfolio_builder import (
+    select_candidates,
+    calc_equal_weights,
+    calc_score_weights,
+)
+from kabusys.portfolio.risk_adjustment import (
+    apply_sector_cap,
+    calc_regime_multiplier,
+)
+from kabusys.portfolio.position_sizing import calc_position_sizes
+from kabusys.config import (
+    _parse_env_line,
+    _load_env_file,
+    Settings,
+)
+from kabusys.research.feature_exploration import calc_ic, rank
+
+# process_priority のテストでモックするためインポート
 
 
-def test_parse_env_line_blank_and_comment():
+# -----------------------
+# run_monitoring._get_poll_interval
+# -----------------------
+@pytest.mark.parametrize(
+    ("env_val", "expected"),
+    [
+        ("10", 10),
+        (None, 60),  # デフォルト
+    ],
+)
+def test_get_poll_interval_valid(monkeypatch, env_val, expected):
+    if env_val is None:
+        monkeypatch.delenv("MONITOR_POLL_INTERVAL", raising=False)
+    else:
+        monkeypatch.setenv("MONITOR_POLL_INTERVAL", env_val)
+    assert _get_poll_interval() == expected
+
+
+def test_get_poll_interval_invalid_nonint(monkeypatch, caplog):
+    monkeypatch.setenv("MONITOR_POLL_INTERVAL", "notint")
+    caplog.clear()
+    val = _get_poll_interval()
+    assert val == 60
+    # 警告ログが出ていること
+    assert any(
+        "MONITOR_POLL_INTERVAL の値が不正" in rec.message for rec in caplog.records
+    )
+
+
+def test_get_poll_interval_zero_or_negative(monkeypatch):
+    for v in ("0", "-5"):
+        monkeypatch.setenv("MONITOR_POLL_INTERVAL", v)
+        assert _get_poll_interval() == 60
+
+
+# -----------------------
+# config._parse_env_line / _load_env_file
+# -----------------------
+def test_parse_env_line_basic():
+    assert _parse_env_line("KEY=val") == ("KEY", "val")
+    assert _parse_env_line("  export KEY2 = some ") == ("KEY2", "some")
+    assert _parse_env_line("# comment") is None
     assert _parse_env_line("") is None
-    assert _parse_env_line("   \n") is None
-    assert _parse_env_line("# a comment") is None
+    assert _parse_env_line("NOEQ") is None
 
 
-def test_parse_env_line_export_and_simple():
-    assert _parse_env_line("export KEY=val") == ("KEY", "val")
-    assert _parse_env_line("KEY = value with spaces ") == ("KEY", "value with spaces")
-    # missing '='
-    assert _parse_env_line("INVALIDLINE") is None
-
-
-def test_parse_env_line_quoted_and_escapes():
-    # single quotes with escaped single quote inside (using backslash)
-    line = "S='a\\'b#notcomment'  # trailing comment"
+def test_parse_env_line_quoted_and_escaped():
+    # シングルクォート内のエスケープ
+    line = r"SECRET='pa\'ss\"word'"
     k, v = _parse_env_line(line)
-    assert k == "S"
-    assert (
-        v == "a'b#notcomment"
-    )  # backslash unescaped and comment inside quotes preserved
+    assert k == "SECRET"
+    # エスケープがデコードされていること
+    assert "pa'ss\"word" == v
 
-    # double quotes and escape of double quote
-    line2 = 'D="x\\"y"'
+    # ダブルクォートとインラインコメント
+    line2 = 'FOO="a=b # not comment"  # trailing comment'
     k2, v2 = _parse_env_line(line2)
-    assert k2 == "D"
-    assert v2 == 'x"y'
-
-
-def test_parse_env_line_unquoted_inline_comment():
-    # '#' preceded by space is taken as comment
-    assert _parse_env_line("A=foo # comment")[1] == "foo"
-    # '#' not preceded by space is part of value
-    assert _parse_env_line("B=foo#bar")[1] == "foo#bar"
+    assert k2 == "FOO"
+    assert v2 == "a=b # not comment"
 
 
 def test_load_env_file_override_and_protected(tmp_path, monkeypatch):
-    env_file = tmp_path / ".env.test"
-    env_file.write_text(
-        "\n".join(["A=1", "B=2", "C=override_me"]) + "\n", encoding="utf-8"
+    envfile = tmp_path / ".env.test"
+    envfile.write_text(
+        "\n".join(
+            [
+                "A=1",
+                "B=from_file",
+                "SECRET='x\\'y'",
+                "SKIP_ME=noeq",
+            ]
+        )
     )
-
-    # prepare existing os.environ
+    # 初期 OS 環境
     monkeypatch.delenv("A", raising=False)
-    monkeypatch.setenv("B", "existing")
-    # protected keys should not be overridden even when override=True
-    protected = frozenset({"B"})
-
-    # load with override=False: A set, B not overwritten
-    _load_env_file(Path(env_file), override=False, protected=protected)
+    monkeypatch.setenv("B", "os_b")
+    # protected は既存の OS 環境キー集合として扱われる
+    protected = frozenset(["B"])
+    # override=False: 未設定のキーのみセット
+    _load_env_file(envfile, override=False, protected=protected)
     assert os.environ.get("A") == "1"
-    assert os.environ.get("B") == "existing"
+    # B は既にあるので上書きされない
+    assert os.environ.get("B") == "os_b"
+    # override=True: protected に含まれるキーは上書きされない
+    monkeypatch.setenv("B", "os_b2")
+    _load_env_file(envfile, override=True, protected=protected)
+    assert os.environ.get("B") == "os_b2"
+    # SECRET がパースされている
+    assert os.environ.get("SECRET") == "x'y"
 
-    # load with override=True but protected prevents B overwrite
-    monkeypatch.setenv("B", "existing2")
-    _load_env_file(Path(env_file), override=True, protected=protected)
-    assert os.environ.get("B") == "existing2"
-    # C should be set/overwritten
-    assert os.environ.get("C") == "override_me"
 
-
-def test_settings_paper_fill_mode_and_env(monkeypatch):
-    s = Settings()
-    # default PAPER_FILL_MODE is "instant"
-    monkeypatch.delenv("PAPER_FILL_MODE", raising=False)
-    assert s.paper_fill_mode == "instant"
-
-    monkeypatch.setenv("PAPER_FILL_MODE", "PARTIAL")
-    assert s.paper_fill_mode == "partial"
-
-    monkeypatch.setenv("PAPER_FILL_MODE", "invalid-mode")
-    with pytest.raises(ValueError):
-        _ = s.paper_fill_mode
-
-    # env validation
-    monkeypatch.setenv("KABUSYS_ENV", "live")
-    assert s.env == "live"
-    assert s.is_live is True
+# -----------------------
+# Settings クラスの主要挙動
+# -----------------------
+def test_settings_env_and_flags(monkeypatch):
     monkeypatch.setenv("KABUSYS_ENV", "development")
-    assert s.is_dev is True
+    s = Settings()
+    assert s.env == "development"
+    assert s.is_dev
+    monkeypatch.setenv("KABUSYS_ENV", "paper_trading")
+    s2 = Settings()
+    assert s2.is_paper
+    monkeypatch.setenv("KABUSYS_ENV", "live")
+    s3 = Settings()
+    assert s3.is_live
 
-    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
-    assert s.log_level == "DEBUG"
-    monkeypatch.setenv("LOG_LEVEL", "nope")
+
+def test_settings_invalid_env(monkeypatch):
+    monkeypatch.setenv("KABUSYS_ENV", "invalid_env_value")
+    s = Settings()
     with pytest.raises(ValueError):
-        _ = s.log_level
+        _ = s.env  # property アクセス時に例外
+
+
+def test_settings_paper_fill_mode_valid_and_invalid(monkeypatch):
+    monkeypatch.delenv("PAPER_FILL_MODE", raising=False)
+    s = Settings()
+    assert s.paper_fill_mode == "instant"
+    monkeypatch.setenv("PAPER_FILL_MODE", "partial")
+    assert Settings().paper_fill_mode == "partial"
+    monkeypatch.setenv("PAPER_FILL_MODE", "INVALID")
+    with pytest.raises(ValueError):
+        _ = Settings().paper_fill_mode
+
+
+# -----------------------
+# portfolio_builder: select / weights
+# -----------------------
+def test_select_candidates_and_weights():
+    signals = [
+        {"code": "AAA", "score": 1.0, "signal_rank": 2},
+        {"code": "BBB", "score": 2.0, "signal_rank": 1},
+        {"code": "CCC", "score": 2.0, "signal_rank": 3},
+    ]
+    selected = select_candidates(signals, max_positions=2)
+    # score 降順 -> BBB (2.0, rank1), CCC (2.0, rank3) が上位2件
+    assert [s["code"] for s in selected] == ["BBB", "CCC"]
+
+    eq_weights = calc_equal_weights(selected)
+    assert math.isclose(eq_weights["BBB"], 0.5)
+    assert math.isclose(eq_weights["CCC"], 0.5)
+
+    # score_weights: sum(scores)=4.0 -> weights 2/4,2/4 -> 0.5 each
+    sw = calc_score_weights(selected)
+    assert pytest.approx(sw["BBB"]) == 0.5
+    assert pytest.approx(sw["CCC"]) == 0.5
+
+    # 全スコアが 0 の場合は等金額フォールバック
+    zero_signals = [{"code": "X", "score": 0.0}, {"code": "Y", "score": 0.0}]
+    with mock.patch("kabusys.portfolio.portfolio_builder.logger") as mocked_logger:
+        w = calc_score_weights(zero_signals)
+        assert w == {"X": 0.5, "Y": 0.5}
+        # 警告が出ていること
+        mocked_logger.warning.assert_called()
+
+
+# -----------------------
+# risk_adjustment.apply_sector_cap / calc_regime_multiplier
+# -----------------------
+def test_apply_sector_cap_basic_and_sell_codes():
+    candidates = [{"code": "A"}, {"code": "B"}, {"code": "C"}]
+    sector_map = {"A": "Tech", "B": "Tech", "C": "Food"}
+    portfolio_value = 1000000.0
+    # 現在 A,B を大量保有して Tech が上限を超えるようにする
+    current_positions = {"A": 1000, "B": 500}
+    price_map = {"A": 100.0, "B": 100.0, "C": 10.0}
+    # 1セクター上限 30% -> Tech exposure = (1000+500)*100 = 150000 -> 15% -> not blocked
+    filtered = apply_sector_cap(
+        candidates,
+        sector_map,
+        portfolio_value,
+        current_positions,
+        price_map,
+        max_sector_pct=0.10,  # 10% にすると 150k / 1M = 15% -> blocked
+    )
+    # C (Food) は残り、Tech がブロックされるため only C remains
+    assert all(c["code"] == "C" for c in filtered)
+
+    # sell_codes に A を入れると exposure が減りブロックされなくなる
+    filtered2 = apply_sector_cap(
+        candidates,
+        sector_map,
+        portfolio_value,
+        current_positions,
+        price_map,
+        max_sector_pct=0.10,
+        sell_codes={"A"},
+    )
+    # now Tech exposure = B only => 50k -> 5% -> not blocked -> all candidates remain
+    codes = {c["code"] for c in filtered2}
+    assert codes == {"A", "B", "C"}
+
+
+def test_calc_regime_multiplier_known_and_unknown(monkeypatch):
+    assert calc_regime_multiplier("bull") == 1.0
+    assert calc_regime_multiplier("neutral") == pytest.approx(0.7)
+    assert calc_regime_multiplier("bear") == pytest.approx(0.3)
+    # unknown regime: warning and fallback 1.0
+    with mock.patch("kabusys.portfolio.risk_adjustment.logger") as mocked_logger:
+        assert calc_regime_multiplier("weird") == 1.0
+        mocked_logger.warning.assert_called()
+
+
+# -----------------------
+# position_sizing.calc_position_sizes（主なケース）
+# -----------------------
+def test_calc_position_sizes_equal_and_aggregate_scaling():
+    # Simple equal weights case
+    candidates = [{"code": "AAA"}, {"code": "BBB"}]
+    weights = {"AAA": 0.5, "BBB": 0.5}
+    portfolio_value = 100_0000.0  # 1,000,000
+    available_cash = 200_000.0
+    current_positions = {}
+    open_prices = {"AAA": 1000.0, "BBB": 1000.0}
+    # max_utilization default 0.7 used in function; but available_cash limits aggregate
+    sizes = calc_position_sizes(
+        weights,
+        candidates,
+        portfolio_value,
+        available_cash,
+        current_positions,
+        open_prices,
+        allocation_method="equal",
+        lot_size=100,
+    )
+    # available_cash = 200_000 が制約: per stock = 200_000 / 2 = 100_000
+    # shares = floor(100_000 / 1000) = 100 → 100株（1単元）
+    assert sizes["AAA"] == 100
+    assert sizes["BBB"] == 100
+
+    # If available_cash smaller than total cost, aggregate scaling should reduce sizes
+    small_cash = 100_000.0
+    scaled = calc_position_sizes(
+        weights,
+        candidates,
+        portfolio_value,
+        small_cash,
+        current_positions,
+        open_prices,
+        allocation_method="equal",
+        lot_size=100,
+    )
+    # scaled total cost must not exceed small_cash
+    total_cost = sum(scaled[c] * open_prices[c] for c in scaled)
+    assert total_cost <= small_cash + 1e-6
+
+
+def test_calc_position_sizes_risk_based_and_price_missing(caplog):
+    candidates = [{"code": "X"}, {"code": "Y"}]
+    weights = {}
+    portfolio_value = 1_000_000
+    available_cash = 500_000
+    current_positions = {"X": 0}
+    open_prices = {"X": 0.0}  # price missing / zero -> skip
+    res = calc_position_sizes(
+        weights,
+        candidates,
+        portfolio_value,
+        available_cash,
+        current_positions,
+        open_prices,
+        allocation_method="risk_based",
+        lot_size=100,
+    )
+    # X skipped due to price 0, Y not in open_prices -> skipped -> empty dict
+    assert res == {}
+
+
+# -----------------------
+# feature_exploration.rank / calc_ic
+# -----------------------
+
+
+def test_rank_with_ties():
+    vals = [1.0, 2.0, 2.0, 4.0]
+    r = rank(vals)
+    # ranks should be [1, 2.5, 2.5, 4]
+    assert pytest.approx(r[0]) == 1.0
+    assert pytest.approx(r[1]) == 2.5
+    assert pytest.approx(r[2]) == 2.5
+    assert pytest.approx(r[3]) == 4.0
+
+
+def test_calc_ic_basic_and_insufficient():
+    factor = [
+        {"code": "A", "mom_1m": 0.1},
+        {"code": "B", "mom_1m": 0.2},
+        {"code": "C", "mom_1m": 0.3},
+    ]
+    forward = [
+        {"code": "A", "fwd_1d": 0.01},
+        {"code": "B", "fwd_1d": -0.02},
+        {"code": "C", "fwd_1d": 0.03},
+    ]
+    ic = calc_ic(factor, forward, "mom_1m", "fwd_1d")
+    # Should return a finite float
+    assert isinstance(ic, float)
+
+    # insufficient pairs -> None
+    ic2 = calc_ic(factor[:2], forward[:2], "mom_1m", "fwd_1d")
+    assert ic2 is None

--- a/tests/test_run_execution.py
+++ b/tests/test_run_execution.py
@@ -6,6 +6,7 @@ import pytest
 import yaml as yaml_mod
 
 import kabusys.run_execution as re_mod
+from kabusys.execution.broker_api import Position
 from kabusys.execution.risk_manager import RiskConfig
 from kabusys.run_execution import main
 
@@ -14,6 +15,7 @@ def _run_main(is_paper: bool = False):
     """全依存をモックして main() を実行するヘルパー。"""
     mock_broker = MagicMock()
     mock_broker.get_available_cash.return_value = 10_000_000.0
+    mock_broker.get_positions.return_value = []
     mock_engine = MagicMock()
 
     with (
@@ -30,6 +32,7 @@ def _run_main(is_paper: bool = False):
         patch("kabusys.run_execution.RiskManager"),
         patch("kabusys.run_execution.Reconciler"),
         patch("kabusys.run_execution.ExecutionEngine", return_value=mock_engine),
+        patch("kabusys.run_execution._load_risk_config", return_value=MagicMock()),
     ):
         settings = MagicMock()
         settings.is_paper = is_paper
@@ -60,6 +63,77 @@ class TestRunExecutionMain:
     def test_calls_run_session(self):
         _, _, mock_engine, _ = _run_main()
         mock_engine.run_session.assert_called_once()
+
+    def test_initial_portfolio_value_includes_positions(self):
+        mock_broker = MagicMock()
+        mock_broker.get_available_cash.return_value = 1_000_000.0
+        mock_broker.get_positions.return_value = [
+            Position(code="1234", qty=100, avg_price=2000.0, current_price=2500.0),
+            # 100 * 2500 = 250_000
+        ]
+        mock_engine = MagicMock()
+
+        with (
+            patch("kabusys.run_execution.set_process_priority"),
+            patch("kabusys.run_execution.Settings") as mock_settings_cls,
+            patch("kabusys.run_execution.sqlite3.connect"),
+            patch("kabusys.run_execution.init_monitoring_db"),
+            patch("kabusys.run_execution.duckdb.connect"),
+            patch("kabusys.run_execution.BrokerClientFactory.create", return_value=mock_broker),
+            patch("kabusys.run_execution.OrderRepository"),
+            patch("kabusys.run_execution.OrderManager"),
+            patch("kabusys.run_execution.RiskManager"),
+            patch("kabusys.run_execution.Reconciler"),
+            patch("kabusys.run_execution.ExecutionEngine", return_value=mock_engine),
+            patch("kabusys.run_execution._load_risk_config") as mock_load,
+        ):
+            mock_load.return_value = MagicMock()
+            settings = MagicMock()
+            settings.is_paper = False
+            settings.sqlite_path = Path("/prod.db")
+            settings.duckdb_path = Path("/data.duckdb")
+            mock_settings_cls.return_value = settings
+
+            main()
+
+        # _load_risk_config は total_assets = 1_000_000 + 250_000 = 1_250_000 で呼ばれる
+        mock_load.assert_called_once()
+        assert mock_load.call_args.kwargs["initial_portfolio_value"] == 1_250_000.0
+
+    def test_initial_portfolio_value_fallback_to_avg_price_when_no_current_price(self):
+        mock_broker = MagicMock()
+        mock_broker.get_available_cash.return_value = 500_000.0
+        mock_broker.get_positions.return_value = [
+            Position(code="9999", qty=200, avg_price=1500.0, current_price=None),
+            # current_price=None → avg_price で代替: 200 * 1500 = 300_000
+        ]
+        mock_engine = MagicMock()
+
+        with (
+            patch("kabusys.run_execution.set_process_priority"),
+            patch("kabusys.run_execution.Settings") as mock_settings_cls,
+            patch("kabusys.run_execution.sqlite3.connect"),
+            patch("kabusys.run_execution.init_monitoring_db"),
+            patch("kabusys.run_execution.duckdb.connect"),
+            patch("kabusys.run_execution.BrokerClientFactory.create", return_value=mock_broker),
+            patch("kabusys.run_execution.OrderRepository"),
+            patch("kabusys.run_execution.OrderManager"),
+            patch("kabusys.run_execution.RiskManager"),
+            patch("kabusys.run_execution.Reconciler"),
+            patch("kabusys.run_execution.ExecutionEngine", return_value=mock_engine),
+            patch("kabusys.run_execution._load_risk_config") as mock_load,
+        ):
+            mock_load.return_value = MagicMock()
+            settings = MagicMock()
+            settings.is_paper = False
+            settings.sqlite_path = Path("/prod.db")
+            settings.duckdb_path = Path("/data.duckdb")
+            mock_settings_cls.return_value = settings
+
+            main()
+
+        # total_assets = 500_000 + 300_000 = 800_000
+        assert mock_load.call_args.kwargs["initial_portfolio_value"] == 800_000.0
 
 
 def test_run_execution_stops_on_flag(tmp_path):

--- a/tests/test_run_execution.py
+++ b/tests/test_run_execution.py
@@ -130,3 +130,8 @@ class TestLoadRiskConfig:
         p = self._write_yaml(tmp_path, {"risk": {"max_position_pct": 0.20}})
         with pytest.raises(KeyError):
             re_mod._load_risk_config(p, 0.0)
+
+    def test_missing_top_level_risk_key_raises(self, tmp_path):
+        p = self._write_yaml(tmp_path, {"other": {}})
+        with pytest.raises(KeyError):
+            re_mod._load_risk_config(p, 0.0)

--- a/tests/test_run_execution.py
+++ b/tests/test_run_execution.py
@@ -2,7 +2,11 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+import yaml as yaml_mod
+
 import kabusys.run_execution as re_mod
+from kabusys.execution.risk_manager import RiskConfig
 from kabusys.run_execution import main
 
 
@@ -89,3 +93,40 @@ def test_run_execution_stops_on_flag(tmp_path):
     # フラグが起動前に存在 → エンジンは起動せず早期リターン。stop() は呼ばれない
     mock_engine.run_session.assert_not_called()
     mock_engine.stop.assert_not_called()
+
+
+class TestLoadRiskConfig:
+    def _write_yaml(self, tmp_path, data: dict) -> Path:
+        p = tmp_path / "risk_config.yaml"
+        p.write_text(yaml_mod.dump(data), encoding="utf-8")
+        return p
+
+    def test_loads_all_fields(self, tmp_path):
+        p = self._write_yaml(tmp_path, {
+            "risk": {
+                "max_position_pct": 0.15,
+                "max_utilization": 0.70,
+                "rate_limit_per_sec": 3,
+                "circuit_breaker_errors": 5,
+                "circuit_breaker_window_sec": 30,
+                "max_drawdown": 0.10,
+            }
+        })
+        config = re_mod._load_risk_config(p, initial_portfolio_value=5_000_000.0)
+        assert isinstance(config, RiskConfig)
+        assert config.max_position_pct == 0.15
+        assert config.max_utilization == 0.70
+        assert config.rate_limit_per_sec == 3
+        assert config.circuit_breaker_errors == 5
+        assert config.circuit_breaker_window_sec == 30
+        assert config.max_drawdown == 0.10
+        assert config.initial_portfolio_value == 5_000_000.0
+
+    def test_file_not_found_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            re_mod._load_risk_config(tmp_path / "nonexistent.yaml", 0.0)
+
+    def test_missing_key_raises(self, tmp_path):
+        p = self._write_yaml(tmp_path, {"risk": {"max_position_pct": 0.20}})
+        with pytest.raises(KeyError):
+            re_mod._load_risk_config(p, 0.0)

--- a/tests/test_run_execution.py
+++ b/tests/test_run_execution.py
@@ -298,3 +298,37 @@ class TestLoadRiskConfig:
         )
         with pytest.raises(ValueError, match="max_position_pct"):
             re_mod._load_risk_config(p, 0.0)
+
+    def test_rate_limit_per_sec_zero_raises(self, tmp_path):
+        p = self._write_yaml(
+            tmp_path,
+            {
+                "risk": {
+                    "max_position_pct": 0.20,
+                    "max_utilization": 0.80,
+                    "rate_limit_per_sec": 0,
+                    "circuit_breaker_errors": 10,
+                    "circuit_breaker_window_sec": 60,
+                    "max_drawdown": 0.20,
+                }
+            },
+        )
+        with pytest.raises(ValueError, match="rate_limit_per_sec"):
+            re_mod._load_risk_config(p, 0.0)
+
+    def test_circuit_breaker_errors_negative_raises(self, tmp_path):
+        p = self._write_yaml(
+            tmp_path,
+            {
+                "risk": {
+                    "max_position_pct": 0.20,
+                    "max_utilization": 0.80,
+                    "rate_limit_per_sec": 5,
+                    "circuit_breaker_errors": -1,
+                    "circuit_breaker_window_sec": 60,
+                    "max_drawdown": 0.20,
+                }
+            },
+        )
+        with pytest.raises(ValueError, match="circuit_breaker_errors"):
+            re_mod._load_risk_config(p, 0.0)

--- a/tests/test_run_execution.py
+++ b/tests/test_run_execution.py
@@ -79,7 +79,10 @@ class TestRunExecutionMain:
             patch("kabusys.run_execution.sqlite3.connect"),
             patch("kabusys.run_execution.init_monitoring_db"),
             patch("kabusys.run_execution.duckdb.connect"),
-            patch("kabusys.run_execution.BrokerClientFactory.create", return_value=mock_broker),
+            patch(
+                "kabusys.run_execution.BrokerClientFactory.create",
+                return_value=mock_broker,
+            ),
             patch("kabusys.run_execution.OrderRepository"),
             patch("kabusys.run_execution.OrderManager"),
             patch("kabusys.run_execution.RiskManager"),
@@ -115,7 +118,10 @@ class TestRunExecutionMain:
             patch("kabusys.run_execution.sqlite3.connect"),
             patch("kabusys.run_execution.init_monitoring_db"),
             patch("kabusys.run_execution.duckdb.connect"),
-            patch("kabusys.run_execution.BrokerClientFactory.create", return_value=mock_broker),
+            patch(
+                "kabusys.run_execution.BrokerClientFactory.create",
+                return_value=mock_broker,
+            ),
             patch("kabusys.run_execution.OrderRepository"),
             patch("kabusys.run_execution.OrderManager"),
             patch("kabusys.run_execution.RiskManager"),
@@ -135,7 +141,9 @@ class TestRunExecutionMain:
         # total_assets = 500_000 + 300_000 = 800_000
         assert mock_load.call_args.kwargs["initial_portfolio_value"] == 800_000.0
 
-    def test_initial_portfolio_value_fallback_to_avg_price_when_current_price_is_zero(self):
+    def test_initial_portfolio_value_fallback_to_avg_price_when_current_price_is_zero(
+        self,
+    ):
         mock_broker = MagicMock()
         mock_broker.get_available_cash.return_value = 500_000.0
         mock_broker.get_positions.return_value = [
@@ -150,7 +158,10 @@ class TestRunExecutionMain:
             patch("kabusys.run_execution.sqlite3.connect"),
             patch("kabusys.run_execution.init_monitoring_db"),
             patch("kabusys.run_execution.duckdb.connect"),
-            patch("kabusys.run_execution.BrokerClientFactory.create", return_value=mock_broker),
+            patch(
+                "kabusys.run_execution.BrokerClientFactory.create",
+                return_value=mock_broker,
+            ),
             patch("kabusys.run_execution.OrderRepository"),
             patch("kabusys.run_execution.OrderManager"),
             patch("kabusys.run_execution.RiskManager"),
@@ -211,16 +222,19 @@ class TestLoadRiskConfig:
         return p
 
     def test_loads_all_fields(self, tmp_path):
-        p = self._write_yaml(tmp_path, {
-            "risk": {
-                "max_position_pct": 0.15,
-                "max_utilization": 0.70,
-                "rate_limit_per_sec": 3,
-                "circuit_breaker_errors": 5,
-                "circuit_breaker_window_sec": 30,
-                "max_drawdown": 0.10,
-            }
-        })
+        p = self._write_yaml(
+            tmp_path,
+            {
+                "risk": {
+                    "max_position_pct": 0.15,
+                    "max_utilization": 0.70,
+                    "rate_limit_per_sec": 3,
+                    "circuit_breaker_errors": 5,
+                    "circuit_breaker_window_sec": 30,
+                    "max_drawdown": 0.10,
+                }
+            },
+        )
         config = re_mod._load_risk_config(p, initial_portfolio_value=5_000_000.0)
         assert isinstance(config, RiskConfig)
         assert config.max_position_pct == 0.15
@@ -252,25 +266,35 @@ class TestLoadRiskConfig:
             re_mod._load_risk_config(p, 0.0)
 
     def test_max_position_pct_out_of_range_raises(self, tmp_path):
-        p = self._write_yaml(tmp_path, {"risk": {
-            "max_position_pct": 1.5,  # > 1
-            "max_utilization": 0.80,
-            "rate_limit_per_sec": 5,
-            "circuit_breaker_errors": 10,
-            "circuit_breaker_window_sec": 60,
-            "max_drawdown": 0.20,
-        }})
+        p = self._write_yaml(
+            tmp_path,
+            {
+                "risk": {
+                    "max_position_pct": 1.5,  # > 1
+                    "max_utilization": 0.80,
+                    "rate_limit_per_sec": 5,
+                    "circuit_breaker_errors": 10,
+                    "circuit_breaker_window_sec": 60,
+                    "max_drawdown": 0.20,
+                }
+            },
+        )
         with pytest.raises(ValueError, match="max_position_pct"):
             re_mod._load_risk_config(p, 0.0)
 
     def test_max_position_pct_exceeds_max_utilization_raises(self, tmp_path):
-        p = self._write_yaml(tmp_path, {"risk": {
-            "max_position_pct": 0.90,
-            "max_utilization": 0.80,
-            "rate_limit_per_sec": 5,
-            "circuit_breaker_errors": 10,
-            "circuit_breaker_window_sec": 60,
-            "max_drawdown": 0.20,
-        }})
+        p = self._write_yaml(
+            tmp_path,
+            {
+                "risk": {
+                    "max_position_pct": 0.90,
+                    "max_utilization": 0.80,
+                    "rate_limit_per_sec": 5,
+                    "circuit_breaker_errors": 10,
+                    "circuit_breaker_window_sec": 60,
+                    "max_drawdown": 0.20,
+                }
+            },
+        )
         with pytest.raises(ValueError, match="max_position_pct"):
             re_mod._load_risk_config(p, 0.0)

--- a/tests/test_run_execution.py
+++ b/tests/test_run_execution.py
@@ -135,6 +135,41 @@ class TestRunExecutionMain:
         # total_assets = 500_000 + 300_000 = 800_000
         assert mock_load.call_args.kwargs["initial_portfolio_value"] == 800_000.0
 
+    def test_initial_portfolio_value_fallback_to_avg_price_when_current_price_is_zero(self):
+        mock_broker = MagicMock()
+        mock_broker.get_available_cash.return_value = 500_000.0
+        mock_broker.get_positions.return_value = [
+            Position(code="8888", qty=100, avg_price=1000.0, current_price=0.0),
+            # current_price=0 → avg_price で代替: 100 * 1000 = 100_000
+        ]
+        mock_engine = MagicMock()
+
+        with (
+            patch("kabusys.run_execution.set_process_priority"),
+            patch("kabusys.run_execution.Settings") as mock_settings_cls,
+            patch("kabusys.run_execution.sqlite3.connect"),
+            patch("kabusys.run_execution.init_monitoring_db"),
+            patch("kabusys.run_execution.duckdb.connect"),
+            patch("kabusys.run_execution.BrokerClientFactory.create", return_value=mock_broker),
+            patch("kabusys.run_execution.OrderRepository"),
+            patch("kabusys.run_execution.OrderManager"),
+            patch("kabusys.run_execution.RiskManager"),
+            patch("kabusys.run_execution.Reconciler"),
+            patch("kabusys.run_execution.ExecutionEngine", return_value=mock_engine),
+            patch("kabusys.run_execution._load_risk_config") as mock_load,
+        ):
+            mock_load.return_value = MagicMock()
+            settings = MagicMock()
+            settings.is_paper = False
+            settings.sqlite_path = Path("/prod.db")
+            settings.duckdb_path = Path("/data.duckdb")
+            mock_settings_cls.return_value = settings
+
+            main()
+
+        # total_assets = 500_000 + 100_000 = 600_000
+        assert mock_load.call_args.kwargs["initial_portfolio_value"] == 600_000.0
+
 
 def test_run_execution_stops_on_flag(tmp_path):
     """停止フラグが事前に存在するとき、エンジンを起動せず終了することを確認する。
@@ -208,4 +243,34 @@ class TestLoadRiskConfig:
     def test_missing_top_level_risk_key_raises(self, tmp_path):
         p = self._write_yaml(tmp_path, {"other": {}})
         with pytest.raises(KeyError):
+            re_mod._load_risk_config(p, 0.0)
+
+    def test_invalid_yaml_raises_value_error(self, tmp_path):
+        p = tmp_path / "bad.yaml"
+        p.write_text("risk: [\ninvalid yaml", encoding="utf-8")
+        with pytest.raises(ValueError, match="パース失敗"):
+            re_mod._load_risk_config(p, 0.0)
+
+    def test_max_position_pct_out_of_range_raises(self, tmp_path):
+        p = self._write_yaml(tmp_path, {"risk": {
+            "max_position_pct": 1.5,  # > 1
+            "max_utilization": 0.80,
+            "rate_limit_per_sec": 5,
+            "circuit_breaker_errors": 10,
+            "circuit_breaker_window_sec": 60,
+            "max_drawdown": 0.20,
+        }})
+        with pytest.raises(ValueError, match="max_position_pct"):
+            re_mod._load_risk_config(p, 0.0)
+
+    def test_max_position_pct_exceeds_max_utilization_raises(self, tmp_path):
+        p = self._write_yaml(tmp_path, {"risk": {
+            "max_position_pct": 0.90,
+            "max_utilization": 0.80,
+            "rate_limit_per_sec": 5,
+            "circuit_breaker_errors": 10,
+            "circuit_breaker_window_sec": 60,
+            "max_drawdown": 0.20,
+        }})
+        with pytest.raises(ValueError, match="max_position_pct"):
             re_mod._load_risk_config(p, 0.0)


### PR DESCRIPTION
## Summary

- J-Quants Bulk Download API (`/v2/bulk/*`) を使った初回一括データ投入機能を実装 (Issue #187)
- 6エンドポイント対応: 株価・銘柄マスタ・財務・カレンダー・配当・TOPIX
- `bootstrap_load_history` テーブルによるファイル単位の冪等処理（再実行しても二重取り込みなし）

## Changed Files

- `src/kabusys/data/schema.py` — `dividends`, `topix_daily`, `bootstrap_load_history` テーブル追加 / `raw_prices` に `adj_factor` カラム追加
- `src/kabusys/config.py` / `config_setup.py` — `JQUANTS_BULK_API_KEY` 設定を追加
- `src/kabusys/data/bootstrap/bulk_client.py` — Bulk API クライアント (`list_files`, `get_presigned_url`, `download_file`, リトライ付き)
- `src/kabusys/data/bootstrap/loaders.py` — 6エンドポイント分のgzip CSV → DuckDB チャンクロード
- `src/kabusys/data/bootstrap/runner.py` — オーケストレーター + `main()` CLI
- `src/kabusys/data/bootstrap/__main__.py` — `python -m kabusys.data.bootstrap` エントリポイント
- `tests/conftest.py` — `MINIMAL_DDL` に `adj_factor` を追加

## Test Plan

- [ ] `pytest tests/test_bootstrap_schema.py` — スキーマ追加・マイグレーション確認
- [ ] `pytest tests/test_bootstrap_client.py` — Bulk API クライアント (リトライ・エラーハンドリング)
- [ ] `pytest tests/test_bootstrap_loaders.py` — 6ローダーの正常系・冪等性・バリデーション
- [ ] `pytest tests/test_bootstrap_runner.py` — dry-run・スキップ・失敗継続・ステータス記録
- [ ] `python -m kabusys.data.bootstrap --help` — CLI エントリポイント動作確認
- [ ] 全テスト: `pytest` → 915 passed

Closes #187