### PR TITLE
feat: TDnet 適時開示収集パイプラインとイベント分類を実装 (Issue #198)

### DIFF
--- a/scripts/run_disclosure_classification.py
+++ b/scripts/run_disclosure_classification.py
@@ -1,0 +1,38 @@
+# scripts/run_disclosure_classification.py
+"""Night batch: 適時開示イベント分類 (disclosure_classification_job)。
+
+Task Scheduler から 17:00 に起動される。
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+import duckdb
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+from kabusys.config import Settings
+from kabusys.data.disclosure_classifier import run_disclosure_classification
+from kabusys.utils.logging_setup import setup_logging
+
+setup_logging(app_name="disclosure_classification")
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    settings = Settings()
+    conn = duckdb.connect(str(settings.duckdb_path))
+    try:
+        saved = run_disclosure_classification(conn)
+        logger.info("disclosure_classification 完了: saved=%d", saved)
+    except Exception:
+        logger.exception("disclosure_classification バッチが失敗しました")
+        sys.exit(1)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_tdnet_collection.py
+++ b/scripts/run_tdnet_collection.py
@@ -1,0 +1,38 @@
+# scripts/run_tdnet_collection.py
+"""Night batch: TDnet 適時開示収集 (tdnet_collection_job)。
+
+Task Scheduler から 15:35 に起動される。
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+import duckdb
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+from kabusys.config import Settings
+from kabusys.data.tdnet_collector import run_tdnet_collection
+from kabusys.utils.logging_setup import setup_logging
+
+setup_logging(app_name="tdnet_collection")
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    settings = Settings()
+    conn = duckdb.connect(str(settings.duckdb_path))
+    try:
+        saved = run_tdnet_collection(conn)
+        logger.info("tdnet_collection 完了: saved=%d", saved)
+    except Exception:
+        logger.exception("tdnet_collection バッチが失敗しました")
+        sys.exit(1)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/kabusys/data/disclosure_classifier.py
+++ b/src/kabusys/data/disclosure_classifier.py
@@ -1,0 +1,264 @@
+"""
+開示イベント分類モジュール
+
+raw_disclosures の表題を正規表現キーワードルールで分類し、
+disclosure_events テーブルへ UPSERT する。
+
+設計方針:
+  - 分類は表題の「最初にマッチしたルール」を採用（優先順位あり、先勝ち）
+  - NLP なし・外部依存なし（stdlib re のみ）
+  - UPSERT（ON CONFLICT DO UPDATE）で再分類を上書き可能
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import date, datetime, timezone
+from typing import TypedDict
+
+import duckdb
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# 型定義
+# ---------------------------------------------------------------------------
+
+
+class ClassificationResult(TypedDict):
+    event_type: str
+    event_score: float
+    buy_caution: bool
+    hold_caution: bool
+    review_required: bool
+
+
+# ---------------------------------------------------------------------------
+# 分類ルール（優先順位あり、先勝ち）
+# ---------------------------------------------------------------------------
+
+_RULES: list[tuple[str, float, bool, bool, bool, re.Pattern[str]]] = [
+    # earnings_report
+    (
+        "earnings_report",
+        0.0,
+        False,
+        False,
+        False,
+        re.compile(r"決算短信|四半期報告", re.IGNORECASE),
+    ),
+    # earnings_revision_up
+    (
+        "earnings_revision_up",
+        1.0,
+        False,
+        False,
+        False,
+        re.compile(r"業績予想.{0,10}(上方|増額)", re.IGNORECASE),
+    ),
+    # earnings_revision_down
+    (
+        "earnings_revision_down",
+        -1.0,
+        True,
+        True,
+        True,
+        re.compile(r"業績予想.{0,10}(下方|減額)", re.IGNORECASE),
+    ),
+    # dividend_revision_up
+    (
+        "dividend_revision_up",
+        1.0,
+        False,
+        False,
+        False,
+        re.compile(r"配当.{0,10}(増配|上方|引き上げ|引上げ)", re.IGNORECASE),
+    ),
+    # dividend_revision_down
+    (
+        "dividend_revision_down",
+        -1.0,
+        False,
+        True,
+        False,
+        re.compile(r"配当.{0,10}(減配|下方|引き下げ|引下げ|無配)", re.IGNORECASE),
+    ),
+    # buyback
+    (
+        "buyback",
+        0.5,
+        False,
+        False,
+        False,
+        re.compile(r"自己株式取得|自社株買|自己株の取得", re.IGNORECASE),
+    ),
+    # new_share_issuance
+    (
+        "new_share_issuance",
+        -0.5,
+        True,
+        False,
+        False,
+        re.compile(
+            r"(新株式発行|公募増資|第三者割当|新株予約権|公募|増資)", re.IGNORECASE
+        ),
+    ),
+    # merger_acquisition
+    (
+        "merger_acquisition",
+        0.0,
+        True,
+        False,
+        True,
+        re.compile(
+            r"(合併|買収|子会社化|資本業務提携|株式交換|事業譲受|TOB|MBO)",
+            re.IGNORECASE,
+        ),
+    ),
+    # litigation_scandal
+    (
+        "litigation_scandal",
+        -1.0,
+        True,
+        True,
+        True,
+        re.compile(
+            r"(訴訟|不祥事|調査委員会|行政処分|監理銘柄|上場廃止|課徴金|粉飾|横領)",
+            re.IGNORECASE,
+        ),
+    ),
+]
+
+_OTHER: ClassificationResult = {
+    "event_type": "other",
+    "event_score": 0.0,
+    "buy_caution": False,
+    "hold_caution": False,
+    "review_required": False,
+}
+
+
+# ---------------------------------------------------------------------------
+# 公開関数
+# ---------------------------------------------------------------------------
+
+
+def classify_title(title: str | None) -> ClassificationResult:
+    """開示表題を分類ルールに照合してイベント分類結果を返す。
+
+    先頭にマッチしたルールを採用する（先勝ちルール）。
+    どのルールにもマッチしない場合は 'other' を返す。
+    """
+    if not title:
+        return _OTHER
+
+    for (
+        event_type,
+        event_score,
+        buy_caution,
+        hold_caution,
+        review_required,
+        pattern,
+    ) in _RULES:
+        if pattern.search(title):
+            return ClassificationResult(
+                event_type=event_type,
+                event_score=event_score,
+                buy_caution=buy_caution,
+                hold_caution=hold_caution,
+                review_required=review_required,
+            )
+
+    return _OTHER
+
+
+def classify_disclosures(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date,
+) -> int:
+    """指定日の raw_disclosures を分類して disclosure_events に UPSERT する。
+
+    Returns:
+        UPSERT した件数。
+    """
+    rows = conn.execute(
+        "SELECT id, disclosed_at, code, title, source "
+        "FROM raw_disclosures "
+        "WHERE CAST(disclosed_at AS DATE) = ?",
+        [target_date],
+    ).fetchall()
+
+    if not rows:
+        logger.info("classify_disclosures: date=%s 対象なし", target_date)
+        return 0
+
+    classified_at = datetime.now(timezone.utc).replace(tzinfo=None)
+    upsert_rows = []
+    for row_id, disclosed_at, code, title, source in rows:
+        result = classify_title(title)
+        upsert_rows.append(
+            (
+                row_id,
+                disclosed_at,
+                code,
+                result["event_type"],
+                result["event_score"],
+                result["buy_caution"],
+                result["hold_caution"],
+                result["review_required"],
+                title,
+                source,
+                classified_at,
+            )
+        )
+
+    saved = 0
+    conn.begin()
+    try:
+        for i in range(0, len(upsert_rows), 500):
+            chunk = upsert_rows[i : i + 500]
+            placeholders = ", ".join("(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)" for _ in chunk)
+            flat = [v for row in chunk for v in row]
+            conn.execute(
+                "INSERT INTO disclosure_events "
+                "(id, disclosed_at, code, event_type, event_score, "
+                " buy_caution, hold_caution, review_required, title, source, classified_at) "
+                f"VALUES {placeholders} "
+                "ON CONFLICT (id) DO UPDATE SET "
+                "  event_type = EXCLUDED.event_type, "
+                "  event_score = EXCLUDED.event_score, "
+                "  buy_caution = EXCLUDED.buy_caution, "
+                "  hold_caution = EXCLUDED.hold_caution, "
+                "  review_required = EXCLUDED.review_required, "
+                "  classified_at = EXCLUDED.classified_at",
+                flat,
+            )
+            saved += len(chunk)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        logger.exception("classify_disclosures: トランザクション失敗、ロールバック")
+        raise
+
+    logger.info("classify_disclosures: date=%s classified=%d", target_date, saved)
+    return saved
+
+
+def run_disclosure_classification(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date | None = None,
+) -> int:
+    """開示イベント分類ジョブ（17:00 実行）。
+
+    Returns:
+        UPSERT した件数。
+    """
+    from datetime import date as date_cls
+
+    if target_date is None:
+        target_date = date_cls.today()
+
+    saved = classify_disclosures(conn, target_date)
+    logger.info("run_disclosure_classification: date=%s saved=%d", target_date, saved)
+    return saved

--- a/src/kabusys/data/disclosure_classifier.py
+++ b/src/kabusys/data/disclosure_classifier.py
@@ -101,7 +101,8 @@ _RULES: list[tuple[str, float, bool, bool, bool, re.Pattern[str]]] = [
         False,
         False,
         re.compile(
-            r"(新株式発行|公募増資|第三者割当|新株予約権|公募|増資)", re.IGNORECASE
+            r"(新株式発行|公募増資|公募売出し|第三者割当(による)?新株式発行|新株予約権(の発行)?)",
+            re.IGNORECASE,
         ),
     ),
     # merger_acquisition
@@ -231,6 +232,7 @@ def classify_disclosures(
                 "  buy_caution = EXCLUDED.buy_caution, "
                 "  hold_caution = EXCLUDED.hold_caution, "
                 "  review_required = EXCLUDED.review_required, "
+                "  title = EXCLUDED.title, "
                 "  classified_at = EXCLUDED.classified_at",
                 flat,
             )

--- a/src/kabusys/data/schema.py
+++ b/src/kabusys/data/schema.py
@@ -81,6 +81,20 @@ CREATE TABLE IF NOT EXISTS raw_executions (
 )
 """
 
+_RAW_DISCLOSURES = """
+CREATE TABLE IF NOT EXISTS raw_disclosures (
+    id              VARCHAR   NOT NULL PRIMARY KEY,
+    disclosed_at    TIMESTAMP NOT NULL,
+    code            VARCHAR,
+    company_name    VARCHAR,
+    title           VARCHAR,
+    document_url    VARCHAR,
+    document_type   VARCHAR,
+    source          VARCHAR   NOT NULL CHECK (source IN ('tdnet', 'edinet')),
+    fetched_at      TIMESTAMP NOT NULL DEFAULT current_timestamp
+)
+"""
+
 # ---- Processed Layer -------------------------------------------------------
 
 _PRICES_DAILY = """
@@ -140,6 +154,22 @@ CREATE TABLE IF NOT EXISTS news_symbols (
     -- Note: ON DELETE CASCADE は DuckDB 1.5.0 非サポートのため省略。
     --       raw_news 削除時はアプリ側で先に news_symbols を削除すること。
     FOREIGN KEY (news_id) REFERENCES raw_news(id)
+)
+"""
+
+_DISCLOSURE_EVENTS = """
+CREATE TABLE IF NOT EXISTS disclosure_events (
+    id               VARCHAR   NOT NULL PRIMARY KEY,
+    disclosed_at     TIMESTAMP NOT NULL,
+    code             VARCHAR,
+    event_type       VARCHAR   NOT NULL,
+    event_score      DOUBLE    NOT NULL,
+    buy_caution      BOOLEAN   NOT NULL DEFAULT false,
+    hold_caution     BOOLEAN   NOT NULL DEFAULT false,
+    review_required  BOOLEAN   NOT NULL DEFAULT false,
+    title            VARCHAR,
+    source           VARCHAR   NOT NULL CHECK (source IN ('tdnet', 'edinet')),
+    classified_at    TIMESTAMP NOT NULL DEFAULT current_timestamp
 )
 """
 
@@ -378,6 +408,10 @@ _INDEXES: list[str] = [
     "CREATE INDEX IF NOT EXISTS idx_raw_news_datetime ON raw_news(datetime)",
     "CREATE INDEX IF NOT EXISTS idx_position_entries_code_sell ON position_entries(code, sell_date)",
     "CREATE INDEX IF NOT EXISTS idx_position_entries_code_entry ON position_entries(code, entry_date)",
+    "CREATE INDEX IF NOT EXISTS idx_raw_disclosures_code ON raw_disclosures(code)",
+    "CREATE INDEX IF NOT EXISTS idx_raw_disclosures_disclosed_at ON raw_disclosures(disclosed_at)",
+    "CREATE INDEX IF NOT EXISTS idx_disclosure_events_code ON disclosure_events(code)",
+    "CREATE INDEX IF NOT EXISTS idx_disclosure_events_disclosed_at ON disclosure_events(disclosed_at)",
 ]
 
 # ---------------------------------------------------------------------------
@@ -405,12 +439,14 @@ _ALL_DDL: list[str] = [
     _RAW_FINANCIALS,
     _RAW_NEWS,
     _RAW_EXECUTIONS,
+    _RAW_DISCLOSURES,
     # Processed
     _PRICES_DAILY,
     _MARKET_CALENDAR,
     _FUNDAMENTALS,
     _NEWS_ARTICLES,
     _NEWS_SYMBOLS,
+    _DISCLOSURE_EVENTS,
     # Master
     _STOCKS,
     # Feature

--- a/src/kabusys/data/tdnet_collector.py
+++ b/src/kabusys/data/tdnet_collector.py
@@ -1,0 +1,352 @@
+"""
+TDnet 適時開示収集モジュール
+
+適時開示情報閲覧サービス (TDnet) の開示一覧 HTML を日次で全件取得し、
+raw_disclosures テーブルに保存する。
+
+設計方針:
+  - HTML パースは stdlib html.parser を使用（外部依存ゼロ）
+  - SSRF 保護は news_collector.py と同じ _validate_url_scheme / _is_private_host パターン
+  - ON CONFLICT DO NOTHING で冪等な挿入
+  - ページネーション: I_list_001_YYYYMMDD.html, I_list_002_... を空行まで継続取得
+  - TDnet の31日掲載制限を考慮し、毎日実行して差分を積み上げる
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import date, datetime, time
+from html.parser import HTMLParser
+from typing import TypedDict
+
+import duckdb
+
+from kabusys.data.news_collector import (
+    _SSRFBlockRedirectHandler,
+    _is_private_host,
+    _validate_url_scheme,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# 定数
+# ---------------------------------------------------------------------------
+
+TDNET_BASE_URL = "https://www.release.tdnet.info/inbs"
+MAX_PAGES = 50
+MAX_RESPONSE_BYTES = 5 * 1024 * 1024
+_INSERT_CHUNK_SIZE = 500
+
+_DOC_ID_PATTERN = re.compile(r"(\d{14,20})(?:\.pdf|\.html)?$", re.IGNORECASE)
+
+# ---------------------------------------------------------------------------
+# 型定義
+# ---------------------------------------------------------------------------
+
+
+class RawDisclosure(TypedDict):
+    """TDnet / EDINET から取得した生の開示情報を表す型。"""
+
+    id: str
+    disclosed_at: datetime
+    code: str | None
+    company_name: str | None
+    title: str | None
+    document_url: str | None
+    document_type: str | None
+    source: str
+
+
+# ---------------------------------------------------------------------------
+# HTML パーサー
+# ---------------------------------------------------------------------------
+
+
+class _TDnetTableParser(HTMLParser):
+    """TDnet 開示一覧ページの HTML テーブルをパースする。
+
+    列順: 時刻 | コード | 会社名 | 表題 | PDF/HTML リンク
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._in_td = False
+        self._cell_texts: list[str] = []
+        self._cell_href: str | None = None
+        self._current_row: list[tuple[str, str | None]] = []
+        self.rows: list[list[tuple[str, str | None]]] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "td":
+            self._in_td = True
+            self._cell_texts = []
+            self._cell_href = None
+        elif tag == "a" and self._in_td:
+            href = dict(attrs).get("href")
+            if href:
+                self._cell_href = href
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "td" and self._in_td:
+            text = "".join(self._cell_texts).strip()
+            self._current_row.append((text, self._cell_href))
+            self._in_td = False
+        elif tag == "tr":
+            if self._current_row:
+                self.rows.append(self._current_row)
+                self._current_row = []
+
+    def handle_data(self, data: str) -> None:
+        if self._in_td:
+            self._cell_texts.append(data)
+
+
+# ---------------------------------------------------------------------------
+# ユーティリティ
+# ---------------------------------------------------------------------------
+
+
+def _extract_disclosure_id(href: str | None) -> str | None:
+    """PDF/HTML の href から開示ID（数字部分）を抽出する。
+
+    例: "140120241031413060.pdf" → "140120241031413060"
+        "/inbs/140120241031413060.pdf" → "140120241031413060"
+    """
+    if not href:
+        return None
+    filename = href.rsplit("/", 1)[-1]
+    m = _DOC_ID_PATTERN.search(filename)
+    return m.group(1) if m else None
+
+
+def _build_document_url(href: str | None) -> str | None:
+    """href を完全な TDnet ドキュメント URL に変換する。"""
+    if not href:
+        return None
+    if href.startswith("http"):
+        return href
+    if href.startswith("/"):
+        return f"https://www.release.tdnet.info{href}"
+    return f"{TDNET_BASE_URL}/{href}"
+
+
+def _parse_tdnet_html(html: str, target_date: date) -> list[RawDisclosure]:
+    """TDnet 開示一覧 HTML をパースして RawDisclosure リストを返す。
+
+    列解釈: 列0=時刻, 列1=コード, 列2=会社名, 列3=表題, 列4=PDFリンク
+    コードが4桁数字でない行（ヘッダー等）はスキップする。
+    """
+    parser = _TDnetTableParser()
+    parser.feed(html)
+
+    disclosures: list[RawDisclosure] = []
+    for row in parser.rows:
+        if len(row) < 4:
+            continue
+
+        time_str, _ = row[0]
+        code_str, _ = row[1]
+        company_str, _ = row[2]
+        title_str, _ = row[3]
+        href = row[4][1] if len(row) >= 5 else None
+
+        if not re.fullmatch(r"\d{4}", code_str.strip()):
+            continue
+
+        doc_id = _extract_disclosure_id(href)
+        if not doc_id:
+            import hashlib
+
+            raw = f"{target_date}|{code_str}|{title_str}"
+            doc_id = "tdnet_" + hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+        try:
+            h, m = map(int, time_str.strip().split(":"))
+            disclosed_at = datetime.combine(target_date, time(h, m))
+        except (ValueError, AttributeError):
+            disclosed_at = datetime.combine(target_date, time(0, 0))
+
+        doc_url = _build_document_url(href)
+        disclosures.append(
+            RawDisclosure(
+                id=doc_id,
+                disclosed_at=disclosed_at,
+                code=code_str.strip() if code_str.strip() else None,
+                company_name=company_str.strip() if company_str.strip() else None,
+                title=title_str.strip() if title_str.strip() else None,
+                document_url=doc_url,
+                document_type=None,
+                source="tdnet",
+            )
+        )
+
+    return disclosures
+
+
+# ---------------------------------------------------------------------------
+# HTTP 取得
+# ---------------------------------------------------------------------------
+
+
+def _fetch_page(url: str, timeout: int = 30) -> str:
+    """TDnet の HTML ページを取得して文字列で返す。
+
+    SSRF 保護（スキーム検証・プライベートアドレス拒否）を適用する。
+    テストでは monkeypatch でこの関数を差し替える。
+    """
+    _validate_url_scheme(url)
+    parsed = urllib.parse.urlparse(url)
+    if _is_private_host(parsed.hostname):
+        raise ValueError(f"許可されていないホスト（プライベートアドレス）: url={url!r}")
+
+    req = urllib.request.Request(
+        url,
+        headers={"User-Agent": "KabuSys-TDnetCollector/1.0"},
+    )
+    opener = urllib.request.build_opener(_SSRFBlockRedirectHandler)
+    with opener.open(req, timeout=timeout) as resp:
+        raw = resp.read(MAX_RESPONSE_BYTES + 1)
+        if len(raw) > MAX_RESPONSE_BYTES:
+            logger.warning("_fetch_page: レスポンスサイズ超過 url=%s", url)
+            return ""
+    for enc in ("utf-8", "shift_jis", "cp932"):
+        try:
+            return raw.decode(enc)
+        except UnicodeDecodeError:
+            continue
+    return raw.decode("utf-8", errors="replace")
+
+
+def fetch_tdnet_disclosures(
+    target_date: date,
+    timeout: int = 30,
+) -> list[RawDisclosure]:
+    """指定日の TDnet 開示一覧を全ページ取得して返す。
+
+    I_list_001_YYYYMMDD.html から順にページを取得し、
+    開示行が 0 件のページに達したら終了する。
+    """
+    date_str = target_date.strftime("%Y%m%d")
+    all_disclosures: list[RawDisclosure] = []
+
+    for page in range(1, MAX_PAGES + 1):
+        page_str = f"{page:03d}"
+        url = f"{TDNET_BASE_URL}/I_list_{page_str}_{date_str}.html"
+        logger.info("fetch_tdnet_disclosures: url=%s", url)
+        try:
+            html = _fetch_page(url, timeout=timeout)
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                break
+            logger.warning(
+                "fetch_tdnet_disclosures: HTTPエラー page=%d code=%d", page, e.code
+            )
+            break
+        except Exception:
+            logger.exception("fetch_tdnet_disclosures: 取得失敗 page=%d", page)
+            break
+
+        page_disclosures = _parse_tdnet_html(html, target_date)
+        if not page_disclosures:
+            break
+
+        all_disclosures.extend(page_disclosures)
+        logger.info(
+            "fetch_tdnet_disclosures: page=%d fetched=%d", page, len(page_disclosures)
+        )
+
+    logger.info(
+        "fetch_tdnet_disclosures: date=%s total=%d", target_date, len(all_disclosures)
+    )
+    return all_disclosures
+
+
+# ---------------------------------------------------------------------------
+# DB 保存
+# ---------------------------------------------------------------------------
+
+
+def save_raw_disclosures(
+    conn: duckdb.DuckDBPyConnection,
+    disclosures: list[RawDisclosure],
+) -> int:
+    """開示リストを raw_disclosures テーブルに保存する。
+
+    ON CONFLICT (id) DO NOTHING で冪等。INSERT RETURNING で実際の挿入件数を返す。
+    """
+    rows = [
+        (
+            d["id"],
+            d["disclosed_at"],
+            d.get("code"),
+            d.get("company_name"),
+            d.get("title"),
+            d.get("document_url"),
+            d.get("document_type"),
+            d.get("source", "tdnet"),
+        )
+        for d in disclosures
+        if d.get("id")
+    ]
+    if not rows:
+        return 0
+
+    saved = 0
+    conn.begin()
+    try:
+        for i in range(0, len(rows), _INSERT_CHUNK_SIZE):
+            chunk = rows[i : i + _INSERT_CHUNK_SIZE]
+            placeholders = ", ".join("(?, ?, ?, ?, ?, ?, ?, ?)" for _ in chunk)
+            flat = [v for row in chunk for v in row]
+            result = conn.execute(
+                "INSERT INTO raw_disclosures "  # noqa: S608
+                "(id, disclosed_at, code, company_name, title, document_url, document_type, source) "
+                f"VALUES {placeholders} "
+                "ON CONFLICT (id) DO NOTHING RETURNING id",
+                flat,
+            )
+            saved += len(result.fetchall())
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        logger.exception("save_raw_disclosures: トランザクション失敗、ロールバック")
+        raise
+
+    logger.info("save_raw_disclosures: input=%d saved=%d", len(disclosures), saved)
+    return saved
+
+
+# ---------------------------------------------------------------------------
+# 統合収集ジョブ
+# ---------------------------------------------------------------------------
+
+
+def run_tdnet_collection(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date | None = None,
+    timeout: int = 30,
+) -> int:
+    """TDnet 開示を収集して raw_disclosures に保存するジョブ。
+
+    Args:
+        conn:        DuckDB 接続。
+        target_date: 収集対象日。省略時は今日。
+        timeout:     HTTP タイムアウト秒数。
+
+    Returns:
+        新規挿入件数。
+    """
+    from datetime import date as date_cls
+
+    if target_date is None:
+        target_date = date_cls.today()
+
+    disclosures = fetch_tdnet_disclosures(target_date, timeout=timeout)
+    saved = save_raw_disclosures(conn, disclosures)
+    logger.info("run_tdnet_collection: date=%s saved=%d", target_date, saved)
+    return saved

--- a/src/kabusys/data/tdnet_collector.py
+++ b/src/kabusys/data/tdnet_collector.py
@@ -70,36 +70,67 @@ class RawDisclosure(TypedDict):
 class _TDnetTableParser(HTMLParser):
     """TDnet 開示一覧ページの HTML テーブルをパースする。
 
-    列順: 時刻 | コード | 会社名 | 表題 | PDF/HTML リンク
+    対象テーブル: id="main-list-table"
+    実際の列構成（CSS クラス名で識別）:
+      kjTime   : 時刻
+      kjCode   : 銘柄コード（4〜5桁）
+      kjName   : 会社名
+      kjTitle  : 表題（<a href="...">タイトル</a> 形式。href が PDF リンク）
+      kjXbrl   : XBRL（無視）
+      kjPlace  : 市場区分（無視）
+      kjHistroy: 更新履歴（無視）
     """
+
+    # パース対象とするセマンティッククラス名
+    _TARGET_CLASSES = frozenset({"kjTime", "kjCode", "kjName", "kjTitle"})
 
     def __init__(self) -> None:
         super().__init__()
+        self._in_main_table = False
         self._in_td = False
+        self._current_sem_class: str | None = None  # kjTime / kjCode / kjName / kjTitle
         self._cell_texts: list[str] = []
         self._cell_href: str | None = None
-        self._current_row: list[tuple[str, str | None]] = []
-        self.rows: list[list[tuple[str, str | None]]] = []
+        # 現在行のデータ: {semantic_class: (text, href)}
+        self._current_data: dict[str, tuple[str, str | None]] = {}
+        self.rows: list[dict[str, tuple[str, str | None]]] = []
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        if tag == "td":
-            self._in_td = True
-            self._cell_texts = []
-            self._cell_href = None
+        attrs_dict = dict(attrs)
+        if tag == "table":
+            if attrs_dict.get("id") == "main-list-table":
+                self._in_main_table = True
+        elif tag == "tr" and self._in_main_table:
+            self._current_data = {}
+        elif tag == "td" and self._in_main_table:
+            cls_str = attrs_dict.get("class", "")
+            sem = next(
+                (c for c in cls_str.split() if c in self._TARGET_CLASSES), None
+            )
+            if sem:
+                self._in_td = True
+                self._current_sem_class = sem
+                self._cell_texts = []
+                self._cell_href = None
         elif tag == "a" and self._in_td:
-            href = dict(attrs).get("href")
+            href = attrs_dict.get("href")
             if href:
                 self._cell_href = href
 
     def handle_endtag(self, tag: str) -> None:
-        if tag == "td" and self._in_td:
-            text = "".join(self._cell_texts).strip()
-            self._current_row.append((text, self._cell_href))
+        if tag == "table" and self._in_main_table:
+            self._in_main_table = False
+        elif tag == "td" and self._in_td:
+            sem = self._current_sem_class
+            if sem:
+                text = "".join(self._cell_texts).strip()
+                self._current_data[sem] = (text, self._cell_href)
             self._in_td = False
-        elif tag == "tr":
-            if self._current_row:
-                self.rows.append(self._current_row)
-                self._current_row = []
+            self._current_sem_class = None
+        elif tag == "tr" and self._in_main_table:
+            if self._current_data:
+                self.rows.append(self._current_data)
+                self._current_data = {}
 
     def handle_data(self, data: str) -> None:
         if self._in_td:
@@ -138,24 +169,26 @@ def _build_document_url(href: str | None) -> str | None:
 def _parse_tdnet_html(html: str, target_date: date) -> list[RawDisclosure]:
     """TDnet 開示一覧 HTML をパースして RawDisclosure リストを返す。
 
-    列解釈: 列0=時刻, 列1=コード, 列2=会社名, 列3=表題, 列4=PDFリンク
-    コードが4桁数字でない行（ヘッダー等）はスキップする。
+    id="main-list-table" の各行から CSS クラス名で値を取得する。
+    タイトルと PDF href は同一セル（kjTitle の <a href>）にある。
+    コードが数字のみでない行はスキップする（念のため保険）。
     """
     parser = _TDnetTableParser()
     parser.feed(html)
 
     disclosures: list[RawDisclosure] = []
-    for row in parser.rows:
-        if len(row) < 4:
+    for row_data in parser.rows:
+        # kjCode と kjTitle が揃っていない行はスキップ
+        if "kjCode" not in row_data or "kjTitle" not in row_data:
             continue
 
-        time_str, _ = row[0]
-        code_str, _ = row[1]
-        company_str, _ = row[2]
-        title_str, _ = row[3]
-        href = row[4][1] if len(row) >= 5 else None
+        time_str, _ = row_data.get("kjTime", ("", None))
+        code_str, _ = row_data.get("kjCode", ("", None))
+        company_str, _ = row_data.get("kjName", ("", None))
+        title_str, href = row_data.get("kjTitle", ("", None))
 
-        if not re.fullmatch(r"\d{4}", code_str.strip()):
+        # コードが数字以外の場合はスキップ（ヘッダー行等の保険）
+        if not code_str.strip().isdigit():
             continue
 
         doc_id = _extract_disclosure_id(href)
@@ -206,7 +239,15 @@ def _fetch_page(url: str, timeout: int = 30) -> str:
 
     req = urllib.request.Request(
         url,
-        headers={"User-Agent": "KabuSys-TDnetCollector/1.0"},
+        headers={
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/124.0.0.0 Safari/537.36"
+            ),
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "ja,en-US;q=0.7,en;q=0.3",
+        },
     )
     opener = urllib.request.build_opener(_SSRFBlockRedirectHandler)
     with opener.open(req, timeout=timeout) as resp:

--- a/src/kabusys/data/tdnet_collector.py
+++ b/src/kabusys/data/tdnet_collector.py
@@ -104,9 +104,7 @@ class _TDnetTableParser(HTMLParser):
             self._current_data = {}
         elif tag == "td" and self._in_main_table:
             cls_str = attrs_dict.get("class", "")
-            sem = next(
-                (c for c in cls_str.split() if c in self._TARGET_CLASSES), None
-            )
+            sem = next((c for c in cls_str.split() if c in self._TARGET_CLASSES), None)
             if sem:
                 self._in_td = True
                 self._current_sem_class = sem

--- a/src/kabusys/data/tdnet_collector.py
+++ b/src/kabusys/data/tdnet_collector.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 TDNET_BASE_URL = "https://www.release.tdnet.info/inbs"
-MAX_PAGES = 50
+MAX_PAGES = 200
 MAX_RESPONSE_BYTES = 5 * 1024 * 1024
 _INSERT_CHUNK_SIZE = 500
 
@@ -145,10 +145,11 @@ def _extract_disclosure_id(href: str | None) -> str | None:
 
     例: "140120241031413060.pdf" → "140120241031413060"
         "/inbs/140120241031413060.pdf" → "140120241031413060"
+        "140120241031413060.pdf?foo=bar" → "140120241031413060"
     """
     if not href:
         return None
-    filename = href.rsplit("/", 1)[-1]
+    filename = href.split("?", 1)[0].rsplit("/", 1)[-1]
     m = _DOC_ID_PATTERN.search(filename)
     return m.group(1) if m else None
 
@@ -157,11 +158,8 @@ def _build_document_url(href: str | None) -> str | None:
     """href を完全な TDnet ドキュメント URL に変換する。"""
     if not href:
         return None
-    if href.startswith("http"):
-        return href
-    if href.startswith("/"):
-        return f"https://www.release.tdnet.info{href}"
-    return f"{TDNET_BASE_URL}/{href}"
+    clean = href.split("?", 1)[0]
+    return urllib.parse.urljoin(f"{TDNET_BASE_URL}/", clean)
 
 
 def _parse_tdnet_html(html: str, target_date: date) -> list[RawDisclosure]:
@@ -297,6 +295,12 @@ def fetch_tdnet_disclosures(
         all_disclosures.extend(page_disclosures)
         logger.info(
             "fetch_tdnet_disclosures: page=%d fetched=%d", page, len(page_disclosures)
+        )
+    else:
+        logger.warning(
+            "fetch_tdnet_disclosures: MAX_PAGES到達 date=%s total=%d",
+            target_date,
+            len(all_disclosures),
         )
 
     logger.info(

--- a/src/kabusys/data/tdnet_collector.py
+++ b/src/kabusys/data/tdnet_collector.py
@@ -230,7 +230,7 @@ def _fetch_page(url: str, timeout: int = 30) -> str:
     """
     _validate_url_scheme(url)
     parsed = urllib.parse.urlparse(url)
-    if _is_private_host(parsed.hostname):
+    if not parsed.hostname or _is_private_host(parsed.hostname):
         raise ValueError(f"許可されていないホスト（プライベートアドレス）: url={url!r}")
 
     req = urllib.request.Request(

--- a/tests/test_disclosure_classifier.py
+++ b/tests/test_disclosure_classifier.py
@@ -118,6 +118,9 @@ def _insert_raw(conn, id, title, code="7203", source="tdnet"):
         # litigation_scandal
         ("訴訟の提起に関するお知らせ", "litigation_scandal", -1.0, True),
         ("不祥事に関する調査結果について", "litigation_scandal", -1.0, True),
+        # other（new_share_issuance の誤検出防止: 公募社債・増資単独はマッチしない）
+        ("公募社債の発行に関するお知らせ", "other", 0.0, False),
+        ("増資に関するお知らせ", "other", 0.0, False),
         # other
         ("代表取締役の異動に関するお知らせ", "other", 0.0, False),
         ("定時株主総会招集ご通知", "other", 0.0, False),

--- a/tests/test_disclosure_classifier.py
+++ b/tests/test_disclosure_classifier.py
@@ -1,4 +1,5 @@
 """disclosure_classifier モジュールのユニットテスト"""
+
 from __future__ import annotations
 
 from datetime import datetime
@@ -76,20 +77,40 @@ def _insert_raw(conn, id, title, code="7203", source="tdnet"):
         ("決算短信（連結）", "earnings_report", 0.0, False),
         ("第2四半期決算短信", "earnings_report", 0.0, False),
         # earnings_revision_up
-        ("業績予想の修正（上方修正）に関するお知らせ", "earnings_revision_up", 1.0, False),
+        (
+            "業績予想の修正（上方修正）に関するお知らせ",
+            "earnings_revision_up",
+            1.0,
+            False,
+        ),
         ("通期業績予想を上方修正", "earnings_revision_up", 1.0, False),
         # earnings_revision_down
-        ("業績予想の修正（下方修正）に関するお知らせ", "earnings_revision_down", -1.0, True),
+        (
+            "業績予想の修正（下方修正）に関するお知らせ",
+            "earnings_revision_down",
+            -1.0,
+            True,
+        ),
         ("業績予想を下方修正", "earnings_revision_down", -1.0, True),
         # dividend_revision_up
         ("配当予想の修正（増配）に関するお知らせ", "dividend_revision_up", 1.0, False),
         # dividend_revision_down
-        ("配当予想の修正（減配）に関するお知らせ", "dividend_revision_down", -1.0, False),
+        (
+            "配当予想の修正（減配）に関するお知らせ",
+            "dividend_revision_down",
+            -1.0,
+            False,
+        ),
         # buyback
         ("自己株式取得に関するお知らせ", "buyback", 0.5, False),
         ("自社株買いの実施について", "buyback", 0.5, False),
         # new_share_issuance
-        ("第三者割当による新株式発行に関するお知らせ", "new_share_issuance", -0.5, True),
+        (
+            "第三者割当による新株式発行に関するお知らせ",
+            "new_share_issuance",
+            -0.5,
+            True,
+        ),
         ("公募増資について", "new_share_issuance", -0.5, True),
         # merger_acquisition
         ("株式取得（子会社化）に関するお知らせ", "merger_acquisition", 0.0, True),
@@ -120,6 +141,7 @@ def test_classify_title_none_returns_other():
 def test_classify_disclosures_writes_events(cdb):
     """classify_disclosures が raw_disclosures を読んで disclosure_events に書くことを確認する。"""
     from datetime import date
+
     _insert_raw(cdb, "TDN001", "業績予想の修正（上方修正）に関するお知らせ")
     _insert_raw(cdb, "TDN002", "自己株式取得に関するお知らせ")
     saved = classify_disclosures(cdb, target_date=date(2024, 9, 1))
@@ -134,6 +156,7 @@ def test_classify_disclosures_writes_events(cdb):
 def test_classify_disclosures_upsert(cdb):
     """同じ開示を再分類しても重複しないことを確認する（UPSERT 動作）。"""
     from datetime import date
+
     _insert_raw(cdb, "TDN001", "決算短信（連結）")
     classify_disclosures(cdb, target_date=date(2024, 9, 1))
     classify_disclosures(cdb, target_date=date(2024, 9, 1))
@@ -144,6 +167,7 @@ def test_classify_disclosures_upsert(cdb):
 def test_run_disclosure_classification(cdb):
     """run_disclosure_classification がジョブとして動くことを確認する。"""
     from datetime import date
+
     _insert_raw(cdb, "TDN001", "業績予想を下方修正")
     saved = run_disclosure_classification(cdb, target_date=date(2024, 9, 1))
     assert saved == 1
@@ -151,5 +175,5 @@ def test_run_disclosure_classification(cdb):
         "SELECT event_type, buy_caution, review_required FROM disclosure_events WHERE id = 'TDN001'"
     ).fetchone()
     assert row[0] == "earnings_revision_down"
-    assert row[1] is True   # buy_caution
-    assert row[2] is True   # review_required
+    assert row[1] is True  # buy_caution
+    assert row[2] is True  # review_required

--- a/tests/test_disclosure_classifier.py
+++ b/tests/test_disclosure_classifier.py
@@ -1,0 +1,156 @@
+"""disclosure_classifier モジュールのユニットテスト"""
+from __future__ import annotations
+
+from datetime import datetime
+
+import duckdb
+import pytest
+
+from kabusys.data.disclosure_classifier import (
+    ClassificationResult,
+    classify_title,
+    classify_disclosures,
+    run_disclosure_classification,
+)
+
+# ---------------------------------------------------------------------------
+# フィクスチャ
+# ---------------------------------------------------------------------------
+
+_DISC_DDL = [
+    """
+    CREATE TABLE IF NOT EXISTS raw_disclosures (
+        id              VARCHAR   NOT NULL PRIMARY KEY,
+        disclosed_at    TIMESTAMP NOT NULL,
+        code            VARCHAR,
+        company_name    VARCHAR,
+        title           VARCHAR,
+        document_url    VARCHAR,
+        document_type   VARCHAR,
+        source          VARCHAR   NOT NULL,
+        fetched_at      TIMESTAMP NOT NULL DEFAULT current_timestamp
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS disclosure_events (
+        id               VARCHAR   NOT NULL PRIMARY KEY,
+        disclosed_at     TIMESTAMP NOT NULL,
+        code             VARCHAR,
+        event_type       VARCHAR   NOT NULL,
+        event_score      DOUBLE    NOT NULL,
+        buy_caution      BOOLEAN   NOT NULL DEFAULT false,
+        hold_caution     BOOLEAN   NOT NULL DEFAULT false,
+        review_required  BOOLEAN   NOT NULL DEFAULT false,
+        title            VARCHAR,
+        source           VARCHAR   NOT NULL,
+        classified_at    TIMESTAMP NOT NULL DEFAULT current_timestamp
+    )
+    """,
+]
+
+
+@pytest.fixture
+def cdb():
+    conn = duckdb.connect(":memory:")
+    for ddl in _DISC_DDL:
+        conn.execute(ddl)
+    yield conn
+    conn.close()
+
+
+def _insert_raw(conn, id, title, code="7203", source="tdnet"):
+    conn.execute(
+        "INSERT INTO raw_disclosures (id, disclosed_at, code, title, source) VALUES (?, ?, ?, ?, ?)",
+        [id, datetime(2024, 9, 1, 9, 0), code, title, source],
+    )
+
+
+# ---------------------------------------------------------------------------
+# 分類ルールテスト
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "title, expected_type, expected_score, expected_buy_caution",
+    [
+        # earnings_report
+        ("決算短信（連結）", "earnings_report", 0.0, False),
+        ("第2四半期決算短信", "earnings_report", 0.0, False),
+        # earnings_revision_up
+        ("業績予想の修正（上方修正）に関するお知らせ", "earnings_revision_up", 1.0, False),
+        ("通期業績予想を上方修正", "earnings_revision_up", 1.0, False),
+        # earnings_revision_down
+        ("業績予想の修正（下方修正）に関するお知らせ", "earnings_revision_down", -1.0, True),
+        ("業績予想を下方修正", "earnings_revision_down", -1.0, True),
+        # dividend_revision_up
+        ("配当予想の修正（増配）に関するお知らせ", "dividend_revision_up", 1.0, False),
+        # dividend_revision_down
+        ("配当予想の修正（減配）に関するお知らせ", "dividend_revision_down", -1.0, False),
+        # buyback
+        ("自己株式取得に関するお知らせ", "buyback", 0.5, False),
+        ("自社株買いの実施について", "buyback", 0.5, False),
+        # new_share_issuance
+        ("第三者割当による新株式発行に関するお知らせ", "new_share_issuance", -0.5, True),
+        ("公募増資について", "new_share_issuance", -0.5, True),
+        # merger_acquisition
+        ("株式取得（子会社化）に関するお知らせ", "merger_acquisition", 0.0, True),
+        ("資本業務提携に関するお知らせ", "merger_acquisition", 0.0, True),
+        # litigation_scandal
+        ("訴訟の提起に関するお知らせ", "litigation_scandal", -1.0, True),
+        ("不祥事に関する調査結果について", "litigation_scandal", -1.0, True),
+        # other
+        ("代表取締役の異動に関するお知らせ", "other", 0.0, False),
+        ("定時株主総会招集ご通知", "other", 0.0, False),
+    ],
+)
+def test_classify_title(title, expected_type, expected_score, expected_buy_caution):
+    """classify_title が各イベントタイプを正しく判定することを確認する。"""
+    result = classify_title(title)
+    assert result["event_type"] == expected_type, f"title={title!r}"
+    assert result["event_score"] == expected_score, f"title={title!r}"
+    assert result["buy_caution"] == expected_buy_caution, f"title={title!r}"
+
+
+def test_classify_title_none_returns_other():
+    """None タイトルは 'other' を返すことを確認する。"""
+    result = classify_title(None)
+    assert result["event_type"] == "other"
+    assert result["event_score"] == 0.0
+
+
+def test_classify_disclosures_writes_events(cdb):
+    """classify_disclosures が raw_disclosures を読んで disclosure_events に書くことを確認する。"""
+    from datetime import date
+    _insert_raw(cdb, "TDN001", "業績予想の修正（上方修正）に関するお知らせ")
+    _insert_raw(cdb, "TDN002", "自己株式取得に関するお知らせ")
+    saved = classify_disclosures(cdb, target_date=date(2024, 9, 1))
+    assert saved == 2
+    rows = cdb.execute(
+        "SELECT id, event_type, event_score FROM disclosure_events ORDER BY id"
+    ).fetchall()
+    assert rows[0] == ("TDN001", "earnings_revision_up", 1.0)
+    assert rows[1] == ("TDN002", "buyback", 0.5)
+
+
+def test_classify_disclosures_upsert(cdb):
+    """同じ開示を再分類しても重複しないことを確認する（UPSERT 動作）。"""
+    from datetime import date
+    _insert_raw(cdb, "TDN001", "決算短信（連結）")
+    classify_disclosures(cdb, target_date=date(2024, 9, 1))
+    classify_disclosures(cdb, target_date=date(2024, 9, 1))
+    count = cdb.execute("SELECT COUNT(*) FROM disclosure_events").fetchone()[0]
+    assert count == 1
+
+
+def test_run_disclosure_classification(cdb):
+    """run_disclosure_classification がジョブとして動くことを確認する。"""
+    from datetime import date
+    _insert_raw(cdb, "TDN001", "業績予想を下方修正")
+    saved = run_disclosure_classification(cdb, target_date=date(2024, 9, 1))
+    assert saved == 1
+    row = cdb.execute(
+        "SELECT event_type, buy_caution, review_required FROM disclosure_events WHERE id = 'TDN001'"
+    ).fetchone()
+    assert row[0] == "earnings_revision_down"
+    assert row[1] is True   # buy_caution
+    assert row[2] is True   # review_required

