### PR TITLE
feat: Streamlit 4ページ構成ダッシュボードを実装 (Issue #231)

### DIFF
--- a/src/kabusys/monitoring/dashboard_data.py
+++ b/src/kabusys/monitoring/dashboard_data.py
@@ -1,0 +1,148 @@
+"""dashboard_data.py — Streamlit ダッシュボード各ページ共通のデータロード関数。
+
+各関数は DuckDB / SQLite コネクションを受け取り DataFrame / list[dict] を返す。
+Streamlit に依存しないため単体テスト可能。
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import duckdb
+import pandas as pd
+
+
+# ---------------------------------------------------------------------------
+# Home ページ（SQLite）
+# ---------------------------------------------------------------------------
+
+
+def load_error_logs(conn: sqlite3.Connection, limit: int = 20) -> list[dict]:
+    """ERROR / CRITICAL レベルのリスクイベントを返す。"""
+    conn.row_factory = sqlite3.Row
+    cursor = conn.execute(
+        """SELECT * FROM risk_logs
+           WHERE event_type IN ('CRITICAL', 'ORDER_ERROR', 'RISK_BREACH', 'KILL_SWITCH')
+           ORDER BY logged_at DESC LIMIT ?""",
+        (limit,),
+    )
+    return [dict(row) for row in cursor.fetchall()]
+
+
+# ---------------------------------------------------------------------------
+# Signal Queue ページ（DuckDB）
+# ---------------------------------------------------------------------------
+
+
+def load_signal_queue(conn: duckdb.DuckDBPyConnection) -> pd.DataFrame:
+    """signal_queue テーブルから全シグナルを返す。"""
+    return conn.execute(
+        """SELECT signal_id, date, code, side, size, order_type, price, status, created_at
+           FROM signal_queue
+           ORDER BY date DESC, created_at DESC
+           LIMIT 200"""
+    ).df()
+
+
+def load_signals(conn: duckdb.DuckDBPyConnection) -> pd.DataFrame:
+    """直近7日分の signals テーブルを返す。"""
+    return conn.execute(
+        """SELECT date, code, side, score, signal_rank, size_multiplier
+           FROM signals
+           WHERE date >= current_date - INTERVAL 7 DAY
+           ORDER BY date DESC, signal_rank ASC"""
+    ).df()
+
+
+def load_portfolio_targets(conn: duckdb.DuckDBPyConnection) -> pd.DataFrame:
+    """最新日付の portfolio_targets を返す。"""
+    return conn.execute(
+        """SELECT date, code, target_weight, target_size
+           FROM portfolio_targets
+           WHERE date = (SELECT MAX(date) FROM portfolio_targets)
+           ORDER BY target_weight DESC NULLS LAST"""
+    ).df()
+
+
+# ---------------------------------------------------------------------------
+# Performance ページ（DuckDB）
+# ---------------------------------------------------------------------------
+
+
+def load_portfolio_performance(
+    conn: duckdb.DuckDBPyConnection, days: int = 90
+) -> pd.DataFrame:
+    """直近 N 日分の portfolio_performance を返す。"""
+    return conn.execute(
+        """SELECT date, env, equity, cash, drawdown, daily_return
+           FROM portfolio_performance
+           WHERE date >= current_date - INTERVAL (?) DAY
+           ORDER BY date ASC""",
+        [days],
+    ).df()
+
+
+def load_open_positions(conn: duckdb.DuckDBPyConnection) -> pd.DataFrame:
+    """最新日付のゼロ以外ポジションを返す。"""
+    return conn.execute(
+        """SELECT date, code, position_size, avg_price, market_value
+           FROM positions
+           WHERE date = (SELECT MAX(date) FROM positions)
+             AND position_size != 0
+           ORDER BY market_value DESC NULLS LAST"""
+    ).df()
+
+
+def load_recent_trades(
+    conn: duckdb.DuckDBPyConnection, limit: int = 50
+) -> pd.DataFrame:
+    """直近 N 件の取引履歴を返す。"""
+    return conn.execute(
+        """SELECT trade_id, order_id, datetime, code, price, size
+           FROM trades
+           ORDER BY datetime DESC
+           LIMIT ?""",
+        [limit],
+    ).df()
+
+
+# ---------------------------------------------------------------------------
+# Strategy Lab ページ（DuckDB）
+# ---------------------------------------------------------------------------
+
+
+def load_market_regime(conn: duckdb.DuckDBPyConnection, days: int = 30) -> pd.DataFrame:
+    """直近 N 日分の market_regime を返す。"""
+    return conn.execute(
+        """SELECT date, regime_score, regime_label, ma200_ratio, macro_sentiment
+           FROM market_regime
+           WHERE date >= current_date - INTERVAL (?) DAY
+           ORDER BY date ASC""",
+        [days],
+    ).df()
+
+
+def load_ai_scores(conn: duckdb.DuckDBPyConnection) -> pd.DataFrame:
+    """最新日付の AI スコアを返す。"""
+    return conn.execute(
+        """SELECT date, code, sentiment_score, regime_score, ai_score
+           FROM ai_scores
+           WHERE date = (SELECT MAX(date) FROM ai_scores)
+           ORDER BY ai_score DESC NULLS LAST"""
+    ).df()
+
+
+def load_signal_summary(
+    conn: duckdb.DuckDBPyConnection, days: int = 30
+) -> pd.DataFrame:
+    """直近 N 日のシグナル集計（日別 buy/sell 件数）を返す。"""
+    return conn.execute(
+        """SELECT date,
+                  COUNT(*) FILTER (WHERE side='buy')  AS buy_count,
+                  COUNT(*) FILTER (WHERE side='sell') AS sell_count
+           FROM signals
+           WHERE date >= current_date - INTERVAL (?) DAY
+           GROUP BY date
+           ORDER BY date ASC""",
+        [days],
+    ).df()

--- a/src/kabusys/monitoring/dashboard_data.py
+++ b/src/kabusys/monitoring/dashboard_data.py
@@ -7,6 +7,7 @@ Streamlit に依存しないため単体テスト可能。
 from __future__ import annotations
 
 import sqlite3
+from datetime import date, timedelta
 
 import duckdb
 import pandas as pd
@@ -19,14 +20,14 @@ import pandas as pd
 
 def load_error_logs(conn: sqlite3.Connection, limit: int = 20) -> list[dict]:
     """ERROR / CRITICAL レベルのリスクイベントを返す。"""
-    conn.row_factory = sqlite3.Row
-    cursor = conn.execute(
+    cur = conn.execute(
         """SELECT * FROM risk_logs
            WHERE event_type IN ('CRITICAL', 'ORDER_ERROR', 'RISK_BREACH', 'KILL_SWITCH')
            ORDER BY logged_at DESC LIMIT ?""",
         (limit,),
     )
-    return [dict(row) for row in cursor.fetchall()]
+    cols = [d[0] for d in cur.description]
+    return [dict(zip(cols, row)) for row in cur.fetchall()]
 
 
 # ---------------------------------------------------------------------------
@@ -46,11 +47,13 @@ def load_signal_queue(conn: duckdb.DuckDBPyConnection) -> pd.DataFrame:
 
 def load_signals(conn: duckdb.DuckDBPyConnection) -> pd.DataFrame:
     """直近7日分の signals テーブルを返す。"""
+    cutoff = (date.today() - timedelta(days=7)).isoformat()
     return conn.execute(
         """SELECT date, code, side, score, signal_rank, size_multiplier
            FROM signals
-           WHERE date >= current_date - INTERVAL 7 DAY
-           ORDER BY date DESC, signal_rank ASC"""
+           WHERE date >= ?::DATE
+           ORDER BY date DESC, signal_rank ASC""",
+        [cutoff],
     ).df()
 
 
