### PR TITLE
fix: portfolio_performance の PRIMARY KEY を (date, env) に変更 (Issue #221)

### DIFF
--- a/src/kabusys/data/schema.py
+++ b/src/kabusys/data/schema.py
@@ -433,63 +433,6 @@ _ALL_DDL: list[str] = [
 
 
 # ---------------------------------------------------------------------------
-# 複合 PK マイグレーション
-# ---------------------------------------------------------------------------
-
-
-def _migrate_portfolio_performance_pk(conn: duckdb.DuckDBPyConnection) -> None:
-    """portfolio_performance の PRIMARY KEY を (date, env) に変更する。
-
-    DuckDB は ALTER TABLE ... DROP/ADD PRIMARY KEY をサポートしないため、
-    テーブル再作成で対応する。既に (date, env) PK の場合は何もしない（冪等）。
-    """
-    row = conn.execute(
-        "SELECT constraint_column_names FROM duckdb_constraints()"
-        " WHERE table_name = 'portfolio_performance'"
-        " AND constraint_type = 'PRIMARY KEY'"
-    ).fetchone()
-    if row and list(row[0]) == ["date", "env"]:
-        return
-
-    conn.execute("DROP TABLE IF EXISTS portfolio_performance_new")
-    conn.execute("BEGIN")
-    try:
-        conn.execute(
-            """
-            CREATE TABLE portfolio_performance_new (
-                date            DATE          NOT NULL,
-                env             VARCHAR       NOT NULL DEFAULT 'live',
-                equity          DECIMAL(20,4) NOT NULL,
-                cash            DECIMAL(20,4) NOT NULL DEFAULT 0,
-                drawdown        DOUBLE,
-                daily_return    DOUBLE,
-                PRIMARY KEY (date, env)
-            )
-            """
-        )
-        conn.execute(
-            """
-            INSERT INTO portfolio_performance_new
-            SELECT date, COALESCE(env, 'live'), equity, cash, drawdown, daily_return
-            FROM portfolio_performance
-            """
-        )
-        conn.execute("DROP TABLE portfolio_performance")
-        conn.execute(
-            "ALTER TABLE portfolio_performance_new RENAME TO portfolio_performance"
-        )
-        conn.execute("COMMIT")
-    except Exception:
-        try:
-            conn.execute("ROLLBACK")
-        except Exception as rb_exc:
-            logger.warning(
-                "_migrate_portfolio_performance_pk: ROLLBACK failed: %s", rb_exc
-            )
-        raise
-
-
-# ---------------------------------------------------------------------------
 # 公開 API
 # ---------------------------------------------------------------------------
 
@@ -531,9 +474,6 @@ def init_schema(db_path: str | Path) -> duckdb.DuckDBPyConnection:
             conn.execute(migration)
         except Exception:
             pass
-
-    # portfolio_performance の PK を (date, env) に変更（テーブル再作成）
-    _migrate_portfolio_performance_pk(conn)
 
     return conn
 

--- a/src/kabusys/data/schema.py
+++ b/src/kabusys/data/schema.py
@@ -312,12 +312,13 @@ CREATE TABLE IF NOT EXISTS earnings_calendar (
 
 _PORTFOLIO_PERFORMANCE = """
 CREATE TABLE IF NOT EXISTS portfolio_performance (
-    date            DATE        NOT NULL PRIMARY KEY,
+    date            DATE          NOT NULL,
+    env             VARCHAR       NOT NULL DEFAULT 'live',
     equity          DECIMAL(20,4) NOT NULL,
     cash            DECIMAL(20,4) NOT NULL DEFAULT 0,
     drawdown        DOUBLE,
     daily_return    DOUBLE,
-    env             VARCHAR     NOT NULL DEFAULT 'live'
+    PRIMARY KEY (date, env)
 )
 """
 
@@ -432,6 +433,63 @@ _ALL_DDL: list[str] = [
 
 
 # ---------------------------------------------------------------------------
+# 複合 PK マイグレーション
+# ---------------------------------------------------------------------------
+
+
+def _migrate_portfolio_performance_pk(conn: duckdb.DuckDBPyConnection) -> None:
+    """portfolio_performance の PRIMARY KEY を (date, env) に変更する。
+
+    DuckDB は ALTER TABLE ... DROP/ADD PRIMARY KEY をサポートしないため、
+    テーブル再作成で対応する。既に (date, env) PK の場合は何もしない（冪等）。
+    """
+    row = conn.execute(
+        "SELECT constraint_column_names FROM duckdb_constraints()"
+        " WHERE table_name = 'portfolio_performance'"
+        " AND constraint_type = 'PRIMARY KEY'"
+    ).fetchone()
+    if row and list(row[0]) == ["date", "env"]:
+        return
+
+    conn.execute("DROP TABLE IF EXISTS portfolio_performance_new")
+    conn.execute("BEGIN")
+    try:
+        conn.execute(
+            """
+            CREATE TABLE portfolio_performance_new (
+                date            DATE          NOT NULL,
+                env             VARCHAR       NOT NULL DEFAULT 'live',
+                equity          DECIMAL(20,4) NOT NULL,
+                cash            DECIMAL(20,4) NOT NULL DEFAULT 0,
+                drawdown        DOUBLE,
+                daily_return    DOUBLE,
+                PRIMARY KEY (date, env)
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO portfolio_performance_new
+            SELECT date, COALESCE(env, 'live'), equity, cash, drawdown, daily_return
+            FROM portfolio_performance
+            """
+        )
+        conn.execute("DROP TABLE portfolio_performance")
+        conn.execute(
+            "ALTER TABLE portfolio_performance_new RENAME TO portfolio_performance"
+        )
+        conn.execute("COMMIT")
+    except Exception:
+        try:
+            conn.execute("ROLLBACK")
+        except Exception as rb_exc:
+            logger.warning(
+                "_migrate_portfolio_performance_pk: ROLLBACK failed: %s", rb_exc
+            )
+        raise
+
+
+# ---------------------------------------------------------------------------
 # 公開 API
 # ---------------------------------------------------------------------------
 
@@ -473,6 +531,9 @@ def init_schema(db_path: str | Path) -> duckdb.DuckDBPyConnection:
             conn.execute(migration)
         except Exception:
             pass
+
+    # portfolio_performance の PK を (date, env) に変更（テーブル再作成）
+    _migrate_portfolio_performance_pk(conn)
 
     return conn
 

--- a/tests/test_performance_report.py
+++ b/tests/test_performance_report.py
@@ -25,12 +25,13 @@ def _make_conn(
     conn.execute(
         """
         CREATE TABLE portfolio_performance (
-            date         DATE          NOT NULL PRIMARY KEY,
+            date         DATE          NOT NULL,
+            env          VARCHAR       NOT NULL DEFAULT 'live',
             equity       DECIMAL(20,4) NOT NULL,
             cash         DECIMAL(20,4) NOT NULL DEFAULT 0,
             drawdown     DOUBLE,
             daily_return DOUBLE,
-            env          VARCHAR       NOT NULL DEFAULT 'live'
+            PRIMARY KEY (date, env)
         )
         """
     )
@@ -586,9 +587,9 @@ def test_cli_returns_1_when_no_data(tmp_path, monkeypatch):
     conn.execute(
         """
         CREATE TABLE portfolio_performance (
-            date DATE NOT NULL PRIMARY KEY, equity DECIMAL(20,4) NOT NULL,
-            cash DECIMAL(20,4) NOT NULL DEFAULT 0, drawdown DOUBLE,
-            daily_return DOUBLE, env VARCHAR NOT NULL DEFAULT 'live'
+            date DATE NOT NULL, env VARCHAR NOT NULL DEFAULT 'live',
+            equity DECIMAL(20,4) NOT NULL, cash DECIMAL(20,4) NOT NULL DEFAULT 0,
+            drawdown DOUBLE, daily_return DOUBLE, PRIMARY KEY (date, env)
         )
         """
     )
@@ -616,9 +617,9 @@ def test_cli_returns_0_when_data_exists(tmp_path, monkeypatch):
     conn.execute(
         """
         CREATE TABLE portfolio_performance (
-            date DATE NOT NULL PRIMARY KEY, equity DECIMAL(20,4) NOT NULL,
-            cash DECIMAL(20,4) NOT NULL DEFAULT 0, drawdown DOUBLE,
-            daily_return DOUBLE, env VARCHAR NOT NULL DEFAULT 'live'
+            date DATE NOT NULL, env VARCHAR NOT NULL DEFAULT 'live',
+            equity DECIMAL(20,4) NOT NULL, cash DECIMAL(20,4) NOT NULL DEFAULT 0,
+            drawdown DOUBLE, daily_return DOUBLE, PRIMARY KEY (date, env)
         )
         """
     )
@@ -637,3 +638,132 @@ def test_cli_returns_0_when_data_exists(tmp_path, monkeypatch):
     monkeypatch.setenv("DUCKDB_PATH", str(db_path))
     result = main(["--type", "daily", "--from", "2026-04-21", "--to", "2026-04-21"])
     assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #221: portfolio_performance PK (date, env) マイグレーション
+# ---------------------------------------------------------------------------
+
+from kabusys.data.schema import (  # noqa: E402
+    _migrate_portfolio_performance_pk,
+    init_schema,
+)
+
+
+def _make_old_schema_conn() -> duckdb.DuckDBPyConnection:
+    """旧スキーマ（PRIMARY KEY (date) 単独）のインメモリ DB を返す。"""
+    conn = duckdb.connect(":memory:")
+    conn.execute(
+        """
+        CREATE TABLE portfolio_performance (
+            date         DATE          NOT NULL PRIMARY KEY,
+            equity       DECIMAL(20,4) NOT NULL,
+            cash         DECIMAL(20,4) NOT NULL DEFAULT 0,
+            drawdown     DOUBLE,
+            daily_return DOUBLE,
+            env          VARCHAR       NOT NULL DEFAULT 'live'
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO portfolio_performance (date, equity, cash, env)"
+        " VALUES ('2026-04-21', 5000000, 0, 'live')"
+    )
+    return conn
+
+
+def _get_pk_columns(conn: duckdb.DuckDBPyConnection) -> list[str]:
+    row = conn.execute(
+        "SELECT constraint_column_names FROM duckdb_constraints()"
+        " WHERE table_name = 'portfolio_performance'"
+        " AND constraint_type = 'PRIMARY KEY'"
+    ).fetchone()
+    return list(row[0]) if row else []
+
+
+def test_init_schema_creates_composite_pk():
+    """init_schema が PRIMARY KEY (date, env) でテーブルを作成する。"""
+    conn = init_schema(":memory:")
+    assert _get_pk_columns(conn) == ["date", "env"]
+
+
+def test_migrate_pk_from_old_schema():
+    """旧スキーマ (date PK) から (date, env) PK へ正しく移行する。"""
+    conn = _make_old_schema_conn()
+    assert _get_pk_columns(conn) == ["date"]
+
+    _migrate_portfolio_performance_pk(conn)
+
+    assert _get_pk_columns(conn) == ["date", "env"]
+    row = conn.execute("SELECT date, env, equity FROM portfolio_performance").fetchone()
+    assert row is not None
+    assert row[2] == 5_000_000
+
+
+def test_migrate_pk_idempotent():
+    """既に (date, env) PK のテーブルに対してマイグレーションを2回実行しても壊れない。"""
+    conn = _make_conn(
+        {"date": "2026-04-21", "equity": 5_000_000.0, "env": "live"},
+    )
+    _migrate_portfolio_performance_pk(conn)
+    _migrate_portfolio_performance_pk(conn)
+
+    assert _get_pk_columns(conn) == ["date", "env"]
+    rows = conn.execute("SELECT COUNT(*) FROM portfolio_performance").fetchone()
+    assert rows[0] == 1
+
+
+def test_same_date_different_envs_can_coexist():
+    """同一日付で live / paper_trading の2行を共存できる。"""
+    conn = _make_conn(
+        {"date": "2026-04-21", "equity": 5_000_000.0, "env": "live"},
+        {"date": "2026-04-21", "equity": 4_800_000.0, "env": "paper_trading"},
+    )
+    rows = conn.execute(
+        "SELECT env, equity FROM portfolio_performance WHERE date = '2026-04-21'"
+        " ORDER BY env"
+    ).fetchall()
+    assert len(rows) == 2
+    assert rows[0] == ("live", 5_000_000)
+    assert rows[1] == ("paper_trading", 4_800_000)
+
+
+def test_collect_daily_rows_env_isolation_mixed_data():
+    """live と paper_trading が混在しても env で正しく絞り込む。"""
+    conn = _make_conn(
+        {
+            "date": "2026-04-21",
+            "equity": 5_000_000.0,
+            "daily_return": 0.01,
+            "env": "live",
+        },
+        {
+            "date": "2026-04-22",
+            "equity": 5_050_000.0,
+            "daily_return": 0.01,
+            "env": "live",
+        },
+        {
+            "date": "2026-04-21",
+            "equity": 4_800_000.0,
+            "daily_return": -0.02,
+            "env": "paper_trading",
+        },
+        {
+            "date": "2026-04-22",
+            "equity": 4_750_000.0,
+            "daily_return": -0.01,
+            "env": "paper_trading",
+        },
+    )
+    live_rows = collect_daily_rows(conn, "live", date(2026, 4, 21), date(2026, 4, 22))
+    paper_rows = collect_daily_rows(
+        conn, "paper_trading", date(2026, 4, 21), date(2026, 4, 22)
+    )
+
+    assert len(live_rows) == 2
+    assert all(r.env == "live" for r in live_rows)
+    assert len(paper_rows) == 2
+    assert all(r.env == "paper_trading" for r in paper_rows)
+    assert live_rows[0].equity == 5_000_000
+    assert paper_rows[0].equity == 4_800_000

--- a/tests/test_performance_report.py
+++ b/tests/test_performance_report.py
@@ -641,35 +641,10 @@ def test_cli_returns_0_when_data_exists(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Issue #221: portfolio_performance PK (date, env) マイグレーション
+# Issue #221: portfolio_performance PRIMARY KEY (date, env)
 # ---------------------------------------------------------------------------
 
-from kabusys.data.schema import (  # noqa: E402
-    _migrate_portfolio_performance_pk,
-    init_schema,
-)
-
-
-def _make_old_schema_conn() -> duckdb.DuckDBPyConnection:
-    """旧スキーマ（PRIMARY KEY (date) 単独）のインメモリ DB を返す。"""
-    conn = duckdb.connect(":memory:")
-    conn.execute(
-        """
-        CREATE TABLE portfolio_performance (
-            date         DATE          NOT NULL PRIMARY KEY,
-            equity       DECIMAL(20,4) NOT NULL,
-            cash         DECIMAL(20,4) NOT NULL DEFAULT 0,
-            drawdown     DOUBLE,
-            daily_return DOUBLE,
-            env          VARCHAR       NOT NULL DEFAULT 'live'
-        )
-        """
-    )
-    conn.execute(
-        "INSERT INTO portfolio_performance (date, equity, cash, env)"
-        " VALUES ('2026-04-21', 5000000, 0, 'live')"
-    )
-    return conn
+from kabusys.data.schema import init_schema  # noqa: E402
 
 
 def _get_pk_columns(conn: duckdb.DuckDBPyConnection) -> list[str]:
@@ -685,32 +660,6 @@ def test_init_schema_creates_composite_pk():
     """init_schema が PRIMARY KEY (date, env) でテーブルを作成する。"""
     conn = init_schema(":memory:")
     assert _get_pk_columns(conn) == ["date", "env"]
-
-
-def test_migrate_pk_from_old_schema():
-    """旧スキーマ (date PK) から (date, env) PK へ正しく移行する。"""
-    conn = _make_old_schema_conn()
-    assert _get_pk_columns(conn) == ["date"]
-
-    _migrate_portfolio_performance_pk(conn)
-
-    assert _get_pk_columns(conn) == ["date", "env"]
-    row = conn.execute("SELECT date, env, equity FROM portfolio_performance").fetchone()
-    assert row is not None
-    assert row[2] == 5_000_000
-
-
-def test_migrate_pk_idempotent():
-    """既に (date, env) PK のテーブルに対してマイグレーションを2回実行しても壊れない。"""
-    conn = _make_conn(
-        {"date": "2026-04-21", "equity": 5_000_000.0, "env": "live"},
-    )
-    _migrate_portfolio_performance_pk(conn)
-    _migrate_portfolio_performance_pk(conn)
-
-    assert _get_pk_columns(conn) == ["date", "env"]
-    rows = conn.execute("SELECT COUNT(*) FROM portfolio_performance").fetchone()
-    assert rows[0] == 1
 
 
 def test_same_date_different_envs_can_coexist():


### PR DESCRIPTION
## Summary

- `portfolio_performance` の PRIMARY KEY を `(date)` 単独から `(date, env)` 複合キーに変更
- 本番 DB は未初期化のため、マイグレーション関数は不要。DDL 更新のみで対応

## Changes

- `src/kabusys/data/schema.py`: `_PORTFOLIO_PERFORMANCE` DDL を `PRIMARY KEY (date, env)` に更新
- `tests/test_performance_report.py`
  - `_make_conn` ヘルパーおよび CLI テストのスキーマを `PRIMARY KEY (date, env)` に更新
  - 新テスト 3 件追加

## New Tests

| テスト | 内容 |
|---|---|
| `test_init_schema_creates_composite_pk` | `init_schema` が `(date, env)` PK でテーブルを作成する |
| `test_same_date_different_envs_can_coexist` | 同日で `live` / `paper_trading` を共存 INSERT できる |
| `test_collect_daily_rows_env_isolation_mixed_data` | 混在データから `env` で正しく絞り込む |

## Test Plan

- [x] `pytest tests/test_performance_report.py -v` — 28 tests all pass
- [x] `ruff check` + `ruff format --check` — no errors

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)