### PR TITLE
feat: config_setup ウィザードに拡張機能トグルを追加 (Issue #249)

### DIFF
--- a/src/kabusys/config_setup.py
+++ b/src/kabusys/config_setup.py
@@ -15,6 +15,14 @@ from pathlib import Path
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 _ENV_PATH = _PROJECT_ROOT / ".env"
 
+# 拡張機能トグルのキーとデフォルト値。_ITEMS と _write_env の両方がここを参照する。
+# 新しいトグルを追加する場合はここだけ編集すればよい。
+_TOGGLE_DEFAULTS: dict[str, str] = {
+    "LINE_NOTIFY_ENABLED": "false",
+    "ENABLE_AI_SENTIMENT": "false",
+    "ENABLE_TDNET": "false",
+}
+
 # ---------------------------------------------------------------------------
 # 設定項目定義
 # ---------------------------------------------------------------------------
@@ -189,9 +197,7 @@ def _write_env(path: Path, values: dict[str, str]) -> None:
         f"LOG_LEVEL={values.get('LOG_LEVEL', 'INFO')}",
         "",
         "# --- 拡張機能トグル ---",
-        f"LINE_NOTIFY_ENABLED={values.get('LINE_NOTIFY_ENABLED', 'false')}",
-        f"ENABLE_AI_SENTIMENT={values.get('ENABLE_AI_SENTIMENT', 'false')}",
-        f"ENABLE_TDNET={values.get('ENABLE_TDNET', 'false')}",
+        *[f"{k}={values.get(k, v)}" for k, v in _TOGGLE_DEFAULTS.items()],
         "",
         "# --- Kill Switch ---",
         f"KILL_FLAG_CLEAR_ON_START={values.get('KILL_FLAG_CLEAR_ON_START', '0')}",

--- a/src/kabusys/config_setup.py
+++ b/src/kabusys/config_setup.py
@@ -91,6 +91,36 @@ _ITEMS: list[dict] = [
         "description": "  アラート送信先 LINE ユーザー ID（空欄でスキップ）",
     },
     {
+        "key": "LINE_NOTIFY_ENABLED",
+        "label": "LINE 通知の有効化",
+        "choices": ["true", "false"],
+        "default": "false",
+        "description": (
+            "  LINE Messaging API でアラートを通知する（LINE_CHANNEL_ACCESS_TOKEN / LINE_USER_ID が必要）\n"
+            "  false の場合 NullNotifier が使われ Core 機能に影響しない"
+        ),
+    },
+    {
+        "key": "ENABLE_AI_SENTIMENT",
+        "label": "AI センチメント分析の有効化",
+        "choices": ["true", "false"],
+        "default": "false",
+        "description": (
+            "  Yahoo ニュースを OpenAI で分析し売買判断に加味する（OPENAI_API_KEY が別途必要・有料）\n"
+            "  false の場合 news_nlp / regime_detector はスキップされ Core 機能に影響しない"
+        ),
+    },
+    {
+        "key": "ENABLE_TDNET",
+        "label": "TDnet 適時開示収集の有効化",
+        "choices": ["true", "false"],
+        "default": "false",
+        "description": (
+            "  TDnet から当日の開示一覧を収集・分類する（無料）\n"
+            "  false の場合 tdnet_collection / disclosure_classification ジョブはスキップされる"
+        ),
+    },
+    {
         "key": "LOG_LEVEL",
         "label": "ログレベル",
         "choices": ["DEBUG", "INFO", "WARNING", "ERROR"],
@@ -157,6 +187,11 @@ def _write_env(path: Path, values: dict[str, str]) -> None:
         "# --- システム設定 ---",
         f"KABUSYS_ENV={values.get('KABUSYS_ENV', 'development')}",
         f"LOG_LEVEL={values.get('LOG_LEVEL', 'INFO')}",
+        "",
+        "# --- 拡張機能トグル ---",
+        f"LINE_NOTIFY_ENABLED={values.get('LINE_NOTIFY_ENABLED', 'false')}",
+        f"ENABLE_AI_SENTIMENT={values.get('ENABLE_AI_SENTIMENT', 'false')}",
+        f"ENABLE_TDNET={values.get('ENABLE_TDNET', 'false')}",
         "",
         "# --- Kill Switch ---",
         f"KILL_FLAG_CLEAR_ON_START={values.get('KILL_FLAG_CLEAR_ON_START', '0')}",

--- a/tests/test_config_setup.py
+++ b/tests/test_config_setup.py
@@ -65,11 +65,31 @@ def test_write_env_respects_toggle_values(tmp_path):
     from kabusys.config_setup import _write_env
 
     env_file = tmp_path / ".env"
-    _write_env(env_file, {"ENABLE_TDNET": "true", "ENABLE_AI_SENTIMENT": "true"})
+    _write_env(
+        env_file,
+        {
+            "ENABLE_TDNET": "true",
+            "ENABLE_AI_SENTIMENT": "true",
+            "LINE_NOTIFY_ENABLED": "true",
+        },
+    )
 
     content = env_file.read_text(encoding="utf-8")
     assert "ENABLE_TDNET=true" in content
     assert "ENABLE_AI_SENTIMENT=true" in content
+    assert "LINE_NOTIFY_ENABLED=true" in content
+
+
+def test_write_env_toggle_keys_match_toggle_defaults(tmp_path):
+    """_write_env が _TOGGLE_DEFAULTS のすべてのキーを書き出すこと（定数追加時のリグレッション防止）。"""
+    from kabusys.config_setup import _TOGGLE_DEFAULTS, _write_env
+
+    env_file = tmp_path / ".env"
+    _write_env(env_file, {})
+
+    content = env_file.read_text(encoding="utf-8")
+    for key in _TOGGLE_DEFAULTS:
+        assert key in content, f"{key} が .env に書き出されていない"
 
 
 def test_write_env_roundtrip(tmp_path):

--- a/tests/test_config_setup.py
+++ b/tests/test_config_setup.py
@@ -47,6 +47,31 @@ def test_write_env_creates_file(tmp_path):
     assert "KABUSYS_ENV=development" in content
 
 
+def test_write_env_includes_toggles_with_defaults(tmp_path):
+    """_write_env が拡張機能トグルをデフォルト値で書き出すこと。"""
+    from kabusys.config_setup import _write_env
+
+    env_file = tmp_path / ".env"
+    _write_env(env_file, {})
+
+    content = env_file.read_text(encoding="utf-8")
+    assert "ENABLE_TDNET=false" in content
+    assert "ENABLE_AI_SENTIMENT=false" in content
+    assert "LINE_NOTIFY_ENABLED=false" in content
+
+
+def test_write_env_respects_toggle_values(tmp_path):
+    """_write_env がユーザー設定のトグル値を正しく書き出すこと。"""
+    from kabusys.config_setup import _write_env
+
+    env_file = tmp_path / ".env"
+    _write_env(env_file, {"ENABLE_TDNET": "true", "ENABLE_AI_SENTIMENT": "true"})
+
+    content = env_file.read_text(encoding="utf-8")
+    assert "ENABLE_TDNET=true" in content
+    assert "ENABLE_AI_SENTIMENT=true" in content
+
+
 def test_write_env_roundtrip(tmp_path):
     """_write_env → _read_env でラウンドトリップできること。"""
     from kabusys.config_setup import _read_env, _write_env


### PR DESCRIPTION
## Summary

- `_ITEMS` に `LINE_NOTIFY_ENABLED` / `ENABLE_AI_SENTIMENT` / `ENABLE_TDNET` を追加（ウィザード実行時に対話式で設定可能）
- `_write_env` に `# --- 拡張機能トグル ---` セクションを新設し、3項目をデフォルト `false` で書き出すよう修正
- これにより `python -m kabusys.config_setup` 実行後の `.env` にトグル設定が自動的に含まれる

## Test Plan

- [x] `test_write_env_includes_toggles_with_defaults` — デフォルト値で3項目が書き出されること
- [x] `test_write_env_respects_toggle_values` — ユーザー設定値が正しく反映されること
- [x] 全 1457 テスト PASS・ruff clean

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)