### PR TITLE
fix: バックテスト用インメモリDBにmarket_breadthを計算・挿入 (Issue #184)

### DIFF
--- a/docs/superpowers/specs/2026-04-25-jquants-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-04-25-jquants-bootstrap-design.md
@@ -1,0 +1,254 @@
+# J-Quants Bootstrap 実装設計書
+
+**Goal:** J-Quants Bulk Download API を使って初回環境構築時に大量のヒストリカルデータを一括投入し、バックテスト・通常運用が即座に開始できる状態にする。
+
+**Architecture:** Bulk API でファイルリストを取得 → presigned URL 経由で gzip CSV をダウンロード → ローカルキャッシュに保存 → parse & upsert → bootstrap_load_history に処理状態記録。冪等・再実行安全。
+
+**Tech Stack:** Python 3.10+, httpx, DuckDB, gzip/csv stdlib
+
+---
+
+## 1. 対象データ
+
+| Bulk エンドポイント         | Raw テーブル      | Processed テーブル | 備考                        |
+| -------------------------- | ----------------- | ------------------ | --------------------------- |
+| `/equities/bars/daily`     | `raw_prices`      | `prices_daily`     | AdjFactor を raw に保存     |
+| `/equities/master`         | —                 | `stocks`           | 最新日のみ取得              |
+| `/fins/summary`            | `raw_financials`  | `fundamentals`     | DiscDate → report_date      |
+| `/markets/calendar`        | —                 | `market_calendar`  | HolDiv で is_trading_day 判定|
+| `/fins/dividend`           | —                 | `dividends`        | 新規テーブル                |
+| `/indices/bars/daily/topix`| —                 | `topix_daily`      | 新規テーブル・regime 用     |
+
+---
+
+## 2. スキーマ変更
+
+### 2-1. `raw_prices` に `adj_factor` 列を追加
+
+```sql
+ALTER TABLE raw_prices ADD COLUMN IF NOT EXISTS adj_factor DECIMAL(18,6);
+```
+
+Bulk CSV の `AdjFactor` を保存する。差分 API 経由の行は NULL。
+
+### 2-2. `dividends` テーブル（新規）
+
+```sql
+CREATE TABLE IF NOT EXISTS dividends (
+    code         VARCHAR   NOT NULL,
+    pub_date     DATE      NOT NULL,
+    ref_no       VARCHAR   NOT NULL,
+    ex_date      DATE,
+    record_date  DATE,
+    pay_date     DATE,
+    div_rate     DECIMAL(18,4),
+    fetched_at   TIMESTAMP NOT NULL DEFAULT current_timestamp,
+    PRIMARY KEY (code, pub_date, ref_no)
+)
+```
+
+Bulk CSV マッピング: `Code→code, PubDate→pub_date, RefNo→ref_no, ExDate→ex_date, RecDate→record_date, PayDate→pay_date, DivRate→div_rate`
+
+### 2-3. `topix_daily` テーブル（新規）
+
+```sql
+CREATE TABLE IF NOT EXISTS topix_daily (
+    date   DATE          NOT NULL PRIMARY KEY,
+    open   DECIMAL(18,4) NOT NULL,
+    high   DECIMAL(18,4) NOT NULL,
+    low    DECIMAL(18,4) NOT NULL,
+    close  DECIMAL(18,4) NOT NULL
+)
+```
+
+Bulk CSV マッピング: `Date→date, O→open, H→high, L→low, C→close`
+
+### 2-4. `bootstrap_load_history` テーブル（新規）
+
+```sql
+CREATE TABLE IF NOT EXISTS bootstrap_load_history (
+    file_key   VARCHAR   NOT NULL PRIMARY KEY,
+    endpoint   VARCHAR   NOT NULL,
+    file_name  VARCHAR   NOT NULL,
+    status     VARCHAR   NOT NULL DEFAULT 'pending',
+    row_count  BIGINT,
+    error_msg  VARCHAR,
+    loaded_at  TIMESTAMP
+)
+```
+
+status 遷移: `pending → loaded`（成功）/ `pending → failed`（エラー）
+
+---
+
+## 3. モジュール構成
+
+```
+src/kabusys/data/bootstrap/
+├── __init__.py          — 公開 API: run_bootstrap()
+├── bulk_client.py       — Bulk API クライアント（list / get / download）
+├── loaders.py           — エンドポイント別 parse & upsert
+└── runner.py            — オーケストレーション + CLI
+```
+
+### 3-1. `bulk_client.py`
+
+```python
+BASE_URL = "https://api.jquants.com/v2"
+
+def list_files(endpoint: str, api_key: str) -> list[dict]:
+    """GET /v2/bulk/list?endpoint=<ep> → [{key, date, ...}, ...]"""
+
+def get_presigned_url(file_key: str, api_key: str) -> str:
+    """GET /v2/bulk/get?key=<key> → presigned URL（有効期限5分）"""
+
+def download_file(presigned_url: str, dest: Path) -> Path:
+    """presigned URL → gzip CSV をローカルに保存"""
+```
+
+認証: すべてのリクエストに `headers={"x-api-key": api_key}` を付与。
+
+### 3-2. `loaders.py`
+
+各エンドポイントに対応する `load_<name>(conn, csv_path) -> int` 関数を実装。
+
+```python
+def load_prices(conn, csv_path: Path) -> int:
+    """equities/bars/daily CSV → raw_prices & prices_daily"""
+
+def load_master(conn, csv_path: Path) -> int:
+    """equities/master CSV → stocks"""
+
+def load_financials(conn, csv_path: Path) -> int:
+    """fins/summary CSV → raw_financials & fundamentals"""
+
+def load_calendar(conn, csv_path: Path) -> int:
+    """markets/calendar CSV → market_calendar"""
+
+def load_dividend(conn, csv_path: Path) -> int:
+    """fins/dividend CSV → dividends"""
+
+def load_topix(conn, csv_path: Path) -> int:
+    """indices/bars/daily/topix CSV → topix_daily"""
+```
+
+共通処理:
+- `gzip.open(csv_path, "rt", encoding="utf-8")` で読み込み
+- チャンクサイズ 10,000 行でバッファリング
+- 全列に `ON CONFLICT ... DO UPDATE SET` で冪等 upsert
+- PK 欠損行はスキップしてログ警告
+
+### 3-3. `runner.py`
+
+```python
+ENDPOINTS = [
+    "/equities/bars/daily",
+    "/equities/master",
+    "/fins/summary",
+    "/markets/calendar",
+    "/fins/dividend",
+    "/indices/bars/daily/topix",
+]
+
+def run_bootstrap(
+    conn: duckdb.DuckDBPyConnection,
+    api_key: str,
+    raw_dir: Path = Path("data/bootstrap/raw"),
+    dry_run: bool = False,
+) -> BootstrapResult:
+    """全エンドポイントを順次処理する。1ファイル失敗でも継続。"""
+```
+
+オーケストレーション:
+1. `bootstrap_load_history` で `status='loaded'` のファイルはスキップ
+2. `list_files()` でファイルキー一覧を取得
+3. ローカルキャッシュ（`raw_dir/<endpoint>/`）があればダウンロードをスキップ
+4. `get_presigned_url()` + `download_file()` でダウンロード
+5. `load_<name>()` で DuckDB に投入
+6. `bootstrap_load_history` に `loaded / failed` を記録
+
+---
+
+## 4. 設定
+
+`Settings` クラスに追加:
+
+```python
+@property
+def jquants_bulk_api_key(self) -> str:
+    return _require("JQUANTS_BULK_API_KEY")
+```
+
+`config_setup.py` の `_ITEMS` に追加:
+
+```python
+{
+    "key": "JQUANTS_BULK_API_KEY",
+    "label": "J-Quants Bulk Download API キー",
+    "secret": True,
+    "description": "  J-Quants ダッシュボード → 設定 → APIキー から取得",
+}
+```
+
+---
+
+## 5. CLI
+
+```bash
+# 全エンドポイントを bootstrap
+python -m kabusys.data.bootstrap
+
+# ドライラン（ダウンロードせず件数確認のみ）
+python -m kabusys.data.bootstrap --dry-run
+
+# 特定エンドポイントのみ
+python -m kabusys.data.bootstrap --endpoint /equities/bars/daily
+
+# raw_dir を指定
+python -m kabusys.data.bootstrap --raw-dir /mnt/data/bootstrap/raw
+```
+
+完了後に以下のサマリーを出力:
+
+```
+Bootstrap 完了サマリー
+  /equities/bars/daily     : 1,234,567 件 (110 ファイル)
+  /equities/master         :     4,321 件 (1 ファイル)
+  /fins/summary            :   456,789 件 (32 ファイル)
+  /markets/calendar        :     3,650 件 (1 ファイル)
+  /fins/dividend           :    89,012 件 (8 ファイル)
+  /indices/bars/daily/topix:     2,500 件 (1 ファイル)
+  失敗ファイル: 0
+```
+
+---
+
+## 6. 冪等性・エラー処理
+
+| シナリオ | 対処 |
+| --- | --- |
+| 同じファイルを再実行 | `bootstrap_load_history.status = 'loaded'` なのでスキップ |
+| ローカルキャッシュあり | ダウンロードせず直接 load |
+| DuckDB upsert 重複 | `ON CONFLICT DO UPDATE` で上書き |
+| 1ファイルでパースエラー | `failed` 記録 → 次ファイルに継続 |
+| presigned URL 期限切れ | 再取得して retry（最大3回） |
+| DuckDB 接続エラー | 即時 raise（呼び出し元でハンドリング） |
+
+---
+
+## 7. テスト方針
+
+- `test_bulk_client.py`: `httpx` をモックして list / get / download をテスト
+- `test_loaders.py`: tmp_path に小さな gzip CSV を置き、DuckDB への投入件数・スキーマを検証
+- `test_runner.py`: `bulk_client` をモックし、履歴テーブルへの記録・スキップロジックをテスト
+
+---
+
+## 8. 完了条件（Issue #187 との対応）
+
+| Issue 完了条件 | 実装対応 |
+| --- | --- |
+| J-Quants CSV を安全に一括投入できる | Bulk API + loaders で全6種対応 |
+| 通常の日次差分更新と責務が分離される | `kabusys.data.bootstrap` は独立モジュール |
+| 途中失敗しても再実行で安全にリトライできる | `bootstrap_load_history` + スキップロジック |
+| bootstrap 完了後に通常運用へ移行できる | `prices_daily` 等が埋まるため即座に移行可能 |

--- a/documents/01_Data/DataPlatform.md
+++ b/documents/01_Data/DataPlatform.md
@@ -1,7 +1,7 @@
 # Data Platform (データ・インフラ基盤)
 
 - 対象: 日本株自動売買基盤における全データパイプライン
-- 版数: v1.0 (AI統合・完全分離版)
+- 版数: v1.1 (Bootstrap / Bulk API 追記)
 
 ---
 
@@ -41,13 +41,22 @@
 
 ### 3.1 外部データ (API/RSS等)
 
-| データ               | ソース               | 概要                                       |
-| -------------------- | -------------------- | ------------------------------------------ |
-| 株価（日足）、出来高 | J-Quants             | （OHLCV）                                  |
-| 財務データ           | J-Quants             | 四半期ごとのBS/PLサマリ                    |
-| 銘柄マスタ           | J-Quants             | 銘柄一覧・上場情報、コーポレートアクション |
-| JPXカレンダー        | J-Quants             | 祝日、半日取引、SQ日フラグ                 |
-| ニュース記事         | Yahoo News / 日経 等 | RSSやスクレイピングデータ                  |
+| データ               | ソース                         | 取得方式                  | 概要                                       |
+| -------------------- | ------------------------------ | ------------------------- | ------------------------------------------ |
+| 株価（日足）、出来高 | J-Quants                       | 差分 API / Bulk API       | OHLCV・分割調整係数                        |
+| 財務データ           | J-Quants                       | 差分 API / Bulk API       | 四半期ごとのBS/PLサマリ                    |
+| 銘柄マスタ           | J-Quants                       | 差分 API / Bulk API       | 銘柄一覧・上場情報                         |
+| JPXカレンダー        | J-Quants                       | 差分 API / Bulk API       | 祝日、半日取引、SQ日フラグ                 |
+| 配当情報             | J-Quants Bulk API              | Bulk API のみ             | 配当率・権利落ち日・支払日等               |
+| TOPIX 日足           | J-Quants Bulk API              | Bulk API のみ             | regime_detector の ma200_ratio 算出に使用  |
+| ニュース記事         | Yahoo News / 日経 等           | RSS / スクレイピング      | RSSやスクレイピングデータ                  |
+
+#### J-Quants API 認証方式
+
+| API 種別         | エンドポイント        | 認証ヘッダー                    | 設定キー                  |
+| ---------------- | --------------------- | ------------------------------- | ------------------------- |
+| 通常 API (V1)    | `/v1/*`               | `Authorization: Bearer {token}` | `JQUANTS_REFRESH_TOKEN`   |
+| Bulk Download API | `/v2/bulk/*`         | `x-api-key: {key}`              | `JQUANTS_BULK_API_KEY`    |
 
 ### 3.2 内部生成データ (自システム)
 
@@ -72,9 +81,52 @@ Data Fetch -> [ Raw Layer ] -> Data Cleaning -> [ Processed Layer ] -> Feature G
 - **Idempotency (冪等性)**: データ取得・変換ジョブは一意制約（Unique constraints）により、重複して登録されないように設計する。
 - **差分更新とAPIスロットリング**: J-Quants APIの利用上限（120リクエスト/分）等を超えないようにスロットル制御（Rate-limiting）を設け、効率よく差分のみを取得する。
 
-### 4.2 主要ジョブ
+### 4.2 主要ジョブ（日次差分更新）
 
 - `calendar_update_job`: J-Quants等からJPXカレンダー情報（祝日・SQ日など）を取得し、`market_calendar` テーブルを更新する夜間バッチ処理。
+
+### 4.3 Bootstrap フロー（初回一括投入）
+
+通常の差分更新では非効率な初回環境構築時に、**J-Quants Bulk Download API** を使って大量のヒストリカルデータを一括投入する。
+
+```
+J-Quants Bulk API
+  GET /v2/bulk/list?endpoint=<ep>  → ファイルキー一覧
+  GET /v2/bulk/get?key=<key>       → presigned URL（有効期限5分）
+      ↓ gzip CSV ダウンロード
+  data/bootstrap/raw/<endpoint>/   ← ローカルキャッシュ（再実行時スキップ）
+      ↓ parse & schema validation
+  raw_prices / raw_financials / stocks / market_calendar / dividends / topix_daily
+      ↓ ETL（NOT NULL / 型検証 → ON CONFLICT DO UPDATE）
+  prices_daily / fundamentals
+      ↓ 処理結果記録
+  bootstrap_load_history           ← ファイル単位の処理状態管理
+```
+
+#### 取り込み対象エンドポイント（Phase 1）
+
+| Bulk エンドポイント            | 保存先（Raw）     | 保存先（Processed）   | 備考                       |
+| ------------------------------ | ----------------- | --------------------- | -------------------------- |
+| `/equities/bars/daily`         | `raw_prices`      | `prices_daily`        | AdjFactor を raw に保存    |
+| `/equities/master`             | —                 | `stocks`              | 最新日のみ取得             |
+| `/fins/summary`                | `raw_financials`  | `fundamentals`        | 既存スキーマに対応         |
+| `/markets/calendar`            | —                 | `market_calendar`     | 既存スキーマに対応         |
+| `/fins/dividend`               | —                 | `dividends`（新規）   | 戦略で活用可能             |
+| `/indices/bars/daily/topix`    | —                 | `topix_daily`（新規） | regime_detector が参照     |
+
+#### 冪等性・エラー方針
+
+- `bootstrap_load_history` にファイル単位で `pending / loaded / failed` を記録
+- 再実行時は `loaded` 済みファイルをスキップ
+- 1ファイル失敗でも他ファイルは継続し、エラーをログ記録
+- DuckDB への挿入は `ON CONFLICT DO UPDATE` で常に冪等
+
+#### CLI
+
+```bash
+python -m kabusys.data.bootstrap            # 全エンドポイント
+python -m kabusys.data.bootstrap --dry-run  # ダウンロードせず件数確認のみ
+```
 
 ---
 
@@ -83,7 +135,8 @@ Data Fetch -> [ Raw Layer ] -> Data Cleaning -> [ Processed Layer ] -> Feature G
 外部ソースから取得したデータをそのまま保存する。
 
 - **目的**: パースエラー時の再処理担保、元データの保持
-- **主なテーブル**: `raw_prices`, `raw_financials`, `raw_news`, `raw_executions`
+- **主なテーブル**: `raw_prices`（`adj_factor` 列含む）, `raw_financials`, `raw_news`, `raw_executions`
+- **Bootstrap キャッシュ**: `data/bootstrap/raw/<endpoint>/` に gzip CSV を保存（再ダウンロード防止）
 
 ---
 

--- a/documents/01_Data/DataSchema.md
+++ b/documents/01_Data/DataSchema.md
@@ -40,24 +40,53 @@
 
 # 3. 市場データ
 
-## prices_daily
+## raw_prices（Raw Layer）
 
-日足株価データ。
+J-Quants から取得した生の日足株価データ。差分 API・Bulk API どちらも本テーブルに保存する。
+
+  column       type     description
+  ------------ -------- -----------------------------------------
+  date         date     取引日
+  code         string   銘柄コード
+  open         float    始値（調整前）
+  high         float    高値（調整前）
+  low          float    安値（調整前）
+  close        float    終値（調整前）
+  volume       bigint   出来高（調整前）
+  turnover     float    売買代金
+  adj_factor   float    分割調整係数（Bulk CSV の AdjFactor。差分APIは NULL）
+  fetched_at   timestamp 取込日時
+
+主キー: `(date, code)`
+取得元: J-Quants `/prices/daily_quotes`（差分 API）/ Bulk `/equities/bars/daily`
+
+Bulk CSV カラムマッピング:
+  Date → date, Code → code, O → open, H → high, L → low, C → close
+  Vo → volume, Va → turnover, AdjFactor → adj_factor
+  ※ UL・LL・AdjO/H/L/C/Vo は Raw には保存しない（prices_daily は調整前価格を使用）
+
+------------------------------------------------------------------------
+
+## prices_daily（Processed Layer）
+
+日足株価データ（整形済み）。戦略・バックテスト・research が参照する。
 
   column     type     description
   ---------- -------- -------------
   date       date     取引日
   code       string   銘柄コード
-  open       float    始値
-  high       float    高値
-  low        float    安値
-  close      float    終値
-  volume     float    出来高
+  open       float    始値（調整前）
+  high       float    高値（調整前）
+  low        float    安値（調整前）
+  close      float    終値（調整前）
+  volume     bigint   出来高
   turnover   float    売買代金
 
-主キー
+主キー: `(date, code)`
+投入元: `raw_prices` からの ETL コピー（NOT NULL・low<=high を検証後に UPSERT）
 
-    (date, code)
+注: 調整価格（分割対応）は raw_prices.adj_factor を使って算出する。
+    DataPlatform §6.1 の補正ルールを参照。
 
 ------------------------------------------------------------------------
 
@@ -65,7 +94,7 @@
 
 ## stocks
 
-全上場銘柄のマスタ情報。J-Quants `/listed/info` から毎日 UPSERT する。
+全上場銘柄のマスタ情報。毎日 UPSERT する。
 セクター集中制限（PortfolioConstruction Section 8）で参照する。
 
   column      type       description
@@ -73,16 +102,16 @@
   code        string     銘柄コード（PRIMARY KEY）
   name        string     銘柄名
   market      string     市場区分（'Prime' / 'Standard' / 'Growth' / 'Other'）
-  sector      string     TSE 33業種名（J-Quants Sector33CodeName）
+  sector      string     TSE 33業種名
   updated_at  timestamp  最終更新日時
 
-取得元: J-Quants `/listed/info`（MarketCode → market 文字列に変換）
+取得元（差分 API）: J-Quants `/listed/info`
+  "Code" → code, "CompanyName" → name
+  "MarketCode" → market（"0111"→Prime, "0121"→Standard, "0131"→Growth）
+  "Sector33CodeName" → sector
 
-フィールドマッピング:
-  J-Quants "Code"             → code
-  J-Quants "CompanyName"      → name
-  J-Quants "MarketCode"       → market（"0111"→"Prime", "0121"→"Standard", "0131"→"Growth"）
-  J-Quants "Sector33CodeName" → sector
+取得元（Bulk API）: `/equities/master`
+  Code → code, CoName → name, MktNm → market, S33Nm → sector
 
 ------------------------------------------------------------------------
 
@@ -107,21 +136,113 @@ JPXのカレンダー情報（祝日・半休・SQ等）。
 
 # 5. 財務データ
 
-## fundamentals
+## raw_financials（Raw Layer）
+
+J-Quants から取得した生の財務データ。
+
+  column             type      description
+  ------------------ --------- -------------
+  code               string    銘柄コード
+  report_date        date      開示日
+  period_type        string    会計期間タイプ（1Q/2Q/3Q/FY 等）
+  revenue            float     売上
+  operating_profit   float     営業利益
+  net_income         float     純利益
+  eps                float     EPS
+  roe                float     ROE
+  fetched_at         timestamp 取込日時
+
+主キー: `(code, report_date, period_type)`
+取得元（差分 API）: J-Quants `/fins/statements`
+取得元（Bulk API）: `/fins/summary`
+  DiscDate→report_date, CurPerType→period_type, Sales→revenue, OP→operating_profit
+  NP→net_income, EPS→eps, Eq/TA→roe
+
+------------------------------------------------------------------------
+
+## fundamentals（Processed Layer）
+
+整形済み財務データ。戦略・research が参照する。
 
   column             type     description
   ------------------ -------- -------------
   code               string   銘柄コード
   report_date        date     決算日
+  period_type        string   会計期間タイプ
   revenue            float    売上
   operating_profit   float    営業利益
   net_income         float    純利益
   eps                float    EPS
   roe                float    ROE
 
+主キー: `(code, report_date, period_type)`
+投入元: `raw_financials` からの ETL コピー
+
 ------------------------------------------------------------------------
 
-# 5. ニュースデータ
+## dividends（新規）
+
+配当情報。Bulk API `/fins/dividend` から取得。
+
+  column       type      description
+  ------------ --------- ---------------------------------------
+  code         string    銘柄コード
+  pub_date     date      公告日（PRIMARY KEY の一部）
+  ref_no       string    参照番号（PRIMARY KEY の一部）
+  ex_date      date      権利落ち日
+  record_date  date      基準日
+  pay_date     date      支払日
+  div_rate     float     配当率（円）
+  fetched_at   timestamp 取込日時
+
+主キー: `(code, pub_date, ref_no)`
+取得元: Bulk API `/fins/dividend`
+
+------------------------------------------------------------------------
+
+# 5b. 指数データ
+
+## topix_daily（新規）
+
+TOPIX 日足データ。regime_detector の ma200_ratio 算出に使用する。
+
+  column   type   description
+  -------- ------ -----------
+  date     date   取引日（PRIMARY KEY）
+  open     float  始値
+  high     float  高値
+  low      float  安値
+  close    float  終値
+
+取得元: Bulk API `/indices/bars/daily/topix`
+  Date→date, O→open, H→high, L→low, C→close
+
+------------------------------------------------------------------------
+
+# 5c. Bootstrap 管理
+
+## bootstrap_load_history
+
+Bulk API からのファイル単位の処理状態を管理する。再実行時のスキップ制御に使用。
+
+  column       type      description
+  ------------ --------- -----------------------------------------
+  file_key     string    Bulk API のファイルキー（PRIMARY KEY）
+  endpoint     string    Bulk エンドポイント（例: /equities/bars/daily）
+  file_name    string    ダウンロードファイル名
+  status       string    pending / loaded / failed
+  row_count    bigint    ロードしたレコード件数
+  error_msg    string    失敗時のエラーメッセージ
+  loaded_at    timestamp 処理完了日時
+
+状態遷移:
+  pending → loaded（正常完了）
+  pending → failed（エラー）
+  failed  → pending（手動リセット後に再実行）
+
+------------------------------------------------------------------------
+
+# 7. ニュースデータ
 
 ## news_articles
 
@@ -136,7 +257,7 @@ JPXのカレンダー情報（祝日・半休・SQ等）。
 
 ------------------------------------------------------------------------
 
-# 6. ニュース銘柄マッピング
+# 8. ニュース銘柄マッピング
 
 ## news_symbols
 
@@ -147,7 +268,7 @@ JPXのカレンダー情報（祝日・半休・SQ等）。
 
 ------------------------------------------------------------------------
 
-# 7. AIスコア
+# 9. AIスコア
 
 ## ai_scores
 
@@ -187,7 +308,7 @@ JPXのカレンダー情報（祝日・半休・SQ等）。
 
 ------------------------------------------------------------------------
 
-# 8. 特徴量
+# 10. 特徴量
 
 ## features
 
@@ -204,7 +325,7 @@ JPXのカレンダー情報（祝日・半休・SQ等）。
 
 ------------------------------------------------------------------------
 
-# 9. シグナル
+# 11. シグナル
 
 ## signals
 
@@ -220,7 +341,7 @@ JPXのカレンダー情報（祝日・半休・SQ等）。
 
 ------------------------------------------------------------------------
 
-# 10. シグナルキュー
+# 12. シグナルキュー
 
 ## signal_queue
 
@@ -263,7 +384,7 @@ Executionの処理フロー:
 
 ------------------------------------------------------------------------
 
-# 11. ポートフォリオ
+# 13. ポートフォリオ
 
 ## portfolio_targets
 
@@ -278,7 +399,7 @@ Executionの処理フロー:
 
 ------------------------------------------------------------------------
 
-# 11. 注文
+# 14. 注文
 
 ## orders
 
@@ -302,7 +423,7 @@ Executionの処理フロー:
 
 ------------------------------------------------------------------------
 
-# 12. 約定
+# 15. 約定
 
 ## trades
 
@@ -317,7 +438,7 @@ Executionの処理フロー:
 
 ------------------------------------------------------------------------
 
-# 13. ポジション
+# 16. ポジション
 
 ## positions
 
@@ -331,7 +452,7 @@ Executionの処理フロー:
 
 ------------------------------------------------------------------------
 
-# 14. パフォーマンス
+# 17. パフォーマンス
 
 ## portfolio_performance
 
@@ -345,29 +466,41 @@ Executionの処理フロー:
 
 ------------------------------------------------------------------------
 
-# 15. データフロー
+# 18. データフロー
 
-    Market Data / News        J-Quants /listed/info
-    ↓                         ↓
-    prices_daily / news_articles    stocks（銘柄マスタ）
-    ↓                               ↓
-    features / ai_scores        ────┘（セクター参照）
+## 初回 Bootstrap フロー
+
+    J-Quants Bulk API
+      /equities/bars/daily  → raw_prices → prices_daily
+      /equities/master      →              stocks
+      /fins/summary         → raw_financials → fundamentals
+      /markets/calendar     →              market_calendar
+      /fins/dividend        →              dividends（新規）
+      /indices/bars/daily/topix →          topix_daily（新規）
+    ↓ 処理状態記録
+    bootstrap_load_history
+
+## 日次差分更新フロー（通常運用）
+
+    J-Quants 差分 API
+      /prices/daily_quotes  → raw_prices → prices_daily
+      /fins/statements      → raw_financials → fundamentals
+      /listed/info          →              stocks
+      /market/trading_calendar →           market_calendar
+    ↓
+    news_articles（RSS取得）
+    ↓
+    features / ai_scores / topix_daily（regime_detector 参照）
     ↓
     signals
     ↓
-    portfolio_targets（ポートフォリオ構築モジュールが生成）
+    portfolio_targets
     ↓
-    orders
-    ↓
-    trades
-    ↓
-    positions
-    ↓
-    portfolio_performance
+    orders → trades → positions → portfolio_performance
 
 ------------------------------------------------------------------------
 
-# 16. まとめ
+# 19. まとめ
 
 本データスキーマは以下の領域をカバーする。
 

--- a/src/kabusys/backtest/engine.py
+++ b/src/kabusys/backtest/engine.py
@@ -134,7 +134,42 @@ def _build_backtest_conn(
             "_build_backtest_conn: earnings_calendar のコピーをスキップ: %s", exc
         )
 
+    # market_breadth はインメモリDB上の prices_daily から計算（外部データ依存なし）
+    _populate_backtest_breadth(bt_conn, start_date, end_date)
+
     return bt_conn
+
+
+def _populate_backtest_breadth(
+    bt_conn: duckdb.DuckDBPyConnection,
+    start_date: date,
+    end_date: date,
+) -> None:
+    """バックテスト対象期間の market_breadth を prices_daily から計算して挿入する。
+
+    prices_daily は data_start（start_date - 300日）から既にコピー済みのため、
+    breadth 計算に必要な過去データは揃っている。
+    """
+    from kabusys.data.breadth import calc_and_save_breadth
+
+    try:
+        trading_dates = bt_conn.execute(
+            "SELECT DISTINCT date FROM prices_daily "
+            "WHERE date >= ? AND date <= ? ORDER BY date",
+            [start_date, end_date],
+        ).fetchall()
+    except Exception as exc:
+        logger.warning(
+            "_populate_backtest_breadth: trading_dates 取得失敗 → market_breadth をスキップ: %s",
+            exc,
+        )
+        return
+
+    for (d,) in trading_dates:
+        try:
+            calc_and_save_breadth(bt_conn, d)
+        except Exception as exc:
+            logger.warning("_populate_backtest_breadth: date=%s のスキップ: %s", d, exc)
 
 
 def _fetch_open_prices(

--- a/src/kabusys/backtest/engine.py
+++ b/src/kabusys/backtest/engine.py
@@ -153,9 +153,14 @@ def _populate_backtest_breadth(
     from kabusys.data.breadth import calc_and_save_breadth
 
     try:
+        # EXCEPT で既存行をスキップし、未計算日のみ対象にする（再実行コスト削減）
         trading_dates = bt_conn.execute(
-            "SELECT DISTINCT date FROM prices_daily "
-            "WHERE date >= ? AND date <= ? ORDER BY date",
+            """
+            SELECT DISTINCT date FROM prices_daily
+            WHERE date >= ? AND date <= ?
+            EXCEPT SELECT date FROM market_breadth
+            ORDER BY date
+            """,
             [start_date, end_date],
         ).fetchall()
     except Exception as exc:
@@ -165,11 +170,21 @@ def _populate_backtest_breadth(
         )
         return
 
+    processed, failed = 0, 0
     for (d,) in trading_dates:
         try:
-            calc_and_save_breadth(bt_conn, d)
+            if calc_and_save_breadth(bt_conn, d):
+                processed += 1
         except Exception as exc:
+            failed += 1
             logger.warning("_populate_backtest_breadth: date=%s のスキップ: %s", d, exc)
+
+    logger.info(
+        "_populate_backtest_breadth: 完了 対象=%d processed=%d failed=%d",
+        len(trading_dates),
+        processed,
+        failed,
+    )
 
 
 def _fetch_open_prices(

--- a/tests/test_backtest_framework.py
+++ b/tests/test_backtest_framework.py
@@ -949,3 +949,88 @@ def test_position_entries_sell_date_updated(conn):
     ).fetchone()
     assert str(row[1]) == "2026-04-05"
     bt_conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Issue #184: market_breadth バックテスト対応
+# ---------------------------------------------------------------------------
+
+
+def _insert_prices_for_breadth(conn, base_date: date, n_days: int = 30) -> None:
+    """breadth 計算に必要な十分な price データを挿入する。
+
+    n_days 日分の価格データを 10 銘柄分作成する。
+    base_date の当日分も含めるため range(n_days + 1) とする。
+    """
+    codes = [f"{1000 + i:04d}" for i in range(10)]
+    for i in range(n_days + 1):
+        d = base_date - timedelta(days=n_days - i)
+        for j, code in enumerate(codes):
+            close_price = 1000.0 + j * 10 + i  # 単調増加で上昇銘柄が多い
+            conn.execute(
+                "INSERT INTO prices_daily (date, code, open, high, low, close, volume) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                [d, code, close_price, close_price, close_price, close_price, 100_000],
+            )
+
+
+def test_populate_backtest_breadth_inserts_rows(conn):
+    """_populate_backtest_breadth: 対象期間に market_breadth が挿入される。"""
+    from kabusys.backtest.engine import _populate_backtest_breadth
+
+    target = date(2024, 3, 1)
+    _insert_prices_for_breadth(conn, target, n_days=30)
+
+    _populate_backtest_breadth(conn, target, target)
+
+    row = conn.execute(
+        "SELECT adv_decline_ratio, ma25_above_pct, breadth_stop "
+        "FROM market_breadth WHERE date = ?",
+        [target],
+    ).fetchone()
+    assert row is not None, "market_breadth に行が挿入されているべき"
+    assert row[1] is not None, "ma25_above_pct が NULL であってはならない"
+    assert isinstance(row[2], bool), "breadth_stop は bool であるべき"
+
+
+def test_populate_backtest_breadth_idempotent(conn):
+    """_populate_backtest_breadth: 2回呼んでも同じ日付が重複しない（冪等）。"""
+    from kabusys.backtest.engine import _populate_backtest_breadth
+
+    target = date(2024, 3, 1)
+    _insert_prices_for_breadth(conn, target, n_days=30)
+
+    _populate_backtest_breadth(conn, target, target)
+    _populate_backtest_breadth(conn, target, target)
+
+    count = conn.execute(
+        "SELECT COUNT(*) FROM market_breadth WHERE date = ?", [target]
+    ).fetchone()[0]
+    assert count == 1, "同日を2回呼んでも1行のみであるべき"
+
+
+def test_populate_backtest_breadth_skips_when_no_prices(conn):
+    """_populate_backtest_breadth: prices_daily が空でもエラーにならない。"""
+    from kabusys.backtest.engine import _populate_backtest_breadth
+
+    # prices_daily は空のまま
+    _populate_backtest_breadth(conn, date(2024, 3, 1), date(2024, 3, 5))
+
+    count = conn.execute("SELECT COUNT(*) FROM market_breadth").fetchone()[0]
+    assert count == 0
+
+
+def test_build_backtest_conn_populates_breadth(conn):
+    """_build_backtest_conn: bt_conn の market_breadth が計算済みになっている。"""
+    from kabusys.backtest.engine import _build_backtest_conn
+
+    target = date(2024, 3, 1)
+    _insert_prices_for_breadth(conn, target, n_days=30)
+
+    bt_conn = _build_backtest_conn(conn, target, target)
+    row = bt_conn.execute(
+        "SELECT breadth_stop FROM market_breadth WHERE date = ?", [target]
+    ).fetchone()
+    bt_conn.close()
+
+    assert row is not None, "_build_backtest_conn 後に market_breadth が存在するべき"


### PR DESCRIPTION
## Summary

- `_build_backtest_conn()` 末尾で新設の `_populate_backtest_breadth()` を呼び出すよう修正
- `_populate_backtest_breadth()` はインメモリDB上の `prices_daily` を集計し、バックテスト対象期間の各日付に対して `calc_and_save_breadth()` を実行して `market_breadth` を埋める
- これにより `_is_breadth_stop()` がバックテスト中も正常に機能し、本番との乖離が解消される

## 実装の要点

- **外部データ依存なし**: `prices_daily` は `start_date - 300日` から既にコピー済みのため、breadth 計算に必要な過去データは揃っている
- **冪等**: `calc_and_save_breadth()` は既存行をスキップするため、2回呼んでも重複しない
- **フォールバック**: データ不足日は WARNING ログのみで無視（`_is_breadth_stop()` は `False` にフォールバック）

## Test Plan

- [x] `test_populate_backtest_breadth_inserts_rows` — 対象期間に `market_breadth` が挿入される
- [x] `test_populate_backtest_breadth_idempotent` — 2回呼んでも1行のみ
- [x] `test_populate_backtest_breadth_skips_when_no_prices` — データなしでもエラーにならない
- [x] `test_build_backtest_conn_populates_breadth` — `_build_backtest_conn` 後に breadth が存在する
- [x] 全テスト 879 passed

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)