@@ -70,15 +73,17 @@ def load_portfolio_targets(conn: duckdb.DuckDBPyConnection) -> pd.DataFrame:
 
 
 def load_portfolio_performance(
-    conn: duckdb.DuckDBPyConnection, days: int = 90
+    conn: duckdb.DuckDBPyConnection, env: str, days: int = 90
 ) -> pd.DataFrame:
-    """直近 N 日分の portfolio_performance を返す。"""
+    """指定 env の直近 N 日分の portfolio_performance を返す。"""
+    cutoff = (date.today() - timedelta(days=days)).isoformat()
     return conn.execute(
         """SELECT date, env, equity, cash, drawdown, daily_return
            FROM portfolio_performance
-           WHERE date >= current_date - INTERVAL (?) DAY
+           WHERE env = ?
+             AND date >= ?::DATE
            ORDER BY date ASC""",
-        [days],
+        [env, cutoff],
     ).df()
 
 
@@ -113,12 +118,13 @@ def load_recent_trades(
 
 def load_market_regime(conn: duckdb.DuckDBPyConnection, days: int = 30) -> pd.DataFrame:
     """直近 N 日分の market_regime を返す。"""
+    cutoff = (date.today() - timedelta(days=days)).isoformat()
     return conn.execute(
         """SELECT date, regime_score, regime_label, ma200_ratio, macro_sentiment
            FROM market_regime
-           WHERE date >= current_date - INTERVAL (?) DAY
+           WHERE date >= ?::DATE
            ORDER BY date ASC""",
-        [days],
+        [cutoff],
     ).df()
 
 
@@ -136,13 +142,14 @@ def load_signal_summary(
     conn: duckdb.DuckDBPyConnection, days: int = 30
 ) -> pd.DataFrame:
     """直近 N 日のシグナル集計（日別 buy/sell 件数）を返す。"""
+    cutoff = (date.today() - timedelta(days=days)).isoformat()
     return conn.execute(
         """SELECT date,
                   COUNT(*) FILTER (WHERE side='buy')  AS buy_count,
                   COUNT(*) FILTER (WHERE side='sell') AS sell_count
            FROM signals
-           WHERE date >= current_date - INTERVAL (?) DAY
+           WHERE date >= ?::DATE
            GROUP BY date
            ORDER BY date ASC""",
-        [days],
+        [cutoff],
     ).df()

--- a/src/kabusys/monitoring/pages/2_Signal_Queue.py
+++ b/src/kabusys/monitoring/pages/2_Signal_Queue.py
@@ -1,0 +1,65 @@
+"""pages/2_Signal_Queue.py — 翌営業日の発注予定・シグナル確認ビュー。"""
+
+from __future__ import annotations
+
+import duckdb
+import streamlit as st
+
+from kabusys.config import Settings
+from kabusys.monitoring.dashboard_data import (
+    load_portfolio_targets,
+    load_signal_queue,
+    load_signals,
+)
+
+st.set_page_config(page_title="Signal Queue", layout="wide", page_icon="📋")
+st.title("📋 Signal Queue — 発注予定・シグナル確認")
+
+settings = Settings()
+with st.sidebar:
+    st.caption(f"環境: **{settings.env}**")
+    if st.button("🔄 Refresh"):
+        st.rerun()
+
+try:
+    conn = duckdb.connect(str(settings.duckdb_path), read_only=True)
+except Exception as e:
+    st.error(f"DuckDB 接続失敗: {e}")
+    st.stop()
+
+try:
+    tab_queue, tab_targets, tab_signals = st.tabs(
+        ["発注キュー", "ポートフォリオ目標", "シグナル（直近7日）"]
+    )
+
+    with tab_queue:
+        st.subheader("Signal Queue（全件）")
+        df = load_signal_queue(conn)
+        if df.empty:
+            st.info("発注キューにシグナルはありません。")
+        else:
+            pending = df[df["status"] == "pending"]
+            st.metric("pending 件数", len(pending))
+            st.dataframe(df, use_container_width=True)
+
+    with tab_targets:
+        st.subheader("ポートフォリオ目標（最新日）")
+        df = load_portfolio_targets(conn)
+        if df.empty:
+            st.info("ポートフォリオ目標データがありません。")
+        else:
+            st.caption(f"基準日: {df['date'].iloc[0]}")
+            st.dataframe(df, use_container_width=True)
+
+    with tab_signals:
+        st.subheader("生成シグナル（直近7日）")
+        df = load_signals(conn)
+        if df.empty:
+            st.info("シグナルデータがありません。")
+        else:
+            col1, col2 = st.columns(2)
+            col1.metric("買いシグナル", len(df[df["side"] == "buy"]))
+            col2.metric("売りシグナル", len(df[df["side"] == "sell"]))
+            st.dataframe(df, use_container_width=True)
+finally:
+    conn.close()

--- a/src/kabusys/monitoring/pages/3_Performance.py
+++ b/src/kabusys/monitoring/pages/3_Performance.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import duckdb
+import pandas as pd
 import streamlit as st
 
 from kabusys.config import Settings
@@ -34,7 +35,7 @@ try:
     )
 
     with tab_perf:
