### PR TITLE
feat: ペーパートレードE2E検証環境の強化 (Issue #255)

### DIFF
--- a/scripts/setup_db.py
+++ b/scripts/setup_db.py
@@ -31,6 +31,11 @@ def main() -> None:
         action="store_true",
         help="paper_trading.db も初期化する",
     )
+    parser.add_argument(
+        "--paper-reset",
+        action="store_true",
+        help="paper_trading.db を削除してから空テーブルで再初期化する（全データ消去）",
+    )
     args = parser.parse_args()
 
     from kabusys.config import Settings
@@ -57,9 +62,12 @@ def main() -> None:
     logger.info("SQLite (monitoring) 初期化完了")
 
     # --- SQLite (paper_trading) ---
-    if args.paper:
+    if args.paper_reset or args.paper:
         paper_path = settings.paper_sqlite_path
         paper_path.parent.mkdir(parents=True, exist_ok=True)
+        if args.paper_reset and paper_path.exists():
+            paper_path.unlink()
+            logger.info("SQLite (paper_trading) を削除しました: %s", paper_path)
         logger.info("SQLite (paper_trading) を初期化します: %s", paper_path)
         with sqlite3.connect(paper_path) as paper_conn:
             init_orders_db(paper_conn)

--- a/scripts/setup_db.py
+++ b/scripts/setup_db.py
@@ -66,7 +66,15 @@ def main() -> None:
         paper_path = settings.paper_sqlite_path
         paper_path.parent.mkdir(parents=True, exist_ok=True)
         if args.paper_reset and paper_path.exists():
-            paper_path.unlink()
+            try:
+                paper_path.unlink()
+            except (PermissionError, OSError) as exc:
+                logger.error(
+                    "paper_trading.db を削除できませんでした: %s\n"
+                    "  ヒント: ExecutionEngine や Streamlit ダッシュボードが DB を開いていないか確認してください。",
+                    exc,
+                )
+                sys.exit(1)
             logger.info("SQLite (paper_trading) を削除しました: %s", paper_path)
         logger.info("SQLite (paper_trading) を初期化します: %s", paper_path)
         with sqlite3.connect(paper_path) as paper_conn:

--- a/src/kabusys/config.py
+++ b/src/kabusys/config.py
@@ -242,6 +242,38 @@ class Settings:
         return Path(os.environ.get("SQLITE_PATH", "data/monitoring.db")).expanduser()
 
     @property
