### PR TITLE
feat: TDnet 収集をオプション機能に変更（ENABLE_TDNET フラグ追加）(Issue #244)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,9 @@ KABU_API_BASE_URL=http://localhost:18080/kabusapi
 # AI センチメント分析 (OpenAI API キーが必要。デフォルト: false = 無効)
 # false の場合、news_nlp / regime_detector はスキップされ Core 機能に影響しない
 ENABLE_AI_SENTIMENT=false
+# TDnet 適時開示収集 (デフォルト: false = 無効)
+# true にすると run_tdnet_collection / run_disclosure_classification が実行される
+ENABLE_TDNET=false
 # LINE 通知 (LINE Messaging API キーが必要。デフォルト: false = 無効)
 # false の場合 NullNotifier が使われ Core 機能に影響しない
 LINE_NOTIFY_ENABLED=false

--- a/scripts/run_disclosure_classification.py
+++ b/scripts/run_disclosure_classification.py
@@ -23,6 +23,11 @@ logger = logging.getLogger(__name__)
 
 def main() -> None:
     settings = Settings()
+    if not settings.enable_tdnet:
+        logger.info(
+            "TDnet 収集はオプション機能です（ENABLE_TDNET=false）。スキップします。"
+        )
+        return
     conn = duckdb.connect(str(settings.duckdb_path))
     try:
         saved = run_disclosure_classification(conn)

--- a/scripts/run_tdnet_collection.py
+++ b/scripts/run_tdnet_collection.py
@@ -23,6 +23,11 @@ logger = logging.getLogger(__name__)
 
 def main() -> None:
     settings = Settings()
+    if not settings.enable_tdnet:
+        logger.info(
+            "TDnet 収集はオプション機能です（ENABLE_TDNET=false）。スキップします。"
+        )
+        return
     conn = duckdb.connect(str(settings.duckdb_path))
     try:
         saved = run_tdnet_collection(conn)

--- a/src/kabusys/config.py
+++ b/src/kabusys/config.py
@@ -182,6 +182,15 @@ class Settings:
         """
         return _parse_bool_env("ENABLE_AI_SENTIMENT", default=False)
 
+    @property
+    def enable_tdnet(self) -> bool:
+        """TDnet 適時開示収集機能の有効フラグ（ENABLE_TDNET、デフォルト: False）。
+
+        "1" / "true" / "yes" / "on" のみ True。デフォルト無効。
+        False の場合、tdnet_collection / disclosure_classification ジョブはスキップされる。
+        """
+        return _parse_bool_env("ENABLE_TDNET", default=False)
+
     # --- LINE Messaging API ---
     @property
     def line_channel_access_token(self) -> str:

--- a/tests/test_scripts_batch.py
+++ b/tests/test_scripts_batch.py
@@ -167,3 +167,72 @@ def test_portfolio_construction_no_signals_exits_0():
     ):
         mock_settings.return_value.duckdb_path = Path("/fake.duckdb")
         run_portfolio_construction.main()  # SystemExit が起きないこと
+
+
+# ---------- run_tdnet_collection ----------
+
+
+def test_run_tdnet_collection_skipped_when_disabled():
+    """ENABLE_TDNET=false のとき run_tdnet_collection を呼ばずにリターンする。"""
+    import run_tdnet_collection
+
+    with (
+        patch("run_tdnet_collection.Settings") as mock_settings,
+        patch("run_tdnet_collection.run_tdnet_collection") as mock_fn,
+    ):
+        mock_settings.return_value.enable_tdnet = False
+        run_tdnet_collection.main()
+
+    mock_fn.assert_not_called()
+
+
+def test_run_tdnet_collection_runs_when_enabled():
+    """ENABLE_TDNET=true のとき run_tdnet_collection が実行される。"""
+    import run_tdnet_collection
+
+    with (
+        patch("run_tdnet_collection.Settings") as mock_settings,
+        patch("run_tdnet_collection.duckdb.connect"),
+        patch("run_tdnet_collection.run_tdnet_collection", return_value=3) as mock_fn,
+    ):
+        mock_settings.return_value.enable_tdnet = True
+        mock_settings.return_value.duckdb_path = Path("/fake.duckdb")
+        run_tdnet_collection.main()
+
+    mock_fn.assert_called_once()
+
+
+# ---------- run_disclosure_classification ----------
+
+
+def test_run_disclosure_classification_skipped_when_disabled():
+    """ENABLE_TDNET=false のとき run_disclosure_classification を呼ばずにリターンする。"""
+    import run_disclosure_classification
+
+    with (
+        patch("run_disclosure_classification.Settings") as mock_settings,
+        patch("run_disclosure_classification.run_disclosure_classification") as mock_fn,
+    ):
+        mock_settings.return_value.enable_tdnet = False
+        run_disclosure_classification.main()
+
+    mock_fn.assert_not_called()
+
+
+def test_run_disclosure_classification_runs_when_enabled():
+    """ENABLE_TDNET=true のとき run_disclosure_classification が実行される。"""
+    import run_disclosure_classification
+
+    with (
+        patch("run_disclosure_classification.Settings") as mock_settings,
+        patch("run_disclosure_classification.duckdb.connect"),
+        patch(
+            "run_disclosure_classification.run_disclosure_classification",
+            return_value=2,
+        ) as mock_fn,
+    ):
+        mock_settings.return_value.enable_tdnet = True
+        mock_settings.return_value.duckdb_path = Path("/fake.duckdb")
+        run_disclosure_classification.main()
+
+    mock_fn.assert_called_once()


### PR DESCRIPTION
## Summary

- `Settings.enable_tdnet` プロパティを追加（環境変数 `ENABLE_TDNET`、デフォルト: `false`）
- `run_tdnet_collection.py` / `run_disclosure_classification.py`: `enable_tdnet=false` 時はスキップしてログ出力
- `.env.example` に `ENABLE_TDNET=false` を追記
- `run_tdnet_collection` / `run_disclosure_classification` の実装自体は変更なし（呼び出し側で制御）

## Test Plan

- [x] `test_run_tdnet_collection_skipped_when_disabled` — 無効時にスキップ確認
- [x] `test_run_tdnet_collection_runs_when_enabled` — 有効時に実行確認
- [x] `test_run_disclosure_classification_skipped_when_disabled` — 無効時にスキップ確認
- [x] `test_run_disclosure_classification_runs_when_enabled` — 有効時に実行確認
- [x] 全 1455 テスト PASS

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)