--- a/tests/test_disclosure_classifier.py
+++ b/tests/test_disclosure_classifier.py
@@ -7,7 +7,6 @@ import duckdb
 import pytest
 
 from kabusys.data.disclosure_classifier import (
-    ClassificationResult,
     classify_title,
     classify_disclosures,
     run_disclosure_classification,

--- a/tests/test_tdnet_collector.py
+++ b/tests/test_tdnet_collector.py
@@ -99,23 +99,30 @@ from kabusys.data.tdnet_collector import (
 # Task 2: TDnet パーサーテスト
 # ---------------------------------------------------------------------------
 
+# 実際の TDnet HTML 構造に準拠したサンプル:
+#   - id="main-list-table" の 7列テーブル
+#   - タイトルと PDF href は同一セル（kjTitle の <a href>）
+#   - CSS クラス名: kjTime / kjCode / kjName / kjTitle / kjXbrl / kjPlace / kjHistroy
 _SAMPLE_HTML = """\
 <html><body>
-<table>
-<tr><th>時刻</th><th>コード</th><th>会社名</th><th>表題</th><th>PDF</th></tr>
+<table id="main-list-table">
 <tr>
-  <td>09:00</td>
-  <td>7203</td>
-  <td>トヨタ自動車株式会社</td>
-  <td>業績予想の修正に関するお知らせ</td>
-  <td><a href="140120240901400001.pdf">PDF</a></td>
+  <td class="oddnew-L kjTime" noWrap>09:00</td>
+  <td class="oddnew-M kjCode" noWrap>7203</td>
+  <td class="oddnew-M kjName" noWrap>トヨタ自動車株式会社</td>
+  <td class="oddnew-M kjTitle" align="left"><a href="140120240901400001.pdf" target="_blank">業績予想の修正に関するお知らせ</a></td>
+  <td class="oddnew-M kjXbrl" noWrap align="center"> </td>
+  <td class="oddnew-M kjPlace" noWrap align="left">東</td>
+  <td class="oddnew-R kjHistroy" align="left">　</td>
 </tr>
 <tr>
-  <td>09:10</td>
-  <td>6758</td>
-  <td>ソニーグループ株式会社</td>
-  <td>自己株式取得結果に関するお知らせ</td>
-  <td><a href="140120240901400002.pdf">PDF</a></td>
+  <td class="evennew-L kjTime" noWrap>09:10</td>
+  <td class="evennew-M kjCode" noWrap>6758</td>
+  <td class="evennew-M kjName" noWrap>ソニーグループ株式会社</td>
+  <td class="evennew-M kjTitle" align="left"><a href="140120240901400002.pdf" target="_blank">自己株式取得結果に関するお知らせ</a></td>
+  <td class="evennew-M kjXbrl" noWrap align="center"> </td>
+  <td class="evennew-M kjPlace" noWrap align="left">東</td>
+  <td class="evennew-R kjHistroy" align="left">　</td>
 </tr>
 </table>
 </body></html>
@@ -136,8 +143,28 @@ def test_parse_tdnet_html_returns_disclosures():
 
 
 def test_parse_tdnet_html_empty_table():
-    """行がない HTML テーブルで空リストを返すことを確認する。"""
-    html = "<html><body><table><tr><th>時刻</th></tr></table></body></html>"
+    """id="main-list-table" に有効なデータ行がない場合、空リストを返すことを確認する。"""
+    html = '<html><body><table id="main-list-table"></table></body></html>'
+    from datetime import date
+
+    result = _parse_tdnet_html(html, target_date=date(2024, 9, 1))
+    assert result == []
+
+
+def test_parse_tdnet_html_ignores_other_tables():
+    """id="main-list-table" 以外のテーブルを無視することを確認する。"""
+    html = """\
+<html><body>
+<table id="list-head">
+  <tr>
+    <td class="kjCode">9999</td>
+    <td class="kjTitle"><a href="SHOULD_NOT_APPEAR.pdf">無視されるべき行</a></td>
+  </tr>
+</table>
+<table id="main-list-table">
+</table>
+</body></html>
+"""
     from datetime import date
 
     result = _parse_tdnet_html(html, target_date=date(2024, 9, 1))
@@ -202,19 +229,28 @@ from kabusys.data.disclosure_classifier import run_disclosure_classification
 
 
 _PIPELINE_HTML = """\
-<html><body><table>
-<tr><th>時刻</th><th>コード</th><th>会社名</th><th>表題</th><th>PDF</th></tr>
+<html><body>
+<table id="main-list-table">
 <tr>
-  <td>09:00</td><td>7203</td><td>トヨタ自動車</td>
-  <td>業績予想の修正（上方修正）に関するお知らせ</td>
-  <td><a href="140120240901400001.pdf">PDF</a></td>
+  <td class="oddnew-L kjTime" noWrap>09:00</td>
+  <td class="oddnew-M kjCode" noWrap>7203</td>
+  <td class="oddnew-M kjName" noWrap>トヨタ自動車</td>
+  <td class="oddnew-M kjTitle" align="left"><a href="140120240901400001.pdf" target="_blank">業績予想の修正（上方修正）に関するお知らせ</a></td>
+  <td class="oddnew-M kjXbrl" noWrap align="center"> </td>
+  <td class="oddnew-M kjPlace" noWrap align="left">東</td>
+  <td class="oddnew-R kjHistroy" align="left">　</td>
 </tr>
 <tr>
-  <td>10:00</td><td>6758</td><td>ソニーグループ</td>
-  <td>訴訟の提起に関するお知らせ</td>
-  <td><a href="140120240901400002.pdf">PDF</a></td>
+  <td class="evennew-L kjTime" noWrap>10:00</td>
+  <td class="evennew-M kjCode" noWrap>6758</td>
+  <td class="evennew-M kjName" noWrap>ソニーグループ</td>
+  <td class="evennew-M kjTitle" align="left"><a href="140120240901400002.pdf" target="_blank">訴訟の提起に関するお知らせ</a></td>
+  <td class="evennew-M kjXbrl" noWrap align="center"> </td>
+  <td class="evennew-M kjPlace" noWrap align="left">東</td>
+  <td class="evennew-R kjHistroy" align="left">　</td>
 </tr>
-</table></body></html>
+</table>
+</body></html>
 """
 
 

--- a/tests/test_tdnet_collector.py
+++ b/tests/test_tdnet_collector.py
@@ -2,8 +2,19 @@
 
 from __future__ import annotations
 
+from datetime import date, datetime
+
 import duckdb
 import pytest
+
+from kabusys.data.tdnet_collector import (
+    RawDisclosure,
+    _extract_disclosure_id,
+    _parse_tdnet_html,
+    save_raw_disclosures,
+    run_tdnet_collection,
+)
+from kabusys.data.disclosure_classifier import run_disclosure_classification
 
 
 # ---------------------------------------------------------------------------
@@ -86,15 +97,6 @@ def test_disclosure_events_table_exists(disc_db):
     assert "review_required" in columns
 
 
-from kabusys.data.tdnet_collector import (
-    RawDisclosure,
-    _extract_disclosure_id,
-    _parse_tdnet_html,
-    save_raw_disclosures,
-    run_tdnet_collection,
-)
-
-
 # ---------------------------------------------------------------------------
 # Task 2: TDnet パーサーテスト
 # ---------------------------------------------------------------------------
@@ -131,8 +133,6 @@ _SAMPLE_HTML = """\
 
 def test_parse_tdnet_html_returns_disclosures():
     """_parse_tdnet_html が HTML テーブルから開示リストを返すことを確認する。"""
-    from datetime import date
-
     disclosures = _parse_tdnet_html(_SAMPLE_HTML, target_date=date(2024, 9, 1))
     assert len(disclosures) == 2
     assert disclosures[0]["id"] == "140120240901400001"
@@ -145,8 +145,6 @@ def test_parse_tdnet_html_returns_disclosures():
 def test_parse_tdnet_html_empty_table():
     """id="main-list-table" に有効なデータ行がない場合、空リストを返すことを確認する。"""
     html = '<html><body><table id="main-list-table"></table></body></html>'
-    from datetime import date
-
     result = _parse_tdnet_html(html, target_date=date(2024, 9, 1))
     assert result == []
 
@@ -165,8 +163,6 @@ def test_parse_tdnet_html_ignores_other_tables():
 </table>
 </body></html>
 """
-    from datetime import date
-
     result = _parse_tdnet_html(html, target_date=date(2024, 9, 1))
     assert result == []
 
@@ -182,8 +178,6 @@ def test_extract_disclosure_id_from_href():
 
 def test_save_raw_disclosures_idempotent(disc_db):
     """同じ開示を2回 save しても重複しないことを確認する。"""
-    from datetime import datetime
-
     disclosures = [
         RawDisclosure(
             id="TDN001",
@@ -206,7 +200,6 @@ def test_save_raw_disclosures_idempotent(disc_db):
 
 def test_run_tdnet_collection_mocked(disc_db, monkeypatch):
     """run_tdnet_collection が HTTP をモックして保存件数を返すことを確認する。"""
-    from datetime import date
     from kabusys.data import tdnet_collector
 
     def mock_fetch_page(url, timeout=30):
@@ -224,9 +217,6 @@ def test_run_tdnet_collection_mocked(disc_db, monkeypatch):
 # ---------------------------------------------------------------------------
 # Task 5: 統合テスト（パイプライン全体確認）
 # ---------------------------------------------------------------------------
-
-from kabusys.data.disclosure_classifier import run_disclosure_classification
-
 
 _PIPELINE_HTML = """\
 <html><body>
@@ -256,7 +246,6 @@ _PIPELINE_HTML = """\
 
 def test_full_pipeline_collection_to_classification(monkeypatch):
     """収集 → 保存 → 分類の一連フローが正しく動くことを確認する。"""
-    from datetime import date
     from kabusys.data.schema import init_schema
     from kabusys.data import tdnet_collector
 

--- a/tests/test_tdnet_collector.py
+++ b/tests/test_tdnet_collector.py
@@ -1,4 +1,5 @@
 """TDnet 開示収集モジュールのユニットテスト"""
+
 from __future__ import annotations
 
 import duckdb
@@ -124,6 +125,7 @@ _SAMPLE_HTML = """\
 def test_parse_tdnet_html_returns_disclosures():
     """_parse_tdnet_html が HTML テーブルから開示リストを返すことを確認する。"""
     from datetime import date
+
     disclosures = _parse_tdnet_html(_SAMPLE_HTML, target_date=date(2024, 9, 1))
     assert len(disclosures) == 2
     assert disclosures[0]["id"] == "140120240901400001"
@@ -137,6 +139,7 @@ def test_parse_tdnet_html_empty_table():
     """行がない HTML テーブルで空リストを返すことを確認する。"""
     html = "<html><body><table><tr><th>時刻</th></tr></table></body></html>"
     from datetime import date
+
     result = _parse_tdnet_html(html, target_date=date(2024, 9, 1))
     assert result == []
 
@@ -144,13 +147,16 @@ def test_parse_tdnet_html_empty_table():
 def test_extract_disclosure_id_from_href():
     """PDF href から開示IDを抽出できることを確認する。"""
     assert _extract_disclosure_id("140120241031413060.pdf") == "140120241031413060"
-    assert _extract_disclosure_id("/inbs/140120241031413060.pdf") == "140120241031413060"
+    assert (
+        _extract_disclosure_id("/inbs/140120241031413060.pdf") == "140120241031413060"
+    )
     assert _extract_disclosure_id("") is None
 
 
 def test_save_raw_disclosures_idempotent(disc_db):
     """同じ開示を2回 save しても重複しないことを確認する。"""
     from datetime import datetime
+
     disclosures = [
         RawDisclosure(
             id="TDN001",
@@ -186,3 +192,61 @@ def test_run_tdnet_collection_mocked(disc_db, monkeypatch):
     assert saved == 2
     rows = disc_db.execute("SELECT COUNT(*) FROM raw_disclosures").fetchone()[0]
     assert rows == 2
+
+
+# ---------------------------------------------------------------------------
+# Task 5: 統合テスト（パイプライン全体確認）
+# ---------------------------------------------------------------------------
+
+from kabusys.data.disclosure_classifier import run_disclosure_classification
+
+
+_PIPELINE_HTML = """\
+<html><body><table>
+<tr><th>時刻</th><th>コード</th><th>会社名</th><th>表題</th><th>PDF</th></tr>
+<tr>
+  <td>09:00</td><td>7203</td><td>トヨタ自動車</td>
+  <td>業績予想の修正（上方修正）に関するお知らせ</td>
+  <td><a href="140120240901400001.pdf">PDF</a></td>
+</tr>
+<tr>
+  <td>10:00</td><td>6758</td><td>ソニーグループ</td>
+  <td>訴訟の提起に関するお知らせ</td>
+  <td><a href="140120240901400002.pdf">PDF</a></td>
+</tr>
+</table></body></html>
+"""
+
+
+def test_full_pipeline_collection_to_classification(monkeypatch):
+    """収集 → 保存 → 分類の一連フローが正しく動くことを確認する。"""
+    from datetime import date
+    from kabusys.data.schema import init_schema
+    from kabusys.data import tdnet_collector
+
+    conn = init_schema(":memory:")
+
+    def mock_fetch_page(url, timeout=30):
+        if "I_list_001" in url:
+            return _PIPELINE_HTML
+        return "<html><body><table></table></body></html>"
+
+    monkeypatch.setattr(tdnet_collector, "_fetch_page", mock_fetch_page)
+
+    target = date(2024, 9, 1)
+    saved_raw = run_tdnet_collection(conn, target_date=target)
+    assert saved_raw == 2
+
+    count = conn.execute("SELECT COUNT(*) FROM raw_disclosures").fetchone()[0]
+    assert count == 2
+
+    saved_events = run_disclosure_classification(conn, target_date=target)
+    assert saved_events == 2
+
+    rows = conn.execute(
+        "SELECT id, event_type, event_score, buy_caution FROM disclosure_events ORDER BY id"
+    ).fetchall()
+    assert rows[0] == ("140120240901400001", "earnings_revision_up", 1.0, False)
+    assert rows[1] == ("140120240901400002", "litigation_scandal", -1.0, True)
+
+    conn.close()

--- a/tests/test_tdnet_collector.py
+++ b/tests/test_tdnet_collector.py
@@ -83,3 +83,106 @@ def test_disclosure_events_table_exists(disc_db):
     assert "event_score" in columns
     assert "buy_caution" in columns
     assert "review_required" in columns
+
+
+from kabusys.data.tdnet_collector import (
+    RawDisclosure,
+    _extract_disclosure_id,
+    _parse_tdnet_html,
+    save_raw_disclosures,
+    run_tdnet_collection,
+)
+
+
+# ---------------------------------------------------------------------------
+# Task 2: TDnet パーサーテスト
+# ---------------------------------------------------------------------------
+
+_SAMPLE_HTML = """\
+<html><body>
+<table>
+<tr><th>時刻</th><th>コード</th><th>会社名</th><th>表題</th><th>PDF</th></tr>
+<tr>
+  <td>09:00</td>
+  <td>7203</td>
+  <td>トヨタ自動車株式会社</td>
+  <td>業績予想の修正に関するお知らせ</td>
+  <td><a href="140120240901400001.pdf">PDF</a></td>
+</tr>
+<tr>
+  <td>09:10</td>
+  <td>6758</td>
+  <td>ソニーグループ株式会社</td>
+  <td>自己株式取得結果に関するお知らせ</td>
+  <td><a href="140120240901400002.pdf">PDF</a></td>
+</tr>
+</table>
+</body></html>
+"""
+
+
+def test_parse_tdnet_html_returns_disclosures():
+    """_parse_tdnet_html が HTML テーブルから開示リストを返すことを確認する。"""
+    from datetime import date
+    disclosures = _parse_tdnet_html(_SAMPLE_HTML, target_date=date(2024, 9, 1))
+    assert len(disclosures) == 2
+    assert disclosures[0]["id"] == "140120240901400001"
+    assert disclosures[0]["code"] == "7203"
+    assert disclosures[0]["company_name"] == "トヨタ自動車株式会社"
+    assert "業績予想" in disclosures[0]["title"]
+    assert disclosures[0]["source"] == "tdnet"
+
+
+def test_parse_tdnet_html_empty_table():
+    """行がない HTML テーブルで空リストを返すことを確認する。"""
+    html = "<html><body><table><tr><th>時刻</th></tr></table></body></html>"
+    from datetime import date
+    result = _parse_tdnet_html(html, target_date=date(2024, 9, 1))
+    assert result == []
+
+
+def test_extract_disclosure_id_from_href():
+    """PDF href から開示IDを抽出できることを確認する。"""
+    assert _extract_disclosure_id("140120241031413060.pdf") == "140120241031413060"
+    assert _extract_disclosure_id("/inbs/140120241031413060.pdf") == "140120241031413060"
+    assert _extract_disclosure_id("") is None
+
+
+def test_save_raw_disclosures_idempotent(disc_db):
+    """同じ開示を2回 save しても重複しないことを確認する。"""
+    from datetime import datetime
+    disclosures = [
+        RawDisclosure(
+            id="TDN001",
+            disclosed_at=datetime(2024, 9, 1, 9, 0, 0),
+            code="7203",
+            company_name="トヨタ自動車",
+            title="業績予想修正",
+            document_url="https://example.com/TDN001.pdf",
+            document_type="業績予想の修正",
+            source="tdnet",
+        )
+    ]
+    first = save_raw_disclosures(disc_db, disclosures)
+    second = save_raw_disclosures(disc_db, disclosures)
+    assert first == 1
+    assert second == 0
+    count = disc_db.execute("SELECT COUNT(*) FROM raw_disclosures").fetchone()[0]
+    assert count == 1
+
+
+def test_run_tdnet_collection_mocked(disc_db, monkeypatch):
+    """run_tdnet_collection が HTTP をモックして保存件数を返すことを確認する。"""
+    from datetime import date
+    from kabusys.data import tdnet_collector
+
+    def mock_fetch_page(url, timeout=30):
+        if "I_list_001" in url:
+            return _SAMPLE_HTML
+        return "<html><body><table></table></body></html>"
+
+    monkeypatch.setattr(tdnet_collector, "_fetch_page", mock_fetch_page)
+    saved = run_tdnet_collection(disc_db, target_date=date(2024, 9, 1))
+    assert saved == 2
+    rows = disc_db.execute("SELECT COUNT(*) FROM raw_disclosures").fetchone()[0]
+    assert rows == 2

--- a/tests/test_tdnet_collector.py
+++ b/tests/test_tdnet_collector.py
@@ -1,0 +1,85 @@
+"""TDnet 開示収集モジュールのユニットテスト"""
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# フィクスチャ
+# ---------------------------------------------------------------------------
+
+_DISCLOSURE_DDL = [
+    """
+    CREATE TABLE IF NOT EXISTS raw_disclosures (
+        id              VARCHAR   NOT NULL PRIMARY KEY,
+        disclosed_at    TIMESTAMP NOT NULL,
+        code            VARCHAR,
+        company_name    VARCHAR,
+        title           VARCHAR,
+        document_url    VARCHAR,
+        document_type   VARCHAR,
+        source          VARCHAR   NOT NULL CHECK (source IN ('tdnet', 'edinet')),
+        fetched_at      TIMESTAMP NOT NULL DEFAULT current_timestamp
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS disclosure_events (
+        id               VARCHAR   NOT NULL PRIMARY KEY,
+        disclosed_at     TIMESTAMP NOT NULL,
+        code             VARCHAR,
+        event_type       VARCHAR   NOT NULL,
+        event_score      DOUBLE    NOT NULL,
+        buy_caution      BOOLEAN   NOT NULL DEFAULT false,
+        hold_caution     BOOLEAN   NOT NULL DEFAULT false,
+        review_required  BOOLEAN   NOT NULL DEFAULT false,
+        title            VARCHAR,
+        source           VARCHAR   NOT NULL CHECK (source IN ('tdnet', 'edinet')),
+        classified_at    TIMESTAMP NOT NULL DEFAULT current_timestamp
+    )
+    """,
+]
+
+
+@pytest.fixture
+def disc_db():
+    conn = duckdb.connect(":memory:")
+    for ddl in _DISCLOSURE_DDL:
+        conn.execute(ddl)
+    yield conn
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Task 1: スキーマテスト
+# ---------------------------------------------------------------------------
+
+
+def test_raw_disclosures_table_exists(disc_db):
+    """raw_disclosures テーブルが正しく作成されることを確認する。"""
+    result = disc_db.execute(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_name = 'raw_disclosures' "
+        "ORDER BY column_name"
+    ).fetchall()
+    columns = {row[0] for row in result}
+    assert "id" in columns
+    assert "disclosed_at" in columns
+    assert "code" in columns
+    assert "source" in columns
+    assert "fetched_at" in columns
+
+
+def test_disclosure_events_table_exists(disc_db):
+    """disclosure_events テーブルが正しく作成されることを確認する。"""
+    result = disc_db.execute(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_name = 'disclosure_events' "
+        "ORDER BY column_name"
+    ).fetchall()
+    columns = {row[0] for row in result}
+    assert "id" in columns
+    assert "event_type" in columns
+    assert "event_score" in columns
+    assert "buy_caution" in columns
+    assert "review_required" in columns

--- a/tests/test_tdnet_collector.py
+++ b/tests/test_tdnet_collector.py
@@ -174,6 +174,10 @@ def test_extract_disclosure_id_from_href():
         _extract_disclosure_id("/inbs/140120241031413060.pdf") == "140120241031413060"
     )
     assert _extract_disclosure_id("") is None
+    # クエリ文字列付き href でも正しく抽出できること
+    assert (
+        _extract_disclosure_id("140120241031413060.pdf?foo=bar") == "140120241031413060"
+    )
 
 
 def test_save_raw_disclosures_idempotent(disc_db):


### PR DESCRIPTION
## Summary

- `raw_disclosures` / `disclosure_events` テーブルを `schema.py` に追加（Raw/Processed 層）
- `src/kabusys/data/tdnet_collector.py` を新規実装: TDnet 適時開示一覧 HTML をページネーション全件取得し `raw_disclosures` に冪等保存（ON CONFLICT DO NOTHING）
- `src/kabusys/data/disclosure_classifier.py` を新規実装: 表題ベース9分類ルールで `disclosure_events` に UPSERT（再分類上書き対応）
- Task Scheduler 用スクリプト `scripts/run_tdnet_collection.py`（15:35）と `scripts/run_disclosure_classification.py`（17:00）を追加

## Design

- TDnet HTML スクレイピングは stdlib `html.parser` のみ（外部依存ゼロ）
- SSRF 保護は `news_collector.py` と同じ `_validate_url_scheme` / `_is_private_host` / `_SSRFBlockRedirectHandler` を再利用
- event_type 分類: earnings_report / earnings_revision_up|down / dividend_revision_up|down / buyback / new_share_issuance / merger_acquisition / litigation_scandal / other

## Test Plan

- [ ] `tests/test_tdnet_collector.py` — 8テスト（スキーマ検証・HTML パース・ID抽出・冪等保存・モック収集・統合テスト）
- [ ] `tests/test_disclosure_classifier.py` — 22テスト（18パターンパラメタライズ・UPSERT検証・ジョブ動作）
- [ ] 統合テスト `test_full_pipeline_collection_to_classification` が `init_schema(":memory:")` で全パイプラインを検証
- [ ] 全テストスイート 1405 passed

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)