+    def paper_trading_initial_cash(self) -> float:
+        """ペーパートレード用初期資金（PAPER_TRADING_INITIAL_CASH、デフォルト: 10,000,000）。"""
+        raw = os.environ.get("PAPER_TRADING_INITIAL_CASH", "10000000")
+        try:
+            val = float(raw)
+        except ValueError as exc:
+            raise ValueError(
+                f"PAPER_TRADING_INITIAL_CASH の値が不正です: '{raw}'. 正の数値で設定してください。"
+            ) from exc
+        if val <= 0:
+            raise ValueError(
+                f"PAPER_TRADING_INITIAL_CASH は正の値で設定してください（現在値: {val}）"
+            )
+        return val
+
+    @property
+    def kabu_use_sandbox(self) -> bool:
+        """kabuステーション検証環境（ポート 18081）を使用するフラグ（KABU_USE_SANDBOX、デフォルト: False）。
+
+        True かつ is_paper のとき、MockBrokerClient の代わりに KabuStationClient（検証 URL）を使用する。
+        """
+        return _parse_bool_env("KABU_USE_SANDBOX", default=False)
+
+    @property
+    def kabu_sandbox_api_password(self) -> str:
+        """kabuステーション検証環境 API パスワード（KABU_SANDBOX_API_PASSWORD）。
+
+        KABU_USE_SANDBOX=true の場合に設定すること。
+        """
+        return os.environ.get("KABU_SANDBOX_API_PASSWORD", "")
+
+    @property
     def paper_fill_mode(self) -> str:
         """Paper Trading 時の MockBrokerClient fill_mode。
 

--- a/src/kabusys/config_setup.py
+++ b/src/kabusys/config_setup.py
@@ -66,6 +66,26 @@ _ITEMS: list[dict] = [
         "description": "  通常はデフォルトのままで可",
     },
     {
+        "key": "KABU_USE_SANDBOX",
+        "label": "kabuステーション検証環境（ポート 18081）の使用",
+        "choices": ["true", "false"],
+        "default": "false",
+        "description": (
+            "  true かつ KABUSYS_ENV=paper_trading のとき検証環境（18081）に接続する\n"
+            "  false の場合 MockBrokerClient を使用してシミュレーションする"
+        ),
+    },
+    {
+        "key": "KABU_SANDBOX_API_PASSWORD",
+        "label": "kabuステーション検証環境 API パスワード（任意）",
+        "secret": True,
+        "optional": True,
+        "description": (
+            "  KABU_USE_SANDBOX=true の場合に使用する検証環境用 API パスワード\n"
+            "  未設定時は KABU_API_PASSWORD を流用する"
+        ),
+    },
+    {
         "key": "KABU_TRADE_PASSWORD",
         "label": "kabuステーション 取引パスワード（任意）",
         "secret": True,
@@ -161,6 +181,15 @@ _ITEMS: list[dict] = [
         ),
     },
     {
+        "key": "PAPER_TRADING_INITIAL_CASH",
+        "label": "ペーパートレード用初期資金（円）",
+        "default": "10000000",
+        "description": (
+            "  KABUSYS_ENV=paper_trading 時の MockBrokerClient 初期現金残高（円）\n"
+            "  デフォルト: 10,000,000 円（1,000 万円）"
+        ),
+    },
+    {
         "key": "LOG_LEVEL",
         "label": "ログレベル",
         "choices": ["DEBUG", "INFO", "WARNING", "ERROR"],
@@ -215,6 +244,8 @@ def _write_env(path: Path, values: dict[str, str]) -> None:
         f"KABU_API_PASSWORD={values.get('KABU_API_PASSWORD', '')}",
         f"KABU_API_BASE_URL={values.get('KABU_API_BASE_URL', 'http://localhost:18080/kabusapi')}",
         f"KABU_TRADE_PASSWORD={values.get('KABU_TRADE_PASSWORD', '')}",
+        f"KABU_USE_SANDBOX={values.get('KABU_USE_SANDBOX', 'false')}",
+        f"KABU_SANDBOX_API_PASSWORD={values.get('KABU_SANDBOX_API_PASSWORD', '')}",
         "",
         "# --- LINE Messaging API (アラート通知用) ---",
         f"LINE_CHANNEL_ACCESS_TOKEN={values.get('LINE_CHANNEL_ACCESS_TOKEN', '')}",
@@ -223,6 +254,9 @@ def _write_env(path: Path, values: dict[str, str]) -> None:
         "# --- データベース ---",
         f"DUCKDB_PATH={values.get('DUCKDB_PATH', 'data/kabusys.duckdb')}",
         f"SQLITE_PATH={values.get('SQLITE_PATH', 'data/monitoring.db')}",
+        "",
+        "# --- ペーパートレード設定 ---",
+        f"PAPER_TRADING_INITIAL_CASH={values.get('PAPER_TRADING_INITIAL_CASH', '10000000')}",
         "",
         "# --- システム設定 ---",
         f"KABUSYS_ENV={values.get('KABUSYS_ENV', 'development')}",

--- a/src/kabusys/execution/broker_factory.py
+++ b/src/kabusys/execution/broker_factory.py
@@ -3,8 +3,10 @@
 
 from __future__ import annotations
 
-from kabusys.execution.broker_api import BrokerAPIProtocol, create_broker_api
+from kabusys.execution.broker_api import BrokerAPIProtocol, Position, create_broker_api
 from kabusys.config import Settings
+
+_SANDBOX_BASE_URL = "http://localhost:18081/kabusapi"
 
 
 class BrokerClientFactory:
@@ -16,15 +18,38 @@ class BrokerClientFactory:
     """
 
     @staticmethod
-    def create(settings: Settings) -> BrokerAPIProtocol:
+    def create(
+        settings: Settings,
+        available_cash: float | None = None,
+        initial_positions: list[Position] | None = None,
+    ) -> BrokerAPIProtocol:
         """設定に応じたブローカークライアントを返す。
 
-        - is_paper or is_dev → MockBrokerClient(fill_mode=settings.paper_fill_mode)
-        - is_live            → NotImplementedError（将来実装）
-        - それ以外           → ValueError（settings.env の評価で確定）
+        - is_paper かつ kabu_use_sandbox → KabuStationClient（検証 URL: port 18081）
+        - is_paper または is_dev         → MockBrokerClient（available_cash / initial_positions を注入）
+        - is_live                        → KabuStationClient（本番）
+        - それ以外                       → ValueError（settings.env の評価で確定）
         """
+        if settings.is_paper and settings.kabu_use_sandbox:
+            password = settings.kabu_sandbox_api_password or settings.kabu_api_password
+            return create_broker_api(
+                mock=False,
+                api_password=password,
+                trade_password=settings.kabu_trade_password,
+                base_url=_SANDBOX_BASE_URL,
+            )
         if settings.is_paper or settings.is_dev:
