### PR TITLE
refactor: is_private_host に strict / fail_closed フラグを追加 (Issue #246)

### DIFF
--- a/src/kabusys/utils/http.py
+++ b/src/kabusys/utils/http.py
@@ -71,6 +71,9 @@ def is_private_host(
             return not ip.is_global
         return ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_multicast
 
+    # 角括弧付き IPv6 リテラル（[::1]）を正規化
+    if hostname.startswith("[") and hostname.endswith("]"):
+        hostname = hostname[1:-1]
     # ゾーンインデックスを除去して IP アドレスとして解析
     hostname_clean = hostname.split("%", 1)[0]
     try:
@@ -80,13 +83,17 @@ def is_private_host(
         pass
     # ホスト名の場合: DNS 解決して全 A/AAAA レコードを検査
     try:
-        for info in socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP):
-            ip_str = info[4][0].split("%", 1)[0]
-            ip = ipaddress.ip_address(ip_str)
-            if _is_blocked(ip):
-                return True
-    except (OSError, ValueError):
+        infos = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
+    except OSError:
         return fail_closed
+    for info in infos:
+        ip_str = info[4][0].split("%", 1)[0]
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            continue
+        if _is_blocked(ip):
+            return True
     return False
 
 

--- a/src/kabusys/utils/http.py
+++ b/src/kabusys/utils/http.py
@@ -11,7 +11,10 @@ SSRF 対策の設計方針:
   - IPv6 ゾーンインデックス（fe80::1%eth0 等）は % 以降を除去して判定
   - リダイレクト時も同様の検証を適用（SSRFBlockRedirectHandler）
   - 相対リダイレクト URL は urljoin で絶対化してから検査
-  - DNS 解決失敗時は fail-open（非プライベートとみなして通過）— 意図的な設計
+  - DNS 解決失敗時のデフォルト挙動は fail-open（非プライベートとみなして通過）
+    → fail_closed=True で fail-closed に切り替え可能
+  - strict=True でブロック条件を「グローバル到達不可なものすべて」に強化
+    （unspecified / reserved / documentation / CGNAT 等も対象になる）
 """
 
 from __future__ import annotations
@@ -38,26 +41,41 @@ def validate_url_scheme(url: str) -> None:
         raise ValueError(f"許可されていないURLスキーム: {scheme!r} (url={url!r})")
 
 
-def is_private_host(hostname: str | None) -> bool:
+def is_private_host(
+    hostname: str | None,
+    *,
+    strict: bool = False,
+    fail_closed: bool = False,
+) -> bool:
     """ホスト/IP がプライベート・ループバック・リンクローカルかを判定する。
 
     IP アドレスは直接判定し、ホスト名は DNS 解決して全 A/AAAA レコードを検査する。
     IPv6 ゾーンインデックス（fe80::1%eth0）は % 以降を除去してから解析する。
-    DNS 解決失敗時は安全側（非プライベート）とみなして通過させる（fail-open）。
 
     Args:
-        hostname: 検査対象のホスト名または IP アドレス文字列。None の場合は True を返す。
+        hostname:    検査対象のホスト名または IP アドレス文字列。None の場合は True を返す。
+        strict:      True のとき「グローバル到達不可（not ip.is_global）」を基準にする。
+                     unspecified / reserved / documentation / CGNAT 等も追加でブロックされる。
+                     False（デフォルト）は private / loopback / link-local / multicast のみ。
+        fail_closed: True のとき DNS 解決失敗をブロック（True を返す）。
+                     False（デフォルト）は fail-open（解決失敗時は通過）。
 
     Returns:
-        プライベート/ループバック/リンクローカル/マルチキャストの場合 True。
+        ブロック対象と判定した場合 True。
     """
     if not hostname:
         return True
+
+    def _is_blocked(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+        if strict:
+            return not ip.is_global
+        return ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_multicast
+
     # ゾーンインデックスを除去して IP アドレスとして解析
     hostname_clean = hostname.split("%", 1)[0]
     try:
         ip = ipaddress.ip_address(hostname_clean)
-        return ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_multicast
+        return _is_blocked(ip)
     except ValueError:
         pass
     # ホスト名の場合: DNS 解決して全 A/AAAA レコードを検査
@@ -65,10 +83,10 @@ def is_private_host(hostname: str | None) -> bool:
         for info in socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP):
             ip_str = info[4][0].split("%", 1)[0]
             ip = ipaddress.ip_address(ip_str)
-            if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_multicast:
+            if _is_blocked(ip):
                 return True
     except (OSError, ValueError):
-        pass
+        return fail_closed
     return False
 
 

--- a/tests/test_http_utils.py
+++ b/tests/test_http_utils.py
@@ -152,6 +152,26 @@ def test_is_private_host_strict_public_ip_passes():
     assert is_private_host("1.1.1.1", strict=True) is False
 
 
+def test_is_private_host_bracketed_ipv6_loopback():
+    """角括弧付き IPv6 リテラル [::1] が正しくブロックされることを確認する。"""
+    assert is_private_host("[::1]") is True
+
+
+def test_is_private_host_bracketed_ipv6_link_local():
+    """角括弧付き IPv6 リンクローカル [fe80::1] がブロックされることを確認する。"""
+    assert is_private_host("[fe80::1]") is True
+
+
+def test_is_private_host_bad_dns_record_does_not_trigger_fail_closed():
+    """DNS 応答に不正な IP 文字列が含まれていても他のレコードの判定を継続することを確認する。"""
+    fake_addrs = [
+        (None, None, None, None, ("not-an-ip", 0)),  # 不正レコード → スキップ
+        (None, None, None, None, ("8.8.8.8", 0)),  # 正常なパブリック IP
+    ]
+    with patch("socket.getaddrinfo", return_value=fake_addrs):
+        assert is_private_host("example.com") is False
+
+
 # ---------------------------------------------------------------------------
 # SSRFBlockRedirectHandler
 # ---------------------------------------------------------------------------

--- a/tests/test_http_utils.py
+++ b/tests/test_http_utils.py
@@ -86,6 +86,13 @@ def test_is_private_host_dns_failure_is_fail_open():
     assert result is False
 
 
+def test_is_private_host_dns_failure_fail_closed():
+    """fail_closed=True のとき DNS 解決失敗で True を返すことを確認する。"""
+    with patch("socket.getaddrinfo", side_effect=OSError("NXDOMAIN")):
+        result = is_private_host("nonexistent.invalid", fail_closed=True)
+    assert result is True
+
+
 def test_is_private_host_mixed_records_returns_true():
     """DNS が public/private 混在で返す場合は True を返すことを確認する。"""
     fake_addrs = [
@@ -94,6 +101,55 @@ def test_is_private_host_mixed_records_returns_true():
     ]
     with patch("socket.getaddrinfo", return_value=fake_addrs):
         assert is_private_host("mixed.example.com") is True
+
+
+# ---------------------------------------------------------------------------
+# is_private_host: strict モード
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "hostname",
+    [
+        "0.0.0.0",  # unspecified
+        "::",  # unspecified IPv6
+        "100.64.0.1",  # CGNAT
+        "192.0.2.1",  # documentation (TEST-NET-1)
+        "198.51.100.1",  # documentation (TEST-NET-2)
+        "203.0.113.1",  # documentation (TEST-NET-3)
+        "240.0.0.1",  # reserved
+    ],
+)
+def test_is_private_host_strict_blocks_non_global(hostname):
+    """strict=True のとき unspecified/CGNAT/documentation/reserved もブロックされることを確認する。"""
+    # デフォルトでは通過するが strict では拒否される
+    assert is_private_host(hostname, strict=True) is True
+
+
+def test_is_private_host_default_allows_cgnat():
+    """デフォルト（strict=False）では CGNAT（100.64.0.0/10）が通過することを確認する。
+
+    Python 3.11+ では is_private の定義が拡張されているが、
+    CGNAT は is_private=False のため strict=False では通過する。
+    strict=True（not ip.is_global）ではブロックされる。
+    """
+    assert is_private_host("100.64.0.1", strict=False) is False
+    assert is_private_host("100.64.0.1", strict=True) is True
+
+
+def test_is_private_host_strict_dns_fail_closed():
+    """strict=True かつ fail_closed=True のとき DNS 失敗でブロックされることを確認する。"""
+    with patch("socket.getaddrinfo", side_effect=OSError("NXDOMAIN")):
+        assert (
+            is_private_host("nonexistent.invalid", strict=True, fail_closed=True)
+            is True
+        )
+
+
+def test_is_private_host_strict_public_ip_passes():
+    """strict=True でもグローバル IP はブロックされないことを確認する。"""
+    assert is_private_host("8.8.8.8", strict=True) is False
+    assert is_private_host("1.1.1.1", strict=True) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `is_private_host(hostname, *, strict=False, fail_closed=False)` にオプション引数を追加
- 既存の呼び出し箇所（`news_collector` / `tdnet_collector`）は引数なしのため変更不要

## 変更詳細

| フラグ | デフォルト | 効果 |
|---|---|---|
| `strict=True` | False | `not ip.is_global` を基準にブロック。CGNAT（100.64.0.0/10）等も対象になる |
| `fail_closed=True` | False | DNS 解決失敗時にブロック（True を返す）。デフォルトは fail-open |

## Python 3.11 との互換性メモ

Python 3.11+ では `is_private` の定義が拡張され、`0.0.0.0` / `192.0.2.x`（documentation）等がデフォルトでもブロック対象になっています。`strict=True` が追加でカバーするのは主に **CGNAT（100.64.0.0/10）** です。

## Test Plan

- [x] 新規テスト 11 件追加（合計 40 テスト、全パス）
- [x] フルスイート 1448 件パス
- [x] ruff lint / format 通過

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)