-        df = load_portfolio_performance(conn, days=days)
+        df = load_portfolio_performance(conn, env=settings.env, days=days)
         if df.empty:
             st.info("パフォーマンスデータがありません。")
         else:
@@ -42,11 +43,8 @@ try:
             col1, col2, col3 = st.columns(3)
             col1.metric("Equity", f"¥{float(latest['equity']):,.0f}")
             col2.metric("Cash", f"¥{float(latest['cash']):,.0f}")
-            dd = (
-                float(latest["drawdown"]) * 100
-                if latest["drawdown"] is not None
-                else 0.0
-            )
+            dd_val = latest.get("drawdown")
+            dd = 0.0 if pd.isna(dd_val) else float(dd_val) * 100
             col3.metric("Drawdown", f"{dd:.2f}%")
 
             st.subheader("エクイティカーブ")
@@ -69,7 +67,9 @@ try:
             st.info("保有ポジションはありません。")
         else:
             st.caption(f"基準日: {df['date'].iloc[0]}")
-            total_mv = float(df["market_value"].sum())
+            total_mv = float(
+                pd.to_numeric(df["market_value"], errors="coerce").fillna(0).sum()
+            )
             st.metric("時価総額合計", f"¥{total_mv:,.0f}")
             st.dataframe(df, use_container_width=True)
 

