### PR TITLE
feat: Position Reconciliation View の実装 (Issue #204)

### DIFF
--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -8,7 +8,10 @@ model = os.environ.get("OPENAI_MODEL", "gpt-4o")
 repo = os.environ["REPO"]
 pr = os.environ["PR_NUMBER"]
 token = os.environ["GITHUB_TOKEN"]
-headers = {"Authorization": f"Bearer {token}", "Accept": "application/vnd.github.v3+json"}
+headers = {
+    "Authorization": f"Bearer {token}",
+    "Accept": "application/vnd.github.v3+json",
+}
 
 with open("diff.txt") as f:
     diff = f.read()
@@ -28,7 +31,12 @@ pr_body = pr_data.get("body") or ""
 comments_url = f"https://api.github.com/repos/{repo}/issues/{pr}/comments"
 comments_resp = requests.get(comments_url, headers=headers)
 comments_data = comments_resp.json() if comments_resp.status_code == 200 else []
-comments_text = "\n".join([f"- {c.get('user', {}).get('login', 'User')}: {c.get('body') or ''}" for c in comments_data])
+comments_text = "\n".join(
+    [
+        f"- {c.get('user', {}).get('login', 'User')}: {c.get('body') or ''}"
+        for c in comments_data
+    ]
+)
 if not comments_text:
     comments_text = "なし"
 

--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -5,11 +5,6 @@ from openai import OpenAI
 client = OpenAI(api_key=os.environ["OPENAI_API_KEY"].strip())
 model = os.environ.get("OPENAI_MODEL", "gpt-4o")
 
-repo = os.environ["REPO"]
-pr = os.environ["PR_NUMBER"]
-token = os.environ["GITHUB_TOKEN"]
-headers = {"Authorization": f"Bearer {token}", "Accept": "application/vnd.github.v3+json"}
-
 with open("diff.txt") as f:
     diff = f.read()
 
@@ -17,43 +12,19 @@ if not diff.strip():
     print("差分がありません。レビューをスキップします。")
     exit(0)
 
-# PRの詳細（タイトル・本文）を取得
-pr_url = f"https://api.github.com/repos/{repo}/pulls/{pr}"
-pr_resp = requests.get(pr_url, headers=headers)
-pr_data = pr_resp.json() if pr_resp.status_code == 200 else {}
-pr_title = pr_data.get("title", "No Title")
-pr_body = pr_data.get("body", "")
-
-# PRのコメントを取得
-comments_url = f"https://api.github.com/repos/{repo}/issues/{pr}/comments"
-comments_resp = requests.get(comments_url, headers=headers)
-comments_data = comments_resp.json() if comments_resp.status_code == 200 else []
-comments_text = "\n".join([f"- {c.get('user', {}).get('login', 'User')}: {c.get('body', '')}" for c in comments_data])
-if not comments_text:
-    comments_text = "なし"
-
 prompt = f"""
 あなたはシニアソフトウェアエンジニアです。
 
 以下のPull Requestの変更をレビューしてください。
-作者の意図（PRのタイトル、本文、これまでのコメント）を最大限に尊重し、それに沿ったレビューを行ってください。
 
-【PR情報】
-タイトル: {pr_title}
-本文:
-{pr_body}
-
-【これまでのコメント】
-{comments_text}
-
-【レビュー観点】
+レビュー観点
 - バグ
 - セキュリティ
 - 可読性
 - 設計
 - パフォーマンス
 
-【コードの差分 (diff)】
+diff:
 {diff}
 """
 
@@ -66,6 +37,10 @@ response = client.chat.completions.create(
 )
 
 review = response.choices[0].message.content
+
+repo = os.environ["REPO"]
+pr = os.environ["PR_NUMBER"]
+token = os.environ["GITHUB_TOKEN"]
 
 url = f"https://api.github.com/repos/{repo}/issues/{pr}/comments"
 

--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -5,6 +5,11 @@ from openai import OpenAI
 client = OpenAI(api_key=os.environ["OPENAI_API_KEY"].strip())
 model = os.environ.get("OPENAI_MODEL", "gpt-4o")
 
+repo = os.environ["REPO"]
+pr = os.environ["PR_NUMBER"]
+token = os.environ["GITHUB_TOKEN"]
+headers = {"Authorization": f"Bearer {token}", "Accept": "application/vnd.github.v3+json"}
+
 with open("diff.txt") as f:
     diff = f.read()
 
@@ -12,19 +17,43 @@ if not diff.strip():
     print("差分がありません。レビューをスキップします。")
     exit(0)
 
+# PRの詳細（タイトル・本文）を取得
+pr_url = f"https://api.github.com/repos/{repo}/pulls/{pr}"
+pr_resp = requests.get(pr_url, headers=headers)
+pr_data = pr_resp.json() if pr_resp.status_code == 200 else {}
+pr_title = pr_data.get("title", "No Title")
+pr_body = pr_data.get("body", "")
+
+# PRのコメントを取得
+comments_url = f"https://api.github.com/repos/{repo}/issues/{pr}/comments"
+comments_resp = requests.get(comments_url, headers=headers)
+comments_data = comments_resp.json() if comments_resp.status_code == 200 else []
+comments_text = "\n".join([f"- {c.get('user', {}).get('login', 'User')}: {c.get('body', '')}" for c in comments_data])
+if not comments_text:
+    comments_text = "なし"
+
 prompt = f"""
 あなたはシニアソフトウェアエンジニアです。
 
 以下のPull Requestの変更をレビューしてください。
+作者の意図（PRのタイトル、本文、これまでのコメント）を最大限に尊重し、それに沿ったレビューを行ってください。
 
-レビュー観点
+【PR情報】
+タイトル: {pr_title}
+本文:
+{pr_body}
+
+【これまでのコメント】
+{comments_text}
+
+【レビュー観点】
 - バグ
 - セキュリティ
 - 可読性
 - 設計
 - パフォーマンス
 
-diff:
+【コードの差分 (diff)】
 {diff}
 """
 
@@ -37,10 +66,6 @@ response = client.chat.completions.create(
 )
 
 review = response.choices[0].message.content
-
-repo = os.environ["REPO"]
-pr = os.environ["PR_NUMBER"]
-token = os.environ["GITHUB_TOKEN"]
 
 url = f"https://api.github.com/repos/{repo}/issues/{pr}/comments"
 

--- a/src/kabusys/operations/position_reconciliation_report.py
+++ b/src/kabusys/operations/position_reconciliation_report.py
@@ -61,7 +61,7 @@ def collect_position_snapshot(broker, repo) -> list[PositionEntry]:
     for record in repo.list_active():
         if record.state not in {OrderState.Filled, OrderState.PartialFill}:
             continue
-        side = (record.side or "").lower()
+        side = (record.side or "").strip().lower()
         if side == "buy":
             local_map[record.code] = local_map.get(record.code, 0) + record.filled_qty
         elif side == "sell":

--- a/src/kabusys/operations/position_reconciliation_report.py
+++ b/src/kabusys/operations/position_reconciliation_report.py
@@ -8,10 +8,13 @@ DB 参照は collect_position_snapshot() のみ。それ以外の関数はすべ
 from __future__ import annotations
 
 import json
+import logging
 import re
 from dataclasses import asdict, dataclass
 from datetime import date, datetime, timezone
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 STATUS_CLEAN = "CLEAN"
 STATUS_DISCREPANCY = "DISCREPANCY"
@@ -45,6 +48,7 @@ def collect_position_snapshot(broker, repo) -> list[PositionEntry]:
 
     ブローカー側は get_positions()、ローカル側は list_active() の
     Filled / PartialFill 注文から net qty を集計する。
+    list_active() は Closed/Cancelled/Rejected 以外を返すため Filled も含まれる。
     結果は code 昇順でソートして返す。
     """
     from kabusys.execution.order_record import OrderState
@@ -62,6 +66,10 @@ def collect_position_snapshot(broker, repo) -> list[PositionEntry]:
             local_map[record.code] = local_map.get(record.code, 0) + record.filled_qty
         elif side == "sell":
             local_map[record.code] = local_map.get(record.code, 0) - record.filled_qty
+        else:
+            logger.warning(
+                "未知の side 値を無視: code=%s side=%r", record.code, record.side
+            )
 
     entries: list[PositionEntry] = []
     for code in sorted(set(broker_map) | set(local_map)):
@@ -83,7 +91,7 @@ def collect_position_snapshot(broker, repo) -> list[PositionEntry]:
 def _generate_warnings(entries: list[PositionEntry]) -> list[str]:
     warnings: list[str] = []
     for e in entries:
-        if e.status == ENTRY_MISMATCH:
+        if e.diff != 0:  # status ではなく diff を真実源として判定
             sign = "+" if e.diff > 0 else ""
             warnings.append(
                 f"code={e.code}: broker={e.broker_qty}株 / local={e.local_qty}株"
@@ -98,8 +106,8 @@ def build_report(
     report_date: date,
 ) -> PositionReconciliationReport:
     """entries リストから PositionReconciliationReport を構築する（純粋関数）。"""
-    match_count = sum(1 for e in entries if e.status == ENTRY_MATCH)
-    mismatch_count = sum(1 for e in entries if e.status == ENTRY_MISMATCH)
+    match_count = sum(1 for e in entries if e.diff == 0)  # diff を真実源として判定
+    mismatch_count = len(entries) - match_count
     total_count = len(entries)
     warnings = _generate_warnings(entries)
     status = STATUS_CLEAN if mismatch_count == 0 else STATUS_DISCREPANCY

--- a/src/kabusys/operations/position_reconciliation_report.py
+++ b/src/kabusys/operations/position_reconciliation_report.py
@@ -61,7 +61,7 @@ def collect_position_snapshot(broker, repo) -> list[PositionEntry]:
     for record in repo.list_active():
         if record.state not in {OrderState.Filled, OrderState.PartialFill}:
             continue
-        side = record.side.lower()
+        side = (record.side or "").lower()
         if side == "buy":
             local_map[record.code] = local_map.get(record.code, 0) + record.filled_qty
         elif side == "sell":

--- a/src/kabusys/operations/position_reconciliation_report.py
+++ b/src/kabusys/operations/position_reconciliation_report.py
@@ -1,0 +1,266 @@
+"""Position Reconciliation View レポート生成モジュール。
+
+DB上のローカル推定ポジション（注文履歴から集計）と証券口座（kabuステーション）のポジションを
+銘柄単位で突き合わせ、CLEAN / DISCREPANCY ステータスと全銘柄一覧を出力する。
+DB 参照は collect_position_snapshot() のみ。それ以外の関数はすべて純粋関数。
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+STATUS_CLEAN = "CLEAN"
+STATUS_DISCREPANCY = "DISCREPANCY"
+ENTRY_MATCH = "MATCH"
+ENTRY_MISMATCH = "MISMATCH"
+
+
+@dataclass
+class PositionEntry:
+    code: str
+    broker_qty: int  # ブローカー側保有数量（未保有なら 0）
+    local_qty: int  # ローカルDB推定数量（Filled/PartialFill の net qty）
+    diff: int  # broker_qty - local_qty（0 なら一致）
+    status: str  # "MATCH" / "MISMATCH"
+
+
+@dataclass
+class PositionReconciliationReport:
+    report_date: str  # ISO date（対象日 YYYY-MM-DD）
+    generated_at: str  # ISO 8601 UTC タイムスタンプ
+    status: str  # "CLEAN" / "DISCREPANCY"
+    total_count: int  # union(broker, local) の銘柄数
+    match_count: int  # diff == 0 の銘柄数
+    mismatch_count: int  # diff != 0 の銘柄数
+    positions: list[dict]  # PositionEntry の dict 化リスト
+    warnings: list[str]
+
+
+def collect_position_snapshot(broker, repo) -> list[PositionEntry]:
+    """ブローカーAPIとOrderRepositoryからポジションを比較して返す。
+
+    ブローカー側は get_positions()、ローカル側は list_active() の
+    Filled / PartialFill 注文から net qty を集計する。
+    結果は code 昇順でソートして返す。
+    """
+    from kabusys.execution.order_record import OrderState
+
+    broker_map: dict[str, int] = {}
+    for p in broker.get_positions():
+        broker_map[p.code] = broker_map.get(p.code, 0) + p.qty
+
+    local_map: dict[str, int] = {}
+    for record in repo.list_active():
+        if record.state not in {OrderState.Filled, OrderState.PartialFill}:
+            continue
+        side = record.side.lower()
+        if side == "buy":
+            local_map[record.code] = local_map.get(record.code, 0) + record.filled_qty
+        elif side == "sell":
+            local_map[record.code] = local_map.get(record.code, 0) - record.filled_qty
+
+    entries: list[PositionEntry] = []
+    for code in sorted(set(broker_map) | set(local_map)):
+        broker_qty = broker_map.get(code, 0)
+        local_qty = local_map.get(code, 0)
+        diff = broker_qty - local_qty
+        entries.append(
+            PositionEntry(
+                code=code,
+                broker_qty=broker_qty,
+                local_qty=local_qty,
+                diff=diff,
+                status=ENTRY_MATCH if diff == 0 else ENTRY_MISMATCH,
+            )
+        )
+    return entries
+
+
+def _generate_warnings(entries: list[PositionEntry]) -> list[str]:
+    warnings: list[str] = []
+    for e in entries:
+        if e.status == ENTRY_MISMATCH:
+            sign = "+" if e.diff > 0 else ""
+            warnings.append(
+                f"code={e.code}: broker={e.broker_qty}株 / local={e.local_qty}株"
+                f" (diff={sign}{e.diff})"
+            )
+    return warnings
+
+
+def build_report(
+    entries: list[PositionEntry],
+    *,
+    report_date: date,
+) -> PositionReconciliationReport:
+    """entries リストから PositionReconciliationReport を構築する（純粋関数）。"""
+    match_count = sum(1 for e in entries if e.status == ENTRY_MATCH)
+    mismatch_count = sum(1 for e in entries if e.status == ENTRY_MISMATCH)
+    total_count = len(entries)
+    warnings = _generate_warnings(entries)
+    status = STATUS_CLEAN if mismatch_count == 0 else STATUS_DISCREPANCY
+    return PositionReconciliationReport(
+        report_date=report_date.isoformat(),
+        generated_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        status=status,
+        total_count=total_count,
+        match_count=match_count,
+        mismatch_count=mismatch_count,
+        positions=[asdict(e) for e in entries],
+        warnings=warnings,
+    )
+
+
+# ---------------------------------------------------------------------------
+# フォーマッター
+# ---------------------------------------------------------------------------
+
+
+def format_cli_summary(report: PositionReconciliationReport) -> str:
+    """CLI 表示用サマリ文字列を返す。"""
+    sep = "=" * 56
+    thin = "-" * 56
+    lines = [
+        f"\n{sep}",
+        f"  Position Reconciliation  {report.report_date}",
+        f"  Status : {report.status}",
+        f"{sep}",
+        f"    total     : {report.total_count:>6}",
+        f"    match     : {report.match_count:>6}",
+        f"    mismatch  : {report.mismatch_count:>6}",
+    ]
+    if report.positions:
+        lines.append(thin)
+        lines.append(
+            f"  {'':3}{'Code':<8}  {'Broker':>8}  {'Local':>8}  {'Diff':>6}  Status"
+        )
+        lines.append(f"  {'':3}{'-' * 8}  {'-' * 8}  {'-' * 8}  {'-' * 6}  {'-' * 10}")
+        for p in report.positions:
+            mark = "[!]" if p["status"] == ENTRY_MISMATCH else "   "
+            sign = "+" if p["diff"] > 0 else ""
+            diff_str = f"{sign}{p['diff']}" if p["diff"] != 0 else "0"
+            lines.append(
+                f"  {mark} {p['code']:<8}  {p['broker_qty']:>8}"
+                f"  {p['local_qty']:>8}  {diff_str:>6}  {p['status']}"
+            )
+    if report.warnings:
+        lines.append(thin)
+        lines.append("  Warnings:")
+        for w in report.warnings:
+            lines.append(f"    [!] {w}")
+    lines.append(f"{sep}\n")
+    return "\n".join(lines)
+
+
+def format_json(report: PositionReconciliationReport) -> str:
+    """全フィールドを含む JSON 文字列を返す。"""
+    return json.dumps(asdict(report), ensure_ascii=False, indent=2)
+
+
+def format_markdown(report: PositionReconciliationReport) -> str:
+    """人間向け Markdown レポート文字列を返す。"""
+    lines: list[str] = [
+        "# Position Reconciliation",
+        "",
+        "## 1. Overview",
+        "",
+        "| Item | Value |",
+        "|------|-------|",
+        f"| 対象日 | {report.report_date} |",
+        f"| 生成時刻 | {report.generated_at} |",
+        f"| **ステータス** | **{report.status}** |",
+        f"| 総銘柄数 | {report.total_count} |",
+        f"| 一致 | {report.match_count} |",
+        f"| 不一致 | {report.mismatch_count} |",
+        "",
+    ]
+
+    sec = 2
+    if report.positions:
+        lines += [
+            f"## {sec}. ポジション一覧",
+            "",
+            "| 銘柄コード | Broker | Local | Diff | 状態 |",
+            "|-----------|--------|-------|------|------|",
+        ]
+        for p in report.positions:
+            sign = "+" if p["diff"] > 0 else ""
+            diff_str = f"{sign}{p['diff']}" if p["diff"] != 0 else "0"
+            mark = "⚠️ " if p["status"] == ENTRY_MISMATCH else ""
+            lines.append(
+                f"| {mark}{p['code']} | {p['broker_qty']}"
+                f" | {p['local_qty']} | {diff_str} | {p['status']} |"
+            )
+        lines.append("")
+        sec += 1
+
+    if report.warnings:
+        lines += [f"## {sec}. Warnings", ""]
+        for w in report.warnings:
+            lines.append(f"- ⚠️ {w}")
+        lines.append("")
+        sec += 1
+
+    lines += [f"## {sec}. Final Decision", ""]
+    if report.status == STATUS_CLEAN:
+        lines += [
+            f"**{STATUS_CLEAN}** — 全銘柄のポジションが一致しています。",
+            "",
+            "- 執行エンジンを安全に起動できます。",
+        ]
+    else:
+        lines += [
+            f"**{STATUS_DISCREPANCY}** — ポジションに差分が検出されました。",
+            "",
+            "- 上記 Warnings を確認し、手動調整を行ってください。",
+            "- 差分が解消されるまで執行エンジンの起動を控えることを推奨します。",
+        ]
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# 保存
+# ---------------------------------------------------------------------------
+
+
+def save_report(
+    report: PositionReconciliationReport,
+    output_dir: Path | str | None = None,
+) -> Path:
+    """レポートを artifacts/position_reconciliation/{report_date}/ に保存する。
+
+    保存ファイル:
+        summary.json    全指標 JSON
+        report.md       Markdown レポート
+        warnings.json   警告リスト JSON
+
+    同一 report_date で再実行した場合は上書き（exist_ok=True）。
+    """
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", report.report_date):
+        raise ValueError(f"Invalid report_date: {report.report_date!r}")
+    try:
+        date.fromisoformat(report.report_date)
+    except ValueError:
+        raise ValueError(
+            f"Invalid report_date (not a valid calendar date): {report.report_date!r}"
+        )
+    base = (
+        Path(output_dir)
+        if output_dir
+        else Path("artifacts") / "position_reconciliation"
+    )
+    run_dir = base / report.report_date
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    (run_dir / "summary.json").write_text(format_json(report), encoding="utf-8")
+    (run_dir / "report.md").write_text(format_markdown(report), encoding="utf-8")
+    (run_dir / "warnings.json").write_text(
+        json.dumps(report.warnings, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    return run_dir

--- a/src/kabusys/operations/pre_market_report.py
+++ b/src/kabusys/operations/pre_market_report.py
@@ -306,6 +306,12 @@ def save_report(
     """
     if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", report.report_date):
         raise ValueError(f"Invalid report_date: {report.report_date!r}")
+    try:
+        date.fromisoformat(report.report_date)
+    except ValueError:
+        raise ValueError(
+            f"Invalid report_date (not a valid calendar date): {report.report_date!r}"
+        )
     base = Path(output_dir) if output_dir else Path("artifacts") / "pre_market"
     run_dir = base / report.report_date
     run_dir.mkdir(parents=True, exist_ok=True)

--- a/src/kabusys/run_position_reconciliation_report.py
+++ b/src/kabusys/run_position_reconciliation_report.py
@@ -70,7 +70,7 @@ def main(argv: list[str] | None = None) -> int:
         type=lambda s: date.fromisoformat(s),
         default=date.today(),
         metavar="YYYY-MM-DD",
-        help="対象日（省略時は今日）",
+        help="レポートの日付ラベル（現在のスナップショットに付与）（省略時は今日）",
     )
     parser.add_argument(
         "--save",
@@ -93,6 +93,7 @@ def main(argv: list[str] | None = None) -> int:
     logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(message)s")
 
     settings = Settings()
+    interval = max(1, args.interval)  # スピンループ防止のため最小 1 秒
 
     if args.watch:
         while True:
@@ -103,7 +104,7 @@ def main(argv: list[str] | None = None) -> int:
             except Exception as e:
                 logger.error("ポーリング中にエラー: %s", e, exc_info=True)
             try:
-                time.sleep(args.interval)
+                time.sleep(interval)
             except KeyboardInterrupt:
                 break
         return 0

--- a/src/kabusys/run_position_reconciliation_report.py
+++ b/src/kabusys/run_position_reconciliation_report.py
@@ -35,13 +35,19 @@ logger = logging.getLogger(__name__)
 
 def _run_once(settings: Settings, target_date: date, args: argparse.Namespace) -> str:
     """1回のポーリングを実行してステータス文字列を返す。"""
-    sqlite_conn = sqlite3.connect(str(settings.sqlite_path))
+    sqlite_conn = sqlite3.connect(f"file:{settings.sqlite_path}?mode=ro", uri=True)
+    broker = None
     try:
         broker = BrokerClientFactory.create(settings)
         repo = OrderRepository(sqlite_conn)
         entries = collect_position_snapshot(broker, repo)
     finally:
         sqlite_conn.close()
+        if broker is not None and hasattr(broker, "close"):
+            try:
+                broker.close()
+            except Exception:
+                logger.warning("broker.close() で例外が発生しました", exc_info=True)
 
     report = build_report(entries, report_date=target_date)
 

--- a/src/kabusys/run_position_reconciliation_report.py
+++ b/src/kabusys/run_position_reconciliation_report.py
@@ -1,0 +1,116 @@
+"""Position Reconciliation View エントリーポイント。
+
+使用方法:
+    python -m kabusys.run_position_reconciliation_report
+    python -m kabusys.run_position_reconciliation_report --date 2026-04-28
+    python -m kabusys.run_position_reconciliation_report --save
+    python -m kabusys.run_position_reconciliation_report --json
+    python -m kabusys.run_position_reconciliation_report --watch
+    python -m kabusys.run_position_reconciliation_report --watch --interval 300
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sqlite3
+import sys
+import time
+from datetime import date
+
+from kabusys.config import Settings
+from kabusys.execution.broker_factory import BrokerClientFactory
+from kabusys.execution.order_repository import OrderRepository
+from kabusys.operations.position_reconciliation_report import (
+    STATUS_DISCREPANCY,
+    build_report,
+    collect_position_snapshot,
+    format_cli_summary,
+    format_json,
+    save_report,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _run_once(settings: Settings, target_date: date, args: argparse.Namespace) -> str:
+    """1回のポーリングを実行してステータス文字列を返す。"""
+    sqlite_conn = sqlite3.connect(str(settings.sqlite_path))
+    try:
+        broker = BrokerClientFactory.create(settings)
+        repo = OrderRepository(sqlite_conn)
+        entries = collect_position_snapshot(broker, repo)
+    finally:
+        sqlite_conn.close()
+
+    report = build_report(entries, report_date=target_date)
+
+    if args.json:
+        print(format_json(report))
+    else:
+        print(format_cli_summary(report))
+
+    if args.save:
+        run_dir = save_report(report)
+        dest_msg = f"保存先: {run_dir}"
+        if args.json:
+            sys.stderr.write(dest_msg + "\n")
+        else:
+            print(dest_msg)
+
+    return report.status
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Position Reconciliation View を生成する"
+    )
+    parser.add_argument(
+        "--date",
+        type=lambda s: date.fromisoformat(s),
+        default=date.today(),
+        metavar="YYYY-MM-DD",
+        help="対象日（省略時は今日）",
+    )
+    parser.add_argument(
+        "--save",
+        action="store_true",
+        help="artifacts/position_reconciliation/ に保存する",
+    )
+    parser.add_argument("--json", action="store_true", help="JSON 形式で出力する")
+    parser.add_argument(
+        "--watch", action="store_true", help="定期ポーリングモードで実行する"
+    )
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=600,
+        metavar="N",
+        help="--watch 時のポーリング間隔（秒）（デフォルト: 600）",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(message)s")
+
+    settings = Settings()
+
+    if args.watch:
+        while True:
+            try:
+                _run_once(settings, args.date, args)
+            except KeyboardInterrupt:
+                break
+            except Exception as e:
+                logger.error("ポーリング中にエラー: %s", e, exc_info=True)
+            try:
+                time.sleep(args.interval)
+            except KeyboardInterrupt:
+                break
+        return 0
+
+    status = _run_once(settings, args.date, args)
+    return 1 if status == STATUS_DISCREPANCY else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kabusys/run_position_reconciliation_report.py
+++ b/src/kabusys/run_position_reconciliation_report.py
@@ -17,6 +17,7 @@ import sqlite3
 import sys
 import time
 from datetime import date
+from pathlib import Path
 
 from kabusys.config import Settings
 from kabusys.execution.broker_factory import BrokerClientFactory
@@ -35,7 +36,8 @@ logger = logging.getLogger(__name__)
 
 def _run_once(settings: Settings, target_date: date, args: argparse.Namespace) -> str:
     """1回のポーリングを実行してステータス文字列を返す。"""
-    sqlite_conn = sqlite3.connect(f"file:{settings.sqlite_path}?mode=ro", uri=True)
+    sqlite_uri = Path(settings.sqlite_path).resolve().as_uri() + "?mode=ro"
+    sqlite_conn = sqlite3.connect(sqlite_uri, uri=True)
     broker = None
     try:
         broker = BrokerClientFactory.create(settings)

--- a/tests/test_generated.py
+++ b/tests/test_generated.py
@@ -323,8 +323,8 @@ def test_pre_market_collector_date_normalization_and_checks(monkeypatch):
     c_pos = C(7)
     assert pmc.check_position_count(c_pos) == 7
 
-    # check_stop_flag
-    p = Path(__file__)
+    # check_stop_flag: 存在しないパスを渡すと False を返す
+    p = Path(__file__).parent / "_nonexistent_stop_flag_for_test"
     assert pmc.check_stop_flag(p) is False
 
     # check_task_scheduler success and failure via mocking subprocess.run

--- a/tests/test_generated.py
+++ b/tests/test_generated.py
@@ -1,0 +1,423 @@
+import os
+import csv
+import json
+import sqlite3
+import subprocess
+from types import SimpleNamespace
+from datetime import date, datetime, timezone
+from io import StringIO
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from kabusys.config import _parse_env_line, _load_env_file, Settings
+from kabusys.tools.paper_verification_report import (
+    _p95,
+    _build_date_filter,
+    _fmt_float,
+    _fmt_int,
+)
+from kabusys.operations import signal_queue_report as sqr
+from kabusys.operations import execution_startup_report as esr
+from kabusys.operations import pre_market_report as pmr
+from kabusys.operations import night_batch_report as nbr
+from kabusys.operations import position_reconciliation_report as prr
+from kabusys.operations import pre_market_collector as pmc
+
+
+def test_parse_env_line_blank_and_comment():
+    assert _parse_env_line("") is None
+    assert _parse_env_line("   \n") is None
+    assert _parse_env_line("# comment") is None
+    assert _parse_env_line("   # inline") is None
+
+
+def test_parse_env_line_export_and_simple():
+    assert _parse_env_line("export KEY=val") == ("KEY", "val")
+    assert _parse_env_line("FOO=bar") == ("FOO", "bar")
+
+
+def test_parse_env_line_no_equal():
+    assert _parse_env_line("NOEQUAL") is None
+
+
+def test_parse_env_line_quoted_with_escapes_and_inline_comment():
+    s = r"KEY='va\'lue' # comment ignored"
+    assert _parse_env_line(s) == ("KEY", "va'lue")
+    s2 = r'KEY2="a\"b"'
+    assert _parse_env_line(s2) == ("KEY2", 'a"b')
+
+
+def test_parse_env_line_unquoted_with_hash_behavior():
+    # '#' preceded by space => comment starts
+    assert _parse_env_line("KEY=value #comment") == ("KEY", "value")
+    # '#' directly after value char => kept
+    assert _parse_env_line("KEY=value#notcomment") == ("KEY", "value#notcomment")
+
+
+def test_load_env_file_override_and_protected(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text("A=1\nB=2\nC=3\n")
+    # set initial environ
+    monkeypatch.setenv("A", "orig")
+    # override=False should not change existing A, but set D if present
+    _load_env_file(env_file, override=False, protected=frozenset())
+    assert os.environ["A"] == "orig"
+    assert os.environ.get("B") == "2"
+    # override True but protect A should not overwrite A
+    env_file.write_text("A=9\nB=8\n")
+    protected = frozenset({"A"})
+    _load_env_file(env_file, override=True, protected=protected)
+    assert os.environ["A"] == "orig"
+    assert os.environ["B"] == "8"
+
+
+def test_settings_paper_fill_mode_valid_and_invalid(monkeypatch):
+    s = Settings()
+    # default should be 'instant'
+    monkeypatch.delenv("PAPER_FILL_MODE", raising=False)
+    assert Settings().paper_fill_mode == "instant"
+    monkeypatch.setenv("PAPER_FILL_MODE", "partial")
+    assert Settings().paper_fill_mode == "partial"
+    monkeypatch.setenv("PAPER_FILL_MODE", "INSTANT")
+    assert Settings().paper_fill_mode == "instant"
+    # invalid value should raise
+    monkeypatch.setenv("PAPER_FILL_MODE", "badvalue")
+    with pytest.raises(ValueError):
+        _ = Settings().paper_fill_mode
+
+
+def test_p95_empty_and_values():
+    assert _p95([]) is None
+    vals = [1, 2, 3, 4, 5, 100]
+    # 95th percentile index ceil(6*0.95)-1 = ceil(5.7)-1=6-1=5 -> value 100
+    assert _p95(vals) == 100
+    vals2 = [10] * 20
+    assert _p95(vals2) == 10
+
+
+def test_build_date_filter_variations():
+    clause, params = _build_date_filter("ts", None, None)
+    assert clause == ""
+    assert params == []
+    clause, params = _build_date_filter("ts", "2021-01-01", None)
+    assert "ts >= ?" in clause and params == ["2021-01-01"]
+    clause, params = _build_date_filter("ts", None, "2021-01-02")
+    assert "ts <= ?" in clause and params == ["2021-01-02"]
+    clause, params = _build_date_filter("ts", "a", "b")
+    assert "AND" in clause and params == ["a", "b"]
+
+
+def test_fmt_float_and_int_none_and_values():
+    assert _fmt_float(None) == "N/A"
+    assert _fmt_float(1.23456, decimals=2, suffix="ms") == "1.23ms"
+    assert _fmt_int(None) == "N/A"
+    assert _fmt_int(5) == "5"
+
+
+def make_signal_example():
+    signals = [
+        {"code": "1301", "side": "buy", "target_size": 10, "target_weight": 0.05, "signal_rank": 1},
+        {"code": "1332", "side": "sell", "target_size": None, "target_weight": None, "signal_rank": None},
+    ]
+    return signals
+
+
+def test_signal_queue_build_format_and_save(tmp_path):
+    signals = make_signal_example()
+    report = sqr.build_report(signals, report_date=date(2026, 4, 28))
+    assert report.total_count == 2
+    assert report.status == sqr.STATUS_READY
+    cli = sqr.format_cli_summary(report)
+    assert "1301" in cli and "1332" in cli
+    js = sqr.format_json(report)
+    parsed = json.loads(js)
+    assert parsed["report_date"] == "2026-04-28"
+    # save_report to tmp dir
+    run_dir = sqr.save_report(report, output_dir=tmp_path)
+    assert (run_dir / "summary.json").exists()
+    assert (run_dir / "report.md").exists()
+    # invalid report_date
+    bad = report
+    bad.report_date = "not-a-date"
+    with pytest.raises(ValueError):
+        sqr.save_report(bad, output_dir=tmp_path)
+
+
+def test_execution_startup_build_and_format_and_save(tmp_path):
+    # craft fake reconcile_result
+    class D:
+        def __init__(self, code, b, l, diff):
+            self.code = code
+            self.broker_qty = b
+            self.local_qty = l
+            self.diff = diff
+
+    rec = SimpleNamespace(
+        orders_synced=5,
+        orders_no_status=0,
+        position_discrepancies=[D("1301", 10, 10, 0), D("1332", 5, 3, 2)],
+    )
+    report = esr.build_report(rec, startup_date=date(2026, 4, 28))
+    assert report.orders_synced == 5
+    # since one discrepancy, expect READY_WITH_WARNINGS
+    assert report.status == esr.STATUS_READY_WITH_WARNINGS
+    cli = esr.format_cli_summary(report)
+    assert "Execution Startup Summary" in cli
+    js = esr.format_json(report)
+    parsed = json.loads(js)
+    assert parsed["startup_date"] == "2026-04-28"
+    # saving
+    out = esr.save_report(report, output_dir=tmp_path)
+    assert (out / "summary.json").exists()
+    # invalid startup_date -> raise
+    bad = report
+    bad.startup_date = "bad-date"
+    with pytest.raises(ValueError):
+        esr.save_report(bad, output_dir=tmp_path)
+
+
+def test_pre_market_build_and_format_variants():
+    r_ready = pmr.build_report(
+        report_date=date(2026, 4, 28),
+        data_freshness_ok=True,
+        signal_queue_pending=1,
+        position_count=5,
+        stop_flag_exists=False,
+        task_scheduler_ready=True,
+    )
+    assert r_ready.status == pmr.STATUS_READY
+    r_blocked = pmr.build_report(
+        report_date=date(2026, 4, 28),
+        data_freshness_ok=True,
+        signal_queue_pending=0,
+        position_count=5,
+        stop_flag_exists=False,
+        task_scheduler_ready=True,
+    )
+    assert r_blocked.status == pmr.STATUS_BLOCKED
+    r_warn = pmr.build_report(
+        report_date=date(2026, 4, 28),
+        data_freshness_ok=False,
+        signal_queue_pending=1,
+        position_count=5,
+        stop_flag_exists=False,
+        task_scheduler_ready=True,
+    )
+    assert r_warn.status == pmr.STATUS_READY_WITH_WARNINGS
+    cli = pmr.format_cli_summary(r_warn)
+    assert "Pre-Market Report" in cli
+    js = pmr.format_json(r_warn)
+    parsed = json.loads(js)
+    assert parsed["report_date"] == "2026-04-28"
+    # save report with invalid date should raise
+    bad = r_warn
+    bad.report_date = "2026-99-99"
+    with pytest.raises(ValueError):
+        pmr.save_report(bad, output_dir=Path("."))
+
+
+def make_job(name, status="success", warnings=None, errors=None, duration=1.2):
+    started = datetime.now(timezone.utc)
+    finished = started
+    return nbr.JobRunResult(
+        job_name=name,
+        status=status,
+        started_at=started,
+        finished_at=finished,
+        duration_sec=duration,
+        updated_rows={},
+        warnings=warnings or [],
+        errors=errors or [],
+    )
+
+
+def test_night_batch_determine_generate_and_save(tmp_path):
+    jobs = [make_job(n) for n in nbr.MANDATORY_JOBS]
+    uc = nbr.UpdateCounts(prices_daily=10, features=5, signals=1, signal_queue=1)
+    nd = nbr.NextDaySummary(buy_count=1, sell_count=0, target_symbols=1, expected_orders=1)
+    report = nbr.build_report(jobs, uc, nd, run_date=date(2026, 4, 28), target_date=date(2026, 4, 29))
+    assert report.status == nbr.STATUS_READY
+    s = nbr.format_cli_summary(report)
+    assert "Night Batch Report" in s
+    js = nbr.format_json(report)
+    parsed = json.loads(js)
+    assert parsed["run_date"] == "2026-04-28"
+    out = nbr.save_report(report, output_dir=tmp_path)
+    assert (out / "summary.json").exists()
+    # missing mandatory job leads to BLOCKED
+    jobs2 = jobs[:-1]
+    report2 = nbr.build_report(jobs2, uc, nd, run_date=date(2026, 4, 28), target_date=date(2026, 4, 29))
+    assert report2.status == nbr.STATUS_BLOCKED
+
+
+def test_position_reconciliation_build_and_format_and_warnings():
+    entries = [
+        prr.PositionEntry(code="1301", broker_qty=10, local_qty=10, diff=0, status=prr.ENTRY_MATCH),
+        prr.PositionEntry(code="1332", broker_qty=5, local_qty=3, diff=2, status=prr.ENTRY_MISMATCH),
+    ]
+    report = prr.build_report(entries, report_date=date(2026, 4, 28))
+    assert report.total_count == 2
+    assert report.mismatch_count == 1
+    assert report.status == prr.STATUS_DISCREPANCY
+    cli = prr.format_cli_summary(report)
+    assert "Position Reconciliation" in cli
+    js = prr.format_json(report)
+    parsed = json.loads(js)
+    assert parsed["report_date"] == "2026-04-28"
+    # markdown includes code and warning
+    md = prr.format_markdown(report)
+    assert "1301" in md and "1332" in md
+    # warnings generation
+    warns = prr._generate_warnings(entries)
+    assert any("1332" in w for w in warns)
+
+
+def test_pre_market_collector_date_normalization_and_checks(monkeypatch):
+    # mock conn objects with execute returning different types for MAX(date)
+    class RowObj:
+        def __init__(self, v):
+            self.v = v
+
+        def fetchone(self):
+            return (self.v,)
+
+    today = date(2026, 4, 28)
+
+    # datetime case
+    dt = datetime(2026, 4, 27, 12, 0, 0)
+    conn = SimpleNamespace(execute=lambda q, *args, **kw: RowObj(dt))
+    assert pmc.check_data_freshness(conn, today) is True
+
+    # string datetime case
+    conn = SimpleNamespace(execute=lambda q, *a, **k: RowObj("2026-04-26T00:00:00"))
+    assert pmc.check_data_freshness(conn, today) is True
+
+    # old date beyond freshness window
+    conn = SimpleNamespace(execute=lambda q, *a, **k: RowObj("2026-04-01"))
+    assert pmc.check_data_freshness(conn, today) is False
+
+    # None result
+    conn = SimpleNamespace(execute=lambda q, *a, **k: RowObj(None))
+    assert pmc.check_data_freshness(conn, today) is False
+
+    # check_signal_queue and check_position_count behavior
+    class C:
+        def __init__(self, value):
+            self.value = value
+
+        def execute(self, q, *args, **kwargs):
+            class R:
+                def __init__(self, v):
+                    self._v = v
+
+                def fetchone(self):
+                    return (self._v,)
+            return R(self.value)
+
+    c_sqlite = C(3)
+    assert pmc.check_signal_queue(c_sqlite, today) == 3
+    c_sqlite2 = C(None)
+    assert pmc.check_signal_queue(c_sqlite2, today) == 0
+    c_pos = C(7)
+    assert pmc.check_position_count(c_pos) == 7
+
+    # check_stop_flag
+    p = Path(__file__)
+    assert pmc.check_stop_flag(p) is False
+
+    # check_task_scheduler success and failure via mocking subprocess.run
+    good_csv = '"TaskName","Next Run Time","Status"\n"\\\\MyTask","N/A","Ready"\n'
+    mock_res = SimpleNamespace(returncode=0, stdout=good_csv, stderr="")
+    with mock.patch("subprocess.run", return_value=mock_res):
+        assert pmc.check_task_scheduler("whatever") is True
+
+    bad_res = SimpleNamespace(returncode=1, stdout="", stderr="error")
+    with mock.patch("subprocess.run", return_value=bad_res):
+        assert pmc.check_task_scheduler("whatever") is False
+
+    # simulate FileNotFoundError
+    with mock.patch("subprocess.run", side_effect=FileNotFoundError()):
+        assert pmc.check_task_scheduler("whatever") is False
+
+
+def test_run_monitoring_get_poll_interval(monkeypatch):
+    from kabusys.run_monitoring import _get_poll_interval, _DEFAULT_POLL_INTERVAL
+
+    monkeypatch.delenv("MONITOR_POLL_INTERVAL", raising=False)
+    assert _get_poll_interval() == _DEFAULT_POLL_INTERVAL
+    monkeypatch.setenv("MONITOR_POLL_INTERVAL", "10")
+    assert _get_poll_interval() == 10
+    monkeypatch.setenv("MONITOR_POLL_INTERVAL", "0")
+    assert _get_poll_interval() == _DEFAULT_POLL_INTERVAL
+    monkeypatch.setenv("MONITOR_POLL_INTERVAL", "-5")
+    assert _get_poll_interval() == _DEFAULT_POLL_INTERVAL
+    monkeypatch.setenv("MONITOR_POLL_INTERVAL", "notint")
+    assert _get_poll_interval() == _DEFAULT_POLL_INTERVAL
+
+
+def test_run_execution_pos_value_behaviour(caplog):
+    from kabusys.run_execution import _pos_value
+
+    class P:
+        def __init__(self, code, qty, current_price, avg_price):
+            self.code = code
+            self.qty = qty
+            self.current_price = current_price
+            self.avg_price = avg_price
+
+    p1 = P("0001", 2, 100.0, 90.0)
+    assert _pos_value(p1) == 200.0
+    p2 = P("0002", 3, None, 50.0)
+    assert _pos_value(p2) == 150.0
+    p3 = P("0003", 1, 0, 0)
+    caplog.clear()
+    val = _pos_value(p3)
+    assert val == 0.0
+    assert any("ポジション評価額を 0 として扱います" in rec.message for rec in caplog.records)
+
+
+def test_execution_risk_config_parsing(tmp_path):
+    # We will test the _load_risk_config function by creating a valid YAML file.
+    # Import function lazily to ensure module is available.
+    from kabusys.run_execution import _load_risk_config
+
+    valid = """
+risk:
+  max_position_pct: 0.3
+  max_utilization: 0.5
+  rate_limit_per_sec: 5
+  circuit_breaker_errors: 3
+  circuit_breaker_window_sec: 60
+  max_drawdown: 0.2
+"""
+    p = tmp_path / "risk_config.yaml"
+    p.write_text(valid, encoding="utf-8")
+    cfg = _load_risk_config(p, initial_portfolio_value=100000)
+    assert cfg.max_position_pct == pytest.approx(0.3)
+    assert cfg.rate_limit_per_sec == 5
+
+    # invalid YAML
+    p.write_text("::: bad yaml :::")
+    with pytest.raises(ValueError):
+        _load_risk_config(p, initial_portfolio_value=1000)
+
+    # missing risk key
+    p.write_text("notrisk: {}")
+    with pytest.raises(KeyError):
+        _load_risk_config(p, initial_portfolio_value=1000)
+
+    # invalid numeric ranges
+    bad = """
+risk:
+  max_position_pct: 2
+  max_utilization: 0.5
+  rate_limit_per_sec: 0
+  circuit_breaker_errors: 0
+  circuit_breaker_window_sec: 0
+  max_drawdown: -0.1
+"""
+    p.write_text(bad)
+    with pytest.raises(ValueError):
+        _load_risk_config(p, initial_portfolio_value=1000)

--- a/tests/test_position_reconciliation_report.py
+++ b/tests/test_position_reconciliation_report.py
@@ -1,4 +1,5 @@
 """position_reconciliation_report のユニットテスト"""
+
 from __future__ import annotations
 
 import json as json_mod
@@ -146,7 +147,7 @@ def test_collect_multiple_codes(repo):
         ]
     )
     _insert_order(repo, "1111", "buy", 100, "ord-001")  # MATCH
-    _insert_order(repo, "2222", "buy", 30, "ord-002")   # MISMATCH
+    _insert_order(repo, "2222", "buy", 30, "ord-002")  # MISMATCH
     result = collect_position_snapshot(broker, repo)
     codes = [e.code for e in result]
     assert "1111" in codes
@@ -172,8 +173,13 @@ def test_collect_partial_fill_counts(repo):
     """PartialFill の filled_qty がローカル数量に反映される"""
     broker = MockBrokerClient()
     _insert_order(
-        repo, "7203", "buy", 100, "ord-001",
-        state=OrderState.PartialFill, filled_qty=50,
+        repo,
+        "7203",
+        "buy",
+        100,
+        "ord-001",
+        state=OrderState.PartialFill,
+        filled_qty=50,
     )
     result = collect_position_snapshot(broker, repo)
     assert len(result) == 1
@@ -194,8 +200,13 @@ def test_collect_skips_non_filled_states(repo):
     """OrderCreated は local 集計に含まない"""
     broker = MockBrokerClient()
     _insert_order(
-        repo, "7203", "buy", 100, "ord-001",
-        state=OrderState.OrderCreated, filled_qty=0,
+        repo,
+        "7203",
+        "buy",
+        100,
+        "ord-001",
+        state=OrderState.OrderCreated,
+        filled_qty=0,
     )
     result = collect_position_snapshot(broker, repo)
     assert result == []
@@ -208,16 +219,18 @@ def test_collect_skips_non_filled_states(repo):
 
 def test_generate_warnings_clean():
     entries = [
-        PositionEntry(code="7203", broker_qty=100, local_qty=100, diff=0,
-                      status=ENTRY_MATCH)
+        PositionEntry(
+            code="7203", broker_qty=100, local_qty=100, diff=0, status=ENTRY_MATCH
+        )
     ]
     assert _generate_warnings(entries) == []
 
 
 def test_generate_warnings_mismatch_contains_code():
     entries = [
-        PositionEntry(code="7203", broker_qty=100, local_qty=80, diff=20,
-                      status=ENTRY_MISMATCH)
+        PositionEntry(
+            code="7203", broker_qty=100, local_qty=80, diff=20, status=ENTRY_MISMATCH
+        )
     ]
     warnings = _generate_warnings(entries)
     assert len(warnings) == 1
@@ -228,10 +241,12 @@ def test_generate_warnings_mismatch_contains_code():
 
 def test_generate_warnings_multiple_mismatch():
     entries = [
-        PositionEntry(code="1111", broker_qty=100, local_qty=80, diff=20,
-                      status=ENTRY_MISMATCH),
-        PositionEntry(code="2222", broker_qty=0, local_qty=50, diff=-50,
-                      status=ENTRY_MISMATCH),
+        PositionEntry(
+            code="1111", broker_qty=100, local_qty=80, diff=20, status=ENTRY_MISMATCH
+        ),
+        PositionEntry(
+            code="2222", broker_qty=0, local_qty=50, diff=-50, status=ENTRY_MISMATCH
+        ),
     ]
     assert len(_generate_warnings(entries)) == 2
 
@@ -243,26 +258,30 @@ def test_generate_warnings_multiple_mismatch():
 
 def test_build_report_clean_status():
     entries = [
-        PositionEntry(code="7203", broker_qty=100, local_qty=100, diff=0,
-                      status=ENTRY_MATCH)
+        PositionEntry(
+            code="7203", broker_qty=100, local_qty=100, diff=0, status=ENTRY_MATCH
+        )
     ]
     assert build_report(entries, report_date=TARGET_DATE).status == STATUS_CLEAN
 
 
 def test_build_report_discrepancy_status():
     entries = [
-        PositionEntry(code="7203", broker_qty=100, local_qty=80, diff=20,
-                      status=ENTRY_MISMATCH)
+        PositionEntry(
+            code="7203", broker_qty=100, local_qty=80, diff=20, status=ENTRY_MISMATCH
+        )
     ]
     assert build_report(entries, report_date=TARGET_DATE).status == STATUS_DISCREPANCY
 
 
 def test_build_report_counts():
     entries = [
-        PositionEntry(code="1111", broker_qty=100, local_qty=100, diff=0,
-                      status=ENTRY_MATCH),
-        PositionEntry(code="2222", broker_qty=50, local_qty=30, diff=20,
-                      status=ENTRY_MISMATCH),
+        PositionEntry(
+            code="1111", broker_qty=100, local_qty=100, diff=0, status=ENTRY_MATCH
+        ),
+        PositionEntry(
+            code="2222", broker_qty=50, local_qty=30, diff=20, status=ENTRY_MISMATCH
+        ),
     ]
     report = build_report(entries, report_date=TARGET_DATE)
     assert report.total_count == 2
@@ -289,8 +308,9 @@ def test_build_report_empty_entries_is_clean():
 
 def test_format_cli_clean_no_mark():
     entries = [
-        PositionEntry(code="7203", broker_qty=100, local_qty=100, diff=0,
-                      status=ENTRY_MATCH)
+        PositionEntry(
+            code="7203", broker_qty=100, local_qty=100, diff=0, status=ENTRY_MATCH
+        )
     ]
     report = build_report(entries, report_date=TARGET_DATE)
     s = format_cli_summary(report)
@@ -301,8 +321,9 @@ def test_format_cli_clean_no_mark():
 
 def test_format_cli_discrepancy_shows_mark():
     entries = [
-        PositionEntry(code="7203", broker_qty=100, local_qty=80, diff=20,
-                      status=ENTRY_MISMATCH)
+        PositionEntry(
+            code="7203", broker_qty=100, local_qty=80, diff=20, status=ENTRY_MISMATCH
+        )
     ]
     report = build_report(entries, report_date=TARGET_DATE)
     s = format_cli_summary(report)
@@ -313,10 +334,12 @@ def test_format_cli_discrepancy_shows_mark():
 def test_format_cli_shows_all_positions():
     """MATCH 銘柄も出力に含まれる"""
     entries = [
-        PositionEntry(code="1111", broker_qty=100, local_qty=100, diff=0,
-                      status=ENTRY_MATCH),
-        PositionEntry(code="2222", broker_qty=50, local_qty=30, diff=20,
-                      status=ENTRY_MISMATCH),
+        PositionEntry(
+            code="1111", broker_qty=100, local_qty=100, diff=0, status=ENTRY_MATCH
+        ),
+        PositionEntry(
+            code="2222", broker_qty=50, local_qty=30, diff=20, status=ENTRY_MISMATCH
+        ),
     ]
     report = build_report(entries, report_date=TARGET_DATE)
     s = format_cli_summary(report)
@@ -331,13 +354,22 @@ def test_format_cli_shows_all_positions():
 
 def test_format_json_parseable():
     entries = [
-        PositionEntry(code="7203", broker_qty=100, local_qty=100, diff=0,
-                      status=ENTRY_MATCH)
+        PositionEntry(
+            code="7203", broker_qty=100, local_qty=100, diff=0, status=ENTRY_MATCH
+        )
     ]
     report = build_report(entries, report_date=TARGET_DATE)
     data = json_mod.loads(format_json(report))
-    for key in ("status", "report_date", "generated_at", "total_count",
-                "match_count", "mismatch_count", "positions", "warnings"):
+    for key in (
+        "status",
+        "report_date",
+        "generated_at",
+        "total_count",
+        "match_count",
+        "mismatch_count",
+        "positions",
+        "warnings",
+    ):
         assert key in data
 
 
@@ -356,15 +388,17 @@ def test_format_markdown_required_sections():
 
 def test_format_markdown_warnings_only_when_discrepancy():
     clean_entries = [
-        PositionEntry(code="7203", broker_qty=100, local_qty=100, diff=0,
-                      status=ENTRY_MATCH)
+        PositionEntry(
+            code="7203", broker_qty=100, local_qty=100, diff=0, status=ENTRY_MATCH
+        )
     ]
     assert "Warnings" not in format_markdown(
         build_report(clean_entries, report_date=TARGET_DATE)
     )
     disc_entries = [
-        PositionEntry(code="7203", broker_qty=100, local_qty=80, diff=20,
-                      status=ENTRY_MISMATCH)
+        PositionEntry(
+            code="7203", broker_qty=100, local_qty=80, diff=20, status=ENTRY_MISMATCH
+        )
     ]
     assert "Warnings" in format_markdown(
         build_report(disc_entries, report_date=TARGET_DATE)
@@ -373,8 +407,9 @@ def test_format_markdown_warnings_only_when_discrepancy():
 
 def test_format_markdown_position_table():
     entries = [
-        PositionEntry(code="7203", broker_qty=100, local_qty=80, diff=20,
-                      status=ENTRY_MISMATCH)
+        PositionEntry(
+            code="7203", broker_qty=100, local_qty=80, diff=20, status=ENTRY_MISMATCH
+        )
     ]
     report = build_report(entries, report_date=TARGET_DATE)
     md = format_markdown(report)
@@ -400,8 +435,11 @@ def test_save_report_invalid_format_raises(tmp_path):
         report_date="invalid-date",
         generated_at="2026-04-27T00:00:00+00:00",
         status=STATUS_CLEAN,
-        total_count=0, match_count=0, mismatch_count=0,
-        positions=[], warnings=[],
+        total_count=0,
+        match_count=0,
+        mismatch_count=0,
+        positions=[],
+        warnings=[],
     )
     with pytest.raises(ValueError, match="Invalid report_date"):
         save_report(report, output_dir=tmp_path)
@@ -412,8 +450,11 @@ def test_save_report_impossible_calendar_date_raises(tmp_path):
         report_date="2026-02-30",
         generated_at="2026-04-27T00:00:00+00:00",
         status=STATUS_CLEAN,
-        total_count=0, match_count=0, mismatch_count=0,
-        positions=[], warnings=[],
+        total_count=0,
+        match_count=0,
+        mismatch_count=0,
+        positions=[],
+        warnings=[],
     )
     with pytest.raises(ValueError, match="Invalid report_date"):
         save_report(report, output_dir=tmp_path)

--- a/tests/test_position_reconciliation_report.py
+++ b/tests/test_position_reconciliation_report.py
@@ -1,0 +1,426 @@
+"""position_reconciliation_report のユニットテスト"""
+from __future__ import annotations
+
+import json as json_mod
+import sqlite3
+from datetime import date, datetime, timezone
+
+import pytest
+
+from kabusys.execution.broker_api import Position
+from kabusys.execution.mock_client import MockBrokerClient
+from kabusys.execution.order_record import OrderRecord, OrderState
+from kabusys.execution.order_repository import OrderRepository, init_orders_db
+from kabusys.operations.position_reconciliation_report import (
+    ENTRY_MATCH,
+    ENTRY_MISMATCH,
+    STATUS_CLEAN,
+    STATUS_DISCREPANCY,
+    PositionEntry,
+    PositionReconciliationReport,
+    _generate_warnings,
+    build_report,
+    collect_position_snapshot,
+    format_cli_summary,
+    format_json,
+    format_markdown,
+    save_report,
+)
+
+TARGET_DATE = date(2026, 4, 28)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def conn():
+    c = sqlite3.connect(":memory:")
+    init_orders_db(c)
+    yield c
+    c.close()
+
+
+@pytest.fixture()
+def repo(conn):
+    return OrderRepository(conn)
+
+
+def _insert_order(
+    repo: OrderRepository,
+    code: str,
+    side: str,
+    qty: int,
+    cid: str,
+    state: OrderState = OrderState.Filled,
+    filled_qty: int | None = None,
+) -> None:
+    """指定状態の注文を DB に挿入するヘルパー。"""
+    record = OrderRecord(
+        client_order_id=cid,
+        signal_id=f"sig_{cid}",
+        code=code,
+        side=side,
+        qty=qty,
+        order_type="limit",
+        price=1500.0,
+        state=state,
+        filled_qty=filled_qty if filled_qty is not None else qty,
+        broker_order_id=f"BRK_{cid}",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    repo.save(record)
+
+
+# ---------------------------------------------------------------------------
+# collect_position_snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_collect_empty_returns_empty_list(repo):
+    broker = MockBrokerClient()
+    assert collect_position_snapshot(broker, repo) == []
+
+
+def test_collect_broker_only_is_mismatch(repo):
+    """broker のみ保有（local 注文なし）→ MISMATCH, diff=broker_qty"""
+    broker = MockBrokerClient(
+        initial_positions=[Position(code="7203", qty=100, avg_price=1500.0)]
+    )
+    result = collect_position_snapshot(broker, repo)
+    assert len(result) == 1
+    assert result[0].code == "7203"
+    assert result[0].broker_qty == 100
+    assert result[0].local_qty == 0
+    assert result[0].diff == 100
+    assert result[0].status == ENTRY_MISMATCH
+
+
+def test_collect_local_only_is_mismatch(repo):
+    """local に Filled 注文あり、broker に未反映 → MISMATCH, diff 負"""
+    broker = MockBrokerClient()
+    _insert_order(repo, "9984", "buy", 50, "ord-001")
+    result = collect_position_snapshot(broker, repo)
+    assert len(result) == 1
+    assert result[0].code == "9984"
+    assert result[0].broker_qty == 0
+    assert result[0].local_qty == 50
+    assert result[0].diff == -50
+    assert result[0].status == ENTRY_MISMATCH
+
+
+def test_collect_matching_position_is_match(repo):
+    """broker と local が一致 → MATCH, diff=0"""
+    broker = MockBrokerClient(
+        initial_positions=[Position(code="7203", qty=100, avg_price=1500.0)]
+    )
+    _insert_order(repo, "7203", "buy", 100, "ord-001")
+    result = collect_position_snapshot(broker, repo)
+    assert len(result) == 1
+    assert result[0].status == ENTRY_MATCH
+    assert result[0].diff == 0
+
+
+def test_collect_qty_mismatch(repo):
+    """broker=100, local Filled=80 → MISMATCH, diff=+20"""
+    broker = MockBrokerClient(
+        initial_positions=[Position(code="7203", qty=100, avg_price=1500.0)]
+    )
+    _insert_order(repo, "7203", "buy", 80, "ord-001")
+    result = collect_position_snapshot(broker, repo)
+    assert result[0].broker_qty == 100
+    assert result[0].local_qty == 80
+    assert result[0].diff == 20
+    assert result[0].status == ENTRY_MISMATCH
+
+
+def test_collect_multiple_codes(repo):
+    """複数銘柄: 一致・不一致の混在"""
+    broker = MockBrokerClient(
+        initial_positions=[
+            Position(code="1111", qty=100, avg_price=1000.0),
+            Position(code="2222", qty=50, avg_price=2000.0),
+        ]
+    )
+    _insert_order(repo, "1111", "buy", 100, "ord-001")  # MATCH
+    _insert_order(repo, "2222", "buy", 30, "ord-002")   # MISMATCH
+    result = collect_position_snapshot(broker, repo)
+    codes = [e.code for e in result]
+    assert "1111" in codes
+    assert "2222" in codes
+    assert next(e for e in result if e.code == "1111").status == ENTRY_MATCH
+    assert next(e for e in result if e.code == "2222").status == ENTRY_MISMATCH
+
+
+def test_collect_sorted_by_code(repo):
+    """結果は code 昇順でソートされる"""
+    broker = MockBrokerClient(
+        initial_positions=[
+            Position(code="9999", qty=10, avg_price=100.0),
+            Position(code="1111", qty=10, avg_price=100.0),
+            Position(code="5555", qty=10, avg_price=100.0),
+        ]
+    )
+    result = collect_position_snapshot(broker, repo)
+    assert [e.code for e in result] == ["1111", "5555", "9999"]
+
+
+def test_collect_partial_fill_counts(repo):
+    """PartialFill の filled_qty がローカル数量に反映される"""
+    broker = MockBrokerClient()
+    _insert_order(
+        repo, "7203", "buy", 100, "ord-001",
+        state=OrderState.PartialFill, filled_qty=50,
+    )
+    result = collect_position_snapshot(broker, repo)
+    assert len(result) == 1
+    assert result[0].local_qty == 50
+
+
+def test_collect_sell_reduces_local_qty(repo):
+    """buy Filled 100 - sell Filled 30 → local_qty=70"""
+    broker = MockBrokerClient()
+    _insert_order(repo, "7203", "buy", 100, "ord-001")
+    _insert_order(repo, "7203", "sell", 30, "ord-002")
+    result = collect_position_snapshot(broker, repo)
+    assert len(result) == 1
+    assert result[0].local_qty == 70
+
+
+def test_collect_skips_non_filled_states(repo):
+    """OrderCreated は local 集計に含まない"""
+    broker = MockBrokerClient()
+    _insert_order(
+        repo, "7203", "buy", 100, "ord-001",
+        state=OrderState.OrderCreated, filled_qty=0,
+    )
+    result = collect_position_snapshot(broker, repo)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _generate_warnings
+# ---------------------------------------------------------------------------
+
+
+def test_generate_warnings_clean():
+    entries = [
+        PositionEntry(code="7203", broker_qty=100, local_qty=100, diff=0,
+                      status=ENTRY_MATCH)
+    ]
+    assert _generate_warnings(entries) == []
+
+
+def test_generate_warnings_mismatch_contains_code():
+    entries = [
+        PositionEntry(code="7203", broker_qty=100, local_qty=80, diff=20,
+                      status=ENTRY_MISMATCH)
+    ]
+    warnings = _generate_warnings(entries)
+    assert len(warnings) == 1
+    assert "7203" in warnings[0]
+    assert "100" in warnings[0]
+    assert "80" in warnings[0]
+
+
+def test_generate_warnings_multiple_mismatch():
+    entries = [
+        PositionEntry(code="1111", broker_qty=100, local_qty=80, diff=20,
+                      status=ENTRY_MISMATCH),
+        PositionEntry(code="2222", broker_qty=0, local_qty=50, diff=-50,
+                      status=ENTRY_MISMATCH),
+    ]
+    assert len(_generate_warnings(entries)) == 2
+
+
+# ---------------------------------------------------------------------------
+# build_report
+# ---------------------------------------------------------------------------
+
+
+def test_build_report_clean_status():
+    entries = [
+        PositionEntry(code="7203", broker_qty=100, local_qty=100, diff=0,
+                      status=ENTRY_MATCH)
+    ]
+    assert build_report(entries, report_date=TARGET_DATE).status == STATUS_CLEAN
+
+
+def test_build_report_discrepancy_status():
+    entries = [
+        PositionEntry(code="7203", broker_qty=100, local_qty=80, diff=20,
+                      status=ENTRY_MISMATCH)
+    ]
+    assert build_report(entries, report_date=TARGET_DATE).status == STATUS_DISCREPANCY
+
+
+def test_build_report_counts():
+    entries = [
+        PositionEntry(code="1111", broker_qty=100, local_qty=100, diff=0,
+                      status=ENTRY_MATCH),
+        PositionEntry(code="2222", broker_qty=50, local_qty=30, diff=20,
+                      status=ENTRY_MISMATCH),
+    ]
+    report = build_report(entries, report_date=TARGET_DATE)
+    assert report.total_count == 2
+    assert report.match_count == 1
+    assert report.mismatch_count == 1
+
+
+def test_build_report_generated_at_utc():
+    report = build_report([], report_date=TARGET_DATE)
+    assert "+00:00" in report.generated_at
+
+
+def test_build_report_empty_entries_is_clean():
+    report = build_report([], report_date=TARGET_DATE)
+    assert report.status == STATUS_CLEAN
+    assert report.total_count == 0
+    assert report.warnings == []
+
+
+# ---------------------------------------------------------------------------
+# format_cli_summary
+# ---------------------------------------------------------------------------
+
+
+def test_format_cli_clean_no_mark():
+    entries = [
+        PositionEntry(code="7203", broker_qty=100, local_qty=100, diff=0,
+                      status=ENTRY_MATCH)
+    ]
+    report = build_report(entries, report_date=TARGET_DATE)
+    s = format_cli_summary(report)
+    assert STATUS_CLEAN in s
+    assert "2026-04-28" in s
+    assert "[!]" not in s
+
+
+def test_format_cli_discrepancy_shows_mark():
+    entries = [
+        PositionEntry(code="7203", broker_qty=100, local_qty=80, diff=20,
+                      status=ENTRY_MISMATCH)
+    ]
+    report = build_report(entries, report_date=TARGET_DATE)
+    s = format_cli_summary(report)
+    assert STATUS_DISCREPANCY in s
+    assert "[!]" in s
+
+
+def test_format_cli_shows_all_positions():
+    """MATCH 銘柄も出力に含まれる"""
+    entries = [
+        PositionEntry(code="1111", broker_qty=100, local_qty=100, diff=0,
+                      status=ENTRY_MATCH),
+        PositionEntry(code="2222", broker_qty=50, local_qty=30, diff=20,
+                      status=ENTRY_MISMATCH),
+    ]
+    report = build_report(entries, report_date=TARGET_DATE)
+    s = format_cli_summary(report)
+    assert "1111" in s
+    assert "2222" in s
+
+
+# ---------------------------------------------------------------------------
+# format_json
+# ---------------------------------------------------------------------------
+
+
+def test_format_json_parseable():
+    entries = [
+        PositionEntry(code="7203", broker_qty=100, local_qty=100, diff=0,
+                      status=ENTRY_MATCH)
+    ]
+    report = build_report(entries, report_date=TARGET_DATE)
+    data = json_mod.loads(format_json(report))
+    for key in ("status", "report_date", "generated_at", "total_count",
+                "match_count", "mismatch_count", "positions", "warnings"):
+        assert key in data
+
+
+# ---------------------------------------------------------------------------
+# format_markdown
+# ---------------------------------------------------------------------------
+
+
+def test_format_markdown_required_sections():
+    report = build_report([], report_date=TARGET_DATE)
+    md = format_markdown(report)
+    assert "Position Reconciliation" in md
+    assert "Overview" in md
+    assert "Final Decision" in md
+
+
+def test_format_markdown_warnings_only_when_discrepancy():
+    clean_entries = [
+        PositionEntry(code="7203", broker_qty=100, local_qty=100, diff=0,
+                      status=ENTRY_MATCH)
+    ]
+    assert "Warnings" not in format_markdown(
+        build_report(clean_entries, report_date=TARGET_DATE)
+    )
+    disc_entries = [
+        PositionEntry(code="7203", broker_qty=100, local_qty=80, diff=20,
+                      status=ENTRY_MISMATCH)
+    ]
+    assert "Warnings" in format_markdown(
+        build_report(disc_entries, report_date=TARGET_DATE)
+    )
+
+
+def test_format_markdown_position_table():
+    entries = [
+        PositionEntry(code="7203", broker_qty=100, local_qty=80, diff=20,
+                      status=ENTRY_MISMATCH)
+    ]
+    report = build_report(entries, report_date=TARGET_DATE)
+    md = format_markdown(report)
+    assert "7203" in md
+    assert "ポジション一覧" in md
+
+
+# ---------------------------------------------------------------------------
+# save_report
+# ---------------------------------------------------------------------------
+
+
+def test_save_report_creates_three_files(tmp_path):
+    report = build_report([], report_date=TARGET_DATE)
+    dest = save_report(report, output_dir=tmp_path)
+    assert (dest / "summary.json").exists()
+    assert (dest / "report.md").exists()
+    assert (dest / "warnings.json").exists()
+
+
+def test_save_report_invalid_format_raises(tmp_path):
+    report = PositionReconciliationReport(
+        report_date="invalid-date",
+        generated_at="2026-04-27T00:00:00+00:00",
+        status=STATUS_CLEAN,
+        total_count=0, match_count=0, mismatch_count=0,
+        positions=[], warnings=[],
+    )
+    with pytest.raises(ValueError, match="Invalid report_date"):
+        save_report(report, output_dir=tmp_path)
+
+
+def test_save_report_impossible_calendar_date_raises(tmp_path):
+    report = PositionReconciliationReport(
+        report_date="2026-02-30",
+        generated_at="2026-04-27T00:00:00+00:00",
+        status=STATUS_CLEAN,
+        total_count=0, match_count=0, mismatch_count=0,
+        positions=[], warnings=[],
+    )
+    with pytest.raises(ValueError, match="Invalid report_date"):
+        save_report(report, output_dir=tmp_path)
+
+
+def test_save_report_idempotent(tmp_path):
+    report = build_report([], report_date=TARGET_DATE)
+    save_report(report, output_dir=tmp_path)
+    save_report(report, output_dir=tmp_path)
+    assert (tmp_path / "2026-04-28" / "summary.json").exists()


### PR DESCRIPTION
## Summary

- `src/kabusys/operations/position_reconciliation_report.py` を新規作成
  - `collect_position_snapshot()`: ブローカーAPIとOrderRepositoryからポジションを比較取得
  - `build_report()` / `format_cli_summary()` / `format_json()` / `format_markdown()` / `save_report()`: 純粋関数群
  - ステータス: `CLEAN`（全銘柄一致）/ `DISCREPANCY`（1件以上差分あり）
  - 全保有銘柄を表示（一致銘柄も含む）。MISMATCH行に `[!]` マーク
- `src/kabusys/run_position_reconciliation_report.py` を新規作成
  - `--date YYYY-MM-DD` / `--save` / `--json` / `--watch` / `--interval N` オプション
  - `--watch` モード: SQLite接続を各ループで開閉し、エラー時も継続
  - 終了コード: CLEAN=0, DISCREPANCY=1（`--watch` は常に 0）
- `tests/test_position_reconciliation_report.py` に 29 件のユニットテストを追加
- 保存先: `artifacts/position_reconciliation/{date}/summary.json|report.md|warnings.json`

Closes #204

## Test Plan

- [ ] `python -m pytest tests/test_position_reconciliation_report.py -v` → 29 passed
- [ ] `python -m ruff check src/kabusys/operations/position_reconciliation_report.py src/kabusys/run_position_reconciliation_report.py` → All checks passed
- [ ] CI (Lint + Tests) PASS