### PR TITLE
feat: PBR・配当利回り特徴量実装 (Issue #185)

### DIFF
--- a/config/strategy.toml
+++ b/config/strategy.toml
@@ -1,0 +1,13 @@
+# config/strategy.toml
+# バリュースコアの重みと正規化基準値
+# _compute_value_score() が読み込む。変更後は次回シグナル生成から反映される。
+
+[value_score.weights]
+per       = 0.50   # PER の重み
+pbr       = 0.30   # PBR の重み
+div_yield = 0.20   # 配当利回りの重み（合計 1.0）
+
+[value_score.normalization]
+per_mid       = 20.0  # PER がこの値のとき score = 0.5（東証平均水準）
+pbr_mid       = 1.5   # PBR がこの値のとき score = 0.5（東証平均付近）
+div_yield_max = 3.0   # この配当利回り(%)で score = 1.0（上限）

--- a/docs/superpowers/specs/2026-05-03-pbr-div-yield-design.md
+++ b/docs/superpowers/specs/2026-05-03-pbr-div-yield-design.md
@@ -1,0 +1,169 @@
+# PBR・配当利回り特徴量実装 設計書 (Issue #185)
+
+## 概要
+
+`features` テーブルの `pbr` / `div_yield` カラムは定義済みだが値が NULL のまま。
+本実装では J-Quants からのデータ取得パイプライン追加 → `features` への書き込み → `_compute_value_score()` の拡張を行い、バリュースコアを PER・PBR・配当利回りの3指標加重平均に更新する。
+
+## 設計方針
+
+### スコア統合方式
+
+3指標を 0〜1 に正規化して**加重平均**する。重みと正規化基準値はすべて設定ファイルで管理し、コードに埋め込まない。
+
+```toml
+# config/strategy.toml
+[value_score.weights]
+per       = 0.50
+pbr       = 0.30
+div_yield = 0.20
+
+[value_score.normalization]
+per_mid       = 20.0   # PER がこの値のとき score = 0.5
+pbr_mid       = 1.5    # PBR がこの値のとき score = 0.5
+div_yield_max = 3.0    # この配当利回り(%)で score = 1.0（上限）
+```
+
+データ欠損時は有効な指標のみで重み正規化して計算する（全欠損時は `None`）。
+
+### 配当利回りの定義
+
+`div_yield = (直近12ヶ月の div_rate 合計 / close) × 100`
+
+`dividends.ex_date` が `target_date - 1年` 〜 `target_date` の範囲に入るレコードの `div_rate` を合計する。
+
+### PBR の定義
+
+`pbr = close / bps`
+
+`bps`（1株純資産）は J-Quants `/fins/statements` の `BookValuePerShare` フィールドから取得する。
+`raw_financials` テーブルに `bps` カラムを追加して保存する。
+
+## 変更ファイル
+
+### `config/strategy.toml`（新規）
+
+- `[value_score.weights]` — per / pbr / div_yield の重み（合計 1.0）
+- `[value_score.normalization]` — per_mid / pbr_mid / div_yield_max の基準値
+
+### `src/kabusys/data/schema.py`
+
+- `raw_financials` の `CREATE TABLE` 定義に `bps DECIMAL(18,4)` を追加
+- `_migrate_raw_financials_add_bps()` ヘルパーを追加（既存 DB への `ALTER TABLE` 対応）
+- `init_schema()` から migration ヘルパーを呼び出す
+
+### `src/kabusys/data/jquants_client.py`
+
+- `save_financial_statements()` のタプル生成に `_to_float(r.get("BookValuePerShare"))` を追加
+- INSERT 文に `bps` カラムを追加（`ON CONFLICT DO UPDATE` で既存レコードも更新）
+
+### `src/kabusys/data/pipeline.py`
+
+- `run_dividends_etl(conn, target_date, id_token, date_from, backfill_days)` を追加
+  - `/fins/dividend` エンドポイントから差分取得
+  - `dividends` テーブルに冪等 upsert（`ON CONFLICT DO UPDATE SET div_rate=...`）
+  - 実装パターンは既存 `run_financials_etl()` と同一
+- `run_all_etl()` が存在する場合は `run_dividends_etl()` を追加呼び出し
+
+### `src/kabusys/research/factor_research.py`
+
+- `calc_value()` を拡張して `pbr` / `div_yield` を追加計算
+
+```sql
+WITH latest_fin AS (
+    SELECT code, eps, roe, bps
+    FROM (
+        SELECT code, eps, roe, bps,
+               ROW_NUMBER() OVER (PARTITION BY code ORDER BY report_date DESC) AS rn
+        FROM raw_financials WHERE report_date <= ?
+    ) t WHERE rn = 1
+),
+annual_div AS (
+    SELECT code, SUM(div_rate) AS annual_div
+    FROM dividends
+    WHERE ex_date BETWEEN (CAST(? AS DATE) - INTERVAL 1 YEAR) AND ?
+    GROUP BY code
+),
+price_on_date AS (
+    SELECT code, close FROM prices_daily WHERE date = ?
+)
+SELECT
+    ? AS date,
+    p.code,
+    CASE WHEN f.eps  IS NOT NULL AND f.eps  <> 0 THEN p.close / f.eps  END AS per,
+    f.roe,
+    CASE WHEN f.bps  IS NOT NULL AND f.bps  >  0 THEN p.close / f.bps  END AS pbr,
+    CASE WHEN d.annual_div IS NOT NULL AND p.close > 0
+         THEN (d.annual_div / p.close) * 100 END AS div_yield
+FROM price_on_date p
+LEFT JOIN latest_fin f ON p.code = f.code
+LEFT JOIN annual_div d ON p.code = d.code
+ORDER BY p.code
+```
+
+- 戻り値の `list[dict]` に `pbr` / `div_yield` キーを追加
+- `"PBR・配当利回りは現バージョンでは未実装。"` コメントを削除
+
+### `src/kabusys/strategy/signal_generator.py`
+
+- `_load_value_config()` ヘルパーを追加（`config/strategy.toml` を `tomllib` で読み込む）
+  - ファイルが存在しない場合はデフォルト値（per=0.50/pbr=0.30/div_yield=0.20、per_mid=20/pbr_mid=1.5/div_yield_max=3.0）にフォールバック
+- `_compute_value_score(feat, config)` に `config` 引数を追加し、3指標を加重平均するよう拡張
+
+```python
+def _compute_value_score(feat: dict[str, Any], config: dict) -> float | None:
+    w = config["weights"]
+    n = config["normalization"]
+    scores: dict[str, float] = {}
+    per = feat.get("per")
+    if per is not None and per > 0 and math.isfinite(per):
+        scores["per"] = 1.0 / (1.0 + per / n["per_mid"])
+    pbr = feat.get("pbr")
+    if pbr is not None and pbr > 0 and math.isfinite(pbr):
+        scores["pbr"] = 1.0 / (1.0 + pbr / n["pbr_mid"])
+    dy = feat.get("div_yield")
+    if dy is not None and dy > 0 and math.isfinite(dy):
+        scores["div_yield"] = min(dy / n["div_yield_max"], 1.0)
+    if not scores:
+        return None
+    total_w = sum(w[k] for k in scores)
+    return sum(w[k] * v for k, v in scores.items()) / total_w
+```
+
+- `generate_signals()` 内の `_compute_value_score()` 呼び出し箇所に `config` を渡す
+
+### `tests/test_pbr_div_yield.py`（新規）
+
+- `TestBpsExtraction`: `save_financial_statements()` が `BookValuePerShare` を `raw_financials.bps` に保存すること
+- `TestDividendsEtl`: `run_dividends_etl()` が冪等に upsert すること
+- `TestCalcValuePbr`: `pbr = close / bps` が正しく計算されること
+- `TestCalcValueDivYield`: 直近12ヶ月の配当合計から `div_yield` が計算されること
+- `TestCalcValueMissingBps`: `bps = NULL` のとき `pbr = NULL`
+- `TestCalcValueNoDividends`: 配当レコードなしのとき `div_yield = NULL`
+- `TestValueScoreAllThree`: 3指標すべて有効なとき加重平均が正しいこと
+- `TestValueScorePartial`: PBR 欠損時に残り2指標で重み正規化して計算されること
+- `TestValueScoreConfigDriven`: 設定ファイルの基準値変更がスコアに反映されること
+
+### `tests/test_signal_generator.py`（既存）
+
+- `_compute_value_score()` の呼び出し箇所を `config` 引数付きに更新
+
+## パラメータ一覧
+
+| パラメータ | デフォルト | 設定箇所 | 説明 |
+|-----------|-----------|---------|------|
+| `value_score.weights.per` | 0.50 | `config/strategy.toml` | PER の重み |
+| `value_score.weights.pbr` | 0.30 | `config/strategy.toml` | PBR の重み |
+| `value_score.weights.div_yield` | 0.20 | `config/strategy.toml` | 配当利回りの重み |
+| `value_score.normalization.per_mid` | 20.0 | `config/strategy.toml` | PER score=0.5 の基準値 |
+| `value_score.normalization.pbr_mid` | 1.5 | `config/strategy.toml` | PBR score=0.5 の基準値（東証平均付近） |
+| `value_score.normalization.div_yield_max` | 3.0 | `config/strategy.toml` | 配当利回り score=1.0 の上限（%） |
+
+## 設計上の決定事項
+
+1. **加重平均 + 設定ファイル管理**: 将来の戦略方針変更（PER 重視・配当重視など）を `config/strategy.toml` の1行変更で対応可能。
+2. **欠損耐性**: データが揃わない指標は除外し、残りの指標で重み正規化して計算。全欠損時のみ `None`。
+3. **raw_financials 拡張**: BPS を既存の財務データテーブルに追加。新テーブル作成不要。
+4. **スキーママイグレーション**: `init_schema()` 内で `ALTER TABLE IF NOT EXISTS ADD COLUMN` を実行し、既存 DB を安全に更新。
+5. **配当の集計期間**: `dividends.ex_date` ベースで直近12ヶ月を集計。配当落ち日基準が最も一般的かつ正確。
+6. **設定ファイル欠損フォールバック**: `config/strategy.toml` が存在しない環境でもデフォルト値で動作する。

--- a/documents/01_Data/DataPlatform.md
+++ b/documents/01_Data/DataPlatform.md
@@ -121,7 +121,7 @@ J-Quants Bulk API
 | `/equities/master`             | —                 | `stocks`              | 最新日のみ取得             |
 | `/fins/summary`                | `raw_financials`  | `fundamentals`        | 既存スキーマに対応         |
 | `/markets/calendar`            | —                 | `market_calendar`     | 既存スキーマに対応         |
-| `/fins/dividend`               | —                 | `dividends`（新規）   | 戦略で活用可能             |
+| `/fins/dividend`               | —                 | `dividends`           | 配当利回り計算に使用（Issue #185）。差分 ETL は `run_dividends_etl()` |
 | `/indices/bars/daily/topix`    | —                 | `topix_daily`（新規） | regime_detector が参照     |
 
 #### 冪等性・エラー方針

--- a/documents/01_Data/DataSchema.md
+++ b/documents/01_Data/DataSchema.md
@@ -148,12 +148,14 @@ J-Quants から取得した生の財務データ。
   revenue            float     売上
   operating_profit   float     営業利益
   net_income         float     純利益
-  eps                float     EPS
+  eps                float     EPS（1株当たり利益）
   roe                float     ROE
+  bps                float     BPS（1株純資産）※ Issue #185 追加
   fetched_at         timestamp 取込日時
 
 主キー: `(code, report_date, period_type)`
 取得元（差分 API）: J-Quants `/fins/statements`
+  BookValuePerShare→bps（Issue #185 追加）
 取得元（Bulk API）: `/fins/summary`
   DiscDate→report_date, CurPerType→period_type, Sales→revenue, OP→operating_profit
   NP→net_income, EPS→eps, Eq/TA→roe
@@ -180,23 +182,26 @@ J-Quants から取得した生の財務データ。
 
 ------------------------------------------------------------------------
 
-## dividends（新規）
+## dividends
 
-配当情報。Bulk API `/fins/dividend` から取得。
+配当情報。J-Quants `/fins/dividend` から取得。
 
   column       type      description
   ------------ --------- ---------------------------------------
   code         string    銘柄コード
   pub_date     date      公告日（PRIMARY KEY の一部）
   ref_no       string    参照番号（PRIMARY KEY の一部）
-  ex_date      date      権利落ち日
+  ex_date      date      権利落ち日（配当利回り集計の基準日）
   record_date  date      基準日
   pay_date     date      支払日
-  div_rate     float     配当率（円）
+  div_rate     float     1株当たり配当金額（円）
   fetched_at   timestamp 取込日時
 
 主キー: `(code, pub_date, ref_no)`
-取得元: Bulk API `/fins/dividend`
+取得元（初回）: Bulk API `/fins/dividend` CSV（bootstrap）
+取得元（差分）: `/fins/dividend` 差分 API（`run_dividends_etl()`）※ Issue #185 追加
+
+配当利回りの計算: `(直近12ヶ月の div_rate 合計 / close) × 100`（ex_date ベース集計）
 
 ------------------------------------------------------------------------
 

--- a/documents/02_Strategy/StrategyModel.md
+++ b/documents/02_Strategy/StrategyModel.md
@@ -57,6 +57,34 @@ intraday（ザラ場中）の新規シグナル生成は行わない。ザラ場
 ### 3.2 バリュー (Value)
 - **指標**: PER (株価収益率)、PBR (株価純資産倍率)、配当利回り
 - **傾向**: テクニカルな過熱感を抑制し、下値不安の少ない割安銘柄を評価。
+- **データ源**: `raw_financials.eps`（PER）、`raw_financials.bps`（PBR）、`dividends`（配当利回り）
+
+#### スコア計算式
+
+各指標を 0〜1 に正規化し、加重平均する。重みと基準値は `config/strategy.toml` で管理する。
+
+| 指標 | 正規化式 | デフォルト基準値 |
+|------|---------|----------------|
+| PER | `1 / (1 + PER / per_mid)` | `per_mid = 20.0`（東証平均水準） |
+| PBR | `1 / (1 + PBR / pbr_mid)` | `pbr_mid = 1.5`（東証平均付近） |
+| 配当利回り | `min(div_yield / div_yield_max, 1.0)` | `div_yield_max = 3.0`（%） |
+
+```toml
+# config/strategy.toml
+[value_score.weights]
+per       = 0.50
+pbr       = 0.30
+div_yield = 0.20
+
+[value_score.normalization]
+per_mid       = 20.0
+pbr_mid       = 1.5
+div_yield_max = 3.0
+```
+
+データが欠損した指標は除外し、残りの指標で重み正規化して計算する（全欠損時は `None`）。
+
+配当利回りの定義: `(直近12ヶ月の div_rate 合計 / close) × 100`（`dividends.ex_date` ベース）
 
 ### 3.3 ボラティリティ & 流動性 (Volatility / Liquidity)
 - **指標**: 20日ATR（Average True Range）、出来高変化率
@@ -104,8 +132,8 @@ final_score =
 以下のいずれかに抵触した時点で、翌営業日に売却シグナルを発火する。
 1. **ストップロス（絶対防衛ライン）**: 買値から -8% の下落、または 2×ATR 分の下落。最低保有日数・決算回避チェックより優先される（常に即時 SELL）。
 2. **決算前強制 SELL** （Issue #171）: 翌営業日が `earnings_calendar` の決算発表予定日に該当する保有銘柄は `reason=earnings_avoidance` で SELL する。最低保有日数の例外として扱う（5営業日未満でも SELL 許可）。
-3. **トレーリングストップ（利益確保）**: 直近の最高値から -10% の下落。**※未実装**（`positions` テーブルへの `peak_price` カラム追加が必要）。
-4. **時間決済（最大保有期間）**: 保有から 60営業日（約3ヶ月）を経過。60営業日は最大保有上限であり、中期投資の主戦略ではない。**※未実装**（`position_entries.entry_date` から営業日数カウントするロジックが必要）。
+3. **トレーリングストップ（利益確保）** （Issue #182 実装済み）: エントリー日以降の最高値（`peak_close`）から `trailing_stop_atr × ATR_20d` を超えて下落した場合に SELL（`reason=trailing_stop`）。`peak_close > avg_price`（含み益あり）のときのみ発動。`--trailing-stop-atr` CLI 引数で乗数変更可（デフォルト 2.0）。
+4. **時間決済（最大保有期間）** （Issue #183 実装済み）: 保有から 60営業日（約3ヶ月）を経過した場合に SELL（`reason=time_exit`）。`--max-holding-days` CLI 引数で変更可（デフォルト 60）。
 5. **スコア低下**: 日次の計算で `final_score` が上位圏外へ転落。ただし BUY 後 **5営業日** はストップロス・決算回避以外の理由での SELL を抑制する（Issue #174 最低保有日数）。Bear レジームへの移行時はこの制限を解除する。
 
 ---

--- a/src/kabusys/data/jquants_client.py
+++ b/src/kabusys/data/jquants_client.py
@@ -602,11 +602,11 @@ def save_dividends(
     rows = [
         (
             str(r.get("Code", "") or ""),
-            r.get("PubDate"),
+            _to_date_str(r.get("PubDate")),
             str(r.get("RefNo", "") or ""),
-            r.get("ExDate") or None,
-            r.get("RecDate") or None,
-            r.get("PayDate") or None,
+            _to_date_str(r.get("ExDate")),
+            _to_date_str(r.get("RecDate")),
+            _to_date_str(r.get("PayDate")),
             _to_float(r.get("DivRate")),
             fetched_at,
         )
@@ -755,6 +755,19 @@ def fetch_listed_info(
 # ---------------------------------------------------------------------------
 # ユーティリティ
 # ---------------------------------------------------------------------------
+
+
+def _to_date_str(value: Any) -> str | None:
+    """日付文字列を "YYYY-MM-DD" 形式に正規化する。
+
+    J-Quants API は "YYYYMMDD" と "YYYY-MM-DD" の両形式を返すことがある。
+    """
+    if not value:
+        return None
+    s = str(value).strip()
+    if len(s) == 8 and s.isdigit():
+        return f"{s[:4]}-{s[4:6]}-{s[6:]}"
+    return s
 
 
 def _to_float(value: Any) -> float | None:

--- a/src/kabusys/data/jquants_client.py
+++ b/src/kabusys/data/jquants_client.py
@@ -502,6 +502,7 @@ def save_financial_statements(
             _to_float(r.get("Profit")),
             _to_float(r.get("EarningsPerShare")),
             _to_float(r.get("ROE")),
+            _to_float(r.get("BookValuePerShare")),  # 追加
             fetched_at,
         )
         for r in records
@@ -519,14 +520,15 @@ def save_financial_statements(
         """
         INSERT INTO raw_financials
             (code, report_date, period_type, revenue, operating_profit,
-             net_income, eps, roe, fetched_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+             net_income, eps, roe, bps, fetched_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT (code, report_date, period_type) DO UPDATE SET
             revenue          = excluded.revenue,
             operating_profit = excluded.operating_profit,
             net_income       = excluded.net_income,
             eps              = excluded.eps,
             roe              = excluded.roe,
+            bps              = excluded.bps,
             fetched_at       = excluded.fetched_at
         """,
         rows,

--- a/src/kabusys/data/jquants_client.py
+++ b/src/kabusys/data/jquants_client.py
@@ -537,6 +537,104 @@ def save_financial_statements(
     return len(rows)
 
 
+def fetch_dividends(
+    id_token: str | None = None,
+    code: str | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
+) -> list[dict[str, Any]]:
+    """配当データを取得する（ページネーション対応）。
+
+    Args:
+        id_token:  認証トークン。省略時はキャッシュを使用。
+        code:      銘柄コード（省略時は全銘柄）。
+        date_from: 取得開始日。
+        date_to:   取得終了日。
+
+    Returns:
+        配当レコードのリスト。
+    """
+    params: dict[str, str] = {}
+    if code:
+        params["code"] = code
+    if date_from:
+        params["dateFrom"] = date_from.strftime("%Y%m%d")
+    if date_to:
+        params["dateTo"] = date_to.strftime("%Y%m%d")
+
+    result: list[dict[str, Any]] = []
+    seen_keys: set[str] = set()
+    while True:
+        data = _request("/fins/dividend", params=params, id_token=id_token)
+        result.extend(data.get("dividends", []))
+        pagination_key = data.get("pagination_key")
+        if not pagination_key or pagination_key in seen_keys:
+            break
+        seen_keys.add(pagination_key)
+        params["pagination_key"] = pagination_key
+
+    logger.info("fetch_dividends: %d レコード取得", len(result))
+    return result
+
+
+def save_dividends(
+    conn: duckdb.DuckDBPyConnection,
+    records: list[dict[str, Any]],
+) -> int:
+    """配当データを dividends テーブルに保存する（冪等）。
+
+    Args:
+        conn:    DuckDB 接続。
+        records: fetch_dividends() の戻り値。
+                 期待フィールド: Code, PubDate, RefNo, ExDate, RecDate, PayDate, DivRate
+
+    Returns:
+        挿入・更新したレコード数。
+    """
+    if not records:
+        return 0
+
+    fetched_at = (
+        datetime.now(tz=timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
+    rows = [
+        (
+            str(r.get("Code", "") or ""),
+            r.get("PubDate"),
+            str(r.get("RefNo", "") or ""),
+            r.get("ExDate") or None,
+            r.get("RecDate") or None,
+            r.get("PayDate") or None,
+            _to_float(r.get("DivRate")),
+            fetched_at,
+        )
+        for r in records
+        if r.get("Code") and r.get("PubDate") and r.get("RefNo")
+    ]
+    skipped = len(records) - len(rows)
+    if skipped:
+        logger.warning("save_dividends: %d 件を PK 欠損によりスキップ", skipped)
+
+    conn.executemany(
+        """
+        INSERT INTO dividends
+            (code, pub_date, ref_no, ex_date, record_date, pay_date, div_rate, fetched_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT (code, pub_date, ref_no) DO UPDATE SET
+            ex_date     = excluded.ex_date,
+            record_date = excluded.record_date,
+            pay_date    = excluded.pay_date,
+            div_rate    = excluded.div_rate,
+            fetched_at  = excluded.fetched_at
+        """,
+        rows,
+    )
+    logger.info("save_dividends: %d 件を dividends に保存", len(rows))
+    return len(rows)
+
+
 def save_market_calendar(
     conn: duckdb.DuckDBPyConnection,
     records: list[dict[str, Any]],

--- a/src/kabusys/data/pipeline.py
+++ b/src/kabusys/data/pipeline.py
@@ -486,8 +486,9 @@ def run_daily_etl(
       1. 市場カレンダーETL（lookahead_days 先まで取得）
       2. 株価日足ETL（差分更新 + backfill）
       3. 財務データETL（差分更新 + backfill）
-      4. 決算カレンダーETL（翌30日分を先読み取得・冪等保存）
-      5. 品質チェック（オプション）
+      4. 配当データETL（差分更新 + backfill）
+      5. 決算カレンダーETL（翌30日分を先読み取得・冪等保存）
+      6. 品質チェック（オプション）
 
     Args:
         conn:                    DuckDB 接続。
@@ -540,7 +541,7 @@ def run_daily_etl(
         logger.exception("run_financials_etl 失敗")
         result.errors.append("run_financials_etl 失敗")
 
-    # 3b. 配当データETL（Issue #185）
+    # 4. 配当データETL（差分更新 + backfill）
     try:
         fetched, saved = run_dividends_etl(
             conn, trading_day, id_token=id_token, backfill_days=backfill_days
@@ -551,7 +552,7 @@ def run_daily_etl(
         logger.exception("run_dividends_etl 失敗")
         result.errors.append("run_dividends_etl 失敗")
 
-    # 4. 決算カレンダー（翌30日分を先読み取得・冪等保存）
+    # 5. 決算カレンダー（翌30日分を先読み取得・冪等保存）
     try:
         ec_records = jq.fetch_earnings_calendar(
             id_token=id_token,
@@ -565,7 +566,7 @@ def run_daily_etl(
         result.errors.append(f"earnings_calendar: {exc}")
         logger.warning("決算カレンダー取得失敗（ETL継続）: %s", exc)
 
-    # 5. 品質チェック
+    # 6. 品質チェック
     if run_quality_checks:
         try:
             result.quality_issues = quality.run_all_checks(
@@ -582,6 +583,7 @@ def run_daily_etl(
         "run_daily_etl 完了: date=%s "
         "prices fetched=%d saved=%d "
         "financials fetched=%d saved=%d "
+        "dividends fetched=%d saved=%d "
         "calendar fetched=%d saved=%d "
         "earnings_calendar fetched=%d saved=%d "
         "quality_issues=%d errors=%d",
@@ -590,6 +592,8 @@ def run_daily_etl(
         result.prices_saved,
         result.financials_fetched,
         result.financials_saved,
+        result.dividends_fetched,
+        result.dividends_saved,
         result.calendar_fetched,
         result.calendar_saved,
         result.earnings_calendar_fetched,

--- a/src/kabusys/data/pipeline.py
+++ b/src/kabusys/data/pipeline.py
@@ -66,6 +66,8 @@ class ETLResult:
         calendar_saved:              DBに保存したカレンダーレコード数。
         earnings_calendar_fetched:   取得した決算カレンダーレコード数。
         earnings_calendar_saved:     DBに保存を試みた決算カレンダーレコード数。
+        dividends_fetched:           取得した配当レコード数。
+        dividends_saved:             DBに保存した配当レコード数。
         quality_issues:              品質チェックで検出された問題のリスト。
         errors:                      処理中に発生したエラーの概要メッセージのリスト。
     """
@@ -79,6 +81,8 @@ class ETLResult:
     calendar_saved: int = 0
     earnings_calendar_fetched: int = 0
     earnings_calendar_saved: int = 0
+    dividends_fetched: int = 0
+    dividends_saved: int = 0
     quality_issues: list[quality.QualityIssue] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
 
@@ -251,6 +255,18 @@ def get_last_calendar_date(conn: duckdb.DuckDBPyConnection) -> date | None:
     return _get_max_date(conn, "market_calendar", "date")
 
 
+def get_last_dividend_date(conn: duckdb.DuckDBPyConnection) -> date | None:
+    """dividends テーブルの最終取得日（pub_date）を返す。
+
+    Args:
+        conn: DuckDB 接続。
+
+    Returns:
+        最終取得日。テーブル未作成または空の場合は None。
+    """
+    return _get_max_date(conn, "dividends", "pub_date")
+
+
 # ---------------------------------------------------------------------------
 # 個別ETLジョブ
 # ---------------------------------------------------------------------------
@@ -349,6 +365,54 @@ def run_financials_etl(
     )
     saved = jq.save_financial_statements(conn, records)
     logger.info("run_financials_etl: fetched=%d saved=%d", len(records), saved)
+    return len(records), saved
+
+
+def run_dividends_etl(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date,
+    id_token: str | None = None,
+    date_from: date | None = None,
+    backfill_days: int = _DEFAULT_BACKFILL_DAYS,
+) -> tuple[int, int]:
+    """配当データの差分ETLを実行する。
+
+    差分更新: date_from が指定されていない場合、DBの最終取得日から
+    backfill_days 日前を date_from として再取得する。
+
+    Args:
+        conn:          DuckDB 接続。
+        target_date:   取得終了日。
+        id_token:      J-Quants 認証トークン。
+        date_from:     取得開始日。省略時は最終取得日 - backfill_days + 1。
+        backfill_days: 最終取得日の何日前から再取得するか（デフォルト 3 日）。
+
+    Returns:
+        (取得レコード数, 保存レコード数) のタプル。
+    """
+    if date_from is None:
+        last = get_last_dividend_date(conn)
+        if last is not None:
+            date_from = max(_MIN_DATA_DATE, last - timedelta(days=backfill_days - 1))
+        else:
+            date_from = _MIN_DATA_DATE
+
+    if date_from > target_date:
+        logger.info(
+            "run_dividends_etl: すでに最新 date_from=%s target=%s",
+            date_from,
+            target_date,
+        )
+        return 0, 0
+
+    logger.info("run_dividends_etl: date_from=%s date_to=%s", date_from, target_date)
+    records = jq.fetch_dividends(
+        id_token=id_token,
+        date_from=date_from,
+        date_to=target_date,
+    )
+    saved = jq.save_dividends(conn, records)
+    logger.info("run_dividends_etl: fetched=%d saved=%d", len(records), saved)
     return len(records), saved
 
 
@@ -475,6 +539,17 @@ def run_daily_etl(
     except Exception:
         logger.exception("run_financials_etl 失敗")
         result.errors.append("run_financials_etl 失敗")
+
+    # 3b. 配当データETL（Issue #185）
+    try:
+        fetched, saved = run_dividends_etl(
+            conn, trading_day, id_token=id_token, backfill_days=backfill_days
+        )
+        result.dividends_fetched = fetched
+        result.dividends_saved = saved
+    except Exception:
+        logger.exception("run_dividends_etl 失敗")
+        result.errors.append("run_dividends_etl 失敗")
 
     # 4. 決算カレンダー（翌30日分を先読み取得・冪等保存）
     try:

--- a/src/kabusys/data/schema.py
+++ b/src/kabusys/data/schema.py
@@ -50,6 +50,7 @@ CREATE TABLE IF NOT EXISTS raw_financials (
     net_income      DECIMAL(20,4),
     eps             DECIMAL(18,4),
     roe             DECIMAL(10,6),
+    bps             DECIMAL(18,4),
     fetched_at      TIMESTAMP   NOT NULL DEFAULT current_timestamp,
     PRIMARY KEY (code, report_date, period_type)
 )
@@ -390,6 +391,8 @@ _MIGRATIONS: list[str] = [
     "ALTER TABLE raw_prices ADD COLUMN adj_factor DECIMAL(18,6)",
     # v0.x → v0.y: portfolio_performance に env を追加
     "ALTER TABLE portfolio_performance ADD COLUMN env VARCHAR NOT NULL DEFAULT 'live'",
+    # Issue #185: raw_financials に bps を追加
+    "ALTER TABLE raw_financials ADD COLUMN bps DECIMAL(18,4)",
 ]
 
 # ---------------------------------------------------------------------------

--- a/src/kabusys/data/schema.py
+++ b/src/kabusys/data/schema.py
@@ -392,7 +392,7 @@ _MIGRATIONS: list[str] = [
     # v0.x → v0.y: portfolio_performance に env を追加
     "ALTER TABLE portfolio_performance ADD COLUMN env VARCHAR NOT NULL DEFAULT 'live'",
     # Issue #185: raw_financials に bps を追加
-    "ALTER TABLE raw_financials ADD COLUMN bps DECIMAL(18,4)",
+    "ALTER TABLE raw_financials ADD COLUMN IF NOT EXISTS bps DECIMAL(18,4)",
 ]
 
 # ---------------------------------------------------------------------------

--- a/src/kabusys/research/factor_research.py
+++ b/src/kabusys/research/factor_research.py
@@ -260,16 +260,17 @@ def calc_value(
             ) t
             WHERE rn = 1
         ),
-        annual_div AS (
-            SELECT code, SUM(div_rate) AS annual_div
-            FROM dividends
-            WHERE ex_date BETWEEN (CAST(? AS DATE) - INTERVAL 1 YEAR) AND ?
-            GROUP BY code
-        ),
         price_on_date AS (
             SELECT code, close
             FROM prices_daily
             WHERE date = ?
+        ),
+        annual_div AS (
+            SELECT code, SUM(div_rate) AS annual_div
+            FROM dividends
+            WHERE code IN (SELECT code FROM price_on_date)
+              AND ex_date BETWEEN (CAST(? AS DATE) - INTERVAL 1 YEAR) AND ?
+            GROUP BY code
         )
         SELECT
             ? AS date,

--- a/src/kabusys/research/factor_research.py
+++ b/src/kabusys/research/factor_research.py
@@ -233,26 +233,25 @@ def calc_value(
 
     raw_financials テーブルから target_date 以前の最新財務データを取得し、
     prices_daily の株価と組み合わせて以下を計算する。
-      - per : 株価 / EPS（EPS が 0 または欠損の場合は None）
-      - roe : ROE（raw_financials から直接取得）
-
-    Note:
-        PBR・配当利回りは現バージョンでは未実装。
+      - per       : 株価 / EPS（EPS が 0 または欠損の場合は None）
+      - roe       : ROE（raw_financials から直接取得）
+      - pbr       : 株価 / BPS（BPS が 0 または欠損の場合は None）
+      - div_yield : 直近12ヶ月の配当合計 / 株価 × 100（配当なしの場合は None）
 
     Args:
-        conn:        DuckDB 接続。prices_daily / raw_financials テーブルを参照する。
+        conn:        DuckDB 接続。prices_daily / raw_financials / dividends テーブルを参照。
         target_date: 計算基準日。
 
     Returns:
-        [{"date": date, "code": str, "per": float|None, "roe": float|None}, ...] のリスト。
+        [{"date": date, "code": str, "per": float|None, "roe": float|None,
+          "pbr": float|None, "div_yield": float|None}, ...] のリスト。
     """
     rows = conn.execute(
         """
         WITH latest_fin AS (
-            -- target_date 以前の最新財務レコードを銘柄ごとに1件取得（DuckDB 互換: ROW_NUMBER 使用）
-            SELECT code, eps, roe
+            SELECT code, eps, roe, bps
             FROM (
-                SELECT code, eps, roe,
+                SELECT code, eps, roe, bps,
                        ROW_NUMBER() OVER (
                            PARTITION BY code ORDER BY report_date DESC, fetched_at DESC
                        ) AS rn
@@ -260,6 +259,12 @@ def calc_value(
                 WHERE report_date <= ?
             ) t
             WHERE rn = 1
+        ),
+        annual_div AS (
+            SELECT code, SUM(div_rate) AS annual_div
+            FROM dividends
+            WHERE ex_date BETWEEN (CAST(? AS DATE) - INTERVAL 1 YEAR) AND ?
+            GROUP BY code
         ),
         price_on_date AS (
             SELECT code, close
@@ -271,15 +276,20 @@ def calc_value(
             p.code,
             CASE WHEN f.eps IS NOT NULL AND f.eps <> 0
                  THEN p.close / f.eps END AS per,
-            f.roe
+            f.roe,
+            CASE WHEN f.bps IS NOT NULL AND f.bps > 0
+                 THEN p.close / f.bps END AS pbr,
+            CASE WHEN d.annual_div IS NOT NULL AND p.close > 0
+                 THEN (d.annual_div / p.close) * 100 END AS div_yield
         FROM price_on_date p
         LEFT JOIN latest_fin f ON p.code = f.code
+        LEFT JOIN annual_div d ON p.code = d.code
         ORDER BY p.code
         """,
-        [target_date, target_date, target_date],
+        [target_date, target_date, target_date, target_date, target_date],
     ).fetchall()
 
-    cols = ["date", "code", "per", "roe"]
+    cols = ["date", "code", "per", "roe", "pbr", "div_yield"]
     result = [dict(zip(cols, r)) for r in rows]
     logger.debug("calc_value: %d 銘柄 date=%s", len(result), target_date)
     return result

--- a/src/kabusys/strategy/feature_engineering.py
+++ b/src/kabusys/strategy/feature_engineering.py
@@ -144,7 +144,7 @@ def build_features(
                 "atr_pct": v.get("atr_pct"),
                 "volume_ratio": v.get("volume_ratio"),
                 "per": f.get("per"),
-                "pbr": f.get("pbr"),          # 追加
+                "pbr": f.get("pbr"),  # 追加
                 "div_yield": f.get("div_yield"),  # 追加
             }
         )
@@ -174,8 +174,8 @@ def build_features(
             r.get("atr_pct"),
             r.get("volume_ratio"),
             r.get("per"),
-            r.get("pbr"),          # 追加
-            r.get("div_yield"),    # 追加
+            r.get("pbr"),  # 追加
+            r.get("div_yield"),  # 追加
             r.get("ma200_dev"),
         )
         for r in normalized

--- a/src/kabusys/strategy/feature_engineering.py
+++ b/src/kabusys/strategy/feature_engineering.py
@@ -144,6 +144,8 @@ def build_features(
                 "atr_pct": v.get("atr_pct"),
                 "volume_ratio": v.get("volume_ratio"),
                 "per": f.get("per"),
+                "pbr": f.get("pbr"),          # 追加
+                "div_yield": f.get("div_yield"),  # 追加
             }
         )
 
@@ -172,6 +174,8 @@ def build_features(
             r.get("atr_pct"),
             r.get("volume_ratio"),
             r.get("per"),
+            r.get("pbr"),          # 追加
+            r.get("div_yield"),    # 追加
             r.get("ma200_dev"),
         )
         for r in normalized
@@ -184,8 +188,8 @@ def build_features(
                 """
                 INSERT INTO features
                     (date, code, momentum_20, momentum_60, volatility_20, volume_ratio,
-                     per, ma200_dev, created_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, current_timestamp)
+                     per, pbr, div_yield, ma200_dev, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, current_timestamp)
                 """,
                 params,
             )

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -135,15 +135,23 @@ def _load_value_config() -> dict:
     w = {**_VALUE_CONFIG_DEFAULTS["weights"], **(raw.get("weights") or {})}
     n = {**_VALUE_CONFIG_DEFAULTS["normalization"], **(raw.get("normalization") or {})}
 
-    if sum(w.values()) <= 0:
-        logger.warning("value_score.weights の合計が 0 以下。デフォルトを使用")
-        return _VALUE_CONFIG_DEFAULTS
+    if any(v < 0 for v in w.values()) or sum(w.values()) <= 0:
+        logger.warning(
+            "value_score.weights が不正（負値または合計<=0）。デフォルトを使用"
+        )
+        return {
+            "weights": dict(_VALUE_CONFIG_DEFAULTS["weights"]),
+            "normalization": dict(_VALUE_CONFIG_DEFAULTS["normalization"]),
+        }
 
     if any(n.get(k, 0) <= 0 for k in ("per_mid", "pbr_mid", "div_yield_max")):
         logger.warning("value_score.normalization に 0 以下の値。デフォルトを使用")
-        return _VALUE_CONFIG_DEFAULTS
+        return {
+            "weights": dict(_VALUE_CONFIG_DEFAULTS["weights"]),
+            "normalization": dict(_VALUE_CONFIG_DEFAULTS["normalization"]),
+        }
 
-    return {"weights": w, "normalization": n}
+    return {"weights": dict(w), "normalization": dict(n)}
 
 
 def _compute_value_score(feat: dict[str, Any], config: dict) -> float | None:

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -26,7 +26,9 @@ from __future__ import annotations
 
 import logging
 import math
+import tomllib
 from datetime import date
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import duckdb
@@ -114,10 +116,7 @@ def _load_value_config() -> dict:
     Returns:
         {"weights": {...}, "normalization": {...}} 形式の辞書。
     """
-    import tomllib
-    from pathlib import Path
-
-    config_path = Path("config/strategy.toml")
+    config_path = Path(__file__).resolve().parents[3] / "config" / "strategy.toml"
     if config_path.exists():
         with open(config_path, "rb") as f:
             return tomllib.load(f)["value_score"]
@@ -682,7 +681,7 @@ def generate_signals(
             placeholders = ", ".join(["?" for _ in _scope_codes])
             feat_rows = conn.execute(
                 f"""
-                SELECT code, momentum_20, momentum_60, volatility_20, volume_ratio, per, ma200_dev
+                SELECT code, momentum_20, momentum_60, volatility_20, volume_ratio, per, pbr, div_yield, ma200_dev
                 FROM features
                 WHERE date = ? AND code IN ({placeholders})
                 """,
@@ -694,7 +693,7 @@ def generate_signals(
     else:
         feat_rows = conn.execute(
             """
-            SELECT code, momentum_20, momentum_60, volatility_20, volume_ratio, per, ma200_dev
+            SELECT code, momentum_20, momentum_60, volatility_20, volume_ratio, per, pbr, div_yield, ma200_dev
             FROM features
             WHERE date = ?
             """,
@@ -707,6 +706,8 @@ def generate_signals(
         "volatility_20",
         "volume_ratio",
         "per",
+        "pbr",
+        "div_yield",
         "ma200_dev",
     ]
     features = [dict(zip(feat_cols, r)) for r in feat_rows]

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -106,15 +106,54 @@ def _compute_momentum_score(feat: dict[str, Any]) -> float | None:
     )
 
 
-def _compute_value_score(feat: dict[str, Any]) -> float | None:
-    """バリュースコア（PER が低いほど高スコア）。
+def _load_value_config() -> dict:
+    """config/strategy.toml からバリュースコア設定を読み込む。
 
-    PER = 20 で 0.5、PER → 0 で 1.0、PER → ∞ で 0.0 に近似。
+    ファイルが存在しない場合はデフォルト値を返す（設定ファイル任意）。
+
+    Returns:
+        {"weights": {...}, "normalization": {...}} 形式の辞書。
     """
+    import tomllib
+    from pathlib import Path
+
+    config_path = Path("config/strategy.toml")
+    if config_path.exists():
+        with open(config_path, "rb") as f:
+            return tomllib.load(f)["value_score"]
+    return {
+        "weights": {"per": 0.50, "pbr": 0.30, "div_yield": 0.20},
+        "normalization": {"per_mid": 20.0, "pbr_mid": 1.5, "div_yield_max": 3.0},
+    }
+
+
+def _compute_value_score(feat: dict[str, Any], config: dict) -> float | None:
+    """バリュースコア（PER・PBR・配当利回りの加重平均）。
+
+    各指標を 0〜1 に正規化し、config["weights"] で加重平均する。
+    欠損指標は除外して残りの有効指標で重み正規化する（全欠損時は None）。
+    重みと正規化基準値は config/strategy.toml で管理する。
+    """
+    w = config["weights"]
+    n = config["normalization"]
+    scores: dict[str, float] = {}
+
     per = feat.get("per")
-    if per is None or per <= 0 or not math.isfinite(per):
+    if per is not None and per > 0 and math.isfinite(per):
+        scores["per"] = 1.0 / (1.0 + per / n["per_mid"])
+
+    pbr = feat.get("pbr")
+    if pbr is not None and pbr > 0 and math.isfinite(pbr):
+        scores["pbr"] = 1.0 / (1.0 + pbr / n["pbr_mid"])
+
+    dy = feat.get("div_yield")
+    if dy is not None and dy > 0 and math.isfinite(dy):
+        scores["div_yield"] = min(dy / n["div_yield_max"], 1.0)
+
+    if not scores:
         return None
-    return 1.0 / (1.0 + per / 20.0)
+    total_w = sum(w[k] for k in scores)
+    return sum(w[k] * v for k, v in scores.items()) / total_w
 
 
 def _compute_volatility_score(feat: dict[str, Any]) -> float | None:
@@ -712,11 +751,13 @@ def generate_signals(
         )
 
     # 4. 各銘柄の final_score 計算（Section 4.1）
+    # バリュースコア設定を読み込む（ループ外で1回のみ）
+    value_config = _load_value_config()
     scored: list[dict[str, Any]] = []
     for feat in features:
         code = feat["code"]
         s_mom = _compute_momentum_score(feat)
-        s_val = _compute_value_score(feat)
+        s_val = _compute_value_score(feat, value_config)
         s_vol = _compute_volatility_score(feat)
         s_liq = _compute_liquidity_score(feat)
 

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -108,22 +108,42 @@ def _compute_momentum_score(feat: dict[str, Any]) -> float | None:
     )
 
 
+_VALUE_CONFIG_DEFAULTS: dict = {
+    "weights": {"per": 0.50, "pbr": 0.30, "div_yield": 0.20},
+    "normalization": {"per_mid": 20.0, "pbr_mid": 1.5, "div_yield_max": 3.0},
+}
+
+
 def _load_value_config() -> dict:
     """config/strategy.toml からバリュースコア設定を読み込む。
 
-    ファイルが存在しない場合はデフォルト値を返す（設定ファイル任意）。
+    ファイルが存在しない・読み込み失敗・不正値の場合はデフォルト値にフォールバック。
+    存在するキーのみファイル値でマージし、欠損キーはデフォルトで補完する。
 
     Returns:
         {"weights": {...}, "normalization": {...}} 形式の辞書。
     """
     config_path = Path(__file__).resolve().parents[3] / "config" / "strategy.toml"
+    raw: dict = {}
     if config_path.exists():
-        with open(config_path, "rb") as f:
-            return tomllib.load(f)["value_score"]
-    return {
-        "weights": {"per": 0.50, "pbr": 0.30, "div_yield": 0.20},
-        "normalization": {"per_mid": 20.0, "pbr_mid": 1.5, "div_yield_max": 3.0},
-    }
+        try:
+            with open(config_path, "rb") as f:
+                raw = tomllib.load(f).get("value_score", {})
+        except Exception as exc:
+            logger.warning("strategy.toml 読み込み失敗: %s (デフォルトを使用)", exc)
+
+    w = {**_VALUE_CONFIG_DEFAULTS["weights"], **(raw.get("weights") or {})}
+    n = {**_VALUE_CONFIG_DEFAULTS["normalization"], **(raw.get("normalization") or {})}
+
+    if sum(w.values()) <= 0:
+        logger.warning("value_score.weights の合計が 0 以下。デフォルトを使用")
+        return _VALUE_CONFIG_DEFAULTS
+
+    if any(n.get(k, 0) <= 0 for k in ("per_mid", "pbr_mid", "div_yield_max")):
+        logger.warning("value_score.normalization に 0 以下の値。デフォルトを使用")
+        return _VALUE_CONFIG_DEFAULTS
+
+    return {"weights": w, "normalization": n}
 
 
 def _compute_value_score(feat: dict[str, Any], config: dict) -> float | None:
@@ -152,6 +172,8 @@ def _compute_value_score(feat: dict[str, Any], config: dict) -> float | None:
     if not scores:
         return None
     total_w = sum(w[k] for k in scores)
+    if total_w <= 0:
+        return None
     return sum(w[k] * v for k, v in scores.items()) / total_w
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ MINIMAL_DDL = [
         net_income      DECIMAL(20,4),
         eps             DECIMAL(18,4),
         roe             DECIMAL(10,6),
+        bps             DECIMAL(18,4),
         fetched_at      TIMESTAMP     NOT NULL DEFAULT current_timestamp,
         PRIMARY KEY (code, report_date, period_type)
     )""",

--- a/tests/test_factor_research.py
+++ b/tests/test_factor_research.py
@@ -55,18 +55,21 @@ def _insert_prices(conn, rows: list[tuple]):
 
 
 def _insert_financials(conn, rows: list[tuple]):
-    """(code, report_date, period_type, revenue, operating_profit, net_income, eps, roe)
-    を raw_financials に挿入。"""
-    conn.executemany(
-        """
-        INSERT INTO raw_financials
-            (code, report_date, period_type, revenue, operating_profit,
-             net_income, eps, roe, fetched_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, current_timestamp)
-        ON CONFLICT DO NOTHING
-        """,
-        rows,
-    )
+    """(code, report_date, period_type, revenue, operating_profit, net_income, eps, roe[, bps])
+    を raw_financials に挿入。bps は省略可能（省略時 NULL）。"""
+    for row in rows:
+        if len(row) == 8:
+            row = row + (None,)  # bps = NULL
+        conn.execute(
+            """
+            INSERT INTO raw_financials
+                (code, report_date, period_type, revenue, operating_profit,
+                 net_income, eps, roe, bps, fetched_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, current_timestamp)
+            ON CONFLICT DO NOTHING
+            """,
+            row,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pbr_div_yield.py
+++ b/tests/test_pbr_div_yield.py
@@ -189,7 +189,9 @@ class TestDividendsEtl:
         jq.save_dividends(conn, [record])
         record["DivRate"] = "60.0"  # 値を更新
         jq.save_dividends(conn, [record])
-        rows = conn.execute("SELECT div_rate FROM dividends WHERE code = '72030'").fetchall()
+        rows = conn.execute(
+            "SELECT div_rate FROM dividends WHERE code = '72030'"
+        ).fetchall()
         assert len(rows) == 1
         assert abs(float(rows[0][0]) - 60.0) < 0.01  # 更新後の値
         conn.close()
@@ -259,8 +261,12 @@ class TestCalcValuePbr:
         """PBR = close / bps が正しく計算されること。"""
         conn = init_schema(":memory:")
         d = date(2024, 5, 1)
-        _insert_prices(conn, [(d, "8001", 1500.0, 1510.0, 1490.0, 1500.0, 1000, 1500000.0)])
-        _insert_financials_with_bps(conn, [("8001", date(2024, 3, 31), "Q4", 100.0, 0.10, 1000.0)])
+        _insert_prices(
+            conn, [(d, "8001", 1500.0, 1510.0, 1490.0, 1500.0, 1000, 1500000.0)]
+        )
+        _insert_financials_with_bps(
+            conn, [("8001", date(2024, 3, 31), "Q4", 100.0, 0.10, 1000.0)]
+        )
         result = calc_value(conn, d)
         row = next(r for r in result if r["code"] == "8001")
         assert row["pbr"] is not None
@@ -271,8 +277,12 @@ class TestCalcValuePbr:
         """BPS が 0 の場合 pbr は None。"""
         conn = init_schema(":memory:")
         d = date(2024, 5, 2)
-        _insert_prices(conn, [(d, "8002", 1000.0, 1010.0, 990.0, 1000.0, 1000, 1000000.0)])
-        _insert_financials_with_bps(conn, [("8002", date(2024, 3, 31), "Q4", 50.0, 0.05, 0.0)])
+        _insert_prices(
+            conn, [(d, "8002", 1000.0, 1010.0, 990.0, 1000.0, 1000, 1000000.0)]
+        )
+        _insert_financials_with_bps(
+            conn, [("8002", date(2024, 3, 31), "Q4", 50.0, 0.05, 0.0)]
+        )
         result = calc_value(conn, d)
         row = next(r for r in result if r["code"] == "8002")
         assert row["pbr"] is None
@@ -284,12 +294,33 @@ class TestCalcValueDivYield:
         """直近12ヶ月の配当合計 / close × 100 が div_yield になること。"""
         conn = init_schema(":memory:")
         d = date(2024, 5, 1)
-        _insert_prices(conn, [(d, "9001", 2000.0, 2010.0, 1990.0, 2000.0, 1000, 2000000.0)])
+        _insert_prices(
+            conn, [(d, "9001", 2000.0, 2010.0, 1990.0, 2000.0, 1000, 2000000.0)]
+        )
         # 直近12ヶ月に2回配当（合計60円）
-        _insert_dividends(conn, [
-            ("9001", "2023-09-01", "001", "2023-09-27", "2023-09-30", "2023-12-01", 30.0),
-            ("9001", "2024-03-01", "002", "2024-03-27", "2024-03-31", "2024-06-01", 30.0),
-        ])
+        _insert_dividends(
+            conn,
+            [
+                (
+                    "9001",
+                    "2023-09-01",
+                    "001",
+                    "2023-09-27",
+                    "2023-09-30",
+                    "2023-12-01",
+                    30.0,
+                ),
+                (
+                    "9001",
+                    "2024-03-01",
+                    "002",
+                    "2024-03-27",
+                    "2024-03-31",
+                    "2024-06-01",
+                    30.0,
+                ),
+            ],
+        )
         result = calc_value(conn, d)
         row = next(r for r in result if r["code"] == "9001")
         assert row["div_yield"] is not None
@@ -300,7 +331,9 @@ class TestCalcValueDivYield:
         """配当レコードがない場合 div_yield は None。"""
         conn = init_schema(":memory:")
         d = date(2024, 5, 3)
-        _insert_prices(conn, [(d, "9002", 1000.0, 1010.0, 990.0, 1000.0, 1000, 1000000.0)])
+        _insert_prices(
+            conn, [(d, "9002", 1000.0, 1010.0, 990.0, 1000.0, 1000, 1000000.0)]
+        )
         result = calc_value(conn, d)
         row = next((r for r in result if r["code"] == "9002"), None)
         assert row is not None
@@ -311,16 +344,39 @@ class TestCalcValueDivYield:
         """13ヶ月前の配当は集計対象外になること。"""
         conn = init_schema(":memory:")
         d = date(2024, 5, 1)
-        _insert_prices(conn, [(d, "9003", 1000.0, 1010.0, 990.0, 1000.0, 1000, 1000000.0)])
+        _insert_prices(
+            conn, [(d, "9003", 1000.0, 1010.0, 990.0, 1000.0, 1000, 1000000.0)]
+        )
         # 13ヶ月前の配当（対象外）と直近12ヶ月内（対象）
-        _insert_dividends(conn, [
-            ("9003", "2023-01-01", "001", "2023-03-27", "2023-03-31", "2023-06-01", 100.0),  # 対象外
-            ("9003", "2024-03-01", "002", "2024-03-27", "2024-03-31", "2024-06-01", 20.0),   # 対象
-        ])
+        _insert_dividends(
+            conn,
+            [
+                (
+                    "9003",
+                    "2023-01-01",
+                    "001",
+                    "2023-03-27",
+                    "2023-03-31",
+                    "2023-06-01",
+                    100.0,
+                ),  # 対象外
+                (
+                    "9003",
+                    "2024-03-01",
+                    "002",
+                    "2024-03-27",
+                    "2024-03-31",
+                    "2024-06-01",
+                    20.0,
+                ),  # 対象
+            ],
+        )
         result = calc_value(conn, d)
         row = next(r for r in result if r["code"] == "9003")
         assert row["div_yield"] is not None
-        assert abs(row["div_yield"] - 2.0) < 0.01  # 20 / 1000 * 100 = 2.0%（100円は除外）
+        assert (
+            abs(row["div_yield"] - 2.0) < 0.01
+        )  # 20 / 1000 * 100 = 2.0%（100円は除外）
         conn.close()
 
 
@@ -392,7 +448,10 @@ class TestValueScorePartial:
         """3指標すべて欠損のとき None を返すこと。"""
         cfg = _default_config()
         assert _compute_value_score({}, cfg) is None
-        assert _compute_value_score({"per": None, "pbr": None, "div_yield": None}, cfg) is None
+        assert (
+            _compute_value_score({"per": None, "pbr": None, "div_yield": None}, cfg)
+            is None
+        )
 
 
 class TestValueScoreConfigDriven:

--- a/tests/test_pbr_div_yield.py
+++ b/tests/test_pbr_div_yield.py
@@ -1,11 +1,16 @@
 # tests/test_pbr_div_yield.py
 import tomllib
+from datetime import date
 from pathlib import Path
+from unittest.mock import patch
 
 import duckdb
-import pytest
 
+from kabusys.data import jquants_client as jq
+from kabusys.data.pipeline import run_dividends_etl
 from kabusys.data.schema import init_schema
+from kabusys.research.factor_research import calc_value
+from kabusys.strategy.signal_generator import _compute_value_score, _load_value_config
 
 
 # ---------------------------------------------------------------------------
@@ -77,8 +82,6 @@ class TestSchema:
 # Task 2: BPS 抽出
 # ---------------------------------------------------------------------------
 
-from kabusys.data import jquants_client as jq
-
 
 class TestBpsExtraction:
     def test_save_financial_statements_stores_bps(self):
@@ -131,10 +134,6 @@ class TestBpsExtraction:
 # ---------------------------------------------------------------------------
 # Task 3: 配当 ETL
 # ---------------------------------------------------------------------------
-
-from unittest.mock import patch
-
-from kabusys.data.pipeline import run_dividends_etl
 
 
 def _insert_dividends(conn, rows: list[tuple]) -> None:
@@ -197,7 +196,6 @@ class TestDividendsEtl:
 
     def test_run_dividends_etl_calls_fetch_and_save(self):
         """run_dividends_etl が fetch_dividends / save_dividends を呼び出すこと。"""
-        from datetime import date
         conn = init_schema(":memory:")
         fake_records = [
             {
@@ -229,10 +227,6 @@ class TestDividendsEtl:
 # ---------------------------------------------------------------------------
 # Task 4: 特徴量計算
 # ---------------------------------------------------------------------------
-
-from datetime import date, timedelta
-
-from kabusys.research.factor_research import calc_value
 
 
 def _insert_prices(conn, rows: list[tuple]) -> None:
@@ -333,8 +327,6 @@ class TestCalcValueDivYield:
 # ---------------------------------------------------------------------------
 # Task 5: バリュースコア
 # ---------------------------------------------------------------------------
-
-from kabusys.strategy.signal_generator import _compute_value_score, _load_value_config
 
 
 def _default_config() -> dict:

--- a/tests/test_pbr_div_yield.py
+++ b/tests/test_pbr_div_yield.py
@@ -224,3 +224,107 @@ class TestDividendsEtl:
         assert fetched == 1
         assert saved == 1
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Task 4: 特徴量計算
+# ---------------------------------------------------------------------------
+
+from datetime import date, timedelta
+
+from kabusys.research.factor_research import calc_value
+
+
+def _insert_prices(conn, rows: list[tuple]) -> None:
+    """(date, code, open, high, low, close, volume, turnover) を prices_daily に挿入。"""
+    conn.executemany(
+        """
+        INSERT INTO prices_daily (date, code, open, high, low, close, volume, turnover)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT DO NOTHING
+        """,
+        rows,
+    )
+
+
+def _insert_financials_with_bps(conn, rows: list[tuple]) -> None:
+    """(code, report_date, period_type, eps, roe, bps) を raw_financials に挿入。"""
+    conn.executemany(
+        """
+        INSERT INTO raw_financials
+            (code, report_date, period_type, eps, roe, bps, fetched_at)
+        VALUES (?, ?, ?, ?, ?, ?, current_timestamp)
+        ON CONFLICT DO NOTHING
+        """,
+        rows,
+    )
+
+
+class TestCalcValuePbr:
+    def test_pbr_calculation(self):
+        """PBR = close / bps が正しく計算されること。"""
+        conn = init_schema(":memory:")
+        d = date(2024, 5, 1)
+        _insert_prices(conn, [(d, "8001", 1500.0, 1510.0, 1490.0, 1500.0, 1000, 1500000.0)])
+        _insert_financials_with_bps(conn, [("8001", date(2024, 3, 31), "Q4", 100.0, 0.10, 1000.0)])
+        result = calc_value(conn, d)
+        row = next(r for r in result if r["code"] == "8001")
+        assert row["pbr"] is not None
+        assert abs(row["pbr"] - 1.5) < 0.01  # 1500 / 1000 = 1.5
+        conn.close()
+
+    def test_pbr_none_when_bps_zero(self):
+        """BPS が 0 の場合 pbr は None。"""
+        conn = init_schema(":memory:")
+        d = date(2024, 5, 2)
+        _insert_prices(conn, [(d, "8002", 1000.0, 1010.0, 990.0, 1000.0, 1000, 1000000.0)])
+        _insert_financials_with_bps(conn, [("8002", date(2024, 3, 31), "Q4", 50.0, 0.05, 0.0)])
+        result = calc_value(conn, d)
+        row = next(r for r in result if r["code"] == "8002")
+        assert row["pbr"] is None
+        conn.close()
+
+
+class TestCalcValueDivYield:
+    def test_div_yield_calculation(self):
+        """直近12ヶ月の配当合計 / close × 100 が div_yield になること。"""
+        conn = init_schema(":memory:")
+        d = date(2024, 5, 1)
+        _insert_prices(conn, [(d, "9001", 2000.0, 2010.0, 1990.0, 2000.0, 1000, 2000000.0)])
+        # 直近12ヶ月に2回配当（合計60円）
+        _insert_dividends(conn, [
+            ("9001", "2023-09-01", "001", "2023-09-27", "2023-09-30", "2023-12-01", 30.0),
+            ("9001", "2024-03-01", "002", "2024-03-27", "2024-03-31", "2024-06-01", 30.0),
+        ])
+        result = calc_value(conn, d)
+        row = next(r for r in result if r["code"] == "9001")
+        assert row["div_yield"] is not None
+        assert abs(row["div_yield"] - 3.0) < 0.01  # (30+30) / 2000 * 100 = 3.0%
+        conn.close()
+
+    def test_div_yield_none_when_no_dividends(self):
+        """配当レコードがない場合 div_yield は None。"""
+        conn = init_schema(":memory:")
+        d = date(2024, 5, 3)
+        _insert_prices(conn, [(d, "9002", 1000.0, 1010.0, 990.0, 1000.0, 1000, 1000000.0)])
+        result = calc_value(conn, d)
+        row = next((r for r in result if r["code"] == "9002"), None)
+        assert row is not None
+        assert row["div_yield"] is None
+        conn.close()
+
+    def test_div_yield_excludes_old_dividends(self):
+        """13ヶ月前の配当は集計対象外になること。"""
+        conn = init_schema(":memory:")
+        d = date(2024, 5, 1)
+        _insert_prices(conn, [(d, "9003", 1000.0, 1010.0, 990.0, 1000.0, 1000, 1000000.0)])
+        # 13ヶ月前の配当（対象外）と直近12ヶ月内（対象）
+        _insert_dividends(conn, [
+            ("9003", "2023-01-01", "001", "2023-03-27", "2023-03-31", "2023-06-01", 100.0),  # 対象外
+            ("9003", "2024-03-01", "002", "2024-03-27", "2024-03-31", "2024-06-01", 20.0),   # 対象
+        ])
+        result = calc_value(conn, d)
+        row = next(r for r in result if r["code"] == "9003")
+        assert row["div_yield"] is not None
+        assert abs(row["div_yield"] - 2.0) < 0.01  # 20 / 1000 * 100 = 2.0%（100円は除外）
+        conn.close()

--- a/tests/test_pbr_div_yield.py
+++ b/tests/test_pbr_div_yield.py
@@ -216,7 +216,11 @@ class TestDividendsEtl:
             fetched, saved = run_dividends_etl(
                 conn, target_date=date(2024, 4, 1), id_token="dummy"
             )
-        mock_fetch.assert_called_once()
+        mock_fetch.assert_called_once_with(
+            id_token="dummy",
+            date_from=date(2017, 1, 1),  # _MIN_DATA_DATE (empty DB, no prior dividends)
+            date_to=date(2024, 4, 1),
+        )
         assert fetched == 1
         assert saved == 1
         conn.close()

--- a/tests/test_pbr_div_yield.py
+++ b/tests/test_pbr_div_yield.py
@@ -1,0 +1,73 @@
+# tests/test_pbr_div_yield.py
+import tomllib
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from kabusys.data.schema import init_schema
+
+
+# ---------------------------------------------------------------------------
+# Task 1: スキーマ・設定ファイル
+# ---------------------------------------------------------------------------
+
+
+class TestSchema:
+    def test_raw_financials_has_bps_column(self):
+        """init_schema 後に raw_financials に bps カラムが存在すること。"""
+        conn = init_schema(":memory:")
+        cols = {
+            row[0]
+            for row in conn.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'raw_financials'"
+            ).fetchall()
+        }
+        assert "bps" in cols, f"bps カラムが存在しない。現在のカラム: {cols}"
+        conn.close()
+
+    def test_migration_adds_bps_to_existing_db(self, tmp_path):
+        """bps カラムがない既存 DB に init_schema を実行すると bps が追加されること。"""
+        db_path = tmp_path / "test.db"
+        # bps なしで DB を作成
+        conn = duckdb.connect(str(db_path))
+        conn.execute(
+            """
+            CREATE TABLE raw_financials (
+                code VARCHAR NOT NULL,
+                report_date DATE NOT NULL,
+                period_type VARCHAR NOT NULL,
+                eps DECIMAL(18,4),
+                roe DECIMAL(10,6),
+                fetched_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+                PRIMARY KEY (code, report_date, period_type)
+            )
+            """
+        )
+        conn.close()
+        # init_schema でマイグレーション実行
+        conn2 = init_schema(db_path)
+        cols = {
+            row[0]
+            for row in conn2.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'raw_financials'"
+            ).fetchall()
+        }
+        assert "bps" in cols
+        conn2.close()
+
+    def test_strategy_toml_loads_and_has_required_keys(self):
+        """config/strategy.toml が存在し、必要なキーを持つこと。"""
+        toml_path = Path("config/strategy.toml")
+        assert toml_path.exists(), "config/strategy.toml が存在しない"
+        with open(toml_path, "rb") as f:
+            cfg = tomllib.load(f)
+        w = cfg["value_score"]["weights"]
+        n = cfg["value_score"]["normalization"]
+        assert set(w.keys()) == {"per", "pbr", "div_yield"}
+        assert abs(sum(w.values()) - 1.0) < 1e-9, "重みの合計が 1.0 でない"
+        assert "per_mid" in n
+        assert "pbr_mid" in n
+        assert "div_yield_max" in n

--- a/tests/test_pbr_div_yield.py
+++ b/tests/test_pbr_div_yield.py
@@ -60,7 +60,7 @@ class TestSchema:
 
     def test_strategy_toml_loads_and_has_required_keys(self):
         """config/strategy.toml が存在し、必要なキーを持つこと。"""
-        toml_path = Path("config/strategy.toml")
+        toml_path = Path(__file__).resolve().parents[1] / "config" / "strategy.toml"
         assert toml_path.exists(), "config/strategy.toml が存在しない"
         with open(toml_path, "rb") as f:
             cfg = tomllib.load(f)

--- a/tests/test_pbr_div_yield.py
+++ b/tests/test_pbr_div_yield.py
@@ -328,3 +328,100 @@ class TestCalcValueDivYield:
         assert row["div_yield"] is not None
         assert abs(row["div_yield"] - 2.0) < 0.01  # 20 / 1000 * 100 = 2.0%（100円は除外）
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Task 5: バリュースコア
+# ---------------------------------------------------------------------------
+
+from kabusys.strategy.signal_generator import _compute_value_score, _load_value_config
+
+
+def _default_config() -> dict:
+    """テスト用デフォルト設定を返す。"""
+    return {
+        "weights": {"per": 0.50, "pbr": 0.30, "div_yield": 0.20},
+        "normalization": {"per_mid": 20.0, "pbr_mid": 1.5, "div_yield_max": 3.0},
+    }
+
+
+class TestValueScoreAllThree:
+    def test_all_three_indicators(self):
+        """3指標すべて有効なとき加重平均が正しいこと。"""
+        cfg = _default_config()
+        feat = {"per": 20.0, "pbr": 1.5, "div_yield": 3.0}
+        score = _compute_value_score(feat, cfg)
+        # per=20 → 0.5, pbr=1.5 → 0.5, div_yield=3.0 → 1.0
+        # 0.50*0.5 + 0.30*0.5 + 0.20*1.0 = 0.25 + 0.15 + 0.20 = 0.60
+        assert score is not None
+        assert abs(score - 0.60) < 1e-9
+
+    def test_low_per_high_score(self):
+        """PER が低いほどスコアが高いこと。"""
+        cfg = _default_config()
+        score_low = _compute_value_score({"per": 10.0}, cfg)
+        score_high = _compute_value_score({"per": 40.0}, cfg)
+        assert score_low is not None and score_high is not None
+        assert score_low > score_high
+
+    def test_low_pbr_high_score(self):
+        """PBR が低いほどスコアが高いこと。"""
+        cfg = _default_config()
+        score_low = _compute_value_score({"pbr": 0.5}, cfg)
+        score_high = _compute_value_score({"pbr": 3.0}, cfg)
+        assert score_low is not None and score_high is not None
+        assert score_low > score_high
+
+    def test_high_div_yield_high_score(self):
+        """配当利回りが高いほどスコアが高いこと（上限 1.0）。"""
+        cfg = _default_config()
+        score_low = _compute_value_score({"div_yield": 1.0}, cfg)
+        score_high = _compute_value_score({"div_yield": 5.0}, cfg)
+        assert score_low is not None and score_high is not None
+        assert score_low < score_high
+        # 上限チェック: div_yield >= div_yield_max で score=1.0
+        score_cap = _compute_value_score({"div_yield": 10.0}, cfg)
+        assert abs(score_cap - 1.0) < 1e-9
+
+
+class TestValueScorePartial:
+    def test_pbr_missing_uses_per_and_div_yield(self):
+        """PBR 欠損のとき PER と配当利回りで重み正規化して計算すること。"""
+        cfg = _default_config()
+        feat = {"per": 20.0, "div_yield": 3.0}  # pbr なし
+        score = _compute_value_score(feat, cfg)
+        # per=20 → 0.5, div_yield=3.0 → 1.0
+        # total_w = 0.50 + 0.20 = 0.70
+        # (0.50*0.5 + 0.20*1.0) / 0.70 = 0.45 / 0.70 ≈ 0.6429
+        assert score is not None
+        assert abs(score - 0.45 / 0.70) < 1e-6
+
+    def test_all_missing_returns_none(self):
+        """3指標すべて欠損のとき None を返すこと。"""
+        cfg = _default_config()
+        assert _compute_value_score({}, cfg) is None
+        assert _compute_value_score({"per": None, "pbr": None, "div_yield": None}, cfg) is None
+
+
+class TestValueScoreConfigDriven:
+    def test_changing_per_mid_changes_score(self):
+        """per_mid を変更するとスコアが変わること。"""
+        feat = {"per": 20.0}
+        cfg_default = _default_config()
+        cfg_strict = {
+            "weights": {"per": 0.50, "pbr": 0.30, "div_yield": 0.20},
+            "normalization": {"per_mid": 10.0, "pbr_mid": 1.5, "div_yield_max": 3.0},
+        }
+        score_default = _compute_value_score(feat, cfg_default)
+        score_strict = _compute_value_score(feat, cfg_strict)
+        # per_mid=20 → score=0.5; per_mid=10 → 1/(1+20/10)=1/3≈0.333
+        assert score_default is not None and score_strict is not None
+        assert score_default > score_strict
+
+    def test_load_value_config_returns_dict_with_required_keys(self):
+        """_load_value_config が weights と normalization キーを持つ dict を返すこと。"""
+        cfg = _load_value_config()
+        assert "weights" in cfg
+        assert "normalization" in cfg
+        assert "per" in cfg["weights"]
+        assert "per_mid" in cfg["normalization"]

--- a/tests/test_pbr_div_yield.py
+++ b/tests/test_pbr_div_yield.py
@@ -71,3 +71,58 @@ class TestSchema:
         assert "per_mid" in n
         assert "pbr_mid" in n
         assert "div_yield_max" in n
+
+
+# ---------------------------------------------------------------------------
+# Task 2: BPS 抽出
+# ---------------------------------------------------------------------------
+
+from kabusys.data import jquants_client as jq
+
+
+class TestBpsExtraction:
+    def test_save_financial_statements_stores_bps(self):
+        """save_financial_statements が BookValuePerShare を raw_financials.bps に保存すること。"""
+        conn = init_schema(":memory:")
+        records = [
+            {
+                "LocalCode": "72030",
+                "DisclosedDate": "2024-03-31",
+                "TypeOfDocument": "Q4",
+                "NetSales": "1000000",
+                "OperatingProfit": "200000",
+                "Profit": "150000",
+                "EarningsPerShare": "100.0",
+                "ROE": "0.15",
+                "BookValuePerShare": "1500.0",
+            }
+        ]
+        saved = jq.save_financial_statements(conn, records)
+        assert saved == 1
+        row = conn.execute(
+            "SELECT bps FROM raw_financials WHERE code = '72030'"
+        ).fetchone()
+        assert row is not None
+        assert abs(float(row[0]) - 1500.0) < 0.01
+        conn.close()
+
+    def test_save_financial_statements_handles_missing_bps(self):
+        """BookValuePerShare がない場合 bps は NULL になること。"""
+        conn = init_schema(":memory:")
+        records = [
+            {
+                "LocalCode": "72031",
+                "DisclosedDate": "2024-03-31",
+                "TypeOfDocument": "Q4",
+                "EarningsPerShare": "50.0",
+                "ROE": "0.10",
+                # BookValuePerShare なし
+            }
+        ]
+        jq.save_financial_statements(conn, records)
+        row = conn.execute(
+            "SELECT bps FROM raw_financials WHERE code = '72031'"
+        ).fetchone()
+        assert row is not None
+        assert row[0] is None
+        conn.close()

--- a/tests/test_pbr_div_yield.py
+++ b/tests/test_pbr_div_yield.py
@@ -126,3 +126,97 @@ class TestBpsExtraction:
         assert row is not None
         assert row[0] is None
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Task 3: 配当 ETL
+# ---------------------------------------------------------------------------
+
+from unittest.mock import patch
+
+from kabusys.data.pipeline import run_dividends_etl
+
+
+def _insert_dividends(conn, rows: list[tuple]) -> None:
+    """(code, pub_date, ref_no, ex_date, record_date, pay_date, div_rate) を dividends に挿入。"""
+    conn.executemany(
+        """
+        INSERT INTO dividends
+            (code, pub_date, ref_no, ex_date, record_date, pay_date, div_rate, fetched_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, current_timestamp)
+        ON CONFLICT (code, pub_date, ref_no) DO UPDATE SET
+            div_rate = excluded.div_rate, fetched_at = excluded.fetched_at
+        """,
+        rows,
+    )
+
+
+class TestDividendsEtl:
+    def test_save_dividends_stores_records(self):
+        """save_dividends が dividends テーブルに div_rate を保存すること。"""
+        conn = init_schema(":memory:")
+        records = [
+            {
+                "Code": "72030",
+                "PubDate": "2024-01-15",
+                "RefNo": "001",
+                "ExDate": "2024-03-27",
+                "RecDate": "2024-03-31",
+                "PayDate": "2024-06-01",
+                "DivRate": "50.0",
+            }
+        ]
+        saved = jq.save_dividends(conn, records)
+        assert saved == 1
+        row = conn.execute(
+            "SELECT div_rate FROM dividends WHERE code = '72030' AND ref_no = '001'"
+        ).fetchone()
+        assert row is not None
+        assert abs(float(row[0]) - 50.0) < 0.01
+        conn.close()
+
+    def test_save_dividends_is_idempotent(self):
+        """同じレコードを2回保存しても重複しないこと（upsert）。"""
+        conn = init_schema(":memory:")
+        record = {
+            "Code": "72030",
+            "PubDate": "2024-01-15",
+            "RefNo": "001",
+            "ExDate": "2024-03-27",
+            "RecDate": "2024-03-31",
+            "PayDate": "2024-06-01",
+            "DivRate": "50.0",
+        }
+        jq.save_dividends(conn, [record])
+        record["DivRate"] = "60.0"  # 値を更新
+        jq.save_dividends(conn, [record])
+        rows = conn.execute("SELECT div_rate FROM dividends WHERE code = '72030'").fetchall()
+        assert len(rows) == 1
+        assert abs(float(rows[0][0]) - 60.0) < 0.01  # 更新後の値
+        conn.close()
+
+    def test_run_dividends_etl_calls_fetch_and_save(self):
+        """run_dividends_etl が fetch_dividends / save_dividends を呼び出すこと。"""
+        from datetime import date
+        conn = init_schema(":memory:")
+        fake_records = [
+            {
+                "Code": "72030",
+                "PubDate": "2024-01-15",
+                "RefNo": "001",
+                "ExDate": "2024-03-27",
+                "RecDate": "2024-03-31",
+                "PayDate": "2024-06-01",
+                "DivRate": "50.0",
+            }
+        ]
+        with patch(
+            "kabusys.data.pipeline.jq.fetch_dividends", return_value=fake_records
+        ) as mock_fetch:
+            fetched, saved = run_dividends_etl(
+                conn, target_date=date(2024, 4, 1), id_token="dummy"
+            )
+        mock_fetch.assert_called_once()
+        assert fetched == 1
+        assert saved == 1
+        conn.close()

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -129,21 +129,29 @@ def test_compute_momentum_score_positive_higher():
 
 
 def test_compute_value_score_zero_per():
-    assert _compute_value_score({"per": 0}) is None
+    cfg = {"weights": {"per": 0.50, "pbr": 0.30, "div_yield": 0.20},
+           "normalization": {"per_mid": 20.0, "pbr_mid": 1.5, "div_yield_max": 3.0}}
+    assert _compute_value_score({"per": 0}, cfg) is None
 
 
 def test_compute_value_score_none():
-    assert _compute_value_score({"per": None}) is None
+    cfg = {"weights": {"per": 0.50, "pbr": 0.30, "div_yield": 0.20},
+           "normalization": {"per_mid": 20.0, "pbr_mid": 1.5, "div_yield_max": 3.0}}
+    assert _compute_value_score({"per": None}, cfg) is None
 
 
 def test_compute_value_score_per20():
+    cfg = {"weights": {"per": 0.50, "pbr": 0.30, "div_yield": 0.20},
+           "normalization": {"per_mid": 20.0, "pbr_mid": 1.5, "div_yield_max": 3.0}}
     # PER = 20 → score = 1 / (1 + 20/20) = 0.5
-    assert _compute_value_score({"per": 20.0}) == pytest.approx(0.5)
+    assert _compute_value_score({"per": 20.0}, cfg) == pytest.approx(0.5)
 
 
 def test_compute_value_score_lower_per_higher_score():
-    low_per = _compute_value_score({"per": 10.0})
-    high_per = _compute_value_score({"per": 40.0})
+    cfg = {"weights": {"per": 0.50, "pbr": 0.30, "div_yield": 0.20},
+           "normalization": {"per_mid": 20.0, "pbr_mid": 1.5, "div_yield_max": 3.0}}
+    low_per = _compute_value_score({"per": 10.0}, cfg)
+    high_per = _compute_value_score({"per": 40.0}, cfg)
     assert low_per > high_per
 
 

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -129,27 +129,35 @@ def test_compute_momentum_score_positive_higher():
 
 
 def test_compute_value_score_zero_per():
-    cfg = {"weights": {"per": 0.50, "pbr": 0.30, "div_yield": 0.20},
-           "normalization": {"per_mid": 20.0, "pbr_mid": 1.5, "div_yield_max": 3.0}}
+    cfg = {
+        "weights": {"per": 0.50, "pbr": 0.30, "div_yield": 0.20},
+        "normalization": {"per_mid": 20.0, "pbr_mid": 1.5, "div_yield_max": 3.0},
+    }
     assert _compute_value_score({"per": 0}, cfg) is None
 
 
 def test_compute_value_score_none():
-    cfg = {"weights": {"per": 0.50, "pbr": 0.30, "div_yield": 0.20},
-           "normalization": {"per_mid": 20.0, "pbr_mid": 1.5, "div_yield_max": 3.0}}
+    cfg = {
+        "weights": {"per": 0.50, "pbr": 0.30, "div_yield": 0.20},
+        "normalization": {"per_mid": 20.0, "pbr_mid": 1.5, "div_yield_max": 3.0},
+    }
     assert _compute_value_score({"per": None}, cfg) is None
 
 
 def test_compute_value_score_per20():
-    cfg = {"weights": {"per": 0.50, "pbr": 0.30, "div_yield": 0.20},
-           "normalization": {"per_mid": 20.0, "pbr_mid": 1.5, "div_yield_max": 3.0}}
+    cfg = {
+        "weights": {"per": 0.50, "pbr": 0.30, "div_yield": 0.20},
+        "normalization": {"per_mid": 20.0, "pbr_mid": 1.5, "div_yield_max": 3.0},
+    }
     # PER = 20 → score = 1 / (1 + 20/20) = 0.5
     assert _compute_value_score({"per": 20.0}, cfg) == pytest.approx(0.5)
 
 
 def test_compute_value_score_lower_per_higher_score():
-    cfg = {"weights": {"per": 0.50, "pbr": 0.30, "div_yield": 0.20},
-           "normalization": {"per_mid": 20.0, "pbr_mid": 1.5, "div_yield_max": 3.0}}
+    cfg = {
+        "weights": {"per": 0.50, "pbr": 0.30, "div_yield": 0.20},
+        "normalization": {"per_mid": 20.0, "pbr_mid": 1.5, "div_yield_max": 3.0},
+    }
     low_per = _compute_value_score({"per": 10.0}, cfg)
     high_per = _compute_value_score({"per": 40.0}, cfg)
     assert low_per > high_per


### PR DESCRIPTION
## Summary

- `raw_financials` に `bps` カラムを追加し、J-Quants `BookValuePerShare` を取得・保存
- 配当 ETL（`fetch_dividends` / `save_dividends` / `run_dividends_etl`）を追加し、日次バッチに組み込み
- `calc_value()` を拡張して `pbr = close/bps`・`div_yield = 直近12ヶ月配当合計/close×100` を計算
- `_compute_value_score()` を PER・PBR・配当利回りの3指標加重平均に更新（重みと基準値は `config/strategy.toml` で管理）

## Changes

- `config/strategy.toml` — バリュースコアの重み・正規化基準値の設定ファイル（新規）
- `src/kabusys/data/schema.py` — `raw_financials.bps` カラム追加 + マイグレーション
- `src/kabusys/data/jquants_client.py` — BPS 抽出・`fetch_dividends` / `save_dividends` 追加
- `src/kabusys/data/pipeline.py` — 配当 ETL 追加・`ETLResult` 拡張・`run_daily_etl` 統合
- `src/kabusys/research/factor_research.py` — `calc_value()` に `pbr` / `div_yield` 追加
- `src/kabusys/strategy/feature_engineering.py` — `build_features()` に `pbr` / `div_yield` 書き込み
- `src/kabusys/strategy/signal_generator.py` — `_load_value_config()` 追加・`_compute_value_score()` 3指標対応・`generate_signals()` の SELECT に `pbr`/`div_yield` 追加
- `tests/test_pbr_div_yield.py` — 新規テスト（21テスト）

## Test Plan

- [x] `python -m pytest tests/test_pbr_div_yield.py -v` — 21 tests pass
- [x] `python -m pytest --tb=short -q` — 1335 tests pass, 0 failures
- [x] PBR 計算: `close / bps`（bps=0 または NULL は None）
- [x] 配当利回り: 直近12ヶ月の `div_rate` 合計 / `close` × 100（対象外配当の除外確認済み）
- [x] バリュースコア加重平均: 欠損指標は重み正規化して計算、全欠損時は None
- [x] `config/strategy.toml` 変更がスコアに反映されること確認済み

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)