--- a/src/kabusys/monitoring/pages/3_Performance.py
+++ b/src/kabusys/monitoring/pages/3_Performance.py
@@ -1,0 +1,84 @@
+"""pages/3_Performance.py — 運用成績・ポジション・取引履歴ビュー。"""
+
+from __future__ import annotations
+
+import duckdb
+import streamlit as st
+
+from kabusys.config import Settings
+from kabusys.monitoring.dashboard_data import (
+    load_open_positions,
+    load_portfolio_performance,
+    load_recent_trades,
+)
+
+st.set_page_config(page_title="Performance", layout="wide", page_icon="📈")
+st.title("📈 Performance — 運用成績")
+
+settings = Settings()
+with st.sidebar:
+    st.caption(f"環境: **{settings.env}**")
+    days = st.selectbox("表示期間", [30, 60, 90, 180], index=2)
+    if st.button("🔄 Refresh"):
+        st.rerun()
+
+try:
+    conn = duckdb.connect(str(settings.duckdb_path), read_only=True)
+except Exception as e:
+    st.error(f"DuckDB 接続失敗: {e}")
+    st.stop()
+
+try:
+    tab_perf, tab_pos, tab_trades = st.tabs(
+        ["エクイティカーブ", "ポジション", "取引履歴"]
+    )
+
+    with tab_perf:
+        df = load_portfolio_performance(conn, days=days)
+        if df.empty:
+            st.info("パフォーマンスデータがありません。")
+        else:
+            latest = df.iloc[-1]
+            col1, col2, col3 = st.columns(3)
+            col1.metric("Equity", f"¥{float(latest['equity']):,.0f}")
+            col2.metric("Cash", f"¥{float(latest['cash']):,.0f}")
+            dd = (
+                float(latest["drawdown"]) * 100
+                if latest["drawdown"] is not None
+                else 0.0
+            )
+            col3.metric("Drawdown", f"{dd:.2f}%")
+
+            st.subheader("エクイティカーブ")
+            st.line_chart(df.set_index("date")["equity"])
+
+            ret_df = df.set_index("date")["daily_return"].dropna()
+            if not ret_df.empty:
+                st.subheader("日次リターン (%)")
+                st.bar_chart(ret_df * 100)
+
+            dd_df = df.set_index("date")["drawdown"].dropna() * 100
+            if not dd_df.empty:
+                st.subheader("ドローダウン推移 (%)")
+                st.line_chart(dd_df)
+
+    with tab_pos:
+        st.subheader("保有ポジション（最新日）")
+        df = load_open_positions(conn)
+        if df.empty:
+            st.info("保有ポジションはありません。")
+        else:
+            st.caption(f"基準日: {df['date'].iloc[0]}")
+            total_mv = float(df["market_value"].sum())
+            st.metric("時価総額合計", f"¥{total_mv:,.0f}")
+            st.dataframe(df, use_container_width=True)
+
+    with tab_trades:
+        st.subheader("直近50件の取引履歴")
+        df = load_recent_trades(conn)
+        if df.empty:
+            st.info("取引履歴がありません。")
+        else:
+            st.dataframe(df, use_container_width=True)
+finally:
+    conn.close()

--- a/src/kabusys/monitoring/pages/4_Strategy_Lab.py
+++ b/src/kabusys/monitoring/pages/4_Strategy_Lab.py
@@ -1,0 +1,75 @@
+"""pages/4_Strategy_Lab.py — 市場レジーム・AI スコア・戦略状態ビュー。"""
+
+from __future__ import annotations
+
+import duckdb
+import streamlit as st
+
+from kabusys.config import Settings
+from kabusys.monitoring.dashboard_data import (
+    load_ai_scores,
+    load_market_regime,
+    load_signal_summary,
+)
+
+st.set_page_config(page_title="Strategy Lab", layout="wide", page_icon="📊")
+st.title("📊 Strategy Lab — 市場レジーム・AI スコア")
+
+settings = Settings()
+with st.sidebar:
+    st.caption(f"環境: **{settings.env}**")
+    days = st.selectbox("表示期間", [14, 30, 60], index=1)
+    if st.button("🔄 Refresh"):
+        st.rerun()
+
+try:
+    conn = duckdb.connect(str(settings.duckdb_path), read_only=True)
+except Exception as e:
+    st.error(f"DuckDB 接続失敗: {e}")
+    st.stop()
+
+try:
+    tab_regime, tab_ai, tab_signals = st.tabs(
+        ["市場レジーム", "AI スコア", "シグナル推移"]
+    )
+
+    with tab_regime:
+        df = load_market_regime(conn, days=days)
+        if df.empty:
+            st.info("レジームデータがありません。")
+        else:
+            latest = df.iloc[-1]
+            col1, col2 = st.columns(2)
+            col1.metric("最新レジームスコア", f"{float(latest['regime_score']):.3f}")
+            col2.metric("レジームラベル", latest["regime_label"])
+            st.subheader("レジームスコア推移")
+            st.line_chart(df.set_index("date")["regime_score"])
+            st.dataframe(df, use_container_width=True)
+
+    with tab_ai:
+        df = load_ai_scores(conn)
+        if df.empty:
+            st.info(
+                "AI スコアデータがありません（ENABLE_AI_SENTIMENT=false の場合は空）。"
+            )
+        else:
+            st.caption(f"基準日: {df['date'].iloc[0]}")
+            col1, col2 = st.columns(2)
+            col1.metric("スコア最高銘柄", df.iloc[0]["code"])
+            col2.metric("最高 AI スコア", f"{float(df.iloc[0]['ai_score']):.3f}")
+            st.dataframe(df, use_container_width=True)
+
+    with tab_signals:
+        df = load_signal_summary(conn, days=days)
+        if df.empty:
+            st.info("シグナルデータがありません。")
+        else:
+            total_buy = int(df["buy_count"].sum())
+            total_sell = int(df["sell_count"].sum())
+            col1, col2 = st.columns(2)
+            col1.metric(f"買いシグナル合計（{days}日）", total_buy)
+            col2.metric(f"売りシグナル合計（{days}日）", total_sell)
+            st.subheader("日別シグナル件数")
+            st.bar_chart(df.set_index("date")[["buy_count", "sell_count"]])
+finally:
+    conn.close()

