### PR TITLE
feat: ザラ場中監視インターフェース実装 (Issue #203)

### DIFF
--- a/docs/superpowers/specs/2026-04-29-intraday-monitoring-interface-design.md
+++ b/docs/superpowers/specs/2026-04-29-intraday-monitoring-interface-design.md
@@ -1,0 +1,330 @@
+# Intraday Monitoring Interface 設計仕様
+
+- Issue: #203
+- Date: 2026-04-29
+- Status: 承認済み
+
+---
+
+## 1. 目的
+
+ザラ場中（09:00〜15:00）にユーザーが異常を素早く検知し、対応判断できる監視インターフェースを提供する。
+
+- **CLI `--watch` モード**: ターミナルで N 秒ごとに全ステータスを自動更新表示する
+- **Streamlit ダッシュボード強化**: 既存ダッシュボードに Kill Switch・PID 状態・自動更新を追加する
+
+---
+
+## 2. アーキテクチャ
+
+### 2.1 ファイル構成
+
+```
+src/kabusys/operations/
+└── intraday_collector.py        # 新規: monitoring DB 読み取り専用（純粋関数）
+
+src/kabusys/
+└── run_intraday_monitor.py      # 新規: CLI エントリーポイント（--watch）
+
+src/kabusys/monitoring/
+├── streamlit_dashboard.py       # 既存強化: Kill Switch・PID・自動更新を追加
+└── run_monitoring.py            # 既存強化: monitoring.pid 書き込みを追加
+
+tests/
+└── test_intraday_collector.py   # 新規: intraday_collector のユニットテスト
+```
+
+### 2.2 データフロー
+
+```
+monitoring SQLite DB（monitoring_engine が書き込み済み）
+  └─ intraday_collector.collect_intraday_snapshot(conn, settings)
+       └─ IntradaySnapshot (dataclass)
+            ├─ run_intraday_monitor.py  → CLI 表示（--watch）
+            └─ streamlit_dashboard.py  → ブラウザ表示（自動更新）
+```
+
+### 2.3 DB 接続
+
+```python
+sqlite_uri = Path(settings.sqlite_path).resolve().as_uri() + "?mode=ro"
+conn = sqlite3.connect(sqlite_uri, uri=True)
+conn.row_factory = sqlite3.Row
+```
+
+---
+
+## 3. データ収集（intraday_collector.py）
+
+### 3.1 IntradaySnapshot dataclass
+
+```python
+@dataclass
+class IntradaySnapshot:
+    collected_at: str            # ISO8601 UTC
+    # プロセス状態
+    execution_pid_ok: bool       # execution.pid が存在し psutil で生存確認済み
+    monitoring_pid_ok: bool      # monitoring.pid が存在し psutil で生存確認済み
+    kill_switch_active: bool     # data/kill.flag の存在
+    kill_switch_reason: str      # kill.flag の内容（発動していなければ空文字）
+    # リスク
+    drawdown_pct: float | None   # dashboard.drawdown_pct（DB 未更新なら None）
+    stale_order_count: int       # risk_logs の STALE_ORDER 件数（直近1時間）
+    order_error_count: int       # risk_logs の ORDER_ERROR 件数（直近1時間）
+    # システム
+    process_ok: bool             # system_status.process_ok（最新1件、DB 空なら True）
+    cpu_percent: float | None    # system_status.cpu_percent（最新1件）
+    memory_percent: float | None # system_status.memory_percent（最新1件）
+    # 直近リスクイベント
+    recent_risk_events: list[dict]  # risk_logs 直近10件
+```
+
+### 3.2 公開関数
+
+```python
+def check_pid_file(pid_path: Path) -> bool:
+    """PID ファイルが存在し、記録された PID が psutil で生存していれば True。"""
+
+def check_kill_switch(flag_path: Path) -> tuple[bool, str]:
+    """(active, reason) を返す。flag がなければ (False, "")。"""
+
+def get_dashboard_row(conn: sqlite3.Connection) -> dict | None:
+    """dashboard テーブルの最新行を dict で返す。レコードなしなら None。"""
+
+def count_recent_risk_events(
+    conn: sqlite3.Connection, event_type: str, minutes: int = 60
+) -> int:
+    """指定 event_type の直近 N 分以内の件数を返す。"""
+
+def get_latest_system_status(conn: sqlite3.Connection) -> dict | None:
+    """system_status の最新1件を dict で返す。レコードなしなら None。"""
+
+def get_recent_risk_events(
+    conn: sqlite3.Connection, limit: int = 10
+) -> list[dict]:
+    """risk_logs を logged_at DESC で最新 limit 件返す。"""
+
+def collect_intraday_snapshot(
+    conn: sqlite3.Connection, settings: Settings
+) -> IntradaySnapshot:
+    """全チェック関数を呼び出して IntradaySnapshot を返す。"""
+```
+
+### 3.3 データソース一覧
+
+| フィールド | ソース |
+|---|---|
+| `execution_pid_ok` | `settings.pid_file_path`（`data/execution.pid`）+ psutil |
+| `monitoring_pid_ok` | `data/monitoring.pid`（固定パス）+ psutil |
+| `kill_switch_active/reason` | `settings.kill_flag_path`（`data/kill.flag`）|
+| `drawdown_pct` | `dashboard.drawdown_pct`（最新1件）|
+| `stale_order_count` | `risk_logs WHERE event_type='STALE_ORDER' AND logged_at > now-60min` |
+| `order_error_count` | `risk_logs WHERE event_type='ORDER_ERROR' AND logged_at > now-60min` |
+| `process_ok` | `system_status.process_ok`（最新1件、DB 空なら True）|
+| `cpu_percent` / `memory_percent` | `system_status`（最新1件、DB 空なら None）|
+| `recent_risk_events` | `risk_logs ORDER BY logged_at DESC LIMIT 10` |
+
+### 3.4 monitoring.pid パス
+
+```python
+_MONITORING_PID = Path("data/monitoring.pid")
+```
+
+`run_monitoring.py` にこの PID ファイルの書き込みを追加する（§5 参照）。
+
+---
+
+## 4. CLI エントリーポイント（run_intraday_monitor.py）
+
+### 4.1 使用例
+
+```
+python -m kabusys.run_intraday_monitor
+python -m kabusys.run_intraday_monitor --watch
+python -m kabusys.run_intraday_monitor --watch --interval 60
+```
+
+### 4.2 オプション
+
+| オプション | デフォルト | 説明 |
+|---|---|---|
+| `--watch` | なし | N 秒ごとに画面を自動更新し続ける |
+| `--interval SECONDS` | `30` | `--watch` 時の更新間隔（秒）|
+
+### 4.3 ステータス判定
+
+| 全体ステータス | 条件 |
+|---|---|
+| `CRITICAL` 🚫 | Kill Switch 発動 OR `execution_pid_ok == False` |
+| `WARNING` ⚠️ | `drawdown_pct <= -0.10` OR `order_error_count > 0` OR `stale_order_count > 0` OR `monitoring_pid_ok == False` |
+| `OK` ✅ | それ以外 |
+
+### 4.4 出力例（OK 時）
+
+```
+====================================================
+  KabuSys Intraday Monitor  2026-04-29 10:35:00 JST
+  Status : ✅ OK
+====================================================
+  プロセス:
+    [ok  ] execution.pid    稼働中 (PID: 12345)
+    [ok  ] monitoring.pid   稼働中 (PID: 67890)
+    [ok  ] Kill Switch      発動なし
+----------------------------------------------------
+  リスク:
+    [ok  ] ドローダウン      -2.1%
+    [ok  ] 注文エラー        0 件（直近1時間）
+    [ok  ] 滞留注文          0 件（直近1時間）
+----------------------------------------------------
+  システム:
+    [ok  ] API 接続          正常
+    [ok  ] CPU               45.2%
+    [ok  ] Memory            62.3%
+====================================================
+  次回更新: 30秒後  Ctrl+C で終了
+====================================================
+```
+
+### 4.5 出力例（CRITICAL 時）
+
+```
+====================================================
+  KabuSys Intraday Monitor  2026-04-29 10:48:22 JST
+  Status : 🚫 CRITICAL
+====================================================
+  プロセス:
+    [CRIT] execution.pid    停止（PID ファイルなし）
+    [ok  ] monitoring.pid   稼働中 (PID: 67890)
+    [CRIT] Kill Switch      発動中: Max drawdown exceeded
+----------------------------------------------------
+  リスク:
+    [WARN] ドローダウン      -11.3%（閾値 -10% 超過）
+    [WARN] 注文エラー        3 件（直近1時間）
+    [ok  ] 滞留注文          0 件（直近1時間）
+----------------------------------------------------
+  システム:
+    [ok  ] API 接続          正常
+    [ok  ] CPU               52.1%
+    [ok  ] Memory            68.4%
+====================================================
+  次回更新: 30秒後  Ctrl+C で終了
+====================================================
+```
+
+### 4.6 --watch 動作フロー
+
+```python
+while True:
+    snapshot = collect_intraday_snapshot(conn, settings)
+    os.system("cls")          # Windows: 画面クリア
+    print(format_cli_summary(snapshot, interval=args.interval))
+    time.sleep(args.interval)
+```
+
+`--watch` なしの場合は1回表示して終了。
+
+### 4.7 終了コード
+
+| コード | 意味 |
+|---|---|
+| `0` | OK |
+| `1` | WARNING または CRITICAL |
+
+---
+
+## 5. run_monitoring.py 強化（monitoring.pid 追記）
+
+`run_monitoring.py` の main() に以下を追加する:
+
+```python
+_MONITORING_PID = _PROJECT_ROOT / "data" / "monitoring.pid"
+
+# ループ開始前に PID ファイルを書き込む
+_MONITORING_PID.parent.mkdir(parents=True, exist_ok=True)
+_MONITORING_PID.write_text(str(os.getpid()))
+
+# finally ブロックに削除を追加
+_MONITORING_PID.unlink(missing_ok=True)
+```
+
+---
+
+## 6. Streamlit ダッシュボード強化（streamlit_dashboard.py）
+
+### 6.1 自動更新
+
+```python
+# sidebar
+refresh_interval = st.sidebar.selectbox("自動更新間隔", [30, 60, 120], index=0)
+st.sidebar.caption(f"{refresh_interval}秒ごとに自動更新")
+# ページ末尾
+time.sleep(refresh_interval)
+st.rerun()
+```
+
+### 6.2 Overview タブ強化
+
+Kill Switch ステータスを最上部に表示:
+
+```python
+kill_flag = Path(settings.kill_flag_path)
+if kill_flag.exists():
+    reason = kill_flag.read_text().strip()
+    st.error(f"🚫 Kill Switch 発動中: {reason}")
+else:
+    st.success("✅ Kill Switch: 発動なし")
+```
+
+drawdown に WARNING 色付き:
+
+```python
+dd = dashboard["drawdown_pct"] * 100
+st.metric("Drawdown", f"{dd:.2f}%", delta_color="inverse")
+if dd <= -10.0:
+    st.warning(f"⚠️ ドローダウン {dd:.2f}% — 閾値 -10% 超過")
+```
+
+注文エラー・滞留注文件数をメトリクスに追加。
+
+### 6.3 System タブ強化
+
+PID 状態を `st.metric` で表示:
+
+```python
+exec_ok = check_pid_file(Path(settings.pid_file_path))
+mon_ok = check_pid_file(Path("data/monitoring.pid"))
+col1.metric("Execution", "OK" if exec_ok else "DOWN")
+col2.metric("Monitoring", "OK" if mon_ok else "DOWN")
+```
+
+---
+
+## 7. テスト方針
+
+### 7.1 テスト対象
+
+- `intraday_collector.py` の全公開関数: インメモリ SQLite + `tmp_path` でテスト
+- `check_pid_file` / `check_kill_switch`: `tmp_path` フィクスチャで実ファイルを使ってテスト
+
+### 7.2 主要テストケース（15〜20件）
+
+| テスト | 内容 |
+|---|---|
+| `test_check_pid_file_false_when_missing` | PID ファイルなし → False |
+| `test_check_pid_file_true_for_current_process` | 自プロセスの PID を書いた場合 → True |
+| `test_check_pid_file_false_when_stale_pid` | 存在しない PID を書いた場合 → False |
+| `test_check_kill_switch_inactive` | flag ファイルなし → (False, "") |
+| `test_check_kill_switch_active` | flag ファイルあり → (True, "reason string") |
+| `test_get_dashboard_row_none_when_empty` | dashboard テーブル空 → None |
+| `test_get_dashboard_row_returns_drawdown` | dashboard あり → drawdown_pct が正しい |
+| `test_count_recent_risk_events_zero_when_empty` | risk_logs 空 → 0 |
+| `test_count_recent_risk_events_within_window` | 60分以内のレコードのみカウント |
+| `test_count_recent_risk_events_ignores_old` | 60分超のレコードは無視 |
+| `test_count_recent_risk_events_ignores_other_type` | 異なる event_type は無視 |
+| `test_get_latest_system_status_none_when_empty` | system_status 空 → None |
+| `test_get_latest_system_status_returns_latest` | 複数行 → logged_at が最新の1件 |
+| `test_get_recent_risk_events_empty` | risk_logs 空 → [] |
+| `test_get_recent_risk_events_limit` | limit=3 なら3件以内 |
+| `test_collect_intraday_snapshot_all_ok` | 全フィールドを正常値で統合テスト |
+| `test_collect_intraday_snapshot_kill_switch_active` | kill.flag あり → kill_switch_active=True |
+| `test_collect_intraday_snapshot_no_db_data` | DB 空 → drawdown_pct=None, process_ok=True |

--- a/documents/10_Runtime/TODO_OperationsInterfaces.md
+++ b/documents/10_Runtime/TODO_OperationsInterfaces.md
@@ -153,24 +153,49 @@
 
 ## 4.3 Intraday Monitoring Interface
 
+**ステータス: 設計済み (Issue #203, 設計書: `docs/superpowers/specs/2026-04-29-intraday-monitoring-interface-design.md`)**
+
 目的:
 
 - ザラ場中に異常を素早く検知し、ユーザーが対応判断できるようにする
 
 確認対象:
 
-- 注文エラー件数
-- API 接続状態
-- 日次ドローダウン
-- Kill Switch 状態
-- `execution_service` / `monitoring_service` の稼働状態
+- 注文エラー件数（直近1時間）
+- API 接続状態（`system_status.process_ok` 最新値）
+- 日次ドローダウン（`dashboard.drawdown_pct`）
+- Kill Switch 状態（`data/kill.flag` 存在確認）
+- `execution.pid` / `monitoring.pid` の稼働状態（psutil で生存確認）
 
-未検討点:
+設計決定:
 
-- リアルタイム監視画面を作るか
-- ログ監視だけにするか
-- Slack など即時通知を入れるか
-- 閾値超過時の見せ方をどうするか
+- **CLI `--watch` モード** + **Streamlit ダッシュボード強化** の2インターフェースを実装する
+- 共有データ層: `intraday_collector.py`（monitoring SQLite を read-only で参照）
+- CLI ステータス判定: `OK` / `WARNING` / `CRITICAL`（3段階）
+  - `CRITICAL`: Kill Switch 発動 OR `execution.pid` 停止
+  - `WARNING`: drawdown ≤ -10% OR 注文エラー > 0 OR 滞留注文 > 0 OR `monitoring.pid` 停止
+  - `OK`: それ以外
+- Streamlit: 自動更新（30/60/120秒 選択）、Kill Switch を最上部に表示、drawdown 閾値超過で赤表示
+- 終了コード: `0` = OK、`1` = WARNING または CRITICAL
+
+コマンド:
+
+```cmd
+python -m kabusys.run_intraday_monitor
+python -m kabusys.run_intraday_monitor --watch
+python -m kabusys.run_intraday_monitor --watch --interval 60
+streamlit run src/kabusys/monitoring/streamlit_dashboard.py -- --db data/monitoring.db
+```
+
+新規モジュール:
+
+- `src/kabusys/operations/intraday_collector.py`（monitoring DB クエリ）
+- `src/kabusys/run_intraday_monitor.py`（CLI エントリーポイント）
+
+強化モジュール:
+
+- `src/kabusys/monitoring/streamlit_dashboard.py`（Kill Switch・PID・自動更新を追加）
+- `src/kabusys/run_monitoring.py`（`data/monitoring.pid` 書き込みを追加）
 
 ## 4.4 Market Close Summary
 
@@ -351,8 +376,8 @@ python -m kabusys.run_position_reconciliation_report --save --json
 | `ExecutionStartupSummary` | 実装済み (Issue #201, PR #215) |
 | `SignalQueueConfirmationView` | 実装済み (Issue #202, PR #216) |
 | `PositionReconciliationView` | 設計済み (Issue #204) |
-| `IntradayMonitoringInterface` | 未着手 |
-| `MarketCloseSummary` | 未着手 |
+| `IntradayMonitoringInterface` | 設計済み (Issue #203) |
+| `MarketCloseSummary` | 実装済み (Issue #205, PR #218) |
 
 ---
 

--- a/documents/10_Runtime/WebManual_OperationsCycle.md
+++ b/documents/10_Runtime/WebManual_OperationsCycle.md
@@ -124,11 +124,23 @@ Execution 起動直後に `artifacts/execution_startup/{date}/report.md` が自�
 
 ユーザーが行うこと:
 
-- 注文エラーが多発していないか監視する
-- API 接続断が起きていないか確認する
-- ドローダウンが異常に拡大していないか確認する
-- `execution.pid` と `monitoring.pid` が存在するか確認する
-- ログに `ERROR`, `CRITICAL`, `Kill Switch`, `position_discrepancies` が出ていないか確認する
+`run_intraday_monitor` を起動して Intraday Monitoring Interface でステータスを確認する。
+
+```cmd
+python -m kabusys.run_intraday_monitor --watch
+```
+
+または Streamlit ダッシュボードを開いて常時監視する:
+
+```cmd
+streamlit run src/kabusys/monitoring/streamlit_dashboard.py -- --db data/monitoring.db
+```
+
+確認項目:
+
+- ステータスが `OK` であれば継続監視
+- `WARNING` の場合は Warnings 内容を確認し、必要に応じて対処する
+- `CRITICAL` の場合は即時対応（Kill Switch 発動 / Execution プロセス停止）
 
 ザラ場中の基本方針は、**売買判断と執行はシステム、継続運転の最終監督はユーザー** です。
 
@@ -321,11 +333,11 @@ Execution 起動直後に `artifacts/execution_startup/{date}/report.md` が自�
 
 ### ザラ場中
 
-- 注文エラーが連発していないか
-- API 接続が切れていないか
-- ドローダウンが異常に拡大していないか
-- `execution.pid` と `monitoring.pid` は存在するか
-- ログに `ERROR` や `CRITICAL` はないか
+`python -m kabusys.run_intraday_monitor --watch` を起動して以下を確認する:
+
+- ステータスが `OK` であれば継続監視
+- `WARNING`: 注文エラー・滞留注文・ドローダウン超過などの内容を確認し対処する
+- `CRITICAL`: Kill Switch 発動または Execution 停止 → 即時対応する
 
 ### 引け後
 

--- a/src/kabusys/monitoring/streamlit_dashboard.py
+++ b/src/kabusys/monitoring/streamlit_dashboard.py
@@ -16,7 +16,11 @@ import streamlit as st
 
 from kabusys.config import Settings
 from kabusys.monitoring.monitoring_db import MonitoringDB
-from kabusys.operations.intraday_collector import check_kill_switch, check_pid_file
+from kabusys.operations.intraday_collector import (
+    _MONITORING_PID,
+    check_kill_switch,
+    check_pid_file,
+)
 
 
 def _get_db_path() -> str:
@@ -81,84 +85,87 @@ def main(db_path: str) -> None:
         return
     db = MonitoringDB(conn)
 
-    tab_overview, tab_positions, tab_orders, tab_system = st.tabs(
-        ["Overview", "Positions", "Orders", "System"]
-    )
+    try:
+        tab_overview, tab_positions, tab_orders, tab_system = st.tabs(
+            ["Overview", "Positions", "Orders", "System"]
+        )
 
-    with tab_overview:
-        kill_active, kill_reason = check_kill_switch(Path(settings.kill_flag_path))
-        if kill_active:
-            st.error(f"🚫 Kill Switch 発動中: {kill_reason}")
-        else:
-            st.success("✅ Kill Switch: 発動なし")
+        with tab_overview:
+            kill_active, kill_reason = check_kill_switch(Path(settings.kill_flag_path))
+            if kill_active:
+                st.error(f"🚫 Kill Switch 発動中: {kill_reason}")
+            else:
+                st.success("✅ Kill Switch: 発動なし")
 
-        dashboard = db.get_dashboard()
-        if dashboard:
-            col1, col2, col3 = st.columns(3)
-            col1.metric("Portfolio Value", f"¥{dashboard['portfolio_value']:,.0f}")
-            col2.metric("Cash", f"¥{dashboard['cash']:,.0f}")
-            dd = dashboard["drawdown_pct"] * 100
-            col3.metric("Drawdown", f"{dd:.2f}%", delta_color="inverse")
-            if dd <= -10.0:
-                st.warning(f"⚠️ ドローダウン {dd:.2f}% — 閾値 -10% 超過")
-            st.caption(f"Updated: {dashboard['updated_at']}")
+            dashboard = db.get_dashboard()
+            if dashboard:
+                col1, col2, col3 = st.columns(3)
+                col1.metric("Portfolio Value", f"¥{dashboard['portfolio_value']:,.0f}")
+                col2.metric("Cash", f"¥{dashboard['cash']:,.0f}")
+                dd = dashboard["drawdown_pct"] * 100
+                col3.metric("Drawdown", f"{dd:.2f}%", delta_color="inverse")
+                if dd <= -10.0:
+                    st.warning(f"⚠️ ドローダウン {dd:.2f}% — 閾値 -10% 超過")
+                st.caption(f"Updated: {dashboard['updated_at']}")
 
-            cutoff = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
-            conn.row_factory = None
-            order_error_count = conn.execute(
-                "SELECT COUNT(*) FROM risk_logs WHERE event_type='ORDER_ERROR' AND logged_at > ?",
-                (cutoff,),
-            ).fetchone()[0]
-            stale_order_count = conn.execute(
-                "SELECT COUNT(*) FROM risk_logs WHERE event_type='STALE_ORDER' AND logged_at > ?",
-                (cutoff,),
-            ).fetchone()[0]
+                cutoff = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+                conn.row_factory = None
+                order_error_count = conn.execute(
+                    "SELECT COUNT(*) FROM risk_logs WHERE event_type='ORDER_ERROR' AND logged_at > ?",
+                    (cutoff,),
+                ).fetchone()[0]
+                stale_order_count = conn.execute(
+                    "SELECT COUNT(*) FROM risk_logs WHERE event_type='STALE_ORDER' AND logged_at > ?",
+                    (cutoff,),
+                ).fetchone()[0]
 
-            col4, col5 = st.columns(2)
-            col4.metric("注文エラー（直近1時間）", order_error_count)
-            col5.metric("滞留注文（直近1時間）", stale_order_count)
-        else:
-            st.info("No dashboard data yet.")
+                col4, col5 = st.columns(2)
+                col4.metric("注文エラー（直近1時間）", order_error_count)
+                col5.metric("滞留注文（直近1時間）", stale_order_count)
+            else:
+                st.info("No dashboard data yet.")
 
-    with tab_positions:
-        positions = load_positions(conn)
-        if positions:
-            st.dataframe(positions, use_container_width=True)
-        else:
-            st.info("No open positions.")
+        with tab_positions:
+            positions = load_positions(conn)
+            if positions:
+                st.dataframe(positions, use_container_width=True)
+            else:
+                st.info("No open positions.")
 
-    with tab_orders:
-        orders = load_recent_orders(conn)
-        if orders:
-            st.dataframe(orders, use_container_width=True)
-        else:
-            st.info("No trade events yet.")
+        with tab_orders:
+            orders = load_recent_orders(conn)
+            if orders:
+                st.dataframe(orders, use_container_width=True)
+            else:
+                st.info("No trade events yet.")
 
-    with tab_system:
-        exec_ok = check_pid_file(Path(settings.pid_file_path))
-        mon_ok = check_pid_file(Path("data/monitoring.pid"))
-        pid_col1, pid_col2 = st.columns(2)
-        pid_col1.metric("Execution", "OK" if exec_ok else "DOWN")
-        pid_col2.metric("Monitoring", "OK" if mon_ok else "DOWN")
+        with tab_system:
+            exec_ok = check_pid_file(Path(settings.pid_file_path))
+            mon_ok = check_pid_file(_MONITORING_PID)
+            pid_col1, pid_col2 = st.columns(2)
+            pid_col1.metric("Execution", "OK" if exec_ok else "DOWN")
+            pid_col2.metric("Monitoring", "OK" if mon_ok else "DOWN")
 
-        status = load_latest_system_status(conn)
-        if status:
-            col1, col2, col3, col4 = st.columns(4)
-            col1.metric("CPU", f"{status['cpu_percent']:.1f}%")
-            col2.metric("Memory", f"{status['memory_percent']:.1f}%")
-            col3.metric("Disk", f"{status['disk_percent']:.1f}%")
-            col4.metric("Process", "OK" if status["process_ok"] else "DOWN")
-            st.caption(f"Recorded: {status['recorded_at']}")
-        else:
-            st.info("No system status yet.")
+            status = load_latest_system_status(conn)
+            if status:
+                col1, col2, col3, col4 = st.columns(4)
+                col1.metric("CPU", f"{status['cpu_percent']:.1f}%")
+                col2.metric("Memory", f"{status['memory_percent']:.1f}%")
+                col3.metric("Disk", f"{status['disk_percent']:.1f}%")
+                col4.metric("Process", "OK" if status["process_ok"] else "DOWN")
+                st.caption(f"Recorded: {status['recorded_at']}")
+            else:
+                st.info("No system status yet.")
 
-        risk_logs = load_recent_risk_logs(conn)
-        if risk_logs:
-            st.subheader("Recent Risk Events")
-            st.dataframe(risk_logs, use_container_width=True)
+            risk_logs = load_recent_risk_logs(conn)
+            if risk_logs:
+                st.subheader("Recent Risk Events")
+                st.dataframe(risk_logs, use_container_width=True)
 
-    time.sleep(refresh_interval)
-    st.rerun()
+        time.sleep(refresh_interval)
+        st.rerun()
+    finally:
+        conn.close()
 
 
 if __name__ == "__main__":

--- a/src/kabusys/monitoring/streamlit_dashboard.py
+++ b/src/kabusys/monitoring/streamlit_dashboard.py
@@ -109,15 +109,15 @@ def main(db_path: str) -> None:
                 st.caption(f"Updated: {dashboard['updated_at']}")
 
                 cutoff = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
-                conn.row_factory = None
+                conn.row_factory = sqlite3.Row
                 order_error_count = conn.execute(
-                    "SELECT COUNT(*) FROM risk_logs WHERE event_type='ORDER_ERROR' AND logged_at > ?",
+                    "SELECT COUNT(*) AS cnt FROM risk_logs WHERE event_type='ORDER_ERROR' AND logged_at > ?",
                     (cutoff,),
-                ).fetchone()[0]
+                ).fetchone()["cnt"]
                 stale_order_count = conn.execute(
-                    "SELECT COUNT(*) FROM risk_logs WHERE event_type='STALE_ORDER' AND logged_at > ?",
+                    "SELECT COUNT(*) AS cnt FROM risk_logs WHERE event_type='STALE_ORDER' AND logged_at > ?",
                     (cutoff,),
-                ).fetchone()[0]
+                ).fetchone()["cnt"]
 
                 col4, col5 = st.columns(2)
                 col4.metric("注文エラー（直近1時間）", order_error_count)

--- a/src/kabusys/monitoring/streamlit_dashboard.py
+++ b/src/kabusys/monitoring/streamlit_dashboard.py
@@ -8,11 +8,15 @@ from __future__ import annotations
 
 import argparse
 import sqlite3
+import time
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import streamlit as st
 
+from kabusys.config import Settings
 from kabusys.monitoring.monitoring_db import MonitoringDB
+from kabusys.operations.intraday_collector import check_kill_switch, check_pid_file
 
 
 def _get_db_path() -> str:
@@ -59,9 +63,13 @@ def main(db_path: str) -> None:
     st.set_page_config(page_title="KabuSys Monitor", layout="wide")
     st.title("KabuSys 監視ダッシュボード")
 
+    settings = Settings()
+
     with st.sidebar:
         if st.button("Refresh"):
             st.rerun()
+        refresh_interval = st.selectbox("自動更新間隔", [30, 60, 120], index=0)
+        st.caption(f"{refresh_interval}秒ごとに自動更新")
 
     try:
         uri = Path(db_path).resolve().as_uri() + "?mode=ro"
@@ -78,13 +86,37 @@ def main(db_path: str) -> None:
     )
 
     with tab_overview:
+        kill_active, kill_reason = check_kill_switch(Path(settings.kill_flag_path))
+        if kill_active:
+            st.error(f"🚫 Kill Switch 発動中: {kill_reason}")
+        else:
+            st.success("✅ Kill Switch: 発動なし")
+
         dashboard = db.get_dashboard()
         if dashboard:
             col1, col2, col3 = st.columns(3)
             col1.metric("Portfolio Value", f"¥{dashboard['portfolio_value']:,.0f}")
             col2.metric("Cash", f"¥{dashboard['cash']:,.0f}")
-            col3.metric("Drawdown", f"{dashboard['drawdown_pct'] * 100:.2f}%")
+            dd = dashboard["drawdown_pct"] * 100
+            col3.metric("Drawdown", f"{dd:.2f}%", delta_color="inverse")
+            if dd <= -10.0:
+                st.warning(f"⚠️ ドローダウン {dd:.2f}% — 閾値 -10% 超過")
             st.caption(f"Updated: {dashboard['updated_at']}")
+
+            cutoff = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+            conn.row_factory = None
+            order_error_count = conn.execute(
+                "SELECT COUNT(*) FROM risk_logs WHERE event_type='ORDER_ERROR' AND logged_at > ?",
+                (cutoff,),
+            ).fetchone()[0]
+            stale_order_count = conn.execute(
+                "SELECT COUNT(*) FROM risk_logs WHERE event_type='STALE_ORDER' AND logged_at > ?",
+                (cutoff,),
+            ).fetchone()[0]
+
+            col4, col5 = st.columns(2)
+            col4.metric("注文エラー（直近1時間）", order_error_count)
+            col5.metric("滞留注文（直近1時間）", stale_order_count)
         else:
             st.info("No dashboard data yet.")
 
@@ -103,6 +135,12 @@ def main(db_path: str) -> None:
             st.info("No trade events yet.")
 
     with tab_system:
+        exec_ok = check_pid_file(Path(settings.pid_file_path))
+        mon_ok = check_pid_file(Path("data/monitoring.pid"))
+        pid_col1, pid_col2 = st.columns(2)
+        pid_col1.metric("Execution", "OK" if exec_ok else "DOWN")
+        pid_col2.metric("Monitoring", "OK" if mon_ok else "DOWN")
+
         status = load_latest_system_status(conn)
         if status:
             col1, col2, col3, col4 = st.columns(4)
@@ -118,6 +156,9 @@ def main(db_path: str) -> None:
         if risk_logs:
             st.subheader("Recent Risk Events")
             st.dataframe(risk_logs, use_container_width=True)
+
+    time.sleep(refresh_interval)
+    st.rerun()
 
 
 if __name__ == "__main__":

--- a/src/kabusys/operations/intraday_collector.py
+++ b/src/kabusys/operations/intraday_collector.py
@@ -11,7 +11,7 @@ import psutil
 
 from kabusys.config import Settings
 
-_MONITORING_PID = Path("data/monitoring.pid")
+_MONITORING_PID = Path(__file__).resolve().parents[3] / "data" / "monitoring.pid"
 
 
 @dataclass

--- a/src/kabusys/operations/intraday_collector.py
+++ b/src/kabusys/operations/intraday_collector.py
@@ -65,6 +65,7 @@ def count_recent_risk_events(
 ) -> int:
     """指定 event_type の直近 N 分以内の件数を返す。"""
     cutoff = (datetime.now(timezone.utc) - timedelta(minutes=minutes)).isoformat()
+    conn.row_factory = None
     cursor = conn.execute(
         "SELECT COUNT(*) FROM risk_logs WHERE event_type = ? AND logged_at > ?",
         (event_type, cutoff),
@@ -110,7 +111,7 @@ def collect_intraday_snapshot(
     order_error_count = count_recent_risk_events(conn, "ORDER_ERROR")
 
     sys_status = get_latest_system_status(conn)
-    process_ok = bool(sys_status["process_ok"]) if sys_status else True
+    process_ok = bool(sys_status["process_ok"]) if sys_status else False
     cpu_percent = sys_status["cpu_percent"] if sys_status else None
     memory_percent = sys_status["memory_percent"] if sys_status else None
 

--- a/src/kabusys/operations/intraday_collector.py
+++ b/src/kabusys/operations/intraday_collector.py
@@ -1,0 +1,132 @@
+"""intraday_collector.py — ザラ場中監視用 DB 読み取りコレクター（純粋関数）。"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+import psutil
+
+from kabusys.config import Settings
+
+_MONITORING_PID = Path("data/monitoring.pid")
+
+
+@dataclass
+class IntradaySnapshot:
+    collected_at: str
+    execution_pid_ok: bool
+    monitoring_pid_ok: bool
+    kill_switch_active: bool
+    kill_switch_reason: str
+    drawdown_pct: float | None
+    stale_order_count: int
+    order_error_count: int
+    process_ok: bool
+    cpu_percent: float | None
+    memory_percent: float | None
+    recent_risk_events: list[dict] = field(default_factory=list)
+
+
+def check_pid_file(pid_path: Path) -> bool:
+    """PID ファイルが存在し、記録された PID が psutil で生存していれば True。"""
+    if not pid_path.exists():
+        return False
+    try:
+        pid = int(pid_path.read_text().strip())
+        return psutil.pid_exists(pid)
+    except (ValueError, OSError):
+        return False
+
+
+def check_kill_switch(flag_path: Path) -> tuple[bool, str]:
+    """(active, reason) を返す。flag がなければ (False, "")。"""
+    if not flag_path.exists():
+        return False, ""
+    try:
+        reason = flag_path.read_text().strip()
+    except OSError:
+        reason = ""
+    return True, reason
+
+
+def get_dashboard_row(conn: sqlite3.Connection) -> dict | None:
+    """dashboard テーブルの最新行を dict で返す。レコードなしなら None。"""
+    conn.row_factory = sqlite3.Row
+    cursor = conn.execute("SELECT * FROM dashboard ORDER BY updated_at DESC LIMIT 1")
+    row = cursor.fetchone()
+    return dict(row) if row else None
+
+
+def count_recent_risk_events(
+    conn: sqlite3.Connection, event_type: str, minutes: int = 60
+) -> int:
+    """指定 event_type の直近 N 分以内の件数を返す。"""
+    cutoff = (datetime.now(timezone.utc) - timedelta(minutes=minutes)).isoformat()
+    cursor = conn.execute(
+        "SELECT COUNT(*) FROM risk_logs WHERE event_type = ? AND logged_at > ?",
+        (event_type, cutoff),
+    )
+    return cursor.fetchone()[0]
+
+
+def get_latest_system_status(conn: sqlite3.Connection) -> dict | None:
+    """system_status の最新1件を dict で返す。レコードなしなら None。"""
+    conn.row_factory = sqlite3.Row
+    cursor = conn.execute(
+        "SELECT * FROM system_status ORDER BY recorded_at DESC LIMIT 1"
+    )
+    row = cursor.fetchone()
+    return dict(row) if row else None
+
+
+def get_recent_risk_events(conn: sqlite3.Connection, limit: int = 10) -> list[dict]:
+    """risk_logs を logged_at DESC で最新 limit 件返す。"""
+    conn.row_factory = sqlite3.Row
+    cursor = conn.execute(
+        "SELECT * FROM risk_logs ORDER BY logged_at DESC LIMIT ?", (limit,)
+    )
+    return [dict(row) for row in cursor.fetchall()]
+
+
+def collect_intraday_snapshot(
+    conn: sqlite3.Connection, settings: Settings
+) -> IntradaySnapshot:
+    """全チェック関数を呼び出して IntradaySnapshot を返す。"""
+    now = datetime.now(timezone.utc).isoformat()
+
+    execution_pid_ok = check_pid_file(Path(settings.pid_file_path))
+    monitoring_pid_ok = check_pid_file(_MONITORING_PID)
+    kill_switch_active, kill_switch_reason = check_kill_switch(
+        Path(settings.kill_flag_path)
+    )
+
+    dashboard = get_dashboard_row(conn)
+    drawdown_pct = dashboard["drawdown_pct"] if dashboard else None
+
+    stale_order_count = count_recent_risk_events(conn, "STALE_ORDER")
+    order_error_count = count_recent_risk_events(conn, "ORDER_ERROR")
+
+    sys_status = get_latest_system_status(conn)
+    process_ok = bool(sys_status["process_ok"]) if sys_status else True
+    cpu_percent = sys_status["cpu_percent"] if sys_status else None
+    memory_percent = sys_status["memory_percent"] if sys_status else None
+
+    recent_risk_events = get_recent_risk_events(conn)
+
+    return IntradaySnapshot(
+        collected_at=now,
+        execution_pid_ok=execution_pid_ok,
+        monitoring_pid_ok=monitoring_pid_ok,
+        kill_switch_active=kill_switch_active,
+        kill_switch_reason=kill_switch_reason,
+        drawdown_pct=drawdown_pct,
+        stale_order_count=stale_order_count,
+        order_error_count=order_error_count,
+        process_ok=process_ok,
+        cpu_percent=cpu_percent,
+        memory_percent=memory_percent,
+        recent_risk_events=recent_risk_events,
+    )

--- a/src/kabusys/operations/intraday_collector.py
+++ b/src/kabusys/operations/intraday_collector.py
@@ -111,7 +111,7 @@ def collect_intraday_snapshot(
     order_error_count = count_recent_risk_events(conn, "ORDER_ERROR")
 
     sys_status = get_latest_system_status(conn)
-    process_ok = bool(sys_status["process_ok"]) if sys_status else False
+    process_ok = bool(sys_status["process_ok"]) if sys_status else True
     cpu_percent = sys_status["cpu_percent"] if sys_status else None
     memory_percent = sys_status["memory_percent"] if sys_status else None
 

--- a/src/kabusys/run_intraday_monitor.py
+++ b/src/kabusys/run_intraday_monitor.py
@@ -1,0 +1,172 @@
+"""run_intraday_monitor.py — ザラ場中監視 CLI エントリーポイント。
+
+使用例:
+    python -m kabusys.run_intraday_monitor
+    python -m kabusys.run_intraday_monitor --watch
+    python -m kabusys.run_intraday_monitor --watch --interval 60
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from kabusys.config import Settings
+from kabusys.operations.intraday_collector import (
+    IntradaySnapshot,
+    collect_intraday_snapshot,
+)
+
+_JST = ZoneInfo("Asia/Tokyo")
+
+STATUS_OK = "OK"
+STATUS_WARNING = "WARNING"
+STATUS_CRITICAL = "CRITICAL"
+
+
+def _determine_status(snap: IntradaySnapshot) -> str:
+    if snap.kill_switch_active or not snap.execution_pid_ok:
+        return STATUS_CRITICAL
+    if (
+        (snap.drawdown_pct is not None and snap.drawdown_pct <= -0.10)
+        or snap.order_error_count > 0
+        or snap.stale_order_count > 0
+        or not snap.monitoring_pid_ok
+    ):
+        return STATUS_WARNING
+    return STATUS_OK
+
+
+def format_cli_summary(snap: IntradaySnapshot, interval: int | None = None) -> str:
+    status = _determine_status(snap)
+    now_jst = datetime.now(tz=_JST).strftime("%Y-%m-%d %H:%M:%S JST")
+
+    if status == STATUS_OK:
+        status_label = f"✅ {STATUS_OK}"
+    elif status == STATUS_WARNING:
+        status_label = f"⚠️  {STATUS_WARNING}"
+    else:
+        status_label = f"🚫 {STATUS_CRITICAL}"
+
+    lines = [
+        "====================================================",
+        f"  KabuSys Intraday Monitor  {now_jst}",
+        f"  Status : {status_label}",
+        "====================================================",
+        "  プロセス:",
+    ]
+
+    if snap.execution_pid_ok:
+        lines.append("    [ok  ] execution.pid    稼働中")
+    else:
+        lines.append("    [CRIT] execution.pid    停止（PID ファイルなし）")
+
+    if snap.monitoring_pid_ok:
+        lines.append("    [ok  ] monitoring.pid   稼働中")
+    else:
+        lines.append("    [WARN] monitoring.pid   停止（PID ファイルなし）")
+
+    if snap.kill_switch_active:
+        lines.append(f"    [CRIT] Kill Switch      発動中: {snap.kill_switch_reason}")
+    else:
+        lines.append("    [ok  ] Kill Switch      発動なし")
+
+    lines.append("----------------------------------------------------")
+    lines.append("  リスク:")
+
+    if snap.drawdown_pct is None:
+        lines.append("    [ok  ] ドローダウン      データなし")
+    elif snap.drawdown_pct <= -0.10:
+        lines.append(
+            f"    [WARN] ドローダウン      {snap.drawdown_pct * 100:.1f}%（閾値 -10% 超過）"
+        )
+    else:
+        lines.append(f"    [ok  ] ドローダウン      {snap.drawdown_pct * 100:.1f}%")
+
+    if snap.order_error_count > 0:
+        lines.append(
+            f"    [WARN] 注文エラー        {snap.order_error_count} 件（直近1時間）"
+        )
+    else:
+        lines.append(
+            f"    [ok  ] 注文エラー        {snap.order_error_count} 件（直近1時間）"
+        )
+
+    if snap.stale_order_count > 0:
+        lines.append(
+            f"    [WARN] 滞留注文          {snap.stale_order_count} 件（直近1時間）"
+        )
+    else:
+        lines.append(
+            f"    [ok  ] 滞留注文          {snap.stale_order_count} 件（直近1時間）"
+        )
+
+    lines.append("----------------------------------------------------")
+    lines.append("  システム:")
+
+    if snap.process_ok:
+        lines.append("    [ok  ] API 接続          正常")
+    else:
+        lines.append("    [WARN] API 接続          異常")
+
+    if snap.cpu_percent is not None:
+        lines.append(f"    [ok  ] CPU               {snap.cpu_percent:.1f}%")
+    else:
+        lines.append("    [ok  ] CPU               データなし")
+
+    if snap.memory_percent is not None:
+        lines.append(f"    [ok  ] Memory            {snap.memory_percent:.1f}%")
+    else:
+        lines.append("    [ok  ] Memory            データなし")
+
+    lines.append("====================================================")
+    if interval is not None:
+        lines.append(f"  次回更新: {interval}秒後  Ctrl+C で終了")
+        lines.append("====================================================")
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="KabuSys ザラ場中監視 CLI")
+    parser.add_argument("--watch", action="store_true", help="N 秒ごとに自動更新")
+    parser.add_argument("--interval", type=int, default=30, help="更新間隔（秒）")
+    args = parser.parse_args()
+
+    settings = Settings()
+    sqlite_uri = Path(settings.sqlite_path).resolve().as_uri() + "?mode=ro"
+
+    try:
+        conn = sqlite3.connect(sqlite_uri, uri=True)
+    except Exception as exc:
+        print(f"[ERROR] DB に接続できません: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    conn.row_factory = sqlite3.Row
+
+    try:
+        if args.watch:
+            while True:
+                snap = collect_intraday_snapshot(conn, settings)
+                os.system("cls")
+                print(format_cli_summary(snap, interval=args.interval))
+                time.sleep(args.interval)
+        else:
+            snap = collect_intraday_snapshot(conn, settings)
+            print(format_cli_summary(snap))
+            status = _determine_status(snap)
+            sys.exit(0 if status == STATUS_OK else 1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/kabusys/run_intraday_monitor.py
+++ b/src/kabusys/run_intraday_monitor.py
@@ -65,12 +65,12 @@ def format_cli_summary(snap: IntradaySnapshot, interval: int | None = None) -> s
     if snap.execution_pid_ok:
         lines.append("    [ok  ] execution.pid    稼働中")
     else:
-        lines.append("    [CRIT] execution.pid    停止（PID ファイルなし）")
+        lines.append("    [CRIT] execution.pid    停止（未検出）")
 
     if snap.monitoring_pid_ok:
         lines.append("    [ok  ] monitoring.pid   稼働中")
     else:
-        lines.append("    [WARN] monitoring.pid   停止（PID ファイルなし）")
+        lines.append("    [WARN] monitoring.pid   停止（未検出）")
 
     if snap.kill_switch_active:
         lines.append(f"    [CRIT] Kill Switch      発動中: {snap.kill_switch_reason}")
@@ -139,11 +139,15 @@ def main() -> None:
     parser.add_argument("--interval", type=int, default=30, help="更新間隔（秒）")
     args = parser.parse_args()
 
+    if args.watch and args.interval <= 0:
+        print("[ERROR] --interval は1以上を指定してください", file=sys.stderr)
+        sys.exit(2)
+
     settings = Settings()
     sqlite_uri = Path(settings.sqlite_path).resolve().as_uri() + "?mode=ro"
 
     try:
-        conn = sqlite3.connect(sqlite_uri, uri=True)
+        conn = sqlite3.connect(sqlite_uri, uri=True, isolation_level=None)
     except Exception as exc:
         print(f"[ERROR] DB に接続できません: {exc}", file=sys.stderr)
         sys.exit(1)

--- a/src/kabusys/run_intraday_monitor.py
+++ b/src/kabusys/run_intraday_monitor.py
@@ -154,7 +154,7 @@ def main() -> None:
         if args.watch:
             while True:
                 snap = collect_intraday_snapshot(conn, settings)
-                os.system("cls")
+                os.system("cls" if os.name == "nt" else "clear")
                 print(format_cli_summary(snap, interval=args.interval))
                 time.sleep(args.interval)
         else:

--- a/src/kabusys/run_monitoring.py
+++ b/src/kabusys/run_monitoring.py
@@ -18,6 +18,7 @@ import duckdb
 from kabusys.config import Settings
 
 _STOP_FLAG = Path(__file__).resolve().parents[2] / "data" / "stop_requested.flag"
+_MONITORING_PID = Path(__file__).resolve().parents[2] / "data" / "monitoring.pid"
 from kabusys.monitoring.monitoring_db import init_monitoring_db  # noqa: E402
 from kabusys.monitoring.system_monitor import SystemMonitor  # noqa: E402
 from kabusys.utils.logging_setup import setup_logging  # noqa: E402
@@ -71,6 +72,8 @@ def main() -> None:
     # 4. ポーリングループ
     poll_interval = _get_poll_interval()
     logger.info("監視ループ開始（ポーリング間隔: %d 秒）", poll_interval)
+    _MONITORING_PID.parent.mkdir(parents=True, exist_ok=True)
+    _MONITORING_PID.write_text(str(os.getpid()))
     try:
         while True:
             if _STOP_FLAG.exists():
@@ -88,6 +91,7 @@ def main() -> None:
     finally:
         sqlite_conn.close()
         duckdb_conn.close()
+        _MONITORING_PID.unlink(missing_ok=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_intraday_collector.py
+++ b/tests/test_intraday_collector.py
@@ -209,4 +209,4 @@ def test_collect_intraday_snapshot_no_db_data(conn, tmp_path):
 
     snap = collect_intraday_snapshot(conn, settings)
     assert snap.drawdown_pct is None
-    assert snap.process_ok is True
+    assert snap.process_ok is False

--- a/tests/test_intraday_collector.py
+++ b/tests/test_intraday_collector.py
@@ -211,7 +211,7 @@ def test_collect_intraday_snapshot_no_db_data(conn, tmp_path):
 
     snap = collect_intraday_snapshot(conn, settings)
     assert snap.drawdown_pct is None
-    assert snap.process_ok is False
+    assert snap.process_ok is True
 
 
 # --- _determine_status / format_cli_summary ---

--- a/tests/test_intraday_collector.py
+++ b/tests/test_intraday_collector.py
@@ -11,14 +11,16 @@ import pytest
 
 from kabusys.monitoring.monitoring_db import init_monitoring_db
 from kabusys.operations.intraday_collector import (
+    IntradaySnapshot,
     check_pid_file,
     check_kill_switch,
-    get_dashboard_row,
+    collect_intraday_snapshot,
     count_recent_risk_events,
+    get_dashboard_row,
     get_latest_system_status,
     get_recent_risk_events,
-    collect_intraday_snapshot,
 )
+from kabusys.run_intraday_monitor import _determine_status, format_cli_summary
 
 
 @pytest.fixture
@@ -214,11 +216,8 @@ def test_collect_intraday_snapshot_no_db_data(conn, tmp_path):
 
 # --- _determine_status / format_cli_summary ---
 
-from kabusys.run_intraday_monitor import _determine_status, format_cli_summary
-from kabusys.operations.intraday_collector import IntradaySnapshot as _Snap
 
-
-def _make_snap(**kwargs) -> _Snap:
+def _make_snap(**kwargs) -> IntradaySnapshot:
     defaults = dict(
         collected_at="2026-04-29T01:35:00+00:00",
         execution_pid_ok=True,
@@ -234,7 +233,7 @@ def _make_snap(**kwargs) -> _Snap:
         recent_risk_events=[],
     )
     defaults.update(kwargs)
-    return _Snap(**defaults)
+    return IntradaySnapshot(**defaults)
 
 
 def test_determine_status_ok():

--- a/tests/test_intraday_collector.py
+++ b/tests/test_intraday_collector.py
@@ -1,0 +1,212 @@
+"""intraday_collector のユニットテスト（インメモリ SQLite + tmp_path）"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+import pytest
+
+from kabusys.monitoring.monitoring_db import init_monitoring_db
+from kabusys.operations.intraday_collector import (
+    check_pid_file,
+    check_kill_switch,
+    get_dashboard_row,
+    count_recent_risk_events,
+    get_latest_system_status,
+    get_recent_risk_events,
+    collect_intraday_snapshot,
+)
+
+
+@pytest.fixture
+def conn():
+    c = sqlite3.connect(":memory:")
+    init_monitoring_db(c)
+    yield c
+    c.close()
+
+
+def _insert_risk_event(conn, event_type: str, minutes_ago: int):
+    ts = (datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)).isoformat()
+    conn.execute(
+        "INSERT INTO risk_logs (event_type, metric_name, metric_value, threshold, detail, logged_at)"
+        " VALUES (?, ?, ?, ?, ?, ?)",
+        (event_type, "test_metric", 0.0, 0.0, "test", ts),
+    )
+    conn.commit()
+
+
+# --- check_pid_file ---
+
+
+def test_check_pid_file_false_when_missing(tmp_path):
+    assert check_pid_file(tmp_path / "no.pid") is False
+
+
+def test_check_pid_file_true_for_current_process(tmp_path):
+    pid_file = tmp_path / "proc.pid"
+    pid_file.write_text(str(os.getpid()))
+    assert check_pid_file(pid_file) is True
+
+
+def test_check_pid_file_false_when_stale_pid(tmp_path):
+    pid_file = tmp_path / "stale.pid"
+    pid_file.write_text("999999999")
+    assert check_pid_file(pid_file) is False
+
+
+# --- check_kill_switch ---
+
+
+def test_check_kill_switch_inactive(tmp_path):
+    active, reason = check_kill_switch(tmp_path / "kill.flag")
+    assert active is False
+    assert reason == ""
+
+
+def test_check_kill_switch_active(tmp_path):
+    flag = tmp_path / "kill.flag"
+    flag.write_text("Max drawdown exceeded")
+    active, reason = check_kill_switch(flag)
+    assert active is True
+    assert reason == "Max drawdown exceeded"
+
+
+# --- get_dashboard_row ---
+
+
+def test_get_dashboard_row_none_when_empty(conn):
+    assert get_dashboard_row(conn) is None
+
+
+def test_get_dashboard_row_returns_drawdown(conn):
+    from kabusys.monitoring.monitoring_db import MonitoringDB
+
+    db = MonitoringDB(conn)
+    db.upsert_dashboard(
+        portfolio_value=1_000_000,
+        cash=500_000,
+        drawdown_pct=-0.05,
+        open_order_count=0,
+        position_count=0,
+    )
+    row = get_dashboard_row(conn)
+    assert row is not None
+    assert abs(row["drawdown_pct"] - (-0.05)) < 1e-9
+
+
+# --- count_recent_risk_events ---
+
+
+def test_count_recent_risk_events_zero_when_empty(conn):
+    assert count_recent_risk_events(conn, "STALE_ORDER") == 0
+
+
+def test_count_recent_risk_events_within_window(conn):
+    _insert_risk_event(conn, "STALE_ORDER", 30)
+    _insert_risk_event(conn, "STALE_ORDER", 10)
+    assert count_recent_risk_events(conn, "STALE_ORDER") == 2
+
+
+def test_count_recent_risk_events_ignores_old(conn):
+    _insert_risk_event(conn, "STALE_ORDER", 90)
+    assert count_recent_risk_events(conn, "STALE_ORDER") == 0
+
+
+def test_count_recent_risk_events_ignores_other_type(conn):
+    _insert_risk_event(conn, "ORDER_ERROR", 5)
+    assert count_recent_risk_events(conn, "STALE_ORDER") == 0
+
+
+# --- get_latest_system_status ---
+
+
+def test_get_latest_system_status_none_when_empty(conn):
+    assert get_latest_system_status(conn) is None
+
+
+def test_get_latest_system_status_returns_latest(conn):
+    from kabusys.monitoring.monitoring_db import MonitoringDB
+
+    db = MonitoringDB(conn)
+    db.log_system_status(40.0, 50.0, 60.0, True)
+    db.log_system_status(80.0, 70.0, 60.0, True)
+    row = get_latest_system_status(conn)
+    assert row is not None
+    assert abs(row["cpu_percent"] - 80.0) < 1e-9
+
+
+# --- get_recent_risk_events ---
+
+
+def test_get_recent_risk_events_empty(conn):
+    assert get_recent_risk_events(conn) == []
+
+
+def test_get_recent_risk_events_limit(conn):
+    for i in range(5):
+        _insert_risk_event(conn, "ORDER_ERROR", i)
+    assert len(get_recent_risk_events(conn, limit=3)) == 3
+
+
+# --- collect_intraday_snapshot ---
+
+
+class FakeSettings:
+    def __init__(self, pid_file_path: Path, kill_flag_path: Path):
+        self.pid_file_path = pid_file_path
+        self.kill_flag_path = kill_flag_path
+        self.sqlite_path = Path("data/monitoring.db")
+
+
+def test_collect_intraday_snapshot_all_ok(conn, tmp_path):
+    from kabusys.monitoring.monitoring_db import MonitoringDB
+
+    pid_file = tmp_path / "execution.pid"
+    pid_file.write_text(str(os.getpid()))
+    kill_flag = tmp_path / "kill.flag"
+
+    settings = FakeSettings(pid_file_path=pid_file, kill_flag_path=kill_flag)
+
+    db = MonitoringDB(conn)
+    db.upsert_dashboard(
+        portfolio_value=1_000_000,
+        cash=500_000,
+        drawdown_pct=-0.02,
+        open_order_count=0,
+        position_count=0,
+    )
+    db.log_system_status(30.0, 50.0, 60.0, True)
+
+    snap = collect_intraday_snapshot(conn, settings)
+    assert snap.execution_pid_ok is True
+    assert snap.kill_switch_active is False
+    assert snap.kill_switch_reason == ""
+    assert snap.drawdown_pct is not None
+    assert snap.process_ok is True
+
+
+def test_collect_intraday_snapshot_kill_switch_active(conn, tmp_path):
+    pid_file = tmp_path / "execution.pid"
+    kill_flag = tmp_path / "kill.flag"
+    kill_flag.write_text("Max drawdown exceeded")
+
+    settings = FakeSettings(pid_file_path=pid_file, kill_flag_path=kill_flag)
+
+    snap = collect_intraday_snapshot(conn, settings)
+    assert snap.kill_switch_active is True
+    assert snap.kill_switch_reason == "Max drawdown exceeded"
+
+
+def test_collect_intraday_snapshot_no_db_data(conn, tmp_path):
+    settings = FakeSettings(
+        pid_file_path=tmp_path / "no.pid",
+        kill_flag_path=tmp_path / "no.flag",
+    )
+
+    snap = collect_intraday_snapshot(conn, settings)
+    assert snap.drawdown_pct is None
+    assert snap.process_ok is True

--- a/tests/test_intraday_collector.py
+++ b/tests/test_intraday_collector.py
@@ -210,3 +210,71 @@ def test_collect_intraday_snapshot_no_db_data(conn, tmp_path):
     snap = collect_intraday_snapshot(conn, settings)
     assert snap.drawdown_pct is None
     assert snap.process_ok is False
+
+
+# --- _determine_status / format_cli_summary ---
+
+from kabusys.run_intraday_monitor import _determine_status, format_cli_summary
+from kabusys.operations.intraday_collector import IntradaySnapshot as _Snap
+
+
+def _make_snap(**kwargs) -> _Snap:
+    defaults = dict(
+        collected_at="2026-04-29T01:35:00+00:00",
+        execution_pid_ok=True,
+        monitoring_pid_ok=True,
+        kill_switch_active=False,
+        kill_switch_reason="",
+        drawdown_pct=-0.02,
+        stale_order_count=0,
+        order_error_count=0,
+        process_ok=True,
+        cpu_percent=30.0,
+        memory_percent=50.0,
+        recent_risk_events=[],
+    )
+    defaults.update(kwargs)
+    return _Snap(**defaults)
+
+
+def test_determine_status_ok():
+    snap = _make_snap()
+    assert _determine_status(snap) == "OK"
+
+
+def test_determine_status_critical_kill_switch():
+    snap = _make_snap(kill_switch_active=True, kill_switch_reason="drawdown")
+    assert _determine_status(snap) == "CRITICAL"
+
+
+def test_determine_status_critical_execution_down():
+    snap = _make_snap(execution_pid_ok=False)
+    assert _determine_status(snap) == "CRITICAL"
+
+
+def test_determine_status_warning_drawdown():
+    snap = _make_snap(drawdown_pct=-0.11)
+    assert _determine_status(snap) == "WARNING"
+
+
+def test_determine_status_warning_order_error():
+    snap = _make_snap(order_error_count=2)
+    assert _determine_status(snap) == "WARNING"
+
+
+def test_format_cli_summary_ok_contains_ok():
+    snap = _make_snap()
+    output = format_cli_summary(snap)
+    assert "✅ OK" in output
+
+
+def test_format_cli_summary_critical_contains_crit():
+    snap = _make_snap(execution_pid_ok=False)
+    output = format_cli_summary(snap)
+    assert "🚫 CRITICAL" in output
+
+
+def test_format_cli_summary_shows_interval():
+    snap = _make_snap()
+    output = format_cli_summary(snap, interval=30)
+    assert "30秒後" in output


### PR DESCRIPTION
## Summary

- `src/kabusys/operations/intraday_collector.py` を新規作成: monitoring SQLite DB を読み取り専用でクエリし `IntradaySnapshot` dataclass を返す純粋関数コレクター（7 公開関数）
- `src/kabusys/run_intraday_monitor.py` を新規作成: `--watch`/`--interval` CLI。OK/WARNING/CRITICAL 判定 + JST タイムスタンプ付き表示。終了コード 0=OK, 1=WARNING/CRITICAL
- `src/kabusys/run_monitoring.py` を変更: 起動時に `data/monitoring.pid` を書き込み、終了時に削除
- `src/kabusys/monitoring/streamlit_dashboard.py` を強化: Kill Switch バナー・PID 状態・注文エラー件数・自動更新（30/60/120秒セレクトボックス）を追加

## Test Plan

- [ ] 1155 tests passing (`python -m pytest --tb=short -q`)
- [ ] `python -m kabusys.run_intraday_monitor` で一回表示 → 終了コード確認
- [ ] `python -m kabusys.run_intraday_monitor --watch --interval 10` で自動更新確認
- [ ] `streamlit run src/kabusys/monitoring/streamlit_dashboard.py -- --db data/monitoring.db` でダッシュボード確認
- [ ] Kill Switch バナー・PID 状態・自動更新が Overview/System タブに表示されることを確認

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)