### PR TITLE
feat: Market Close Summary を実装 (Issue #205)

### DIFF
--- a/docs/superpowers/plans/2026-04-29-market-close-summary.md
+++ b/docs/superpowers/plans/2026-04-29-market-close-summary.md
@@ -1,0 +1,1160 @@
+# Market Close Summary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 引け後の締め確認レポート（Market Close Summary）を実装し、`python -m kabusys.run_market_close_report` の 1 コマンドで夜間バッチへ進んでよいかを OK / BLOCKED で判定できるようにする。
+
+**Architecture:** pre_market_report と同様の 3 ファイル構成（collector + report + runner）。DuckDB（positions, portfolio_performance）と SQLite（signal_queue）を read-only で参照し、純粋関数層でレポートを生成する。build_report はキーワード引数のみ受け取り、DB への依存を持たない。
+
+**Tech Stack:** Python 3.10+, DuckDB（`duckdb` パッケージ）, SQLite（`sqlite3` 標準ライブラリ）, pytest
+
+---
+
+## File Map
+
+| ファイル | 役割 |
+|---|---|
+| `src/kabusys/operations/market_close_report.py` | 純粋関数のみ（データクラス・build_report・フォーマッター・save_report）|
+| `src/kabusys/operations/market_close_collector.py` | DB クエリ専用（DuckDB + SQLite、MarketCloseData を返す）|
+| `src/kabusys/run_market_close_report.py` | CLI エントリーポイント |
+| `tests/test_market_close_report.py` | 全ユニットテスト |
+
+---
+
+### Task 1: market_close_report.py — データクラスとビジネスロジック
+
+**Files:**
+- Create: `tests/test_market_close_report.py`
+- Create: `src/kabusys/operations/market_close_report.py`
+
+- [ ] **Step 1: テストを書く**
+
+`tests/test_market_close_report.py` を新規作成:
+
+```python
+"""Market Close Summary レポートのテスト。"""
+from __future__ import annotations
+
+import json
+import sqlite3 as _sqlite3
+from datetime import date
+
+import duckdb as _duckdb
+import pytest
+
+from kabusys.operations.market_close_report import (
+    STATUS_BLOCKED,
+    STATUS_OK,
+    CheckItem,
+    MarketCloseReport,
+    build_report,
+    format_cli_summary,
+    format_json,
+    format_markdown,
+    save_report,
+)
+
+
+# ---------------------------------------------------------------------------
+# ヘルパー
+# ---------------------------------------------------------------------------
+
+def _make_report(
+    *,
+    signal_pending_count: int = 0,
+    positions_updated: bool = True,
+    performance_recorded: bool = True,
+    filled_count: int = 3,
+    daily_return: float | None = 0.0032,
+    equity_today: float | None = 5_234_000.0,
+    equity_prev: float | None = 5_217_600.0,
+    report_date: date = date(2026, 4, 28),
+) -> MarketCloseReport:
+    return build_report(
+        report_date=report_date,
+        signal_pending_count=signal_pending_count,
+        positions_updated=positions_updated,
+        performance_recorded=performance_recorded,
+        filled_count=filled_count,
+        daily_return=daily_return,
+        equity_today=equity_today,
+        equity_prev=equity_prev,
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_report — ステータス判定
+# ---------------------------------------------------------------------------
+
+def test_build_report_ok():
+    report = _make_report()
+    assert report.status == STATUS_OK
+
+
+def test_build_report_blocked_pending():
+    report = _make_report(signal_pending_count=2)
+    assert report.status == STATUS_BLOCKED
+
+
+def test_build_report_blocked_positions():
+    report = _make_report(positions_updated=False)
+    assert report.status == STATUS_BLOCKED
+
+
+def test_build_report_blocked_performance():
+    report = _make_report(performance_recorded=False)
+    assert report.status == STATUS_BLOCKED
+
+
+def test_build_report_all_blocked():
+    report = _make_report(
+        signal_pending_count=1,
+        positions_updated=False,
+        performance_recorded=False,
+    )
+    assert report.status == STATUS_BLOCKED
+    assert len(report.warnings) == 3
+
+
+# ---------------------------------------------------------------------------
+# build_report — チェック項目
+# ---------------------------------------------------------------------------
+
+def test_build_report_check_items_count():
+    report = _make_report()
+    assert len(report.checks) == 3
+
+
+def test_build_report_checks_all_ok():
+    report = _make_report()
+    assert all(c.status == "ok" for c in report.checks)
+
+
+def test_build_report_checks_signal_failed():
+    report = _make_report(signal_pending_count=3)
+    sq = next(c for c in report.checks if c.name == "signal_queue")
+    assert sq.status == "failed"
+    assert "3 件" in sq.detail
+
+
+def test_build_report_checks_positions_failed():
+    report = _make_report(positions_updated=False)
+    pos = next(c for c in report.checks if c.name == "positions")
+    assert pos.status == "failed"
+
+
+def test_build_report_checks_performance_failed():
+    report = _make_report(performance_recorded=False)
+    perf = next(c for c in report.checks if c.name == "portfolio_performance")
+    assert perf.status == "failed"
+
+
+# ---------------------------------------------------------------------------
+# build_report — summary（損益額計算）
+# ---------------------------------------------------------------------------
+
+def test_build_report_pnl_amount_calculated():
+    report = _make_report(equity_today=5_234_000.0, equity_prev=5_217_600.0)
+    assert report.summary["pnl_amount"] == pytest.approx(16_400.0)
+
+
+def test_build_report_pnl_amount_none_when_equity_today_missing():
+    report = _make_report(equity_today=None, equity_prev=5_217_600.0)
+    assert report.summary["pnl_amount"] is None
+
+
+def test_build_report_pnl_amount_none_when_equity_prev_missing():
+    report = _make_report(equity_today=5_234_000.0, equity_prev=None)
+    assert report.summary["pnl_amount"] is None
+
+
+def test_build_report_summary_fields():
+    report = _make_report(filled_count=5, daily_return=0.0032)
+    assert report.summary["filled_count"] == 5
+    assert report.summary["daily_return"] == pytest.approx(0.0032)
+
+
+# ---------------------------------------------------------------------------
+# format_cli_summary
+# ---------------------------------------------------------------------------
+
+def test_format_cli_summary_ok():
+    report = _make_report()
+    out = format_cli_summary(report)
+    assert "✅" in out
+    assert STATUS_OK in out
+    assert "pending: 0 件" in out
+
+
+def test_format_cli_summary_blocked():
+    report = _make_report(signal_pending_count=2)
+    out = format_cli_summary(report)
+    assert "🚫" in out
+    assert STATUS_BLOCKED in out
+    assert "Warnings" in out
+    assert "2 件" in out
+
+
+def test_format_cli_summary_summary_section():
+    report = _make_report(
+        filled_count=5,
+        daily_return=0.0032,
+        equity_today=5_234_000.0,
+        equity_prev=5_217_600.0,
+    )
+    out = format_cli_summary(report)
+    assert "5 件" in out
+    assert "0.32%" in out
+    assert "16,400" in out
+    assert "5,234,000" in out
+
+
+def test_format_cli_summary_none_values():
+    report = _make_report(daily_return=None, equity_today=None, equity_prev=None)
+    out = format_cli_summary(report)
+    assert "N/A" in out
+
+
+# ---------------------------------------------------------------------------
+# format_json
+# ---------------------------------------------------------------------------
+
+def test_format_json_is_valid_json():
+    report = _make_report()
+    data = json.loads(format_json(report))
+    assert data["status"] == STATUS_OK
+    assert data["report_date"] == "2026-04-28"
+    assert "checks" in data
+    assert "summary" in data
+    assert "warnings" in data
+
+
+# ---------------------------------------------------------------------------
+# format_markdown
+# ---------------------------------------------------------------------------
+
+def test_format_markdown_contains_sections():
+    report = _make_report()
+    md = format_markdown(report)
+    assert "# Market Close Summary" in md
+    assert "Overview" in md
+    assert "Checks" in md
+    assert "Summary" in md
+    assert "Final Decision" in md
+    assert STATUS_OK in md
+
+
+def test_format_markdown_blocked_contains_warnings():
+    report = _make_report(signal_pending_count=1)
+    md = format_markdown(report)
+    assert "Warnings" in md
+    assert STATUS_BLOCKED in md
+
+
+# ---------------------------------------------------------------------------
+# save_report
+# ---------------------------------------------------------------------------
+
+def test_save_report_creates_files(tmp_path):
+    report = _make_report()
+    run_dir = save_report(report, output_dir=tmp_path)
+    assert (run_dir / "summary.json").exists()
+    assert (run_dir / "report.md").exists()
+    assert (run_dir / "warnings.json").exists()
+
+
+def test_save_report_directory_name(tmp_path):
+    report = _make_report()
+    run_dir = save_report(report, output_dir=tmp_path)
+    assert run_dir.name == "2026-04-28"
+
+
+def test_save_report_invalid_date_format(tmp_path):
+    report = _make_report()
+    report.report_date = "20260428"
+    with pytest.raises(ValueError):
+        save_report(report, output_dir=tmp_path)
+
+
+def test_save_report_invalid_calendar_date(tmp_path):
+    report = _make_report()
+    report.report_date = "2026-99-99"
+    with pytest.raises(ValueError):
+        save_report(report, output_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# collector fixtures（Task 2 で使用）
+# ---------------------------------------------------------------------------
+
+TODAY = date(2026, 4, 28)
+PREV = date(2026, 4, 25)
+
+
+@pytest.fixture
+def ddb():
+    """インメモリ DuckDB（positions + portfolio_performance テーブル付き）。"""
+    conn = _duckdb.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE positions ("
+        "  date DATE, code VARCHAR, position_size INTEGER,"
+        "  avg_price FLOAT, market_value FLOAT"
+        ")"
+    )
+    conn.execute(
+        "CREATE TABLE portfolio_performance ("
+        "  date DATE, equity FLOAT, cash FLOAT,"
+        "  drawdown FLOAT, daily_return FLOAT"
+        ")"
+    )
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def sdb():
+    """インメモリ SQLite（signal_queue テーブル付き）。"""
+    conn = _sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE signal_queue ("
+        "  signal_id TEXT, date TEXT, code TEXT, side TEXT,"
+        "  size INTEGER, order_type TEXT, price REAL,"
+        "  status TEXT, created_at TEXT, processed_at TEXT"
+        ")"
+    )
+    conn.commit()
+    yield conn
+    conn.close()
+
+
+def _insert_signal(sdb, date_str: str, status: str, code: str = "1234") -> None:
+    sdb.execute(
+        "INSERT INTO signal_queue"
+        " (signal_id, date, code, side, size, order_type, price, status, created_at, processed_at)"
+        " VALUES (?, ?, ?, 'buy', 100, 'market', NULL, ?, '2026-04-28T08:00:00', NULL)",
+        (f"sig-{code}-{status}", date_str, code, status),
+    )
+    sdb.commit()
+
+
+def _insert_position(ddb, date_val: date, code: str = "1234") -> None:
+    ddb.execute(
+        "INSERT INTO positions VALUES (?, ?, 100, 1500.0, 150000.0)",
+        [date_val.isoformat(), code],
+    )
+
+
+def _insert_performance(
+    ddb,
+    date_val: date,
+    equity: float = 5_234_000.0,
+    daily_return: float = 0.0032,
+) -> None:
+    ddb.execute(
+        "INSERT INTO portfolio_performance VALUES (?, ?, 1000000.0, -0.005, ?)",
+        [date_val.isoformat(), equity, daily_return],
+    )
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```bash
+python -m pytest tests/test_market_close_report.py -v 2>&1 | head -20
+```
+
+Expected: `ModuleNotFoundError: No module named 'kabusys.operations.market_close_report'`
+
+- [ ] **Step 3: market_close_report.py を実装する**
+
+`src/kabusys/operations/market_close_report.py` を新規作成:
+
+```python
+"""
+Market Close Summary レポート生成モジュール。
+
+引け後（15:30 頃）に「今日の運用が正常に締まったか」を確認し、
+夜間バッチへ進んでよいかを OK / BLOCKED で判定する。
+DB への参照は行わず、呼び出し元から受け取ったデータのみを使用する。
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+STATUS_OK = "OK"
+STATUS_BLOCKED = "BLOCKED"
+
+_STATUS_EMOJI = {
+    STATUS_OK: "✅",
+    STATUS_BLOCKED: "🚫",
+}
+
+_CHECK_STATUS_LABEL = {
+    "ok": "ok  ",
+    "failed": "FAIL",
+}
+
+
+@dataclass
+class CheckItem:
+    """1 チェック項目の結果。"""
+
+    name: str
+    status: str  # "ok" | "failed"
+    detail: str
+
+
+@dataclass
+class MarketCloseReport:
+    """Market Close Summary レポート全体。"""
+
+    report_date: str   # ISO date（YYYY-MM-DD）
+    generated_at: str  # ISO 8601 UTC
+    status: str        # "OK" / "BLOCKED"
+    checks: list[CheckItem]
+    summary: dict
+    warnings: list[str]
+
+
+def _determine_status(
+    *,
+    signal_pending_count: int,
+    positions_updated: bool,
+    performance_recorded: bool,
+) -> str:
+    """OK / BLOCKED を判定する。
+
+    BLOCKED 条件（いずれかが真）:
+      - signal_pending_count > 0（pending シグナル残件あり）
+      - positions_updated == False（positions 未更新）
+      - performance_recorded == False（portfolio_performance 未記録）
+    """
+    if signal_pending_count > 0 or not positions_updated or not performance_recorded:
+        return STATUS_BLOCKED
+    return STATUS_OK
+
+
+def _generate_warnings(
+    *,
+    signal_pending_count: int,
+    positions_updated: bool,
+    performance_recorded: bool,
+) -> list[str]:
+    """警告メッセージのリストを生成する。"""
+    warnings: list[str] = []
+    if signal_pending_count > 0:
+        warnings.append(
+            f"signal_queue に本日の pending シグナルが {signal_pending_count} 件残っています"
+        )
+    if not positions_updated:
+        warnings.append("positions に当日分が記録されていません")
+    if not performance_recorded:
+        warnings.append("portfolio_performance に当日分が記録されていません")
+    return warnings
+
+
+def _build_check_items(
+    *,
+    signal_pending_count: int,
+    positions_updated: bool,
+    performance_recorded: bool,
+) -> list[CheckItem]:
+    return [
+        CheckItem(
+            name="signal_queue",
+            status="ok" if signal_pending_count == 0 else "failed",
+            detail=(
+                "pending: 0 件（全シグナル処理済み）"
+                if signal_pending_count == 0
+                else f"pending: {signal_pending_count} 件（未処理シグナルあり）"
+            ),
+        ),
+        CheckItem(
+            name="positions",
+            status="ok" if positions_updated else "failed",
+            detail=(
+                "positions: 当日分 更新済み"
+                if positions_updated
+                else "positions: 当日分 未更新"
+            ),
+        ),
+        CheckItem(
+            name="portfolio_performance",
+            status="ok" if performance_recorded else "failed",
+            detail=(
+                "portfolio_performance: 当日分 記録済み"
+                if performance_recorded
+                else "portfolio_performance: 当日分 未記録"
+            ),
+        ),
+    ]
+
+
+def build_report(
+    *,
+    report_date: date,
+    signal_pending_count: int,
+    positions_updated: bool,
+    performance_recorded: bool,
+    filled_count: int,
+    daily_return: float | None,
+    equity_today: float | None,
+    equity_prev: float | None,
+) -> MarketCloseReport:
+    """MarketCloseReport を構築する。"""
+    kwargs = dict(
+        signal_pending_count=signal_pending_count,
+        positions_updated=positions_updated,
+        performance_recorded=performance_recorded,
+    )
+    pnl_amount = (
+        equity_today - equity_prev
+        if equity_today is not None and equity_prev is not None
+        else None
+    )
+    return MarketCloseReport(
+        report_date=report_date.isoformat(),
+        generated_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        status=_determine_status(**kwargs),
+        checks=_build_check_items(**kwargs),
+        summary={
+            "filled_count": filled_count,
+            "daily_return": daily_return,
+            "pnl_amount": pnl_amount,
+            "equity_today": equity_today,
+        },
+        warnings=_generate_warnings(**kwargs),
+    )
+
+
+# ---------------------------------------------------------------------------
+# フォーマッター
+# ---------------------------------------------------------------------------
+
+
+def _fmt_return(v: float | None) -> str:
+    """日次リターンを符号付きパーセント文字列に変換する。"""
+    if v is None:
+        return "N/A"
+    sign = "+" if v > 0 else ""
+    return f"{sign}{v:.2%}"
+
+
+def _fmt_yen(v: float | None) -> str:
+    """金額を符号付き円表記に変換する。"""
+    if v is None:
+        return "N/A"
+    sign = "+" if v > 0 else ""
+    return f"{sign}¥{int(v):,}"
+
+
+def format_cli_summary(report: MarketCloseReport) -> str:
+    """CLI 表示用サマリ文字列を返す。"""
+    sep = "=" * 52
+    thin = "-" * 52
+    emoji = _STATUS_EMOJI.get(report.status, "")
+    s = report.summary
+    lines = [
+        f"\n{sep}",
+        f"  Market Close Summary  {report.report_date}",
+        f"  Status : {emoji} {report.status}",
+        f"{sep}",
+        "  Checks:",
+    ]
+    for c in report.checks:
+        label = _CHECK_STATUS_LABEL.get(c.status, c.status.upper())
+        lines.append(f"    [{label}] {c.name:<22} {c.detail}")
+    lines += [
+        thin,
+        "  Summary:",
+        f"    約定件数    : {s['filled_count']} 件",
+        f"    日次リターン : {_fmt_return(s['daily_return'])}",
+        f"    当日損益額  : {_fmt_yen(s['pnl_amount'])}",
+        f"    期末総資産  : {_fmt_yen(s['equity_today'])}",
+    ]
+    if report.warnings:
+        lines.append(thin)
+        lines.append("  Warnings:")
+        for w in report.warnings:
+            lines.append(f"    [!] {w}")
+    lines.append(f"{sep}\n")
+    return "\n".join(lines)
+
+
+def _to_serializable(obj: object) -> object:
+    if isinstance(obj, dict):
+        return {k: _to_serializable(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_to_serializable(i) for i in obj]
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    if isinstance(obj, date):
+        return obj.isoformat()
+    return obj
+
+
+def format_json(report: MarketCloseReport) -> str:
+    """全フィールドを含む JSON 文字列を返す。"""
+    return json.dumps(_to_serializable(asdict(report)), ensure_ascii=False, indent=2)
+
+
+def format_markdown(report: MarketCloseReport) -> str:
+    """人間向け Markdown レポート文字列を返す。"""
+    lines: list[str] = []
+    sec = 0
+
+    def _section(title: str) -> str:
+        nonlocal sec
+        sec += 1
+        return f"## {sec}. {title}"
+
+    emoji = _STATUS_EMOJI.get(report.status, "")
+    s = report.summary
+
+    lines += [
+        "# Market Close Summary",
+        "",
+        _section("Overview"),
+        "",
+        "| 項目 | 値 |",
+        "|-----|---|",
+        f"| 実行日 | {report.report_date} |",
+        f"| 生成時刻 | {report.generated_at} |",
+        f"| **最終判定** | **{emoji} {report.status}** |",
+        "",
+        _section("Checks"),
+        "",
+        "| チェック項目 | ステータス | 詳細 |",
+        "|------------|-----------|------|",
+    ]
+    for c in report.checks:
+        lines.append(f"| {c.name} | {c.status} | {c.detail} |")
+    lines += [
+        "",
+        _section("Summary"),
+        "",
+        "| 項目 | 値 |",
+        "|-----|---|",
+        f"| 約定件数 | {s['filled_count']} 件 |",
+        f"| 日次リターン | {_fmt_return(s['daily_return'])} |",
+        f"| 当日損益額 | {_fmt_yen(s['pnl_amount'])} |",
+        f"| 期末総資産 | {_fmt_yen(s['equity_today'])} |",
+        "",
+    ]
+    if report.warnings:
+        lines += [_section("Warnings"), ""]
+        for w in report.warnings:
+            lines.append(f"- ⚠️ {w}")
+        lines.append("")
+
+    lines += [_section("Final Decision"), ""]
+    if report.status == STATUS_OK:
+        lines += [
+            f"**{STATUS_OK}** — 夜間バッチへ進んでください。",
+            "",
+            "- 全チェック項目が正常です。",
+        ]
+    else:
+        lines += [
+            f"**{STATUS_BLOCKED}** — 夜間バッチへ **進まないでください**。",
+            "",
+            "- 上記 Warnings を確認し、問題を解消してから再実行してください。",
+        ]
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# 保存
+# ---------------------------------------------------------------------------
+
+
+def save_report(
+    report: MarketCloseReport,
+    output_dir: Path | str | None = None,
+) -> Path:
+    """レポートを artifacts/market_close/{report_date}/ に保存する。
+
+    Returns:
+        保存先ディレクトリのパス。
+    """
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", report.report_date):
+        raise ValueError(f"Invalid report_date: {report.report_date!r}")
+    try:
+        date.fromisoformat(report.report_date)
+    except ValueError:
+        raise ValueError(f"Invalid report_date: {report.report_date!r}")
+    base = Path(output_dir) if output_dir else Path("artifacts") / "market_close"
+    run_dir = base / report.report_date
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "summary.json").write_text(format_json(report), encoding="utf-8")
+    (run_dir / "report.md").write_text(format_markdown(report), encoding="utf-8")
+    (run_dir / "warnings.json").write_text(
+        json.dumps(report.warnings, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    return run_dir
+```
+
+- [ ] **Step 4: テストを実行して通ることを確認**
+
+```bash
+python -m pytest tests/test_market_close_report.py -v -k "not ddb and not sdb and not collect"
+```
+
+Expected: collector fixture 以外の全テスト PASS（`ddb`/`sdb` fixture は Task 2 で使用）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add tests/test_market_close_report.py src/kabusys/operations/market_close_report.py
+git commit -m "feat: Market Close Summary レポートモジュールを実装 (Issue #205)"
+```
+
+---
+
+### Task 2: market_close_collector.py — DB クエリ関数と collect_market_close_data
+
+**Files:**
+- Create: `src/kabusys/operations/market_close_collector.py`
+- Test: `tests/test_market_close_report.py`（collector テストは既に Step 1 で記述済み）
+
+- [ ] **Step 1: collector テストが失敗することを確認**
+
+```bash
+python -m pytest tests/test_market_close_report.py -v -k "ddb or sdb or collect"
+```
+
+Expected: `ModuleNotFoundError: No module named 'kabusys.operations.market_close_collector'`
+
+- [ ] **Step 2: market_close_collector.py を実装する**
+
+`src/kabusys/operations/market_close_collector.py` を新規作成:
+
+```python
+"""
+Market Close Summary データ収集モジュール。
+
+DuckDB（positions, portfolio_performance）と SQLite（signal_queue）を
+read-only で参照し、MarketCloseData を返す。
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MarketCloseData:
+    """collect_market_close_data() が返す生データ。"""
+
+    signal_pending_count: int     # 当日 pending シグナル件数
+    positions_updated: bool       # positions に当日分が存在するか
+    performance_recorded: bool    # portfolio_performance に当日分が存在するか
+    filled_count: int             # 当日 filled シグナル件数
+    daily_return: float | None    # 当日日次リターン（未記録なら None）
+    equity_today: float | None    # 当日期末資産（未記録なら None）
+    equity_prev: float | None     # 前営業日期末資産（存在しなければ None）
+
+
+def check_signal_pending(sqlite_conn, today: date) -> int:
+    """当日の pending シグナル件数を返す。"""
+    row = sqlite_conn.execute(
+        "SELECT COUNT(*) FROM signal_queue WHERE status = 'pending' AND date = ?",
+        (today.isoformat(),),
+    ).fetchone()
+    return int(row[0]) if row and row[0] is not None else 0
+
+
+def check_signal_filled(sqlite_conn, today: date) -> int:
+    """当日の filled シグナル件数を返す。"""
+    row = sqlite_conn.execute(
+        "SELECT COUNT(*) FROM signal_queue WHERE status = 'filled' AND date = ?",
+        (today.isoformat(),),
+    ).fetchone()
+    return int(row[0]) if row and row[0] is not None else 0
+
+
+def check_positions_updated(duckdb_conn, today: date) -> bool:
+    """positions テーブルに当日分のレコードが存在すれば True。"""
+    row = duckdb_conn.execute(
+        "SELECT COUNT(*) FROM positions WHERE date = ?",
+        [today.isoformat()],
+    ).fetchone()
+    return int(row[0] if row and row[0] is not None else 0) > 0
+
+
+def check_performance_recorded(duckdb_conn, today: date) -> bool:
+    """portfolio_performance テーブルに当日分のレコードが存在すれば True。"""
+    row = duckdb_conn.execute(
+        "SELECT COUNT(*) FROM portfolio_performance WHERE date = ?",
+        [today.isoformat()],
+    ).fetchone()
+    return int(row[0] if row and row[0] is not None else 0) > 0
+
+
+def get_performance_row(
+    duckdb_conn, today: date
+) -> tuple[float | None, float | None]:
+    """(daily_return, equity) を返す。当日レコードがなければ (None, None)。"""
+    row = duckdb_conn.execute(
+        "SELECT daily_return, equity FROM portfolio_performance WHERE date = ?",
+        [today.isoformat()],
+    ).fetchone()
+    if row is None:
+        return None, None
+    return (
+        float(row[0]) if row[0] is not None else None,
+        float(row[1]) if row[1] is not None else None,
+    )
+
+
+def get_prev_equity(duckdb_conn, today: date) -> float | None:
+    """today より前の最新 equity を返す。存在しなければ None。"""
+    row = duckdb_conn.execute(
+        "SELECT equity FROM portfolio_performance"
+        " WHERE date < ? ORDER BY date DESC LIMIT 1",
+        [today.isoformat()],
+    ).fetchone()
+    return float(row[0]) if row and row[0] is not None else None
+
+
+def collect_market_close_data(
+    duckdb_conn, sqlite_conn, today: date
+) -> MarketCloseData:
+    """全チェック関数を呼び出して MarketCloseData を返す。"""
+    daily_return, equity_today = get_performance_row(duckdb_conn, today)
+    return MarketCloseData(
+        signal_pending_count=check_signal_pending(sqlite_conn, today),
+        positions_updated=check_positions_updated(duckdb_conn, today),
+        performance_recorded=check_performance_recorded(duckdb_conn, today),
+        filled_count=check_signal_filled(sqlite_conn, today),
+        daily_return=daily_return,
+        equity_today=equity_today,
+        equity_prev=get_prev_equity(duckdb_conn, today),
+    )
+```
+
+- [ ] **Step 3: collector テストに不足している import を追加する**
+
+`tests/test_market_close_report.py` の既存 import ブロックの末尾に追加:
+
+```python
+from kabusys.operations.market_close_collector import (
+    MarketCloseData,
+    check_signal_pending,
+    check_signal_filled,
+    check_positions_updated,
+    check_performance_recorded,
+    get_performance_row,
+    get_prev_equity,
+    collect_market_close_data,
+)
+```
+
+そして `tests/test_market_close_report.py` の末尾（`_insert_performance` 関数の後）に以下を追記:
+
+```python
+# ---------------------------------------------------------------------------
+# check_signal_pending
+# ---------------------------------------------------------------------------
+
+def test_check_signal_pending_zero_when_empty(sdb):
+    assert check_signal_pending(sdb, TODAY) == 0
+
+
+def test_check_signal_pending_counts_pending(sdb):
+    _insert_signal(sdb, TODAY.isoformat(), "pending", "1234")
+    _insert_signal(sdb, TODAY.isoformat(), "pending", "5678")
+    assert check_signal_pending(sdb, TODAY) == 2
+
+
+def test_check_signal_pending_ignores_other_status(sdb):
+    _insert_signal(sdb, TODAY.isoformat(), "filled")
+    assert check_signal_pending(sdb, TODAY) == 0
+
+
+def test_check_signal_pending_ignores_other_date(sdb):
+    _insert_signal(sdb, "2026-04-27", "pending")
+    assert check_signal_pending(sdb, TODAY) == 0
+
+
+# ---------------------------------------------------------------------------
+# check_signal_filled
+# ---------------------------------------------------------------------------
+
+def test_check_signal_filled_zero_when_empty(sdb):
+    assert check_signal_filled(sdb, TODAY) == 0
+
+
+def test_check_signal_filled_counts_filled(sdb):
+    _insert_signal(sdb, TODAY.isoformat(), "filled", "1234")
+    _insert_signal(sdb, TODAY.isoformat(), "filled", "5678")
+    assert check_signal_filled(sdb, TODAY) == 2
+
+
+def test_check_signal_filled_ignores_pending(sdb):
+    _insert_signal(sdb, TODAY.isoformat(), "pending")
+    assert check_signal_filled(sdb, TODAY) == 0
+
+
+# ---------------------------------------------------------------------------
+# check_positions_updated
+# ---------------------------------------------------------------------------
+
+def test_check_positions_updated_false_when_empty(ddb):
+    assert check_positions_updated(ddb, TODAY) is False
+
+
+def test_check_positions_updated_true_when_today_exists(ddb):
+    _insert_position(ddb, TODAY)
+    assert check_positions_updated(ddb, TODAY) is True
+
+
+def test_check_positions_updated_false_when_only_prev(ddb):
+    _insert_position(ddb, PREV)
+    assert check_positions_updated(ddb, TODAY) is False
+
+
+# ---------------------------------------------------------------------------
+# check_performance_recorded
+# ---------------------------------------------------------------------------
+
+def test_check_performance_recorded_false_when_empty(ddb):
+    assert check_performance_recorded(ddb, TODAY) is False
+
+
+def test_check_performance_recorded_true_when_today_exists(ddb):
+    _insert_performance(ddb, TODAY)
+    assert check_performance_recorded(ddb, TODAY) is True
+
+
+# ---------------------------------------------------------------------------
+# get_performance_row
+# ---------------------------------------------------------------------------
+
+def test_get_performance_row_none_when_empty(ddb):
+    daily_return, equity = get_performance_row(ddb, TODAY)
+    assert daily_return is None
+    assert equity is None
+
+
+def test_get_performance_row_returns_values(ddb):
+    _insert_performance(ddb, TODAY, equity=5_234_000.0, daily_return=0.0032)
+    daily_return, equity = get_performance_row(ddb, TODAY)
+    assert daily_return == pytest.approx(0.0032)
+    assert equity == pytest.approx(5_234_000.0)
+
+
+# ---------------------------------------------------------------------------
+# get_prev_equity
+# ---------------------------------------------------------------------------
+
+def test_get_prev_equity_none_when_no_history(ddb):
+    assert get_prev_equity(ddb, TODAY) is None
+
+
+def test_get_prev_equity_returns_most_recent_before_today(ddb):
+    _insert_performance(ddb, PREV, equity=5_217_600.0)
+    _insert_performance(ddb, date(2026, 4, 24), equity=5_200_000.0)
+    result = get_prev_equity(ddb, TODAY)
+    assert result == pytest.approx(5_217_600.0)
+
+
+def test_get_prev_equity_ignores_today(ddb):
+    _insert_performance(ddb, TODAY, equity=5_234_000.0)
+    assert get_prev_equity(ddb, TODAY) is None
+
+
+# ---------------------------------------------------------------------------
+# collect_market_close_data
+# ---------------------------------------------------------------------------
+
+def test_collect_market_close_data_all_ok(ddb, sdb):
+    _insert_signal(sdb, TODAY.isoformat(), "filled")
+    _insert_position(ddb, TODAY)
+    _insert_performance(ddb, TODAY, equity=5_234_000.0, daily_return=0.0032)
+    _insert_performance(ddb, PREV, equity=5_217_600.0)
+    data = collect_market_close_data(ddb, sdb, TODAY)
+    assert data.signal_pending_count == 0
+    assert data.filled_count == 1
+    assert data.positions_updated is True
+    assert data.performance_recorded is True
+    assert data.daily_return == pytest.approx(0.0032)
+    assert data.equity_today == pytest.approx(5_234_000.0)
+    assert data.equity_prev == pytest.approx(5_217_600.0)
+
+
+def test_collect_market_close_data_blocked(ddb, sdb):
+    _insert_signal(sdb, TODAY.isoformat(), "pending")
+    data = collect_market_close_data(ddb, sdb, TODAY)
+    assert data.signal_pending_count == 1
+    assert data.positions_updated is False
+    assert data.performance_recorded is False
+```
+
+- [ ] **Step 4: 全テストを実行して通ることを確認**
+
+```bash
+python -m pytest tests/test_market_close_report.py -v
+```
+
+Expected: 全テスト PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add tests/test_market_close_report.py src/kabusys/operations/market_close_collector.py
+git commit -m "feat: market_close_collector.py を実装 (Issue #205)"
+```
+
+---
+
+### Task 3: run_market_close_report.py — CLI エントリーポイント
+
+**Files:**
+- Create: `src/kabusys/run_market_close_report.py`
+
+- [ ] **Step 1: run_market_close_report.py を実装する**
+
+`src/kabusys/run_market_close_report.py` を新規作成:
+
+```python
+"""Market Close Summary エントリーポイント。
+
+使用方法:
+    python -m kabusys.run_market_close_report
+    python -m kabusys.run_market_close_report --date 2026-04-28
+    python -m kabusys.run_market_close_report --save
+    python -m kabusys.run_market_close_report --json
+    python -m kabusys.run_market_close_report --save --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sqlite3
+import sys
+from datetime import date
+from pathlib import Path
+
+import duckdb
+
+from kabusys.config import Settings
+from kabusys.operations.market_close_collector import collect_market_close_data
+from kabusys.operations.market_close_report import (
+    STATUS_BLOCKED,
+    build_report,
+    format_cli_summary,
+    format_json,
+    save_report,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Market Close Summary を生成する"
+    )
+    parser.add_argument(
+        "--date",
+        type=lambda s: date.fromisoformat(s),
+        default=date.today(),
+        metavar="YYYY-MM-DD",
+        help="レポートの日付ラベル兼クエリ対象日（省略時は今日）",
+    )
+    parser.add_argument(
+        "--save",
+        action="store_true",
+        help="artifacts/market_close/ に保存する",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="JSON 形式で出力する",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(message)s")
+
+    settings = Settings()
+    duckdb_conn = duckdb.connect(str(settings.duckdb_path), read_only=True)
+    sqlite_uri = Path(settings.sqlite_path).resolve().as_uri() + "?mode=ro"
+    sqlite_conn = sqlite3.connect(sqlite_uri, uri=True)
+
+    try:
+        data = collect_market_close_data(duckdb_conn, sqlite_conn, args.date)
+    finally:
+        duckdb_conn.close()
+        sqlite_conn.close()
+
+    report = build_report(
+        report_date=args.date,
+        signal_pending_count=data.signal_pending_count,
+        positions_updated=data.positions_updated,
+        performance_recorded=data.performance_recorded,
+        filled_count=data.filled_count,
+        daily_return=data.daily_return,
+        equity_today=data.equity_today,
+        equity_prev=data.equity_prev,
+    )
+
+    if args.json:
+        print(format_json(report))
+    else:
+        print(format_cli_summary(report))
+
+    if args.save:
+        run_dir = save_report(report)
+        dest_msg = f"保存先: {run_dir}"
+        if args.json:
+            sys.stderr.write(dest_msg + "\n")
+        else:
+            print(dest_msg)
+
+    return 1 if report.status == STATUS_BLOCKED else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 2: lint + format チェック**
+
+```bash
+python -m ruff check src/kabusys/operations/market_close_report.py src/kabusys/operations/market_close_collector.py src/kabusys/run_market_close_report.py
+python -m ruff format --check src/kabusys/operations/market_close_report.py src/kabusys/operations/market_close_collector.py src/kabusys/run_market_close_report.py
+```
+
+Expected: `All checks passed!` / `N files already formatted`
+
+フォーマットエラーがあれば修正:
+
+```bash
+python -m ruff format src/kabusys/operations/market_close_report.py src/kabusys/operations/market_close_collector.py src/kabusys/run_market_close_report.py
+```
+
+- [ ] **Step 3: 全テスト実行**
+
+```bash
+python -m pytest tests/test_market_close_report.py -v
+```
+
+Expected: 全テスト PASS
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add src/kabusys/run_market_close_report.py
+git commit -m "feat: run_market_close_report.py CLI エントリーポイントを実装 (Issue #205)"
+```

--- a/docs/superpowers/specs/2026-04-29-market-close-summary-design.md
+++ b/docs/superpowers/specs/2026-04-29-market-close-summary-design.md
@@ -1,0 +1,285 @@
+# Market Close Summary 設計仕様
+
+- Issue: #205
+- Date: 2026-04-29
+- Status: 承認済み
+
+---
+
+## 1. 目的
+
+市場終了後（15:30 頃）に「今日の運用が正常に締まったか」を 1 コマンドで確認し、
+夜間バッチへ進んでよいかを判断できる締めレポートを提供する。
+
+---
+
+## 2. アーキテクチャ
+
+### 2.1 ファイル構成
+
+```
+src/kabusys/operations/
+├── market_close_collector.py   # DB クエリ専用（DuckDB + SQLite）
+├── market_close_report.py      # 純粋関数（build / format / save）
+src/kabusys/
+├── run_market_close_report.py  # CLI エントリーポイント
+tests/
+├── test_market_close_report.py # ユニットテスト
+```
+
+### 2.2 データフロー
+
+```
+run_market_close_report.py
+  └─ market_close_collector.collect_market_close_data(duckdb_conn, sqlite_conn, today)
+       └─ MarketCloseData (dataclass)
+  └─ market_close_report.build_report(data, report_date)
+       └─ MarketCloseReport (dataclass)
+  └─ format_cli_summary / format_json / format_markdown / save_report
+```
+
+### 2.3 DB 接続
+
+- DuckDB（read-only）: `positions`, `portfolio_performance`
+- SQLite（read-only、`mode=ro` URI）: `signal_queue`
+
+---
+
+## 3. データ収集（market_close_collector.py）
+
+### 3.1 MarketCloseData dataclass
+
+```python
+@dataclass
+class MarketCloseData:
+    signal_pending_count: int        # 当日 pending シグナル件数
+    positions_updated: bool          # positions に当日分が存在するか
+    performance_recorded: bool       # portfolio_performance に当日分が存在するか
+    filled_count: int                # 当日 filled シグナル件数
+    daily_return: float | None       # 当日日次リターン（未記録なら None）
+    equity_today: float | None       # 当日期末資産（未記録なら None）
+    equity_prev: float | None        # 前営業日期末資産（存在しなければ None）
+```
+
+### 3.2 クエリ一覧
+
+| フィールド | 情報源 | クエリ概要 |
+|---|---|---|
+| `signal_pending_count` | SQLite: `signal_queue` | `WHERE date=today AND status='pending'` の COUNT |
+| `positions_updated` | DuckDB: `positions` | `MAX(date) = today` なら True |
+| `performance_recorded` | DuckDB: `portfolio_performance` | `WHERE date=today` のレコード存在確認 |
+| `filled_count` | SQLite: `signal_queue` | `WHERE date=today AND status='filled'` の COUNT |
+| `daily_return` | DuckDB: `portfolio_performance` | `WHERE date=today` の `daily_return`（未記録なら None）|
+| `equity_today` | DuckDB: `portfolio_performance` | `WHERE date=today` の `equity`（未記録なら None）|
+| `equity_prev` | DuckDB: `portfolio_performance` | `WHERE date < today ORDER BY date DESC LIMIT 1` の `equity` |
+
+### 3.3 公開関数
+
+pre_market_collector と同様に、各チェック関数を個別に公開して直接テスト可能にする。
+
+```python
+def check_signal_pending(sqlite_conn, today: date) -> int: ...
+def check_signal_filled(sqlite_conn, today: date) -> int: ...
+def check_positions_updated(duckdb_conn, today: date) -> bool: ...
+def check_performance_recorded(duckdb_conn, today: date) -> bool: ...
+def get_performance_row(duckdb_conn, today: date) -> tuple[float | None, float | None]: ...
+    # -> (daily_return, equity_today)
+def get_prev_equity(duckdb_conn, today: date) -> float | None: ...
+
+def collect_market_close_data(
+    duckdb_conn,
+    sqlite_conn,
+    today: date,
+) -> MarketCloseData:
+    """上記の各関数を呼び出して MarketCloseData を返す。"""
+    ...
+```
+
+---
+
+## 4. レポート生成（market_close_report.py）
+
+### 4.1 定数
+
+```python
+STATUS_OK = "OK"
+STATUS_BLOCKED = "BLOCKED"
+```
+
+### 4.2 データクラス
+
+```python
+@dataclass
+class CheckItem:
+    name: str
+    status: str   # "ok" | "failed"
+    detail: str
+
+@dataclass
+class MarketCloseReport:
+    report_date: str        # ISO date（YYYY-MM-DD）
+    generated_at: str       # ISO 8601 UTC
+    status: str             # "OK" / "BLOCKED"
+    checks: list[CheckItem] # 3 項目
+    summary: dict           # 約定件数・日次リターン・損益額・期末資産
+    warnings: list[str]     # BLOCKED 理由の文字列リスト
+```
+
+### 4.3 ステータス判定
+
+BLOCKED 条件（いずれかが真）:
+- `signal_pending_count > 0`（pending シグナル残件あり）
+- `positions_updated == False`（positions 未更新）
+- `performance_recorded == False`（portfolio_performance 未記録）
+
+それ以外: `OK`
+
+### 4.4 チェック項目（3件）
+
+| name | ok 条件 | detail 例（ok） | detail 例（failed） |
+|---|---|---|---|
+| `signal_queue` | `pending == 0` | `pending: 0 件（全シグナル処理済み）` | `pending: 2 件（未処理シグナルあり）` |
+| `positions` | `positions_updated` | `positions: 当日分 更新済み` | `positions: 当日分 未更新` |
+| `portfolio_performance` | `performance_recorded` | `portfolio_performance: 当日分 記録済み` | `portfolio_performance: 当日分 未記録` |
+
+### 4.5 summary フィールド
+
+```python
+summary = {
+    "filled_count": filled_count,           # int
+    "daily_return": daily_return,           # float | None
+    "pnl_amount": equity_today - equity_prev if (equity_today and equity_prev) else None,
+    "equity_today": equity_today,           # float | None
+}
+```
+
+### 4.6 公開関数
+
+```python
+def build_report(data: MarketCloseData, *, report_date: date) -> MarketCloseReport: ...
+def format_cli_summary(report: MarketCloseReport) -> str: ...
+def format_json(report: MarketCloseReport) -> str: ...
+def format_markdown(report: MarketCloseReport) -> str: ...
+def save_report(report: MarketCloseReport, output_dir: Path | str | None = None) -> Path: ...
+```
+
+`save_report` は `report_date` をバリデーション（regex + `date.fromisoformat()`）し、
+`artifacts/market_close/{report_date}/` に以下を保存する:
+- `summary.json`
+- `report.md`
+- `warnings.json`
+
+---
+
+## 5. CLI エントリーポイント（run_market_close_report.py）
+
+### 5.1 使用例
+
+```cmd
+python -m kabusys.run_market_close_report
+python -m kabusys.run_market_close_report --date 2026-04-28
+python -m kabusys.run_market_close_report --save
+python -m kabusys.run_market_close_report --json
+python -m kabusys.run_market_close_report --save --json
+```
+
+### 5.2 オプション
+
+| オプション | デフォルト | 説明 |
+|---|---|---|
+| `--date YYYY-MM-DD` | 今日 | レポートの日付ラベル兼クエリ対象日（`signal_queue.date`・`positions.date`・`portfolio_performance.date` の絞り込みに使用） |
+| `--save` | なし | `artifacts/market_close/` に保存 |
+| `--json` | なし | JSON 形式で標準出力 |
+
+### 5.3 終了コード
+
+| コード | 意味 |
+|---|---|
+| `0` | OK（夜間バッチへ進んでよい） |
+| `1` | BLOCKED（要確認） |
+
+### 5.4 DB 接続
+
+```python
+duckdb_conn = duckdb.connect(str(settings.duckdb_path), read_only=True)
+sqlite_uri = Path(settings.sqlite_path).resolve().as_uri() + "?mode=ro"
+sqlite_conn = sqlite3.connect(sqlite_uri, uri=True)
+```
+
+---
+
+## 6. 出力例
+
+### CLI（OK 時）
+
+```
+====================================================
+  Market Close Summary  2026-04-28
+  Status : ✅ OK
+====================================================
+  Checks:
+    [ok  ] signal_queue         pending: 0 件（全シグナル処理済み）
+    [ok  ] positions            positions: 当日分 更新済み
+    [ok  ] portfolio_performance portfolio_performance: 当日分 記録済み
+----------------------------------------------------
+  Summary:
+    約定件数    : 5 件
+    日次リターン : +0.32%
+    当日損益額  : +¥16,400
+    期末総資産  : ¥5,234,000
+====================================================
+```
+
+### CLI（BLOCKED 時）
+
+```
+====================================================
+  Market Close Summary  2026-04-28
+  Status : 🚫 BLOCKED
+====================================================
+  Checks:
+    [FAIL] signal_queue         pending: 2 件（未処理シグナルあり）
+    [ok  ] positions            positions: 当日分 更新済み
+    [ok  ] portfolio_performance portfolio_performance: 当日分 記録済み
+----------------------------------------------------
+  Warnings:
+    [!] signal_queue に本日の pending シグナルが 2 件残っています
+====================================================
+```
+
+---
+
+## 7. テスト方針
+
+### 7.1 テスト対象
+
+- `market_close_report.py`（純粋関数）: `build_report`、`format_*`、`save_report`
+- `market_close_collector.py`（DB クエリ）: インメモリ DuckDB + SQLite でテスト
+
+### 7.2 主要テストケース（25〜30 件を想定）
+
+| テスト | 内容 |
+|---|---|
+| `test_build_report_ok` | 全チェック OK → status = "OK" |
+| `test_build_report_blocked_pending` | pending > 0 → BLOCKED |
+| `test_build_report_blocked_positions` | positions 未更新 → BLOCKED |
+| `test_build_report_blocked_performance` | portfolio_performance 未記録 → BLOCKED |
+| `test_build_report_all_blocked` | 3 条件すべて → BLOCKED、warnings 3 件 |
+| `test_pnl_amount_calculated` | equity_today - equity_prev が正しく計算される |
+| `test_pnl_amount_none_when_missing` | equity_prev が None → pnl_amount = None |
+| `test_format_cli_summary_ok` | CLI 出力に ✅ OK が含まれる |
+| `test_format_cli_summary_blocked` | CLI 出力に 🚫 BLOCKED と warnings が含まれる |
+| `test_format_cli_summary_summary_section` | 約定件数・日次リターン・損益額・期末資産が表示される |
+| `test_format_json` | JSON が正しくシリアライズされる |
+| `test_format_markdown` | Markdown に全セクションが含まれる |
+| `test_save_report_creates_files` | 3 ファイルが正しいパスに生成される |
+| `test_save_report_invalid_date_format` | 不正フォーマットで ValueError |
+| `test_save_report_invalid_calendar_date` | 不正カレンダー日（2026-99-99）で ValueError |
+| `test_collect_signal_pending_count` | pending 件数クエリが正しい |
+| `test_collect_signal_filled_count` | filled 件数クエリが正しい |
+| `test_collect_positions_updated_true` | 当日 positions あり → True |
+| `test_collect_positions_updated_false` | 当日 positions なし → False |
+| `test_collect_performance_recorded_true` | 当日 portfolio_performance あり → True |
+| `test_collect_performance_recorded_false` | 当日 portfolio_performance なし → False |
+| `test_collect_equity_prev_none_when_no_history` | 前日レコードなし → equity_prev = None |
+| `test_collect_daily_return_none_when_not_recorded` | 当日レコードなし → daily_return = None |

--- a/documents/10_Runtime/TODO_OperationsInterfaces.md
+++ b/documents/10_Runtime/TODO_OperationsInterfaces.md
@@ -174,21 +174,49 @@
 
 ## 4.4 Market Close Summary
 
+**ステータス: 設計済み (Issue #205, 設計書: `docs/superpowers/specs/2026-04-29-market-close-summary-design.md`)**
+
 目的:
 
-- 引け後に「今日の運用が正常に締まったか」を確認する
+- 引け後（15:30 頃）に「今日の運用が正常に締まったか」を確認し、夜間バッチへ進んでよいかを判断する
 
 確認対象:
 
-- `pending` 残件
-- `positions` 更新状態
-- `portfolio_performance` 記録状態
+- `signal_queue` に当日 `pending` が残っていないこと
+- `positions` テーブルに当日分が記録されていること
+- `portfolio_performance` に当日分が記録されていること
 
-未検討点:
+設計決定:
 
-- 引け後専用の締めレポートを出すか
-- DB 手動確認のままにするか
-- 翌夜バッチに進んでよいかの判定を出すか
+- **独立した CLI コマンド** として実装する
+- インターフェース: CLI（stdout）＋ Markdown ＋ JSON（3 ファイル保存）
+- ステータス判定: `OK` / `BLOCKED`（2 段階）
+- BLOCKED 条件（いずれかが真）:
+  - `signal_queue` に当日 `pending` が残っている
+  - `positions` に当日分が記録されていない
+  - `portfolio_performance` に当日分が記録されていない
+- サマリ情報（判定に影響しない表示情報）:
+  - 当日 filled シグナル件数
+  - 日次リターン（`portfolio_performance.daily_return`）
+  - 当日損益額（equity 変動から近似）
+  - 期末総資産
+- 保存先: `artifacts/market_close/{date}/summary.json`, `report.md`, `warnings.json`
+- 終了コード: `0` = OK、`1` = BLOCKED
+
+コマンド:
+
+```cmd
+python -m kabusys.run_market_close_report
+python -m kabusys.run_market_close_report --date 2026-04-28
+python -m kabusys.run_market_close_report --save
+python -m kabusys.run_market_close_report --json
+```
+
+新規モジュール:
+
+- `src/kabusys/operations/market_close_collector.py`（DB クエリ）
+- `src/kabusys/operations/market_close_report.py`（純粋関数）
+- `src/kabusys/run_market_close_report.py`（CLI エントリーポイント）
 
 ## 4.5 Position Reconciliation View
 
@@ -279,10 +307,13 @@ python -m kabusys.run_position_reconciliation_report --save --json
 
 1. Position Reconciliation View（設計済み: Issue #204）
 
+### 優先度中（設計済み）
+
+1. Market Close Summary（設計済み: Issue #205）
+
 ### 優先度中（未着手）
 
 1. Intraday Monitoring Interface
-2. Market Close Summary
 
 ### 優先度低
 

--- a/documents/10_Runtime/WebManual_OperationsCycle.md
+++ b/documents/10_Runtime/WebManual_OperationsCycle.md
@@ -329,9 +329,20 @@ Execution 起動直後に `artifacts/execution_startup/{date}/report.md` が自�
 
 ### 引け後
 
-- `pending` 注文が残っていないか
-- `positions` は更新されたか
-- `portfolio_performance` は記録されたか
+`run_market_close_report.py` を実行して Market Close Summary を確認する。
+
+```cmd
+python -m kabusys.run_market_close_report --save
+```
+
+- ステータスが `OK` であれば夜間バッチへ進む
+- `BLOCKED` の場合は Warnings を確認し、問題を解消してから再実行する
+
+確認項目:
+
+- `signal_queue` に当日 `pending` が残っていないか
+- `positions` は当日分が更新されたか
+- `portfolio_performance` は当日分が記録されたか
 
 ### 夜
 

--- a/src/kabusys/operations/market_close_collector.py
+++ b/src/kabusys/operations/market_close_collector.py
@@ -1,0 +1,101 @@
+"""
+Market Close Summary データ収集モジュール。
+
+DuckDB（positions, portfolio_performance）と SQLite（signal_queue）を
+read-only で参照し、MarketCloseData を返す。
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MarketCloseData:
+    """collect_market_close_data() が返す生データ。"""
+
+    signal_pending_count: int  # 当日 pending シグナル件数
+    positions_updated: bool  # positions に当日分が存在するか
+    performance_recorded: bool  # portfolio_performance に当日分が存在するか
+    filled_count: int  # 当日 filled シグナル件数
+    daily_return: float | None  # 当日日次リターン（未記録なら None）
+    equity_today: float | None  # 当日期末資産（未記録なら None）
+    equity_prev: float | None  # 前営業日期末資産（存在しなければ None）
+
+
+def check_signal_pending(sqlite_conn, today: date) -> int:
+    """当日の pending シグナル件数を返す。"""
+    row = sqlite_conn.execute(
+        "SELECT COUNT(*) FROM signal_queue WHERE status = 'pending' AND date = ?",
+        (today.isoformat(),),
+    ).fetchone()
+    return int(row[0]) if row and row[0] is not None else 0
+
+
+def check_signal_filled(sqlite_conn, today: date) -> int:
+    """当日の filled シグナル件数を返す。"""
+    row = sqlite_conn.execute(
+        "SELECT COUNT(*) FROM signal_queue WHERE status = 'filled' AND date = ?",
+        (today.isoformat(),),
+    ).fetchone()
+    return int(row[0]) if row and row[0] is not None else 0
+
+
+def check_positions_updated(duckdb_conn, today: date) -> bool:
+    """positions テーブルに当日分のレコードが存在すれば True。"""
+    row = duckdb_conn.execute(
+        "SELECT COUNT(*) FROM positions WHERE date = ?",
+        [today.isoformat()],
+    ).fetchone()
+    return int(row[0] if row and row[0] is not None else 0) > 0
+
+
+def check_performance_recorded(duckdb_conn, today: date) -> bool:
+    """portfolio_performance テーブルに当日分のレコードが存在すれば True。"""
+    row = duckdb_conn.execute(
+        "SELECT COUNT(*) FROM portfolio_performance WHERE date = ?",
+        [today.isoformat()],
+    ).fetchone()
+    return int(row[0] if row and row[0] is not None else 0) > 0
+
+
+def get_performance_row(duckdb_conn, today: date) -> tuple[float | None, float | None]:
+    """(daily_return, equity) を返す。当日レコードがなければ (None, None)。"""
+    row = duckdb_conn.execute(
+        "SELECT daily_return, equity FROM portfolio_performance WHERE date = ?",
+        [today.isoformat()],
+    ).fetchone()
+    if row is None:
+        return None, None
+    return (
+        float(row[0]) if row[0] is not None else None,
+        float(row[1]) if row[1] is not None else None,
+    )
+
+
+def get_prev_equity(duckdb_conn, today: date) -> float | None:
+    """today より前の最新 equity を返す。存在しなければ None。"""
+    row = duckdb_conn.execute(
+        "SELECT equity FROM portfolio_performance"
+        " WHERE date < ? ORDER BY date DESC LIMIT 1",
+        [today.isoformat()],
+    ).fetchone()
+    return float(row[0]) if row and row[0] is not None else None
+
+
+def collect_market_close_data(duckdb_conn, sqlite_conn, today: date) -> MarketCloseData:
+    """全チェック関数を呼び出して MarketCloseData を返す。"""
+    daily_return, equity_today = get_performance_row(duckdb_conn, today)
+    return MarketCloseData(
+        signal_pending_count=check_signal_pending(sqlite_conn, today),
+        positions_updated=check_positions_updated(duckdb_conn, today),
+        performance_recorded=check_performance_recorded(duckdb_conn, today),
+        filled_count=check_signal_filled(sqlite_conn, today),
+        daily_return=daily_return,
+        equity_today=equity_today,
+        equity_prev=get_prev_equity(duckdb_conn, today),
+    )

--- a/src/kabusys/operations/market_close_report.py
+++ b/src/kabusys/operations/market_close_report.py
@@ -1,0 +1,315 @@
+"""
+Market Close Summary レポート生成モジュール。
+
+引け後（15:30 頃）に「今日の運用が正常に締まったか」を確認し、
+夜間バッチへ進んでよいかを OK / BLOCKED で判定する。
+DB への参照は行わず、呼び出し元から受け取ったデータのみを使用する。
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+STATUS_OK = "OK"
+STATUS_BLOCKED = "BLOCKED"
+
+_STATUS_EMOJI = {
+    STATUS_OK: "✅",
+    STATUS_BLOCKED: "🚫",
+}
+
+_CHECK_STATUS_LABEL = {
+    "ok": "ok  ",
+    "failed": "FAIL",
+}
+
+
+@dataclass
+class CheckItem:
+    """1 チェック項目の結果。"""
+
+    name: str
+    status: str  # "ok" | "failed"
+    detail: str
+
+
+@dataclass
+class MarketCloseReport:
+    """Market Close Summary レポート全体。"""
+
+    report_date: str  # ISO date（YYYY-MM-DD）
+    generated_at: str  # ISO 8601 UTC
+    status: str  # "OK" / "BLOCKED"
+    checks: list[CheckItem]
+    summary: dict
+    warnings: list[str]
+
+
+def _determine_status(
+    *,
+    signal_pending_count: int,
+    positions_updated: bool,
+    performance_recorded: bool,
+) -> str:
+    if signal_pending_count > 0 or not positions_updated or not performance_recorded:
+        return STATUS_BLOCKED
+    return STATUS_OK
+
+
+def _generate_warnings(
+    *,
+    signal_pending_count: int,
+    positions_updated: bool,
+    performance_recorded: bool,
+) -> list[str]:
+    warnings: list[str] = []
+    if signal_pending_count > 0:
+        warnings.append(
+            f"signal_queue に本日の pending シグナルが {signal_pending_count} 件残っています"
+        )
+    if not positions_updated:
+        warnings.append("positions に当日分が記録されていません")
+    if not performance_recorded:
+        warnings.append("portfolio_performance に当日分が記録されていません")
+    return warnings
+
+
+def _build_check_items(
+    *,
+    signal_pending_count: int,
+    positions_updated: bool,
+    performance_recorded: bool,
+) -> list[CheckItem]:
+    return [
+        CheckItem(
+            name="signal_queue",
+            status="ok" if signal_pending_count == 0 else "failed",
+            detail=(
+                "pending: 0 件（全シグナル処理済み）"
+                if signal_pending_count == 0
+                else f"pending: {signal_pending_count} 件（未処理シグナルあり）"
+            ),
+        ),
+        CheckItem(
+            name="positions",
+            status="ok" if positions_updated else "failed",
+            detail=(
+                "positions: 当日分 更新済み"
+                if positions_updated
+                else "positions: 当日分 未更新"
+            ),
+        ),
+        CheckItem(
+            name="portfolio_performance",
+            status="ok" if performance_recorded else "failed",
+            detail=(
+                "portfolio_performance: 当日分 記録済み"
+                if performance_recorded
+                else "portfolio_performance: 当日分 未記録"
+            ),
+        ),
+    ]
+
+
+def build_report(
+    *,
+    report_date: date,
+    signal_pending_count: int,
+    positions_updated: bool,
+    performance_recorded: bool,
+    filled_count: int,
+    daily_return: float | None,
+    equity_today: float | None,
+    equity_prev: float | None,
+) -> MarketCloseReport:
+    """MarketCloseReport を構築する。"""
+    kwargs = dict(
+        signal_pending_count=signal_pending_count,
+        positions_updated=positions_updated,
+        performance_recorded=performance_recorded,
+    )
+    pnl_amount = (
+        equity_today - equity_prev
+        if equity_today is not None and equity_prev is not None
+        else None
+    )
+    return MarketCloseReport(
+        report_date=report_date.isoformat(),
+        generated_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        status=_determine_status(**kwargs),
+        checks=_build_check_items(**kwargs),
+        summary={
+            "filled_count": filled_count,
+            "daily_return": daily_return,
+            "pnl_amount": pnl_amount,
+            "equity_today": equity_today,
+        },
+        warnings=_generate_warnings(**kwargs),
+    )
+
+
+# ---------------------------------------------------------------------------
+# フォーマッター
+# ---------------------------------------------------------------------------
+
+
+def _fmt_return(v: float | None) -> str:
+    if v is None:
+        return "N/A"
+    sign = "+" if v > 0 else ""
+    return f"{sign}{v:.2%}"
+
+
+def _fmt_yen(v: float | None) -> str:
+    if v is None:
+        return "N/A"
+    sign = "+" if v > 0 else ""
+    return f"{sign}¥{int(v):,}"
+
+
+def format_cli_summary(report: MarketCloseReport) -> str:
+    """CLI 表示用サマリ文字列を返す。"""
+    sep = "=" * 52
+    thin = "-" * 52
+    emoji = _STATUS_EMOJI.get(report.status, "")
+    s = report.summary
+    lines = [
+        f"\n{sep}",
+        f"  Market Close Summary  {report.report_date}",
+        f"  Status : {emoji} {report.status}",
+        f"{sep}",
+        "  Checks:",
+    ]
+    for c in report.checks:
+        label = _CHECK_STATUS_LABEL.get(c.status, c.status.upper())
+        lines.append(f"    [{label}] {c.name:<22} {c.detail}")
+    lines += [
+        thin,
+        "  Summary:",
+        f"    約定件数    : {s['filled_count']} 件",
+        f"    日次リターン : {_fmt_return(s['daily_return'])}",
+        f"    当日損益額  : {_fmt_yen(s['pnl_amount'])}",
+        f"    期末総資産  : {_fmt_yen(s['equity_today'])}",
+    ]
+    if report.warnings:
+        lines.append(thin)
+        lines.append("  Warnings:")
+        for w in report.warnings:
+            lines.append(f"    [!] {w}")
+    lines.append(f"{sep}\n")
+    return "\n".join(lines)
+
+
+def _to_serializable(obj: object) -> object:
+    if isinstance(obj, dict):
+        return {k: _to_serializable(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_to_serializable(i) for i in obj]
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    if isinstance(obj, date):
+        return obj.isoformat()
+    return obj
+
+
+def format_json(report: MarketCloseReport) -> str:
+    """全フィールドを含む JSON 文字列を返す。"""
+    return json.dumps(_to_serializable(asdict(report)), ensure_ascii=False, indent=2)
+
+
+def format_markdown(report: MarketCloseReport) -> str:
+    """人間向け Markdown レポート文字列を返す。"""
+    lines: list[str] = []
+    sec = 0
+
+    def _section(title: str) -> str:
+        nonlocal sec
+        sec += 1
+        return f"## {sec}. {title}"
+
+    emoji = _STATUS_EMOJI.get(report.status, "")
+    s = report.summary
+
+    lines += [
+        "# Market Close Summary",
+        "",
+        _section("Overview"),
+        "",
+        "| 項目 | 値 |",
+        "|-----|---|",
+        f"| 実行日 | {report.report_date} |",
+        f"| 生成時刻 | {report.generated_at} |",
+        f"| **最終判定** | **{emoji} {report.status}** |",
+        "",
+        _section("Checks"),
+        "",
+        "| チェック項目 | ステータス | 詳細 |",
+        "|------------|-----------|------|",
+    ]
+    for c in report.checks:
+        lines.append(f"| {c.name} | {c.status} | {c.detail} |")
+    lines += [
+        "",
+        _section("Summary"),
+        "",
+        "| 項目 | 値 |",
+        "|-----|---|",
+        f"| 約定件数 | {s['filled_count']} 件 |",
+        f"| 日次リターン | {_fmt_return(s['daily_return'])} |",
+        f"| 当日損益額 | {_fmt_yen(s['pnl_amount'])} |",
+        f"| 期末総資産 | {_fmt_yen(s['equity_today'])} |",
+        "",
+    ]
+    if report.warnings:
+        lines += [_section("Warnings"), ""]
+        for w in report.warnings:
+            lines.append(f"- ⚠️ {w}")
+        lines.append("")
+
+    lines += [_section("Final Decision"), ""]
+    if report.status == STATUS_OK:
+        lines += [
+            f"**{STATUS_OK}** — 夜間バッチへ進んでください。",
+            "",
+            "- 全チェック項目が正常です。",
+        ]
+    else:
+        lines += [
+            f"**{STATUS_BLOCKED}** — 夜間バッチへ **進まないでください**。",
+            "",
+            "- 上記 Warnings を確認し、問題を解消してから再実行してください。",
+        ]
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# 保存
+# ---------------------------------------------------------------------------
+
+
+def save_report(
+    report: MarketCloseReport,
+    output_dir: Path | str | None = None,
+) -> Path:
+    """レポートを artifacts/market_close/{report_date}/ に保存する。"""
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", report.report_date):
+        raise ValueError(f"Invalid report_date: {report.report_date!r}")
+    try:
+        date.fromisoformat(report.report_date)
+    except ValueError:
+        raise ValueError(f"Invalid report_date: {report.report_date!r}")
+    base = Path(output_dir) if output_dir else Path("artifacts") / "market_close"
+    run_dir = base / report.report_date
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "summary.json").write_text(format_json(report), encoding="utf-8")
+    (run_dir / "report.md").write_text(format_markdown(report), encoding="utf-8")
+    (run_dir / "warnings.json").write_text(
+        json.dumps(report.warnings, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    return run_dir

--- a/src/kabusys/run_market_close_report.py
+++ b/src/kabusys/run_market_close_report.py
@@ -1,0 +1,97 @@
+"""Market Close Summary エントリーポイント。
+
+使用方法:
+    python -m kabusys.run_market_close_report
+    python -m kabusys.run_market_close_report --date 2026-04-28
+    python -m kabusys.run_market_close_report --save
+    python -m kabusys.run_market_close_report --json
+    python -m kabusys.run_market_close_report --save --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sqlite3
+import sys
+from datetime import date
+from pathlib import Path
+
+import duckdb
+
+from kabusys.config import Settings
+from kabusys.operations.market_close_collector import collect_market_close_data
+from kabusys.operations.market_close_report import (
+    STATUS_BLOCKED,
+    build_report,
+    format_cli_summary,
+    format_json,
+    save_report,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Market Close Summary を生成する")
+    parser.add_argument(
+        "--date",
+        type=lambda s: date.fromisoformat(s),
+        default=date.today(),
+        metavar="YYYY-MM-DD",
+        help="レポートの日付ラベル兼クエリ対象日（省略時は今日）",
+    )
+    parser.add_argument(
+        "--save",
+        action="store_true",
+        help="artifacts/market_close/ に保存する",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="JSON 形式で出力する",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(message)s")
+
+    settings = Settings()
+    duckdb_conn = duckdb.connect(str(settings.duckdb_path), read_only=True)
+    sqlite_uri = Path(settings.sqlite_path).resolve().as_uri() + "?mode=ro"
+    sqlite_conn = sqlite3.connect(sqlite_uri, uri=True)
+
+    try:
+        data = collect_market_close_data(duckdb_conn, sqlite_conn, args.date)
+    finally:
+        duckdb_conn.close()
+        sqlite_conn.close()
+
+    report = build_report(
+        report_date=args.date,
+        signal_pending_count=data.signal_pending_count,
+        positions_updated=data.positions_updated,
+        performance_recorded=data.performance_recorded,
+        filled_count=data.filled_count,
+        daily_return=data.daily_return,
+        equity_today=data.equity_today,
+        equity_prev=data.equity_prev,
+    )
+
+    if args.json:
+        print(format_json(report))
+    else:
+        print(format_cli_summary(report))
+
+    if args.save:
+        run_dir = save_report(report)
+        dest_msg = f"保存先: {run_dir}"
+        if args.json:
+            sys.stderr.write(dest_msg + "\n")
+        else:
+            print(dest_msg)
+
+    return 1 if report.status == STATUS_BLOCKED else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_generated.py
+++ b/tests/test_generated.py
@@ -1,423 +1,358 @@
 import os
-import csv
-import json
 import sqlite3
-import subprocess
-from types import SimpleNamespace
-from datetime import date, datetime, timezone
-from io import StringIO
+import json
+import math
+import tempfile
 from pathlib import Path
+from datetime import date, datetime, timezone
+import pytest
 from unittest import mock
 
-import pytest
-
-from kabusys.config import _parse_env_line, _load_env_file, Settings
-from kabusys.tools.paper_verification_report import (
-    _p95,
-    _build_date_filter,
-    _fmt_float,
-    _fmt_int,
-)
+# Tests for kabusys.config (_parse_env_line, _load_env_file, Settings)
+from kabusys import config as config_mod
+from kabusys.run_monitoring import _get_poll_interval
+from kabusys.run_execution import _pos_value, _load_risk_config
 from kabusys.operations import signal_queue_report as sqr
+from kabusys.tools import paper_verification_report as pvr
 from kabusys.operations import execution_startup_report as esr
-from kabusys.operations import pre_market_report as pmr
-from kabusys.operations import night_batch_report as nbr
-from kabusys.operations import position_reconciliation_report as prr
-from kabusys.operations import pre_market_collector as pmc
+from kabusys.operations import market_close_report as mcr
 
 
-def test_parse_env_line_blank_and_comment():
-    assert _parse_env_line("") is None
-    assert _parse_env_line("   \n") is None
-    assert _parse_env_line("# comment") is None
-    assert _parse_env_line("   # inline") is None
+# -------------------------
+# config._parse_env_line
+# -------------------------
+@pytest.mark.parametrize(
+    "line,expected",
+    [
+        ("", None),
+        ("# comment", None),
+        ("export KEY=val", ("KEY", "val")),
+        ("KEY = value", ("KEY", "value")),
+        ("KEY='a\\'b'", ("KEY", "a'b")),
+        ('KEY="a\\"b"', ("KEY", 'a"b')),
+        ("KEY=unquoted#notacomment", ("KEY", "unquoted#notacomment")),
+        ("KEY=unquoted #comment", ("KEY", "unquoted")),
+        ("=noval", None),
+        ("NOVAL", None),
+    ],
+)
+def test_parse_env_line_various(line, expected):
+    assert config_mod._parse_env_line(line) == expected
 
 
-def test_parse_env_line_export_and_simple():
-    assert _parse_env_line("export KEY=val") == ("KEY", "val")
-    assert _parse_env_line("FOO=bar") == ("FOO", "bar")
-
-
-def test_parse_env_line_no_equal():
-    assert _parse_env_line("NOEQUAL") is None
-
-
-def test_parse_env_line_quoted_with_escapes_and_inline_comment():
-    s = r"KEY='va\'lue' # comment ignored"
-    assert _parse_env_line(s) == ("KEY", "va'lue")
-    s2 = r'KEY2="a\"b"'
-    assert _parse_env_line(s2) == ("KEY2", 'a"b')
-
-
-def test_parse_env_line_unquoted_with_hash_behavior():
-    # '#' preceded by space => comment starts
-    assert _parse_env_line("KEY=value #comment") == ("KEY", "value")
-    # '#' directly after value char => kept
-    assert _parse_env_line("KEY=value#notcomment") == ("KEY", "value#notcomment")
-
-
+# -------------------------
+# config._load_env_file
+# -------------------------
 def test_load_env_file_override_and_protected(tmp_path, monkeypatch):
-    env_file = tmp_path / ".env"
-    env_file.write_text("A=1\nB=2\nC=3\n")
-    # set initial environ
-    monkeypatch.setenv("A", "orig")
-    # override=False should not change existing A, but set D if present
-    _load_env_file(env_file, override=False, protected=frozenset())
-    assert os.environ["A"] == "orig"
+    p = tmp_path / ".envtest"
+    p.write_text("A=1\nB=2\nP=protected\n")
+    # set existing OS env and protected set
+    monkeypatch.setenv("A", "osval")
+    protected = frozenset(os.environ.keys())
+    # override=False should not overwrite A, should set B and P only if not present
+    config_mod._load_env_file(p, override=False, protected=protected)
+    assert os.environ.get("A") == "osval"
     assert os.environ.get("B") == "2"
-    # override True but protect A should not overwrite A
-    env_file.write_text("A=9\nB=8\n")
-    protected = frozenset({"A"})
-    _load_env_file(env_file, override=True, protected=protected)
-    assert os.environ["A"] == "orig"
-    assert os.environ["B"] == "8"
+    assert os.environ.get("P") == "protected"
+    # Now test override=True but protected blocks overwriting A
+    p.write_text("A=changed\nC=3\n")
+    config_mod._load_env_file(p, override=True, protected=protected)
+    assert os.environ.get("A") == "osval"  # protected prevented overwrite
+    assert os.environ.get("C") == "3"
 
 
-def test_settings_paper_fill_mode_valid_and_invalid(monkeypatch):
-    s = Settings()
-    # default should be 'instant'
+# -------------------------
+# Settings: env, paper_fill_mode, log_level validations
+# -------------------------
+def test_settings_env_valid_and_invalid(monkeypatch):
+    # valid
+    monkeypatch.setenv("KABUSYS_ENV", "development")
+    s = config_mod.Settings()
+    assert s.env == "development"
+    # invalid
+    monkeypatch.setenv("KABUSYS_ENV", "invalid_env_value")
+    s2 = config_mod.Settings()
+    with pytest.raises(ValueError):
+        _ = s2.env
+
+
+def test_settings_paper_fill_mode_valid_invalid(monkeypatch):
     monkeypatch.delenv("PAPER_FILL_MODE", raising=False)
-    assert Settings().paper_fill_mode == "instant"
+    s = config_mod.Settings()
+    assert s.paper_fill_mode == "instant"
     monkeypatch.setenv("PAPER_FILL_MODE", "partial")
-    assert Settings().paper_fill_mode == "partial"
-    monkeypatch.setenv("PAPER_FILL_MODE", "INSTANT")
-    assert Settings().paper_fill_mode == "instant"
-    # invalid value should raise
-    monkeypatch.setenv("PAPER_FILL_MODE", "badvalue")
+    assert s.paper_fill_mode == "partial"
+    monkeypatch.setenv("PAPER_FILL_MODE", "BADMODE")
     with pytest.raises(ValueError):
-        _ = Settings().paper_fill_mode
+        _ = s.paper_fill_mode
 
 
-def test_p95_empty_and_values():
-    assert _p95([]) is None
-    vals = [1, 2, 3, 4, 5, 100]
-    # 95th percentile index ceil(6*0.95)-1 = ceil(5.7)-1=6-1=5 -> value 100
-    assert _p95(vals) == 100
-    vals2 = [10] * 20
-    assert _p95(vals2) == 10
-
-
-def test_build_date_filter_variations():
-    clause, params = _build_date_filter("ts", None, None)
-    assert clause == ""
-    assert params == []
-    clause, params = _build_date_filter("ts", "2021-01-01", None)
-    assert "ts >= ?" in clause and params == ["2021-01-01"]
-    clause, params = _build_date_filter("ts", None, "2021-01-02")
-    assert "ts <= ?" in clause and params == ["2021-01-02"]
-    clause, params = _build_date_filter("ts", "a", "b")
-    assert "AND" in clause and params == ["a", "b"]
-
-
-def test_fmt_float_and_int_none_and_values():
-    assert _fmt_float(None) == "N/A"
-    assert _fmt_float(1.23456, decimals=2, suffix="ms") == "1.23ms"
-    assert _fmt_int(None) == "N/A"
-    assert _fmt_int(5) == "5"
-
-
-def make_signal_example():
-    signals = [
-        {"code": "1301", "side": "buy", "target_size": 10, "target_weight": 0.05, "signal_rank": 1},
-        {"code": "1332", "side": "sell", "target_size": None, "target_weight": None, "signal_rank": None},
-    ]
-    return signals
-
-
-def test_signal_queue_build_format_and_save(tmp_path):
-    signals = make_signal_example()
-    report = sqr.build_report(signals, report_date=date(2026, 4, 28))
-    assert report.total_count == 2
-    assert report.status == sqr.STATUS_READY
-    cli = sqr.format_cli_summary(report)
-    assert "1301" in cli and "1332" in cli
-    js = sqr.format_json(report)
-    parsed = json.loads(js)
-    assert parsed["report_date"] == "2026-04-28"
-    # save_report to tmp dir
-    run_dir = sqr.save_report(report, output_dir=tmp_path)
-    assert (run_dir / "summary.json").exists()
-    assert (run_dir / "report.md").exists()
-    # invalid report_date
-    bad = report
-    bad.report_date = "not-a-date"
+def test_settings_log_level_validation(monkeypatch):
+    monkeypatch.setenv("LOG_LEVEL", "INFO")
+    s = config_mod.Settings()
+    assert s.log_level == "INFO"
+    monkeypatch.setenv("LOG_LEVEL", "WRONG")
     with pytest.raises(ValueError):
-        sqr.save_report(bad, output_dir=tmp_path)
+        _ = s.log_level
 
 
-def test_execution_startup_build_and_format_and_save(tmp_path):
-    # craft fake reconcile_result
-    class D:
-        def __init__(self, code, b, l, diff):
-            self.code = code
-            self.broker_qty = b
-            self.local_qty = l
-            self.diff = diff
-
-    rec = SimpleNamespace(
-        orders_synced=5,
-        orders_no_status=0,
-        position_discrepancies=[D("1301", 10, 10, 0), D("1332", 5, 3, 2)],
-    )
-    report = esr.build_report(rec, startup_date=date(2026, 4, 28))
-    assert report.orders_synced == 5
-    # since one discrepancy, expect READY_WITH_WARNINGS
-    assert report.status == esr.STATUS_READY_WITH_WARNINGS
-    cli = esr.format_cli_summary(report)
-    assert "Execution Startup Summary" in cli
-    js = esr.format_json(report)
-    parsed = json.loads(js)
-    assert parsed["startup_date"] == "2026-04-28"
-    # saving
-    out = esr.save_report(report, output_dir=tmp_path)
-    assert (out / "summary.json").exists()
-    # invalid startup_date -> raise
-    bad = report
-    bad.startup_date = "bad-date"
-    with pytest.raises(ValueError):
-        esr.save_report(bad, output_dir=tmp_path)
-
-
-def test_pre_market_build_and_format_variants():
-    r_ready = pmr.build_report(
-        report_date=date(2026, 4, 28),
-        data_freshness_ok=True,
-        signal_queue_pending=1,
-        position_count=5,
-        stop_flag_exists=False,
-        task_scheduler_ready=True,
-    )
-    assert r_ready.status == pmr.STATUS_READY
-    r_blocked = pmr.build_report(
-        report_date=date(2026, 4, 28),
-        data_freshness_ok=True,
-        signal_queue_pending=0,
-        position_count=5,
-        stop_flag_exists=False,
-        task_scheduler_ready=True,
-    )
-    assert r_blocked.status == pmr.STATUS_BLOCKED
-    r_warn = pmr.build_report(
-        report_date=date(2026, 4, 28),
-        data_freshness_ok=False,
-        signal_queue_pending=1,
-        position_count=5,
-        stop_flag_exists=False,
-        task_scheduler_ready=True,
-    )
-    assert r_warn.status == pmr.STATUS_READY_WITH_WARNINGS
-    cli = pmr.format_cli_summary(r_warn)
-    assert "Pre-Market Report" in cli
-    js = pmr.format_json(r_warn)
-    parsed = json.loads(js)
-    assert parsed["report_date"] == "2026-04-28"
-    # save report with invalid date should raise
-    bad = r_warn
-    bad.report_date = "2026-99-99"
-    with pytest.raises(ValueError):
-        pmr.save_report(bad, output_dir=Path("."))
-
-
-def make_job(name, status="success", warnings=None, errors=None, duration=1.2):
-    started = datetime.now(timezone.utc)
-    finished = started
-    return nbr.JobRunResult(
-        job_name=name,
-        status=status,
-        started_at=started,
-        finished_at=finished,
-        duration_sec=duration,
-        updated_rows={},
-        warnings=warnings or [],
-        errors=errors or [],
-    )
-
-
-def test_night_batch_determine_generate_and_save(tmp_path):
-    jobs = [make_job(n) for n in nbr.MANDATORY_JOBS]
-    uc = nbr.UpdateCounts(prices_daily=10, features=5, signals=1, signal_queue=1)
-    nd = nbr.NextDaySummary(buy_count=1, sell_count=0, target_symbols=1, expected_orders=1)
-    report = nbr.build_report(jobs, uc, nd, run_date=date(2026, 4, 28), target_date=date(2026, 4, 29))
-    assert report.status == nbr.STATUS_READY
-    s = nbr.format_cli_summary(report)
-    assert "Night Batch Report" in s
-    js = nbr.format_json(report)
-    parsed = json.loads(js)
-    assert parsed["run_date"] == "2026-04-28"
-    out = nbr.save_report(report, output_dir=tmp_path)
-    assert (out / "summary.json").exists()
-    # missing mandatory job leads to BLOCKED
-    jobs2 = jobs[:-1]
-    report2 = nbr.build_report(jobs2, uc, nd, run_date=date(2026, 4, 28), target_date=date(2026, 4, 29))
-    assert report2.status == nbr.STATUS_BLOCKED
-
-
-def test_position_reconciliation_build_and_format_and_warnings():
-    entries = [
-        prr.PositionEntry(code="1301", broker_qty=10, local_qty=10, diff=0, status=prr.ENTRY_MATCH),
-        prr.PositionEntry(code="1332", broker_qty=5, local_qty=3, diff=2, status=prr.ENTRY_MISMATCH),
-    ]
-    report = prr.build_report(entries, report_date=date(2026, 4, 28))
-    assert report.total_count == 2
-    assert report.mismatch_count == 1
-    assert report.status == prr.STATUS_DISCREPANCY
-    cli = prr.format_cli_summary(report)
-    assert "Position Reconciliation" in cli
-    js = prr.format_json(report)
-    parsed = json.loads(js)
-    assert parsed["report_date"] == "2026-04-28"
-    # markdown includes code and warning
-    md = prr.format_markdown(report)
-    assert "1301" in md and "1332" in md
-    # warnings generation
-    warns = prr._generate_warnings(entries)
-    assert any("1332" in w for w in warns)
-
-
-def test_pre_market_collector_date_normalization_and_checks(monkeypatch):
-    # mock conn objects with execute returning different types for MAX(date)
-    class RowObj:
-        def __init__(self, v):
-            self.v = v
-
-        def fetchone(self):
-            return (self.v,)
-
-    today = date(2026, 4, 28)
-
-    # datetime case
-    dt = datetime(2026, 4, 27, 12, 0, 0)
-    conn = SimpleNamespace(execute=lambda q, *args, **kw: RowObj(dt))
-    assert pmc.check_data_freshness(conn, today) is True
-
-    # string datetime case
-    conn = SimpleNamespace(execute=lambda q, *a, **k: RowObj("2026-04-26T00:00:00"))
-    assert pmc.check_data_freshness(conn, today) is True
-
-    # old date beyond freshness window
-    conn = SimpleNamespace(execute=lambda q, *a, **k: RowObj("2026-04-01"))
-    assert pmc.check_data_freshness(conn, today) is False
-
-    # None result
-    conn = SimpleNamespace(execute=lambda q, *a, **k: RowObj(None))
-    assert pmc.check_data_freshness(conn, today) is False
-
-    # check_signal_queue and check_position_count behavior
-    class C:
-        def __init__(self, value):
-            self.value = value
-
-        def execute(self, q, *args, **kwargs):
-            class R:
-                def __init__(self, v):
-                    self._v = v
-
-                def fetchone(self):
-                    return (self._v,)
-            return R(self.value)
-
-    c_sqlite = C(3)
-    assert pmc.check_signal_queue(c_sqlite, today) == 3
-    c_sqlite2 = C(None)
-    assert pmc.check_signal_queue(c_sqlite2, today) == 0
-    c_pos = C(7)
-    assert pmc.check_position_count(c_pos) == 7
-
-    # check_stop_flag: 存在しないパスを渡すと False を返す
-    p = Path(__file__).parent / "_nonexistent_stop_flag_for_test"
-    assert pmc.check_stop_flag(p) is False
-
-    # check_task_scheduler success and failure via mocking subprocess.run
-    good_csv = '"TaskName","Next Run Time","Status"\n"\\\\MyTask","N/A","Ready"\n'
-    mock_res = SimpleNamespace(returncode=0, stdout=good_csv, stderr="")
-    with mock.patch("subprocess.run", return_value=mock_res):
-        assert pmc.check_task_scheduler("whatever") is True
-
-    bad_res = SimpleNamespace(returncode=1, stdout="", stderr="error")
-    with mock.patch("subprocess.run", return_value=bad_res):
-        assert pmc.check_task_scheduler("whatever") is False
-
-    # simulate FileNotFoundError
-    with mock.patch("subprocess.run", side_effect=FileNotFoundError()):
-        assert pmc.check_task_scheduler("whatever") is False
-
-
-def test_run_monitoring_get_poll_interval(monkeypatch):
-    from kabusys.run_monitoring import _get_poll_interval, _DEFAULT_POLL_INTERVAL
-
+# -------------------------
+# run_monitoring._get_poll_interval
+# -------------------------
+def test_get_poll_interval_default(monkeypatch):
     monkeypatch.delenv("MONITOR_POLL_INTERVAL", raising=False)
-    assert _get_poll_interval() == _DEFAULT_POLL_INTERVAL
-    monkeypatch.setenv("MONITOR_POLL_INTERVAL", "10")
-    assert _get_poll_interval() == 10
+    assert _get_poll_interval() == 60
+
+
+def test_get_poll_interval_valid(monkeypatch):
+    monkeypatch.setenv("MONITOR_POLL_INTERVAL", "5")
+    assert _get_poll_interval() == 5
+
+
+def test_get_poll_interval_invalid_values(monkeypatch):
     monkeypatch.setenv("MONITOR_POLL_INTERVAL", "0")
-    assert _get_poll_interval() == _DEFAULT_POLL_INTERVAL
-    monkeypatch.setenv("MONITOR_POLL_INTERVAL", "-5")
-    assert _get_poll_interval() == _DEFAULT_POLL_INTERVAL
-    monkeypatch.setenv("MONITOR_POLL_INTERVAL", "notint")
-    assert _get_poll_interval() == _DEFAULT_POLL_INTERVAL
+    assert _get_poll_interval() == 60
+    monkeypatch.setenv("MONITOR_POLL_INTERVAL", "-10")
+    assert _get_poll_interval() == 60
+    monkeypatch.setenv("MONITOR_POLL_INTERVAL", "notanint")
+    assert _get_poll_interval() == 60
 
 
-def test_run_execution_pos_value_behaviour(caplog):
-    from kabusys.run_execution import _pos_value
-
-    class P:
-        def __init__(self, code, qty, current_price, avg_price):
-            self.code = code
-            self.qty = qty
-            self.current_price = current_price
-            self.avg_price = avg_price
-
-    p1 = P("0001", 2, 100.0, 90.0)
-    assert _pos_value(p1) == 200.0
-    p2 = P("0002", 3, None, 50.0)
-    assert _pos_value(p2) == 150.0
-    p3 = P("0003", 1, 0, 0)
-    caplog.clear()
-    val = _pos_value(p3)
-    assert val == 0.0
-    assert any("ポジション評価額を 0 として扱います" in rec.message for rec in caplog.records)
+# -------------------------
+# run_execution._pos_value
+# -------------------------
+class _DummyPos:
+    def __init__(self, qty, current_price=None, avg_price=None, code="X"):
+        self.qty = qty
+        self.current_price = current_price
+        self.avg_price = avg_price
+        self.code = code
 
 
-def test_execution_risk_config_parsing(tmp_path):
-    # We will test the _load_risk_config function by creating a valid YAML file.
-    # Import function lazily to ensure module is available.
-    from kabusys.run_execution import _load_risk_config
+def test_pos_value_current_price_used():
+    p = _DummyPos(qty=10, current_price=50.0, avg_price=40.0)
+    assert _pos_value(p) == 10 * 50.0
 
-    valid = """
+
+def test_pos_value_avg_price_used_when_current_none():
+    p = _DummyPos(qty=2, current_price=None, avg_price=25.0)
+    assert _pos_value(p) == 2 * 25.0
+
+
+def test_pos_value_zero_or_negative_price_warns_and_zero(monkeypatch):
+    p1 = _DummyPos(qty=5, current_price=0, avg_price=0)
+    assert _pos_value(p1) == 0.0
+    p2 = _DummyPos(qty=3, current_price=-10, avg_price=100)
+    # current_price negative -> avg_price used (100) because current_price not None and >0 check fails -> falls back to avg_price
+    assert _pos_value(p2) == 3 * 100.0
+    p3 = _DummyPos(qty=1, current_price=None, avg_price=None)
+    assert _pos_value(p3) == 0.0
+
+
+# -------------------------
+# run_execution._load_risk_config
+# -------------------------
+def _write_yaml(path: Path, content: str):
+    path.write_text(content, encoding="utf-8")
+
+
+def test_load_risk_config_valid(tmp_path):
+    ym = tmp_path / "risk.yaml"
+    content = """
 risk:
-  max_position_pct: 0.3
-  max_utilization: 0.5
+  max_position_pct: 0.5
+  max_utilization: 0.6
   rate_limit_per_sec: 5
   circuit_breaker_errors: 3
   circuit_breaker_window_sec: 60
   max_drawdown: 0.2
 """
-    p = tmp_path / "risk_config.yaml"
-    p.write_text(valid, encoding="utf-8")
-    cfg = _load_risk_config(p, initial_portfolio_value=100000)
-    assert cfg.max_position_pct == pytest.approx(0.3)
-    assert cfg.rate_limit_per_sec == 5
+    _write_yaml(ym, content)
+    cfg = _load_risk_config(ym, initial_portfolio_value=100000.0)
+    # check attributes exist and types
+    assert getattr(cfg, "max_position_pct") == pytest.approx(0.5)
+    assert getattr(cfg, "initial_portfolio_value") == 100000.0
 
-    # invalid YAML
-    p.write_text("::: bad yaml :::")
+
+def test_load_risk_config_missing_file(tmp_path):
+    ym = tmp_path / "noexist.yaml"
+    with pytest.raises(FileNotFoundError):
+        _load_risk_config(ym, 1000.0)
+
+
+def test_load_risk_config_bad_yaml(tmp_path):
+    ym = tmp_path / "bad.yaml"
+    ym.write_text("::: not yaml :::")
     with pytest.raises(ValueError):
-        _load_risk_config(p, initial_portfolio_value=1000)
+        _load_risk_config(ym, 1000.0)
 
-    # missing risk key
-    p.write_text("notrisk: {}")
+
+def test_load_risk_config_missing_keys(tmp_path):
+    ym = tmp_path / "nokey.yaml"
+    ym.write_text("notrisk: {}\n")
     with pytest.raises(KeyError):
-        _load_risk_config(p, initial_portfolio_value=1000)
+        _load_risk_config(ym, 1000.0)
 
-    # invalid numeric ranges
-    bad = """
+
+def test_load_risk_config_invalid_ranges(tmp_path):
+    ym = tmp_path / "badvals.yaml"
+    # max_position_pct > max_utilization
+    ym.write_text(
+        """
 risk:
-  max_position_pct: 2
+  max_position_pct: 0.9
   max_utilization: 0.5
-  rate_limit_per_sec: 0
-  circuit_breaker_errors: 0
-  circuit_breaker_window_sec: 0
-  max_drawdown: -0.1
+  rate_limit_per_sec: 1
+  circuit_breaker_errors: 1
+  circuit_breaker_window_sec: 1
+  max_drawdown: 0.5
 """
-    p.write_text(bad)
+    )
     with pytest.raises(ValueError):
-        _load_risk_config(p, initial_portfolio_value=1000)
+        _load_risk_config(ym, 1000.0)
+    # rate_limit_per_sec < 1
+    ym.write_text(
+        """
+risk:
+  max_position_pct: 0.5
+  max_utilization: 0.6
+  rate_limit_per_sec: 0
+  circuit_breaker_errors: 1
+  circuit_breaker_window_sec: 1
+  max_drawdown: 0.5
+"""
+    )
+    with pytest.raises(ValueError):
+        _load_risk_config(ym, 1000.0)
+
+
+# -------------------------
+# signal_queue_report build/format/save
+# -------------------------
+def test_signal_queue_build_and_formats_and_save(tmp_path):
+    # create signals list with buy lacking target_size
+    signals = [
+        {"code": "1111", "side": "buy", "target_size": None, "target_weight": 0.1, "signal_rank": 1},
+        {"code": "2222", "side": "sell", "target_size": 50, "target_weight": None, "signal_rank": 2},
+    ]
+    rpt = sqr.build_report(signals, report_date=date(2026, 4, 28))
+    assert rpt.status == sqr.STATUS_READY
+    # warnings should include BUY missing target_size
+    assert any("target_size" in w for w in rpt.warnings)
+    # format_json valid json
+    js = sqr.format_json(rpt)
+    parsed = json.loads(js)
+    assert parsed["report_date"] == "2026-04-28"
+    # format_cli_summary returns string containing code lines
+    cli = sqr.format_cli_summary(rpt)
+    assert "1111" in cli and "2222" in cli
+    # save_report writes files
+    outdir = sqr.save_report(rpt, output_dir=tmp_path)
+    assert (outdir / "summary.json").exists()
+    assert (outdir / "report.md").exists()
+    assert (outdir / "warnings.json").exists()
+
+
+def test_signal_queue_save_invalid_date_raises(tmp_path):
+    # create a fake report with invalid date
+    rpt = sqr.SignalQueueReport(
+        report_date="bad-date",
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=sqr.STATUS_EMPTY,
+        total_count=0,
+        buy_count=0,
+        sell_count=0,
+        signals=[],
+        warnings=[],
+    )
+    with pytest.raises(ValueError):
+        sqr.save_report(rpt, output_dir=tmp_path)
+
+
+# -------------------------
+# paper_verification_report utilities
+# -------------------------
+def test_p95_empty_and_values():
+    assert pvr._p95([]) is None
+    vals = [1, 2, 3, 4, 100]
+    # 95th percentile index ceil(5*0.95)-1 = ceil(4.75)-1=5-1=4 -> index 4 -> 100
+    assert pvr._p95(vals) == 100
+
+
+def test_build_date_filter():
+    clause, params = pvr._build_date_filter("ts", "2020-01-01", None)
+    assert "ts >= ?" in clause and params == ["2020-01-01"]
+    clause2, params2 = pvr._build_date_filter("ts", None, "2020-12-31")
+    assert "ts <= ?" in clause2 and params2 == ["2020-12-31"]
+    clause3, params3 = pvr._build_date_filter("ts", None, None)
+    assert clause3 == "" and params3 == []
+
+
+def test_fmt_functions():
+    assert pvr._fmt_float(None) == "N/A"
+    assert pvr._fmt_float(12.3456, 2, "ms") == "12.35ms"
+    assert pvr._fmt_int(None) == "N/A"
+    assert pvr._fmt_int(5) == "5"
+
+
+# -------------------------
+# execution_startup_report build/report behaviors
+# -------------------------
+class _FakeDiscrep:
+    def __init__(self, code, broker_qty, local_qty, diff):
+        self.code = code
+        self.broker_qty = broker_qty
+        self.local_qty = local_qty
+        self.diff = diff
+
+
+class _FakeReconcileResult:
+    def __init__(self, orders_synced, orders_no_status, position_discrepancies):
+        self.orders_synced = orders_synced
+        self.orders_no_status = orders_no_status
+        self.position_discrepancies = position_discrepancies
+
+
+def test_execution_startup_report_statuses_and_warnings():
+    # BLOCKED when orders_no_status > 0
+    res_blocked = _FakeReconcileResult(10, 1, [])
+    rpt = esr.build_report(res_blocked, startup_date=date(2026, 4, 28))
+    assert rpt.status == esr.STATUS_BLOCKED
+    assert any("ステータス不明" in w or "ステータス不明" in w for w in rpt.warnings)
+    # READY_WITH_WARNINGS when discrepancies exist but orders_no_status == 0
+    disc = [_FakeDiscrep("AAA", 10, 8, -2)]
+    res_warn = _FakeReconcileResult(5, 0, disc)
+    rpt2 = esr.build_report(res_warn, startup_date=date(2026, 4, 28))
+    assert rpt2.status == esr.STATUS_READY_WITH_WARNINGS
+    assert any("ポジション差分" in w for w in rpt2.warnings)
+    # READY otherwise
+    res_ready = _FakeReconcileResult(0, 0, [])
+    rpt3 = esr.build_report(res_ready, startup_date=date(2026, 4, 28))
+    assert rpt3.status == esr.STATUS_READY
+
+
+def test_execution_startup_save_invalid_startup_date(tmp_path):
+    # create a report with invalid date string
+    rpt = esr.ExecutionStartupReport(
+        startup_date="bad-date",
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=esr.STATUS_READY,
+        orders_synced=0,
+        orders_no_status=0,
+        position_discrepancies=[],
+        warnings=[],
+    )
+    with pytest.raises(ValueError):
+        esr.save_report(rpt, output_dir=tmp_path)
+
+
+# -------------------------
+# market_close_report format helpers
+# -------------------------
+def test_fmt_return_and_yen():
+    assert mcr._fmt_return(None) == "N/A"
+    assert mcr._fmt_return(0.05) == "+5.00%"
+    assert mcr._fmt_return(-0.01) == "-1.00%"
+    assert mcr._fmt_yen(None) == "N/A"
+    assert mcr._fmt_yen(123456.78) == "+¥123,456"
+    assert mcr._fmt_yen(-500) == "¥-500"

--- a/tests/test_market_close_report.py
+++ b/tests/test_market_close_report.py
@@ -9,6 +9,15 @@ from datetime import date
 import duckdb as _duckdb
 import pytest
 
+from kabusys.operations.market_close_collector import (
+    collect_market_close_data,
+    check_signal_pending,
+    check_signal_filled,
+    check_positions_updated,
+    check_performance_recorded,
+    get_performance_row,
+    get_prev_equity,
+)
 from kabusys.operations.market_close_report import (
     STATUS_BLOCKED,
     STATUS_OK,
@@ -329,3 +338,148 @@ def _insert_performance(
         "INSERT INTO portfolio_performance VALUES (?, ?, 1000000.0, -0.005, ?)",
         [date_val.isoformat(), equity, daily_return],
     )
+
+
+# ---------------------------------------------------------------------------
+# check_signal_pending
+# ---------------------------------------------------------------------------
+
+
+def test_check_signal_pending_zero_when_empty(sdb):
+    assert check_signal_pending(sdb, TODAY) == 0
+
+
+def test_check_signal_pending_counts_pending(sdb):
+    _insert_signal(sdb, TODAY.isoformat(), "pending", "1234")
+    _insert_signal(sdb, TODAY.isoformat(), "pending", "5678")
+    assert check_signal_pending(sdb, TODAY) == 2
+
+
+def test_check_signal_pending_ignores_other_status(sdb):
+    _insert_signal(sdb, TODAY.isoformat(), "filled")
+    assert check_signal_pending(sdb, TODAY) == 0
+
+
+def test_check_signal_pending_ignores_other_date(sdb):
+    _insert_signal(sdb, "2026-04-27", "pending")
+    assert check_signal_pending(sdb, TODAY) == 0
+
+
+# ---------------------------------------------------------------------------
+# check_signal_filled
+# ---------------------------------------------------------------------------
+
+
+def test_check_signal_filled_zero_when_empty(sdb):
+    assert check_signal_filled(sdb, TODAY) == 0
+
+
+def test_check_signal_filled_counts_filled(sdb):
+    _insert_signal(sdb, TODAY.isoformat(), "filled", "1234")
+    _insert_signal(sdb, TODAY.isoformat(), "filled", "5678")
+    assert check_signal_filled(sdb, TODAY) == 2
+
+
+def test_check_signal_filled_ignores_pending(sdb):
+    _insert_signal(sdb, TODAY.isoformat(), "pending")
+    assert check_signal_filled(sdb, TODAY) == 0
+
+
+# ---------------------------------------------------------------------------
+# check_positions_updated
+# ---------------------------------------------------------------------------
+
+
+def test_check_positions_updated_false_when_empty(ddb):
+    assert check_positions_updated(ddb, TODAY) is False
+
+
+def test_check_positions_updated_true_when_today_exists(ddb):
+    _insert_position(ddb, TODAY)
+    assert check_positions_updated(ddb, TODAY) is True
+
+
+def test_check_positions_updated_false_when_only_prev(ddb):
+    _insert_position(ddb, PREV)
+    assert check_positions_updated(ddb, TODAY) is False
+
+
+# ---------------------------------------------------------------------------
+# check_performance_recorded
+# ---------------------------------------------------------------------------
+
+
+def test_check_performance_recorded_false_when_empty(ddb):
+    assert check_performance_recorded(ddb, TODAY) is False
+
+
+def test_check_performance_recorded_true_when_today_exists(ddb):
+    _insert_performance(ddb, TODAY)
+    assert check_performance_recorded(ddb, TODAY) is True
+
+
+# ---------------------------------------------------------------------------
+# get_performance_row
+# ---------------------------------------------------------------------------
+
+
+def test_get_performance_row_none_when_empty(ddb):
+    daily_return, equity = get_performance_row(ddb, TODAY)
+    assert daily_return is None
+    assert equity is None
+
+
+def test_get_performance_row_returns_values(ddb):
+    _insert_performance(ddb, TODAY, equity=5_234_000.0, daily_return=0.0032)
+    daily_return, equity = get_performance_row(ddb, TODAY)
+    assert daily_return == pytest.approx(0.0032)
+    assert equity == pytest.approx(5_234_000.0)
+
+
+# ---------------------------------------------------------------------------
+# get_prev_equity
+# ---------------------------------------------------------------------------
+
+
+def test_get_prev_equity_none_when_no_history(ddb):
+    assert get_prev_equity(ddb, TODAY) is None
+
+
+def test_get_prev_equity_returns_most_recent_before_today(ddb):
+    _insert_performance(ddb, PREV, equity=5_217_600.0)
+    _insert_performance(ddb, date(2026, 4, 24), equity=5_200_000.0)
+    result = get_prev_equity(ddb, TODAY)
+    assert result == pytest.approx(5_217_600.0)
+
+
+def test_get_prev_equity_ignores_today(ddb):
+    _insert_performance(ddb, TODAY, equity=5_234_000.0)
+    assert get_prev_equity(ddb, TODAY) is None
+
+
+# ---------------------------------------------------------------------------
+# collect_market_close_data
+# ---------------------------------------------------------------------------
+
+
+def test_collect_market_close_data_all_ok(ddb, sdb):
+    _insert_signal(sdb, TODAY.isoformat(), "filled")
+    _insert_position(ddb, TODAY)
+    _insert_performance(ddb, TODAY, equity=5_234_000.0, daily_return=0.0032)
+    _insert_performance(ddb, PREV, equity=5_217_600.0)
+    data = collect_market_close_data(ddb, sdb, TODAY)
+    assert data.signal_pending_count == 0
+    assert data.filled_count == 1
+    assert data.positions_updated is True
+    assert data.performance_recorded is True
+    assert data.daily_return == pytest.approx(0.0032)
+    assert data.equity_today == pytest.approx(5_234_000.0)
+    assert data.equity_prev == pytest.approx(5_217_600.0)
+
+
+def test_collect_market_close_data_blocked(ddb, sdb):
+    _insert_signal(sdb, TODAY.isoformat(), "pending")
+    data = collect_market_close_data(ddb, sdb, TODAY)
+    assert data.signal_pending_count == 1
+    assert data.positions_updated is False
+    assert data.performance_recorded is False

--- a/tests/test_market_close_report.py
+++ b/tests/test_market_close_report.py
@@ -1,4 +1,5 @@
 """Market Close Summary レポートのテスト。"""
+
 from __future__ import annotations
 
 import json
@@ -11,7 +12,6 @@ import pytest
 from kabusys.operations.market_close_report import (
     STATUS_BLOCKED,
     STATUS_OK,
-    CheckItem,
     MarketCloseReport,
     build_report,
     format_cli_summary,
@@ -24,6 +24,7 @@ from kabusys.operations.market_close_report import (
 # ---------------------------------------------------------------------------
 # ヘルパー
 # ---------------------------------------------------------------------------
+
 
 def _make_report(
     *,
@@ -51,6 +52,7 @@ def _make_report(
 # ---------------------------------------------------------------------------
 # build_report — ステータス判定
 # ---------------------------------------------------------------------------
+
 
 def test_build_report_ok():
     report = _make_report()
@@ -86,6 +88,7 @@ def test_build_report_all_blocked():
 # build_report — チェック項目
 # ---------------------------------------------------------------------------
 
+
 def test_build_report_check_items_count():
     report = _make_report()
     assert len(report.checks) == 3
@@ -119,6 +122,7 @@ def test_build_report_checks_performance_failed():
 # build_report — summary（損益額計算）
 # ---------------------------------------------------------------------------
 
+
 def test_build_report_pnl_amount_calculated():
     report = _make_report(equity_today=5_234_000.0, equity_prev=5_217_600.0)
     assert report.summary["pnl_amount"] == pytest.approx(16_400.0)
@@ -143,6 +147,7 @@ def test_build_report_summary_fields():
 # ---------------------------------------------------------------------------
 # format_cli_summary
 # ---------------------------------------------------------------------------
+
 
 def test_format_cli_summary_ok():
     report = _make_report()
@@ -185,6 +190,7 @@ def test_format_cli_summary_none_values():
 # format_json
 # ---------------------------------------------------------------------------
 
+
 def test_format_json_is_valid_json():
     report = _make_report()
     data = json.loads(format_json(report))
@@ -193,11 +199,13 @@ def test_format_json_is_valid_json():
     assert "checks" in data
     assert "summary" in data
     assert "warnings" in data
+    assert len(data["checks"]) == 3
 
 
 # ---------------------------------------------------------------------------
 # format_markdown
 # ---------------------------------------------------------------------------
+
 
 def test_format_markdown_contains_sections():
     report = _make_report()
@@ -220,6 +228,7 @@ def test_format_markdown_blocked_contains_warnings():
 # ---------------------------------------------------------------------------
 # save_report
 # ---------------------------------------------------------------------------
+
 
 def test_save_report_creates_files(tmp_path):
     report = _make_report()

--- a/tests/test_market_close_report.py
+++ b/tests/test_market_close_report.py
@@ -1,0 +1,322 @@
+"""Market Close Summary レポートのテスト。"""
+from __future__ import annotations
+
+import json
+import sqlite3 as _sqlite3
+from datetime import date
+
+import duckdb as _duckdb
+import pytest
+
+from kabusys.operations.market_close_report import (
+    STATUS_BLOCKED,
+    STATUS_OK,
+    CheckItem,
+    MarketCloseReport,
+    build_report,
+    format_cli_summary,
+    format_json,
+    format_markdown,
+    save_report,
+)
+
+
+# ---------------------------------------------------------------------------
+# ヘルパー
+# ---------------------------------------------------------------------------
+
+def _make_report(
+    *,
+    signal_pending_count: int = 0,
+    positions_updated: bool = True,
+    performance_recorded: bool = True,
+    filled_count: int = 3,
+    daily_return: float | None = 0.0032,
+    equity_today: float | None = 5_234_000.0,
+    equity_prev: float | None = 5_217_600.0,
+    report_date: date = date(2026, 4, 28),
+) -> MarketCloseReport:
+    return build_report(
+        report_date=report_date,
+        signal_pending_count=signal_pending_count,
+        positions_updated=positions_updated,
+        performance_recorded=performance_recorded,
+        filled_count=filled_count,
+        daily_return=daily_return,
+        equity_today=equity_today,
+        equity_prev=equity_prev,
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_report — ステータス判定
+# ---------------------------------------------------------------------------
+
+def test_build_report_ok():
+    report = _make_report()
+    assert report.status == STATUS_OK
+
+
+def test_build_report_blocked_pending():
+    report = _make_report(signal_pending_count=2)
+    assert report.status == STATUS_BLOCKED
+
+
+def test_build_report_blocked_positions():
+    report = _make_report(positions_updated=False)
+    assert report.status == STATUS_BLOCKED
+
+
+def test_build_report_blocked_performance():
+    report = _make_report(performance_recorded=False)
+    assert report.status == STATUS_BLOCKED
+
+
+def test_build_report_all_blocked():
+    report = _make_report(
+        signal_pending_count=1,
+        positions_updated=False,
+        performance_recorded=False,
+    )
+    assert report.status == STATUS_BLOCKED
+    assert len(report.warnings) == 3
+
+
+# ---------------------------------------------------------------------------
+# build_report — チェック項目
+# ---------------------------------------------------------------------------
+
+def test_build_report_check_items_count():
+    report = _make_report()
+    assert len(report.checks) == 3
+
+
+def test_build_report_checks_all_ok():
+    report = _make_report()
+    assert all(c.status == "ok" for c in report.checks)
+
+
+def test_build_report_checks_signal_failed():
+    report = _make_report(signal_pending_count=3)
+    sq = next(c for c in report.checks if c.name == "signal_queue")
+    assert sq.status == "failed"
+    assert "3 件" in sq.detail
+
+
+def test_build_report_checks_positions_failed():
+    report = _make_report(positions_updated=False)
+    pos = next(c for c in report.checks if c.name == "positions")
+    assert pos.status == "failed"
+
+
+def test_build_report_checks_performance_failed():
+    report = _make_report(performance_recorded=False)
+    perf = next(c for c in report.checks if c.name == "portfolio_performance")
+    assert perf.status == "failed"
+
+
+# ---------------------------------------------------------------------------
+# build_report — summary（損益額計算）
+# ---------------------------------------------------------------------------
+
+def test_build_report_pnl_amount_calculated():
+    report = _make_report(equity_today=5_234_000.0, equity_prev=5_217_600.0)
+    assert report.summary["pnl_amount"] == pytest.approx(16_400.0)
+
+
+def test_build_report_pnl_amount_none_when_equity_today_missing():
+    report = _make_report(equity_today=None, equity_prev=5_217_600.0)
+    assert report.summary["pnl_amount"] is None
+
+
+def test_build_report_pnl_amount_none_when_equity_prev_missing():
+    report = _make_report(equity_today=5_234_000.0, equity_prev=None)
+    assert report.summary["pnl_amount"] is None
+
+
+def test_build_report_summary_fields():
+    report = _make_report(filled_count=5, daily_return=0.0032)
+    assert report.summary["filled_count"] == 5
+    assert report.summary["daily_return"] == pytest.approx(0.0032)
+
+
+# ---------------------------------------------------------------------------
+# format_cli_summary
+# ---------------------------------------------------------------------------
+
+def test_format_cli_summary_ok():
+    report = _make_report()
+    out = format_cli_summary(report)
+    assert "✅" in out
+    assert STATUS_OK in out
+    assert "pending: 0 件" in out
+
+
+def test_format_cli_summary_blocked():
+    report = _make_report(signal_pending_count=2)
+    out = format_cli_summary(report)
+    assert "🚫" in out
+    assert STATUS_BLOCKED in out
+    assert "Warnings" in out
+    assert "2 件" in out
+
+
+def test_format_cli_summary_summary_section():
+    report = _make_report(
+        filled_count=5,
+        daily_return=0.0032,
+        equity_today=5_234_000.0,
+        equity_prev=5_217_600.0,
+    )
+    out = format_cli_summary(report)
+    assert "5 件" in out
+    assert "0.32%" in out
+    assert "16,400" in out
+    assert "5,234,000" in out
+
+
+def test_format_cli_summary_none_values():
+    report = _make_report(daily_return=None, equity_today=None, equity_prev=None)
+    out = format_cli_summary(report)
+    assert "N/A" in out
+
+
+# ---------------------------------------------------------------------------
+# format_json
+# ---------------------------------------------------------------------------
+
+def test_format_json_is_valid_json():
+    report = _make_report()
+    data = json.loads(format_json(report))
+    assert data["status"] == STATUS_OK
+    assert data["report_date"] == "2026-04-28"
+    assert "checks" in data
+    assert "summary" in data
+    assert "warnings" in data
+
+
+# ---------------------------------------------------------------------------
+# format_markdown
+# ---------------------------------------------------------------------------
+
+def test_format_markdown_contains_sections():
+    report = _make_report()
+    md = format_markdown(report)
+    assert "# Market Close Summary" in md
+    assert "Overview" in md
+    assert "Checks" in md
+    assert "Summary" in md
+    assert "Final Decision" in md
+    assert STATUS_OK in md
+
+
+def test_format_markdown_blocked_contains_warnings():
+    report = _make_report(signal_pending_count=1)
+    md = format_markdown(report)
+    assert "Warnings" in md
+    assert STATUS_BLOCKED in md
+
+
+# ---------------------------------------------------------------------------
+# save_report
+# ---------------------------------------------------------------------------
+
+def test_save_report_creates_files(tmp_path):
+    report = _make_report()
+    run_dir = save_report(report, output_dir=tmp_path)
+    assert (run_dir / "summary.json").exists()
+    assert (run_dir / "report.md").exists()
+    assert (run_dir / "warnings.json").exists()
+
+
+def test_save_report_directory_name(tmp_path):
+    report = _make_report()
+    run_dir = save_report(report, output_dir=tmp_path)
+    assert run_dir.name == "2026-04-28"
+
+
+def test_save_report_invalid_date_format(tmp_path):
+    report = _make_report()
+    report.report_date = "20260428"
+    with pytest.raises(ValueError):
+        save_report(report, output_dir=tmp_path)
+
+
+def test_save_report_invalid_calendar_date(tmp_path):
+    report = _make_report()
+    report.report_date = "2026-99-99"
+    with pytest.raises(ValueError):
+        save_report(report, output_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# collector fixtures（Task 2 で使用）
+# ---------------------------------------------------------------------------
+
+TODAY = date(2026, 4, 28)
+PREV = date(2026, 4, 25)
+
+
+@pytest.fixture
+def ddb():
+    """インメモリ DuckDB（positions + portfolio_performance テーブル付き）。"""
+    conn = _duckdb.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE positions ("
+        "  date DATE, code VARCHAR, position_size INTEGER,"
+        "  avg_price FLOAT, market_value FLOAT"
+        ")"
+    )
+    conn.execute(
+        "CREATE TABLE portfolio_performance ("
+        "  date DATE, equity FLOAT, cash FLOAT,"
+        "  drawdown FLOAT, daily_return FLOAT"
+        ")"
+    )
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def sdb():
+    """インメモリ SQLite（signal_queue テーブル付き）。"""
+    conn = _sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE signal_queue ("
+        "  signal_id TEXT, date TEXT, code TEXT, side TEXT,"
+        "  size INTEGER, order_type TEXT, price REAL,"
+        "  status TEXT, created_at TEXT, processed_at TEXT"
+        ")"
+    )
+    conn.commit()
+    yield conn
+    conn.close()
+
+
+def _insert_signal(sdb, date_str: str, status: str, code: str = "1234") -> None:
+    sdb.execute(
+        "INSERT INTO signal_queue"
+        " (signal_id, date, code, side, size, order_type, price, status, created_at, processed_at)"
+        " VALUES (?, ?, ?, 'buy', 100, 'market', NULL, ?, '2026-04-28T08:00:00', NULL)",
+        (f"sig-{code}-{status}", date_str, code, status),
+    )
+    sdb.commit()
+
+
+def _insert_position(ddb, date_val: date, code: str = "1234") -> None:
+    ddb.execute(
+        "INSERT INTO positions VALUES (?, ?, 100, 1500.0, 150000.0)",
+        [date_val.isoformat(), code],
+    )
+
+
+def _insert_performance(
+    ddb,
+    date_val: date,
+    equity: float = 5_234_000.0,
+    daily_return: float = 0.0032,
+) -> None:
+    ddb.execute(
+        "INSERT INTO portfolio_performance VALUES (?, ?, 1000000.0, -0.005, ?)",
+        [date_val.isoformat(), equity, daily_return],
+    )


### PR DESCRIPTION
## Summary

- `src/kabusys/operations/market_close_report.py` を新規実装 — 純粋関数のみ（データクラス・build_report・CLI/JSON/Markdown フォーマッター・save_report）
- `src/kabusys/operations/market_close_collector.py` を新規実装 — DuckDB（positions, portfolio_performance）と SQLite（signal_queue）の read-only クエリ
- `src/kabusys/run_market_close_report.py` を新規実装 — CLI エントリーポイント（`--date` / `--save` / `--json` オプション、終了コード 0=OK / 1=BLOCKED）
- 44 件のユニットテストを追加（インメモリ DuckDB + SQLite でコレクターも完全テスト）

## Closes

Closes #205

## Test Plan

- [ ] `python -m pytest tests/test_market_close_report.py -v` — 44 件全通過を確認
- [ ] `python -m ruff check src/kabusys/operations/market_close_report.py src/kabusys/operations/market_close_collector.py src/kabusys/run_market_close_report.py` — lint クリーン
- [ ] `python -m kabusys.run_market_close_report` — CLI 出力（OK or BLOCKED）を確認
- [ ] `python -m kabusys.run_market_close_report --save --json` — JSON 出力と artifacts 保存を確認