--- a/src/kabusys/monitoring/streamlit_dashboard.py
+++ b/src/kabusys/monitoring/streamlit_dashboard.py
@@ -58,14 +58,6 @@ def load_latest_system_status(conn: sqlite3.Connection) -> dict | None:
     return dict(row) if row else None
 
 
-def load_recent_risk_logs(conn: sqlite3.Connection, limit: int = 10) -> list[dict]:
-    conn.row_factory = sqlite3.Row
-    cursor = conn.execute(
-        "SELECT * FROM risk_logs ORDER BY logged_at DESC LIMIT ?", (limit,)
-    )
-    return [dict(row) for row in cursor.fetchall()]
-
-
 def main(db_path: str) -> None:
     st.set_page_config(page_title="KabuSys Monitor", layout="wide", page_icon="🏠")
     st.title("🏠 KabuSys 監視ダッシュボード — Home")
@@ -171,11 +163,6 @@ def main(db_path: str) -> None:
                 st.caption(f"Recorded: {status['recorded_at']}")
             else:
                 st.info("No system status yet.")
-
-            risk_logs = load_recent_risk_logs(conn)
-            if risk_logs:
-                st.subheader("Recent Risk Events")
-                st.dataframe(risk_logs, use_container_width=True)
 
         time.sleep(refresh_interval)
         st.rerun()

--- a/src/kabusys/monitoring/streamlit_dashboard.py
+++ b/src/kabusys/monitoring/streamlit_dashboard.py
@@ -1,4 +1,6 @@
-"""streamlit_dashboard.py — KabuSys 監視ダッシュボード。
+"""streamlit_dashboard.py — KabuSys 監視ダッシュボード（Home ページ）。
+
+マルチページ構成のエントリーポイント。pages/ 配下のページが自動的にサイドバーに表示される。
 
 起動方法:
     streamlit run src/kabusys/monitoring/streamlit_dashboard.py -- --db data/monitoring.db
@@ -15,6 +17,7 @@ from pathlib import Path
 import streamlit as st
 
 from kabusys.config import Settings