-            return create_broker_api(mock=True, fill_mode=settings.paper_fill_mode)
+            cash = (
+                available_cash
+                if available_cash is not None
+                else settings.paper_trading_initial_cash
+            )
+            return create_broker_api(
+                mock=True,
+                fill_mode=settings.paper_fill_mode,
+                available_cash=cash,
+                initial_positions=initial_positions,
+            )
         if settings.is_live:
             return create_broker_api(
                 mock=False,

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -158,7 +158,7 @@ def _restore_paper_state(
     # code → [buy_qty, buy_cost, sell_qty, sell_proceeds]
     data: dict[str, list[float]] = {}
     for row in rows:
-        side = row["side"].lower()
+        side = (row["side"] or "").lower()
         if side not in ("buy", "sell"):
             logger.warning(
                 "orders テーブルに未知の side 値があります。スキップします: side=%r code=%s",
@@ -178,6 +178,8 @@ def _restore_paper_state(
             data[code][2] += filled_qty
             data[code][3] += filled_qty * avg_price
 
+    # net_cash は買いコストを差し引き・売り収入を加算する。
+    # DB の不整合（例: 売り超過）により負値になり得るが MockBrokerClient 側で許容する。
     net_cash = initial_cash
     positions: list[Position] = []
     for code, (buy_qty, buy_cost, sell_qty, sell_proceeds) in data.items():

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -130,7 +130,10 @@ def _restore_paper_state(
     """paper_trading.db の約定履歴からペーパートレードの残高・ポジションを復元する。
 
     DB が存在しない場合や読み込みに失敗した場合は (initial_cash, []) を返す。
+    本システムは現物取引のみ（ショート非対応）のため net_qty < 0 のコードはスキップする。
     """
+    import contextlib
+
     if not sqlite_path.exists():
         logger.info(
             "paper_trading.db が存在しないため初期資金 %.0f 円で起動します。",
@@ -139,15 +142,12 @@ def _restore_paper_state(
         return initial_cash, []
 
     try:
-        conn = sqlite3.connect(str(sqlite_path))
-        conn.row_factory = sqlite3.Row
-        try:
+        with contextlib.closing(sqlite3.connect(str(sqlite_path))) as conn:
+            conn.row_factory = sqlite3.Row
             rows = conn.execute(
                 "SELECT side, code, filled_qty, avg_fill_price FROM orders"
                 " WHERE filled_qty > 0 AND avg_fill_price IS NOT NULL"
             ).fetchall()
-        finally:
-            conn.close()
     except Exception:
         logger.warning(
             "paper_trading.db からの状態復元に失敗しました。初期資金で起動します。",
@@ -158,12 +158,20 @@ def _restore_paper_state(
     # code → [buy_qty, buy_cost, sell_qty, sell_proceeds]
     data: dict[str, list[float]] = {}
     for row in rows:
+        side = row["side"].lower()
+        if side not in ("buy", "sell"):
+            logger.warning(
+                "orders テーブルに未知の side 値があります。スキップします: side=%r code=%s",
+                row["side"],
+                row["code"],
+            )
+            continue
         code = row["code"]
         filled_qty = int(row["filled_qty"])
         avg_price = float(row["avg_fill_price"])
         if code not in data:
             data[code] = [0.0, 0.0, 0.0, 0.0]
-        if row["side"] == "buy":
+        if side == "buy":
             data[code][0] += filled_qty
             data[code][1] += filled_qty * avg_price
         else:
@@ -176,7 +184,14 @@ def _restore_paper_state(
         net_cash -= buy_cost
         net_cash += sell_proceeds
         net_qty = int(buy_qty) - int(sell_qty)
-        if net_qty > 0:
+        if net_qty < 0:
+            # 現物取引のみ対応のためショートポジションは想定外。データ不整合として警告する。
+            logger.warning(
+                "ショートポジションが検出されました（非対応）。スキップします: code=%s net_qty=%d",
+                code,
+                net_qty,
+            )
+        elif net_qty > 0:
             avg_price = buy_cost / buy_qty if buy_qty > 0 else 0.0
             positions.append(Position(code=code, qty=net_qty, avg_price=avg_price))
 

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -17,6 +17,7 @@ import duckdb
 import yaml
 
 from kabusys.config import Settings
+from kabusys.execution.broker_api import Position
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 _STOP_FLAG = _PROJECT_ROOT / "data" / "stop_requested.flag"
@@ -122,6 +123,71 @@ def _load_risk_config(path: Path, initial_portfolio_value: float) -> RiskConfig:
     return config
 
 
+def _restore_paper_state(
+    sqlite_path: Path,
+    initial_cash: float,
+) -> tuple[float, list[Position]]:
+    """paper_trading.db の約定履歴からペーパートレードの残高・ポジションを復元する。
+
+    DB が存在しない場合や読み込みに失敗した場合は (initial_cash, []) を返す。
+    """
+    if not sqlite_path.exists():
+        logger.info(
+            "paper_trading.db が存在しないため初期資金 %.0f 円で起動します。",
+            initial_cash,
+        )
+        return initial_cash, []
+
+    try:
+        conn = sqlite3.connect(str(sqlite_path))
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                "SELECT side, code, filled_qty, avg_fill_price FROM orders"
+                " WHERE filled_qty > 0 AND avg_fill_price IS NOT NULL"
+            ).fetchall()
+        finally:
+            conn.close()
+    except Exception:
+        logger.warning(
+            "paper_trading.db からの状態復元に失敗しました。初期資金で起動します。",
+            exc_info=True,
+        )
+        return initial_cash, []
+
+    # code → [buy_qty, buy_cost, sell_qty, sell_proceeds]
+    data: dict[str, list[float]] = {}
+    for row in rows:
+        code = row["code"]
+        filled_qty = int(row["filled_qty"])
+        avg_price = float(row["avg_fill_price"])
+        if code not in data:
+            data[code] = [0.0, 0.0, 0.0, 0.0]
+        if row["side"] == "buy":
+            data[code][0] += filled_qty
+            data[code][1] += filled_qty * avg_price
+        else:
+            data[code][2] += filled_qty
+            data[code][3] += filled_qty * avg_price
+
+    net_cash = initial_cash
+    positions: list[Position] = []
+    for code, (buy_qty, buy_cost, sell_qty, sell_proceeds) in data.items():
+        net_cash -= buy_cost
+        net_cash += sell_proceeds
+        net_qty = int(buy_qty) - int(sell_qty)
+        if net_qty > 0:
+            avg_price = buy_cost / buy_qty if buy_qty > 0 else 0.0
+            positions.append(Position(code=code, qty=net_qty, avg_price=avg_price))
+
+    logger.info(
+        "ペーパートレード状態復元: 残高 %.0f 円 / ポジション %d 銘柄",
+        net_cash,
+        len(positions),
+    )
+    return net_cash, positions
+
+
 def _pos_value(p: object) -> float:
     price = (
         p.current_price  # type: ignore[attr-defined]
@@ -156,8 +222,18 @@ def main() -> None:
     duckdb_conn = duckdb.connect(str(settings.duckdb_path))
 
     try:
-        # 3. ブローカークライアント
-        broker = BrokerClientFactory.create(settings)
+        # 3. ブローカークライアント（paper mode かつ非サンドボックスは前回状態を復元）
+        restored_cash: float | None = None
+        restored_positions: list[Position] | None = None
+        if settings.is_paper and not settings.kabu_use_sandbox:
+            restored_cash, restored_positions = _restore_paper_state(
+                settings.paper_sqlite_path, settings.paper_trading_initial_cash
+            )
+        broker = BrokerClientFactory.create(
+            settings,
+            available_cash=restored_cash,
+            initial_positions=restored_positions,
+        )
 
         # 4. 起動時総資産を計算（現金 + 保有評価額）
         cash = broker.get_available_cash()

--- a/src/kabusys/validate_config.py
+++ b/src/kabusys/validate_config.py
@@ -272,6 +272,13 @@ def _check_sandbox_config() -> None:
     raw = os.environ.get("KABU_USE_SANDBOX", "false").strip().lower()
     if raw not in ("1", "true", "yes", "on"):
         return
+    # KABU_USE_SANDBOX は paper_trading 環境のみ有効
+    env = os.environ.get("KABUSYS_ENV", "development").lower()
+    if env != "paper_trading":
+        _warn(
+            f"KABU_USE_SANDBOX=true ですが KABUSYS_ENV={env!r} です。"
+            " KABU_USE_SANDBOX は paper_trading 環境時のみ有効です。"
+        )
     if not os.environ.get("KABU_SANDBOX_API_PASSWORD", ""):
         _warn(
             "KABU_USE_SANDBOX=true ですが KABU_SANDBOX_API_PASSWORD が未設定です。"

--- a/src/kabusys/validate_config.py
+++ b/src/kabusys/validate_config.py
@@ -56,6 +56,9 @@ _OPTIONAL_ENV_VARS = [
     "LINE_CHANNEL_ACCESS_TOKEN",
     "LINE_USER_ID",
     "ENABLE_YAHOONEWS",
+    "KABU_USE_SANDBOX",
+    "KABU_SANDBOX_API_PASSWORD",
+    "PAPER_TRADING_INITIAL_CASH",
 ]
 
 _VALID_KABUSYS_ENVS = frozenset({"development", "paper_trading", "live"})
@@ -264,6 +267,36 @@ def _check_config_yaml_files() -> None:
                 _error(f"config/{filename} のパースに失敗しました: {e}")
 
 
+def _check_sandbox_config() -> None:
+    """KABU_USE_SANDBOX=true 時の追加チェック。"""
+    raw = os.environ.get("KABU_USE_SANDBOX", "false").strip().lower()
+    if raw not in ("1", "true", "yes", "on"):
+        return
+    if not os.environ.get("KABU_SANDBOX_API_PASSWORD", ""):
+        _warn(
+            "KABU_USE_SANDBOX=true ですが KABU_SANDBOX_API_PASSWORD が未設定です。"
+            " KABU_API_PASSWORD を流用します。"
+        )
+
+
+def _check_paper_trading_cash() -> None:
+    """PAPER_TRADING_INITIAL_CASH の値域チェック。"""
+    raw = os.environ.get("PAPER_TRADING_INITIAL_CASH", "").strip()
+    if not raw:
+        return
+    try:
+        val = float(raw)
+    except ValueError:
+        _error(
+            f"PAPER_TRADING_INITIAL_CASH の値が不正です: '{raw}'. 正の数値で設定してください。"
+        )
+        return
+    if val <= 0:
+        _error(
+            f"PAPER_TRADING_INITIAL_CASH は正の値で設定してください（現在値: {val}）"
+        )
+
+
 def _check_live_guards() -> None:
     """KABUSYS_ENV=live 時の追加チェック。"""
     env = os.environ.get("KABUSYS_ENV", "development").lower()
@@ -302,6 +335,8 @@ def validate() -> tuple[list[str], list[str], list[str]]:
     _check_log_level()
     _check_db_paths()
     _check_config_yaml_files()
+    _check_sandbox_config()
+    _check_paper_trading_cash()
     _check_live_guards()
 
     return list(_errors), list(_warnings), list(_infos)

--- a/tests/test_broker_factory.py
+++ b/tests/test_broker_factory.py
@@ -126,6 +126,113 @@ class TestBrokerClientFactory:
             BrokerClientFactory.create(Settings())
 
 
+class TestPaperTradingInitialCash:
+    def test_default_is_ten_million(self, monkeypatch):
+        monkeypatch.delenv("PAPER_TRADING_INITIAL_CASH", raising=False)
+        assert Settings().paper_trading_initial_cash == 10_000_000.0
+
+    def test_custom_value(self, monkeypatch):
+        monkeypatch.setenv("PAPER_TRADING_INITIAL_CASH", "5000000")
+        assert Settings().paper_trading_initial_cash == 5_000_000.0
+
+    def test_invalid_raises(self, monkeypatch):
+        monkeypatch.setenv("PAPER_TRADING_INITIAL_CASH", "not_a_number")
+        with pytest.raises(ValueError):
+            Settings().paper_trading_initial_cash
+
+    def test_zero_raises(self, monkeypatch):
+        monkeypatch.setenv("PAPER_TRADING_INITIAL_CASH", "0")
+        with pytest.raises(ValueError):
+            Settings().paper_trading_initial_cash
+
+    def test_negative_raises(self, monkeypatch):
+        monkeypatch.setenv("PAPER_TRADING_INITIAL_CASH", "-1000000")
+        with pytest.raises(ValueError):
+            Settings().paper_trading_initial_cash
+
+
+class TestKabuSandbox:
+    def test_sandbox_default_false(self, monkeypatch):
+        monkeypatch.delenv("KABU_USE_SANDBOX", raising=False)
+        assert Settings().kabu_use_sandbox is False
+
+    def test_sandbox_enabled(self, monkeypatch):
+        monkeypatch.setenv("KABU_USE_SANDBOX", "true")
+        assert Settings().kabu_use_sandbox is True
+
+    def test_sandbox_password_default_empty(self, monkeypatch):
+        monkeypatch.delenv("KABU_SANDBOX_API_PASSWORD", raising=False)
+        assert Settings().kabu_sandbox_api_password == ""
+
+    def test_sandbox_password_set(self, monkeypatch):
+        monkeypatch.setenv("KABU_SANDBOX_API_PASSWORD", "sandbox_pass")
+        assert Settings().kabu_sandbox_api_password == "sandbox_pass"
+
+
+class TestBrokerClientFactoryInitialCash:
+    def test_initial_cash_applied_from_settings(self, monkeypatch):
+        monkeypatch.setenv("KABUSYS_ENV", "paper_trading")
+        monkeypatch.setenv("PAPER_TRADING_INITIAL_CASH", "3000000")
+        monkeypatch.delenv("KABU_USE_SANDBOX", raising=False)
+        broker = BrokerClientFactory.create(Settings())
+        assert isinstance(broker, MockBrokerClient)
+        assert broker.get_available_cash() == 3_000_000.0
+
+    def test_available_cash_override(self, monkeypatch):
+        monkeypatch.setenv("KABUSYS_ENV", "paper_trading")
+        monkeypatch.delenv("KABU_USE_SANDBOX", raising=False)
+        broker = BrokerClientFactory.create(Settings(), available_cash=999_000.0)
+        assert isinstance(broker, MockBrokerClient)
+        assert broker.get_available_cash() == 999_000.0
+
+    def test_initial_positions_override(self, monkeypatch):
+        from kabusys.execution.broker_api import Position
+
+        monkeypatch.setenv("KABUSYS_ENV", "paper_trading")
+        monkeypatch.delenv("KABU_USE_SANDBOX", raising=False)
+        pos = Position(code="1234", qty=100, avg_price=1500.0)
+        broker = BrokerClientFactory.create(Settings(), initial_positions=[pos])
+        assert isinstance(broker, MockBrokerClient)
+        positions = broker.get_positions()
+        assert len(positions) == 1
+        assert positions[0].code == "1234"
+
+    def test_sandbox_mode_returns_kabu_client(self, monkeypatch):
+        from kabusys.execution.kabu_client import KabuStationClient
+
+        monkeypatch.setenv("KABUSYS_ENV", "paper_trading")
+        monkeypatch.setenv("KABU_USE_SANDBOX", "true")
+        monkeypatch.setenv("KABU_API_PASSWORD", "api_pass")
+        monkeypatch.setenv("KABU_SANDBOX_API_PASSWORD", "sandbox_pass")
+        broker = BrokerClientFactory.create(Settings())
+        assert isinstance(broker, KabuStationClient)
+        broker.close()
+
+    def test_sandbox_falls_back_to_api_password(self, monkeypatch):
+        from kabusys.execution.kabu_client import KabuStationClient
+
+        monkeypatch.setenv("KABUSYS_ENV", "paper_trading")
+        monkeypatch.setenv("KABU_USE_SANDBOX", "true")
+        monkeypatch.setenv("KABU_API_PASSWORD", "api_pass")
+        monkeypatch.delenv("KABU_SANDBOX_API_PASSWORD", raising=False)
+        broker = BrokerClientFactory.create(Settings())
+        assert isinstance(broker, KabuStationClient)
+        broker.close()
+
+    def test_sandbox_uses_port_18081(self, monkeypatch):
+        from kabusys.execution.kabu_client import KabuStationClient
+        from kabusys.execution.broker_factory import _SANDBOX_BASE_URL
+
+        monkeypatch.setenv("KABUSYS_ENV", "paper_trading")
+        monkeypatch.setenv("KABU_USE_SANDBOX", "true")
+        monkeypatch.setenv("KABU_API_PASSWORD", "api_pass")
+        monkeypatch.delenv("KABU_SANDBOX_API_PASSWORD", raising=False)
+        broker = BrokerClientFactory.create(Settings())
+        assert isinstance(broker, KabuStationClient)
+        assert "18081" in _SANDBOX_BASE_URL
+        broker.close()
+
+
 class TestKabuTradePassword:
     def test_returns_none_when_not_set(self, monkeypatch):
         monkeypatch.delenv("KABU_TRADE_PASSWORD", raising=False)

--- a/tests/test_restore_paper_state.py
+++ b/tests/test_restore_paper_state.py
@@ -160,3 +160,74 @@ class TestRestorePaperStateBrokenDb:
         cash, positions = _restore_paper_state(db_path, 10_000_000.0)
         assert cash == 10_000_000.0
         assert positions == []
+
+
+class TestRestorePaperStateSideNormalization:
+    def test_unknown_side_is_skipped(self, tmp_path):
+        """未知の side 値（"BUY" ではなく大文字など以外）は除外される。"""
+        db_path = _make_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO orders VALUES (?, ?, ?, ?)",
+            ("unknown_side", "1234", 100, 1000.0),
+        )
+        conn.commit()
+        conn.close()
+
+        cash, positions = _restore_paper_state(db_path, 10_000_000.0)
+        assert cash == 10_000_000.0  # 未知 side は現金に影響しない
+        assert positions == []
+
+    def test_uppercase_buy_is_treated_as_buy(self, tmp_path):
+        """大文字 "BUY" も lower() 正規化で buy として扱う。"""
+        db_path = _make_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO orders VALUES (?, ?, ?, ?)",
+            ("BUY", "1234", 100, 1000.0),
+        )
+        conn.commit()
+        conn.close()
+
+        cash, positions = _restore_paper_state(db_path, 10_000_000.0)
+        assert cash == 10_000_000.0 - 100 * 1000.0
+        assert len(positions) == 1
+        assert positions[0].code == "1234"
+
+    def test_uppercase_sell_is_treated_as_sell(self, tmp_path):
+        """大文字 "SELL" も lower() 正規化で sell として扱う。"""
+        db_path = _make_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.executemany(
+            "INSERT INTO orders VALUES (?, ?, ?, ?)",
+            [
+                ("BUY", "1234", 100, 1000.0),
+                ("SELL", "1234", 100, 1200.0),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        cash, positions = _restore_paper_state(db_path, 10_000_000.0)
+        expected_cash = 10_000_000.0 - 100 * 1000.0 + 100 * 1200.0
+        assert cash == expected_cash
+        assert positions == []  # 全量売却後はポジション 0
+
+
+class TestRestorePaperStateShortPosition:
+    def test_net_qty_negative_position_is_skipped(self, tmp_path):
+        """sell > buy でネット数量が負（ショート）になる場合はポジション生成しない。"""
+        db_path = _make_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.executemany(
+            "INSERT INTO orders VALUES (?, ?, ?, ?)",
+            [
+                ("buy", "1234", 100, 1000.0),
+                ("sell", "1234", 200, 1200.0),  # 売り超過
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        cash, positions = _restore_paper_state(db_path, 10_000_000.0)
+        assert positions == []  # ショートポジションは生成しない

--- a/tests/test_restore_paper_state.py
+++ b/tests/test_restore_paper_state.py
@@ -1,0 +1,162 @@
+# tests/test_restore_paper_state.py
+"""_restore_paper_state のユニットテスト。"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from kabusys.run_execution import _restore_paper_state
+
+
+def _make_db(tmp_path: Path) -> Path:
+    """テスト用 paper_trading.db を作成し、パスを返す。"""
+    db_path = tmp_path / "paper_trading.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("""
+        CREATE TABLE orders (
+            side TEXT, code TEXT, filled_qty INTEGER, avg_fill_price REAL
+        )
+    """)
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+class TestRestorePaperStateNoDb:
+    def test_returns_initial_cash_when_no_db(self, tmp_path):
+        path = tmp_path / "nonexistent.db"
+        cash, positions = _restore_paper_state(path, 10_000_000.0)
+        assert cash == 10_000_000.0
+        assert positions == []
+
+
+class TestRestorePaperStateEmpty:
+    def test_returns_initial_cash_with_no_orders(self, tmp_path):
+        db_path = _make_db(tmp_path)
+        cash, positions = _restore_paper_state(db_path, 10_000_000.0)
+        assert cash == 10_000_000.0
+        assert positions == []
+
+
+class TestRestorePaperStateBuyOnly:
+    def test_single_buy_reduces_cash(self, tmp_path):
+        db_path = _make_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO orders VALUES (?, ?, ?, ?)",
+            ("buy", "1234", 100, 1500.0),
+        )
+        conn.commit()
+        conn.close()
+
+        cash, positions = _restore_paper_state(db_path, 10_000_000.0)
+        assert cash == 10_000_000.0 - 100 * 1500.0
+        assert len(positions) == 1
+        assert positions[0].code == "1234"
+        assert positions[0].qty == 100
+        assert positions[0].avg_price == 1500.0
+
+    def test_multiple_buys_same_code_aggregated(self, tmp_path):
+        db_path = _make_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.executemany(
+            "INSERT INTO orders VALUES (?, ?, ?, ?)",
+            [
+                ("buy", "1234", 100, 1000.0),
+                ("buy", "1234", 200, 2000.0),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        cash, positions = _restore_paper_state(db_path, 10_000_000.0)
+        expected_cash = 10_000_000.0 - 100 * 1000.0 - 200 * 2000.0
+        assert cash == expected_cash
+        assert len(positions) == 1
+        assert positions[0].qty == 300
+        # avg_price = total_cost / total_qty = (100*1000 + 200*2000) / 300
+        expected_avg = (100 * 1000.0 + 200 * 2000.0) / 300
+        assert abs(positions[0].avg_price - expected_avg) < 0.01
+
+
+class TestRestorePaperStateSell:
+    def test_sell_removes_position_and_increases_cash(self, tmp_path):
+        db_path = _make_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.executemany(
+            "INSERT INTO orders VALUES (?, ?, ?, ?)",
+            [
+                ("buy", "1234", 100, 1000.0),
+                ("sell", "1234", 100, 1200.0),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        cash, positions = _restore_paper_state(db_path, 10_000_000.0)
+        expected_cash = 10_000_000.0 - 100 * 1000.0 + 100 * 1200.0
+        assert cash == expected_cash
+        assert positions == []  # net_qty = 0, position は残らない
+
+    def test_partial_sell_leaves_remaining_position(self, tmp_path):
+        db_path = _make_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.executemany(
+            "INSERT INTO orders VALUES (?, ?, ?, ?)",
+            [
+                ("buy", "1234", 200, 1000.0),
+                ("sell", "1234", 100, 1200.0),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        cash, positions = _restore_paper_state(db_path, 10_000_000.0)
+        assert len(positions) == 1
+        assert positions[0].qty == 100
+
+    def test_multiple_codes(self, tmp_path):
+        db_path = _make_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.executemany(
+            "INSERT INTO orders VALUES (?, ?, ?, ?)",
+            [
+                ("buy", "1234", 100, 1000.0),
+                ("buy", "5678", 50, 2000.0),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        cash, positions = _restore_paper_state(db_path, 10_000_000.0)
+        codes = {p.code for p in positions}
+        assert codes == {"1234", "5678"}
+        assert len(positions) == 2
+
+
+class TestRestorePaperStateNullPrice:
+    def test_null_avg_fill_price_is_excluded(self, tmp_path):
+        db_path = _make_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        # avg_fill_price=NULL（未約定）は集計から除外される
+        conn.execute(
+            "INSERT INTO orders VALUES (?, ?, ?, ?)",
+            ("buy", "1234", 100, None),
+        )
+        conn.commit()
+        conn.close()
+
+        cash, positions = _restore_paper_state(db_path, 10_000_000.0)
+        assert cash == 10_000_000.0
+        assert positions == []
+
+
+class TestRestorePaperStateBrokenDb:
+    def test_missing_table_returns_initial(self, tmp_path):
+        db_path = tmp_path / "broken.db"
+        # orders テーブルなしの空 DB
+        sqlite3.connect(str(db_path)).close()
+        cash, positions = _restore_paper_state(db_path, 10_000_000.0)
+        assert cash == 10_000_000.0
+        assert positions == []

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -169,3 +169,69 @@ def test_strict_mode_fails_on_warning(tmp_path):
         result = vc.main(["--strict"])
     # tmp_path には YAML がないので warning → strict では fail
     assert result == 1
+
+
+class TestSandboxConfig:
+    def test_no_warning_when_sandbox_disabled(self, tmp_path):
+        _, warnings, _ = _run_validate(
+            env_overrides={"KABU_USE_SANDBOX": "false"},
+            config_dir=tmp_path,
+        )
+        assert not any("KABU_SANDBOX" in w for w in warnings)
+
+    def test_warning_when_sandbox_enabled_without_password(self, tmp_path):
+        _, warnings, _ = _run_validate(
+            env_overrides={
+                "KABU_USE_SANDBOX": "true",
+                "KABU_SANDBOX_API_PASSWORD": "",
+            },
+            config_dir=tmp_path,
+        )
+        assert any("KABU_SANDBOX_API_PASSWORD" in w for w in warnings)
+
+    def test_no_warning_when_sandbox_enabled_with_password(self, tmp_path):
+        _, warnings, _ = _run_validate(
+            env_overrides={
+                "KABU_USE_SANDBOX": "true",
+                "KABU_SANDBOX_API_PASSWORD": "sandbox_pass",
+            },
+            config_dir=tmp_path,
+        )
+        assert not any("KABU_SANDBOX_API_PASSWORD" in w for w in warnings)
+
+
+class TestPaperTradingCashValidation:
+    def test_no_error_when_not_set(self, tmp_path):
+        errors, _, _ = _run_validate(
+            env_overrides={"PAPER_TRADING_INITIAL_CASH": ""},
+            config_dir=tmp_path,
+        )
+        assert not any("PAPER_TRADING_INITIAL_CASH" in e for e in errors)
+
+    def test_error_when_zero(self, tmp_path):
+        errors, _, _ = _run_validate(
+            env_overrides={"PAPER_TRADING_INITIAL_CASH": "0"},
+            config_dir=tmp_path,
+        )
+        assert any("PAPER_TRADING_INITIAL_CASH" in e for e in errors)
+
+    def test_error_when_negative(self, tmp_path):
+        errors, _, _ = _run_validate(
+            env_overrides={"PAPER_TRADING_INITIAL_CASH": "-500000"},
+            config_dir=tmp_path,
+        )
+        assert any("PAPER_TRADING_INITIAL_CASH" in e for e in errors)
+
+    def test_error_when_invalid_string(self, tmp_path):
+        errors, _, _ = _run_validate(
+            env_overrides={"PAPER_TRADING_INITIAL_CASH": "abc"},
+            config_dir=tmp_path,
+        )
+        assert any("PAPER_TRADING_INITIAL_CASH" in e for e in errors)
+
+    def test_no_error_when_valid(self, tmp_path):
+        errors, _, _ = _run_validate(
+            env_overrides={"PAPER_TRADING_INITIAL_CASH": "5000000"},
+            config_dir=tmp_path,
+        )
+        assert not any("PAPER_TRADING_INITIAL_CASH" in e for e in errors)

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -193,11 +193,23 @@ class TestSandboxConfig:
         _, warnings, _ = _run_validate(
             env_overrides={
                 "KABU_USE_SANDBOX": "true",
+                "KABUSYS_ENV": "paper_trading",
                 "KABU_SANDBOX_API_PASSWORD": "sandbox_pass",
             },
             config_dir=tmp_path,
         )
         assert not any("KABU_SANDBOX_API_PASSWORD" in w for w in warnings)
+
+    def test_warning_when_sandbox_enabled_but_not_paper_env(self, tmp_path):
+        _, warnings, _ = _run_validate(
+            env_overrides={
+                "KABU_USE_SANDBOX": "true",
+                "KABUSYS_ENV": "development",
+                "KABU_SANDBOX_API_PASSWORD": "sandbox_pass",
+            },
+            config_dir=tmp_path,
+        )
+        assert any("paper_trading" in w for w in warnings)
 
 
 class TestPaperTradingCashValidation:


### PR DESCRIPTION
## Summary

- `PAPER_TRADING_INITIAL_CASH` 環境変数を追加し `.env` で初期資金を設定可能にした（デフォルト 10,000,000 円）
- `run_execution.py` に `_restore_paper_state()` を実装し再起動時に `paper_trading.db` の約定履歴から残高・ポジションを自動復元する
- `setup_db.py` に `--paper-reset` オプションを追加（`paper_trading.db` を削除して空テーブルで再初期化）
- `KABU_USE_SANDBOX` / `KABU_SANDBOX_API_PASSWORD` を追加し `is_paper + kabu_use_sandbox=true` 時に kabuステーション検証環境（ポート 18081）に接続できるようにした

## Changes

| ファイル | 変更内容 |
|---|---|
| `src/kabusys/config.py` | `paper_trading_initial_cash`, `kabu_use_sandbox`, `kabu_sandbox_api_password` プロパティ追加 |
| `src/kabusys/execution/broker_factory.py` | `available_cash` / `initial_positions` オーバーライド対応、sandbox mode 分岐追加 |
| `src/kabusys/run_execution.py` | `_restore_paper_state()` 追加、paper mode 起動時に状態復元してから broker を生成 |
| `scripts/setup_db.py` | `--paper-reset` オプション追加 |
| `src/kabusys/config_setup.py` | 新設定項目を wizard に追加 |
| `src/kabusys/validate_config.py` | `_check_sandbox_config()` / `_check_paper_trading_cash()` 追加 |
| `tests/test_broker_factory.py` | 新機能のテスト追加 |
| `tests/test_restore_paper_state.py` | `_restore_paper_state()` のユニットテスト（新規） |
| `tests/test_validate_config.py` | 新バリデーション関数のテスト追加 |

## Test plan

- [x] 1548 tests all passing (`pytest -q`)
- [x] `ruff check` / `ruff format --check` すべてパス
- [ ] `PAPER_TRADING_INITIAL_CASH=5000000` で MockBrokerClient の初期資金が変わることを確認
- [ ] `setup_db.py --paper-reset` で paper_trading.db がリセットされることを確認
- [ ] `KABU_USE_SANDBOX=true` で broker_factory が KabuStationClient（18081）を返すことを確認

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)