+from kabusys.monitoring.dashboard_data import load_error_logs
 from kabusys.monitoring.monitoring_db import MonitoringDB
 from kabusys.operations.intraday_collector import (
     _MONITORING_PID,
@@ -64,13 +67,14 @@ def load_recent_risk_logs(conn: sqlite3.Connection, limit: int = 10) -> list[dic
 
 
 def main(db_path: str) -> None:
-    st.set_page_config(page_title="KabuSys Monitor", layout="wide")
-    st.title("KabuSys 監視ダッシュボード")
+    st.set_page_config(page_title="KabuSys Monitor", layout="wide", page_icon="🏠")
+    st.title("🏠 KabuSys 監視ダッシュボード — Home")
 
     settings = Settings()
 
     with st.sidebar:
-        if st.button("Refresh"):
+        st.caption(f"環境: **{settings.env}**")
+        if st.button("🔄 Refresh"):
             st.rerun()
         refresh_interval = st.selectbox("自動更新間隔", [30, 60, 120], index=0)
         st.caption(f"{refresh_interval}秒ごとに自動更新")
@@ -91,11 +95,20 @@ def main(db_path: str) -> None:
         )
 
         with tab_overview:
+            # --- システム状態サマリ ---
             kill_active, kill_reason = check_kill_switch(Path(settings.kill_flag_path))
+            exec_ok = check_pid_file(Path(settings.pid_file_path))
+            mon_ok = check_pid_file(_MONITORING_PID)
+
+            col_k, col_e, col_m = st.columns(3)
             if kill_active:
-                st.error(f"🚫 Kill Switch 発動中: {kill_reason}")
+                col_k.error(f"🚫 Kill Switch: {kill_reason}")
             else:
-                st.success("✅ Kill Switch: 発動なし")
+                col_k.success("✅ Kill Switch: 発動なし")
+            col_e.metric("Execution Engine", "🟢 UP" if exec_ok else "🔴 DOWN")
+            col_m.metric("Monitoring", "🟢 UP" if mon_ok else "🔴 DOWN")
+
+            st.divider()
 
             dashboard = db.get_dashboard()
             if dashboard:
@@ -125,6 +138,14 @@ def main(db_path: str) -> None:
             else:
                 st.info("No dashboard data yet.")
 
+            st.divider()
+            st.subheader("🚨 直近の ERROR / CRITICAL イベント")
+            error_logs = load_error_logs(conn)
+            if error_logs:
+                st.dataframe(error_logs, use_container_width=True)
+            else:
+                st.success("直近のエラーイベントはありません。")
+
         with tab_positions:
             positions = load_positions(conn)
             if positions:
@@ -140,12 +161,6 @@ def main(db_path: str) -> None:
                 st.info("No trade events yet.")
 
         with tab_system:
-            exec_ok = check_pid_file(Path(settings.pid_file_path))
-            mon_ok = check_pid_file(_MONITORING_PID)
-            pid_col1, pid_col2 = st.columns(2)
-            pid_col1.metric("Execution", "OK" if exec_ok else "DOWN")
-            pid_col2.metric("Monitoring", "OK" if mon_ok else "DOWN")
-
             status = load_latest_system_status(conn)
             if status:
                 col1, col2, col3, col4 = st.columns(4)

--- a/tests/test_dashboard_pages.py
+++ b/tests/test_dashboard_pages.py
@@ -127,8 +127,12 @@ def test_load_error_logs_returns_only_error_events(mon_conn):
     from kabusys.monitoring.monitoring_db import MonitoringDB
 
     db = MonitoringDB(mon_conn)
-    db.log_risk_event("ORDER_ERROR", "order_fail_count", 1.0, 0.0, detail="注文エラー発生")
-    db.log_risk_event("POSITION_UPDATE", "pos_update", 0.0, 0.0, detail="通常イベント")  # 除外されるはず
+    db.log_risk_event(
+        "ORDER_ERROR", "order_fail_count", 1.0, 0.0, detail="注文エラー発生"
+    )
+    db.log_risk_event(
+        "POSITION_UPDATE", "pos_update", 0.0, 0.0, detail="通常イベント"
+    )  # 除外されるはず
 
     result = load_error_logs(mon_conn)
     assert len(result) == 1

--- a/tests/test_dashboard_pages.py
+++ b/tests/test_dashboard_pages.py
@@ -1,0 +1,303 @@
+"""tests/test_dashboard_pages.py — dashboard_data.py のデータロード関数テスト"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import duckdb
+import pytest
+
+from kabusys.monitoring.monitoring_db import init_monitoring_db
+
+
+@pytest.fixture
+def duck_conn():
+    """スキーマ付きのインメモリ DuckDB コネクション。"""
+    conn = duckdb.connect(":memory:")
+    conn.execute("""
+        CREATE TABLE signal_queue (
+            signal_id VARCHAR PRIMARY KEY,
+            date DATE NOT NULL,
+            code VARCHAR NOT NULL,
+            side VARCHAR NOT NULL,
+            size BIGINT NOT NULL,
+            order_type VARCHAR NOT NULL,
+            price DECIMAL(18,4),
+            status VARCHAR NOT NULL DEFAULT 'pending',
+            created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+            processed_at TIMESTAMP
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE signals (
+            date DATE NOT NULL,
+            code VARCHAR NOT NULL,
+            side VARCHAR NOT NULL,
+            score DOUBLE,
+            signal_rank INTEGER,
+            size_multiplier DOUBLE NOT NULL DEFAULT 1.0,
+            PRIMARY KEY (date, code, side)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE portfolio_targets (
+            date DATE NOT NULL,
+            code VARCHAR NOT NULL,
+            target_weight DOUBLE,
+            target_size BIGINT,
+            PRIMARY KEY (date, code)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE portfolio_performance (
+            date DATE NOT NULL,
+            env VARCHAR NOT NULL DEFAULT 'live',
+            equity DECIMAL(20,4) NOT NULL,
+            cash DECIMAL(20,4) NOT NULL DEFAULT 0,
+            drawdown DOUBLE,
+            daily_return DOUBLE,
+            PRIMARY KEY (date, env)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE positions (
+            date DATE NOT NULL,
+            code VARCHAR NOT NULL,
+            position_size BIGINT NOT NULL,
+            avg_price DECIMAL(18,4) NOT NULL,
+            market_value DECIMAL(20,4),
+            PRIMARY KEY (date, code)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE trades (
+            trade_id VARCHAR PRIMARY KEY,
+            order_id VARCHAR NOT NULL,
+            datetime TIMESTAMP NOT NULL,
+            code VARCHAR NOT NULL,
+            price DECIMAL(18,4) NOT NULL,
+            size BIGINT NOT NULL
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE market_regime (
+            date DATE PRIMARY KEY,
+            regime_score DOUBLE NOT NULL,
+            regime_label VARCHAR NOT NULL,
+            ma200_ratio DOUBLE,
+            macro_sentiment DOUBLE,
+            created_at TIMESTAMP NOT NULL DEFAULT current_timestamp
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE ai_scores (
+            date DATE NOT NULL,
+            code VARCHAR NOT NULL,
+            sentiment_score DOUBLE,
+            regime_score DOUBLE,
+            ai_score DOUBLE,
+            created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+            PRIMARY KEY (date, code)
+        )
+    """)
+    return conn
+
+
+@pytest.fixture
+def mon_conn():
+    conn = sqlite3.connect(":memory:")
+    init_monitoring_db(conn)
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Home ページ — load_error_logs（SQLite）
+# ---------------------------------------------------------------------------
+
+
+def test_load_error_logs_empty(mon_conn):
+    from kabusys.monitoring.dashboard_data import load_error_logs
+
+    result = load_error_logs(mon_conn)
+    assert result == []
+
+
+def test_load_error_logs_returns_only_error_events(mon_conn):
+    from kabusys.monitoring.dashboard_data import load_error_logs
+    from kabusys.monitoring.monitoring_db import MonitoringDB
+
+    db = MonitoringDB(mon_conn)
+    db.log_risk_event("ORDER_ERROR", "order_fail_count", 1.0, 0.0, detail="注文エラー発生")
+    db.log_risk_event("POSITION_UPDATE", "pos_update", 0.0, 0.0, detail="通常イベント")  # 除外されるはず
+
+    result = load_error_logs(mon_conn)
+    assert len(result) == 1
+    assert result[0]["event_type"] == "ORDER_ERROR"
+
+
+# ---------------------------------------------------------------------------
+# Signal Queue ページ（DuckDB）
+# ---------------------------------------------------------------------------
+
+
+def test_load_signal_queue_empty(duck_conn):
+    from kabusys.monitoring.dashboard_data import load_signal_queue
+
+    df = load_signal_queue(duck_conn)
+    assert df.empty
+
+
+def test_load_signal_queue_returns_rows(duck_conn):
+    from kabusys.monitoring.dashboard_data import load_signal_queue
+
+    duck_conn.execute("""
+        INSERT INTO signal_queue (signal_id, date, code, side, size, order_type, status)
+        VALUES ('sq-1', '2024-09-01', '7203', 'buy', 100, 'market', 'pending')
+    """)
+    df = load_signal_queue(duck_conn)
+    assert len(df) == 1
+    assert df.iloc[0]["code"] == "7203"
+
+
+def test_load_portfolio_targets_empty(duck_conn):
+    from kabusys.monitoring.dashboard_data import load_portfolio_targets
+
+    df = load_portfolio_targets(duck_conn)
+    assert df.empty
+
+
+def test_load_portfolio_targets_latest_date_only(duck_conn):
+    from kabusys.monitoring.dashboard_data import load_portfolio_targets
+
+    duck_conn.execute("""
+        INSERT INTO portfolio_targets (date, code, target_weight, target_size)
+        VALUES ('2024-09-01', '7203', 0.05, 100),
+               ('2024-09-02', '6758', 0.10, 50)
+    """)
+    df = load_portfolio_targets(duck_conn)
+    assert len(df) == 1
+    assert str(df.iloc[0]["date"])[:10] == "2024-09-02"
+
+
+def test_load_signals_empty(duck_conn):
+    from kabusys.monitoring.dashboard_data import load_signals
+
+    df = load_signals(duck_conn)
+    assert df.empty
+
+
+# ---------------------------------------------------------------------------
+# Performance ページ（DuckDB）
+# ---------------------------------------------------------------------------
+
+
+def test_load_portfolio_performance_empty(duck_conn):
+    from kabusys.monitoring.dashboard_data import load_portfolio_performance
+
+    df = load_portfolio_performance(duck_conn, days=90)
+    assert df.empty
+
+
+def test_load_portfolio_performance_returns_rows(duck_conn):
+    from kabusys.monitoring.dashboard_data import load_portfolio_performance
+
+    duck_conn.execute("""
+        INSERT INTO portfolio_performance (date, env, equity, cash, drawdown, daily_return)
+        VALUES (current_date, 'live', 10000000, 2000000, -0.02, 0.005)
+    """)
+    df = load_portfolio_performance(duck_conn, days=90)
+    assert len(df) == 1
+    assert float(df.iloc[0]["equity"]) == pytest.approx(10000000.0)
+
+
+def test_load_open_positions_empty(duck_conn):
+    from kabusys.monitoring.dashboard_data import load_open_positions
+
+    df = load_open_positions(duck_conn)
+    assert df.empty
+
+
+def test_load_open_positions_excludes_zero_size(duck_conn):
+    from kabusys.monitoring.dashboard_data import load_open_positions
+
+    duck_conn.execute("""
+        INSERT INTO positions (date, code, position_size, avg_price, market_value)
+        VALUES (current_date, '7203', 100, 2500.0, 250000.0),
+               (current_date, '6758', 0,   5000.0,      0.0)
+    """)
+    df = load_open_positions(duck_conn)
+    assert len(df) == 1
+    assert df.iloc[0]["code"] == "7203"
+
+
+def test_load_recent_trades_empty(duck_conn):
+    from kabusys.monitoring.dashboard_data import load_recent_trades
+
+    df = load_recent_trades(duck_conn)
+    assert df.empty
+
+
+# ---------------------------------------------------------------------------
+# Strategy Lab ページ（DuckDB）
+# ---------------------------------------------------------------------------
+
+
+def test_load_market_regime_empty(duck_conn):
+    from kabusys.monitoring.dashboard_data import load_market_regime
+
+    df = load_market_regime(duck_conn, days=30)
+    assert df.empty
+
+
+def test_load_market_regime_returns_rows(duck_conn):
+    from kabusys.monitoring.dashboard_data import load_market_regime
+
+    duck_conn.execute("""
+        INSERT INTO market_regime (date, regime_score, regime_label)
+        VALUES (current_date, 0.65, 'bull')
+    """)
+    df = load_market_regime(duck_conn, days=30)
+    assert len(df) == 1
+    assert df.iloc[0]["regime_label"] == "bull"
+
+
+def test_load_ai_scores_empty(duck_conn):
+    from kabusys.monitoring.dashboard_data import load_ai_scores
+
+    df = load_ai_scores(duck_conn)
+    assert df.empty
+
+
+def test_load_ai_scores_returns_latest_date_only(duck_conn):
+    from kabusys.monitoring.dashboard_data import load_ai_scores
+
+    duck_conn.execute("""
+        INSERT INTO ai_scores (date, code, ai_score)
+        VALUES ('2024-09-01', '7203', 0.8),
+               ('2024-09-02', '6758', 0.9)
+    """)
+    df = load_ai_scores(duck_conn)
+    assert len(df) == 1
+    assert df.iloc[0]["code"] == "6758"
+
+
+def test_load_signal_summary_empty(duck_conn):
+    from kabusys.monitoring.dashboard_data import load_signal_summary
+
+    df = load_signal_summary(duck_conn, days=30)
+    assert df.empty
+
+
+def test_load_signal_summary_counts_by_side(duck_conn):
+    from kabusys.monitoring.dashboard_data import load_signal_summary
+
+    duck_conn.execute("""
+        INSERT INTO signals (date, code, side, score, signal_rank)
+        VALUES (current_date, '7203', 'buy',  0.8, 1),
+               (current_date, '6758', 'buy',  0.6, 2),
+               (current_date, '9984', 'sell', 0.3, 3)
+    """)
+    df = load_signal_summary(duck_conn, days=30)
+    assert len(df) == 1
+    assert int(df.iloc[0]["buy_count"]) == 2
+    assert int(df.iloc[0]["sell_count"]) == 1

--- a/tests/test_dashboard_pages.py
+++ b/tests/test_dashboard_pages.py
@@ -198,7 +198,7 @@ def test_load_signals_empty(duck_conn):
 def test_load_portfolio_performance_empty(duck_conn):
     from kabusys.monitoring.dashboard_data import load_portfolio_performance
 
-    df = load_portfolio_performance(duck_conn, days=90)
+    df = load_portfolio_performance(duck_conn, env="live", days=90)
     assert df.empty
 
 
@@ -209,9 +209,22 @@ def test_load_portfolio_performance_returns_rows(duck_conn):
         INSERT INTO portfolio_performance (date, env, equity, cash, drawdown, daily_return)
         VALUES (current_date, 'live', 10000000, 2000000, -0.02, 0.005)
     """)
-    df = load_portfolio_performance(duck_conn, days=90)
+    df = load_portfolio_performance(duck_conn, env="live", days=90)
     assert len(df) == 1
     assert float(df.iloc[0]["equity"]) == pytest.approx(10000000.0)
+
+
+def test_load_portfolio_performance_filters_env(duck_conn):
+    from kabusys.monitoring.dashboard_data import load_portfolio_performance
+
+    duck_conn.execute("""
+        INSERT INTO portfolio_performance (date, env, equity, cash)
+        VALUES (current_date, 'live',  10000000, 2000000),
+               (current_date, 'paper',  5000000, 1000000)
+    """)
+    df = load_portfolio_performance(duck_conn, env="live", days=90)
+    assert len(df) == 1
+    assert df.iloc[0]["env"] == "live"
 
 
 def test_load_open_positions_empty(duck_conn):

--- a/tests/test_streamlit_dashboard.py
+++ b/tests/test_streamlit_dashboard.py
@@ -90,9 +90,3 @@ def test_load_latest_system_status_returns_latest(mon_conn):
     assert result["cpu_percent"] == pytest.approx(90.0)
 
 
-def test_load_recent_risk_logs_empty(mon_conn):
-    """risk_logs が空の場合は空リストを返す"""
-    from kabusys.monitoring.streamlit_dashboard import load_recent_risk_logs
-
-    result = load_recent_risk_logs(mon_conn)
-    assert result == []

--- a/tests/test_streamlit_dashboard.py
+++ b/tests/test_streamlit_dashboard.py
@@ -88,5 +88,3 @@ def test_load_latest_system_status_returns_latest(mon_conn):
 
     assert result is not None
     assert result["cpu_percent"] == pytest.approx(90.0)
-
-


### PR DESCRIPTION
## Summary

- `dashboard_data.py` を新設し、DuckDB / SQLite からのデータ取得ロジックを Streamlit から分離（数値プレフィックス付きモジュールをインポートできない Python 制約への対処）
- `pages/2_Signal_Queue.py`: 発注キュー・ポートフォリオ目標・シグナル一覧（直近7日）を3タブで表示
- `pages/3_Performance.py`: エクイティカーブ・ドローダウン推移・ポジション・取引履歴を表示
- `pages/4_Strategy_Lab.py`: 市場レジーム推移・AIスコアランキング・日別シグナル件数を表示
- `streamlit_dashboard.py` (Home): Kill Switch / Execution Engine / Monitoring 状態を3カラムで表示、直近エラーイベントセクション追加
- `tests/test_dashboard_pages.py`: 全10データロード関数を対象に18テストを追加（in-memory DuckDB / SQLite フィクスチャ使用）

## Test Plan

- [x] `pytest tests/test_dashboard_pages.py -v` — 18/18 PASSED
- [x] `pytest tests/ -q` — 1476 PASSED
- [x] `ruff check` / `ruff format` — no issues

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)