### PR TITLE
feat: 戦略パラメータの設定ファイル runtime 読み込み (Issue #258)

### DIFF
--- a/config/strategy_config.yaml
+++ b/config/strategy_config.yaml
@@ -1,15 +1,39 @@
 # strategy_config.yaml — 売買戦略パラメータ
+# 変更後は次回 run_strategy_signal.py 実行から反映される（再起動不要）
+
 strategy:
-  name: momentum_strategy
-  universe_size: 500
-  rebalance_frequency: daily
+  # ファクター重み（合計が 1.0 でない場合は自動正規化される）
+  weights:
+    momentum: 0.40
+    value: 0.20
+    volatility: 0.15
+    liquidity: 0.15
+    news: 0.10
+  # BUY シグナル生成の final_score 閾値
+  threshold: 0.60
+  # ストップロス閾値（終値 / avg_price - 1 がこれ以下で SELL）
+  stop_loss_rate: -0.08
+  # 最低保有営業日数（スコア低下による SELL を抑制する日数）
+  min_holding_days: 5
+  # 最大保有営業日数（これを超えると time_exit SELL を発動）
+  max_holding_days: 60
+  # トレーリングストップの ATR 乗数
+  trailing_stop_atr_mult: 2.0
+  # 同一銘柄の再エントリー禁止期間（営業日数）
+  reentry_cooldown_days: 5
+  # ギャップアップ閾値（この比率を超えた寄り高は BUY 抑制）
+  gap_up_threshold: 0.05
+  # ギャップダウン閾値（この比率以下の寄り安は BUY 抑制）
+  gap_down_threshold: -0.03
 
-factors:
-  momentum_20_weight: 0.5
-  momentum_60_weight: 0.3
-  volume_factor_weight: 0.2
-
-ai_overlay:
-  enabled: true
-  # AIオーバーレイの影響度上限（RiskManagement.md §6 に準拠）
-  max_influence: 0.10
+value_score:
+  # バリュースコア計算の重み（合計 1.0）
+  weights:
+    per: 0.50
+    pbr: 0.30
+    div_yield: 0.20
+  # 正規化基準値
+  normalization:
+    per_mid: 20.0
+    pbr_mid: 1.5
+    div_yield_max: 3.0

--- a/config/strategy_config.yaml
+++ b/config/strategy_config.yaml
@@ -2,7 +2,7 @@
 # 変更後は次回 run_strategy_signal.py 実行から反映される（再起動不要）
 
 strategy:
-  # ファクター重み（合計が 1.0 でない場合は自動正規化される）
+  # ファクター重み（合計が 1.0 でない場合、generate_signals() 内で自動スケールされる）
   weights:
     momentum: 0.40
     value: 0.20

--- a/scripts/generate_config.py
+++ b/scripts/generate_config.py
@@ -60,19 +60,29 @@ ai_scores:
     "strategy_config.yaml": """\
 # strategy_config.yaml — 売買戦略パラメータ
 strategy:
-  name: momentum_strategy
-  universe_size: 500
-  rebalance_frequency: daily
-
-factors:
-  momentum_20_weight: 0.5
-  momentum_60_weight: 0.3
-  volume_factor_weight: 0.2
-
-ai_overlay:
-  enabled: true
-  # AIオーバーレイの影響度上限（RiskManagement.md §6 に準拠）
-  max_influence: 0.10
+  weights:
+    momentum: 0.40
+    value: 0.20
+    volatility: 0.15
+    liquidity: 0.15
+    news: 0.10
+  threshold: 0.60
+  stop_loss_rate: -0.08
+  min_holding_days: 5
+  max_holding_days: 60
+  trailing_stop_atr_mult: 2.0
+  reentry_cooldown_days: 5
+  gap_up_threshold: 0.05
+  gap_down_threshold: -0.03
+value_score:
+  weights:
+    per: 0.50
+    pbr: 0.30
+    div_yield: 0.20
+  normalization:
+    per_mid: 20.0
+    pbr_mid: 1.5
+    div_yield_max: 3.0
 """,
     "risk_config.yaml": """\
 # risk_config.yaml — リスク管理設定

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -1168,7 +1168,12 @@ def generate_signals(
                 sector_suppressed += 1
                 continue
             # 再エントリー制限チェック
-            if _is_reentry_blocked(conn, r["code"], target_date, cooldown_days=_cfg["reentry_cooldown_days"]):
+            if _is_reentry_blocked(
+                conn,
+                r["code"],
+                target_date,
+                cooldown_days=_cfg["reentry_cooldown_days"],
+            ):
                 logger.debug("reentry blocked: %s — date=%s", r["code"], target_date)
                 reentry_suppressed += 1
                 continue

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -642,7 +642,7 @@ def _is_reentry_blocked(
     target_date: date,
     cooldown_days: int = _REENTRY_COOLDOWN_DAYS,
 ) -> bool:
-    """最新の sell_date から target_date までの営業日数が _REENTRY_COOLDOWN_DAYS 未満なら True。
+    """最新の sell_date から target_date までの営業日数が cooldown_days 未満なら True。
     sell_date が NULL またはレコードなしは False（制限なし）。
     """
     row = conn.execute(

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -99,12 +99,16 @@ _STRATEGY_CONFIG_PATH = (
     Path(__file__).resolve().parents[3] / "config" / "strategy_config.yaml"
 )
 
+_strategy_config_cache: dict | None = None
+_strategy_config_mtime: float = -1.0
+
 
 def _load_strategy_config() -> dict:
     """config/strategy_config.yaml から戦略パラメータを読み込む。
 
     ファイルが存在しない・読み込み失敗の場合はデフォルト値にフォールバック。
     各キーは個別に検証し、不正値のみデフォルトで補完する。
+    mtime ベースのキャッシュにより、同一ファイルの繰り返し読み込みを回避する。
 
     Returns:
         {
@@ -119,6 +123,7 @@ def _load_strategy_config() -> dict:
             "reentry_cooldown_days": int,
         }
     """
+    global _strategy_config_cache, _strategy_config_mtime
     import yaml  # PyYAML（既存の依存パッケージ）
 
     def _defaults() -> dict:
@@ -132,6 +137,20 @@ def _load_strategy_config() -> dict:
             _STRATEGY_CONFIG_PATH,
         )
         return _defaults()
+
+    try:
+        current_mtime = _STRATEGY_CONFIG_PATH.stat().st_mtime
+    except OSError as exc:
+        logger.warning(
+            "strategy_config.yaml の stat() に失敗: %s (デフォルトを使用)", exc
+        )
+        return _defaults()
+
+    if _strategy_config_cache is not None and current_mtime == _strategy_config_mtime:
+        cached = _strategy_config_cache
+        out = dict(cached)
+        out["weights"] = dict(cached["weights"])
+        return out
 
     try:
         with open(_STRATEGY_CONFIG_PATH, encoding="utf-8") as f:
@@ -149,7 +168,11 @@ def _load_strategy_config() -> dict:
     result = _defaults()
     s = data.get("strategy")
     if not isinstance(s, dict):
-        return result
+        _strategy_config_cache = result
+        _strategy_config_mtime = current_mtime
+        out = dict(result)
+        out["weights"] = dict(result["weights"])
+        return out
 
     # weights — 既知キーのみ受け付け、負値は無視、合計 0 以下ならデフォルト
     raw_w = s.get("weights")
@@ -199,7 +222,11 @@ def _load_strategy_config() -> dict:
             if iv >= 0:
                 result[key] = iv
 
-    return result
+    _strategy_config_cache = result
+    _strategy_config_mtime = current_mtime
+    out = dict(result)
+    out["weights"] = dict(result["weights"])
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -239,19 +266,56 @@ _VALUE_CONFIG_DEFAULTS: dict = {
     "normalization": {"per_mid": 20.0, "pbr_mid": 1.5, "div_yield_max": 3.0},
 }
 
+_value_config_cache: dict | None = None
+_value_config_cache_mtimes: tuple[float, float] = (-1.0, -1.0)
+
 
 def _load_value_config() -> dict:
     """strategy_config.yaml の value_score セクションからバリュースコア設定を読み込む。
 
     value_score セクションが存在しない場合は strategy.toml にフォールバック（後方互換）。
     ファイルが存在しない・読み込み失敗・不正値の場合はデフォルト値にフォールバック。
+    yaml/toml の mtime ベースキャッシュにより繰り返し I/O を回避する。
     """
+    global _value_config_cache, _value_config_cache_mtimes
     import yaml  # PyYAML
 
     def _defaults() -> dict:
         return {
             "weights": dict(_VALUE_CONFIG_DEFAULTS["weights"]),
             "normalization": dict(_VALUE_CONFIG_DEFAULTS["normalization"]),
+        }
+
+    def _current_mtimes() -> tuple[float, float]:
+        toml_path = _STRATEGY_CONFIG_PATH.parent / "strategy.toml"
+        y = t = -1.0
+        try:
+            if _STRATEGY_CONFIG_PATH.exists():
+                y = _STRATEGY_CONFIG_PATH.stat().st_mtime
+        except OSError:
+            pass
+        try:
+            if toml_path.exists():
+                t = toml_path.stat().st_mtime
+        except OSError:
+            pass
+        return (y, t)
+
+    mtimes = _current_mtimes()
+    if _value_config_cache is not None and mtimes == _value_config_cache_mtimes:
+        c = _value_config_cache
+        return {
+            "weights": dict(c["weights"]),
+            "normalization": dict(c["normalization"]),
+        }
+
+    def _cache_and_return(result: dict) -> dict:
+        global _value_config_cache, _value_config_cache_mtimes
+        _value_config_cache = result
+        _value_config_cache_mtimes = mtimes
+        return {
+            "weights": dict(result["weights"]),
+            "normalization": dict(result["normalization"]),
         }
 
     # 1. strategy_config.yaml の value_score セクションを試みる
@@ -270,20 +334,20 @@ def _load_value_config() -> dict:
                     logger.warning(
                         "strategy_config.yaml: value_score.weights が不正。デフォルトを使用"
                     )
-                    return _defaults()
+                    return _cache_and_return(_defaults())
                 if any(
                     n.get(k, 0) <= 0 for k in ("per_mid", "pbr_mid", "div_yield_max")
                 ):
                     logger.warning(
                         "strategy_config.yaml: value_score.normalization に 0 以下の値。デフォルトを使用"
                     )
-                    return _defaults()
-                return {"weights": dict(w), "normalization": dict(n)}
+                    return _cache_and_return(_defaults())
+                return _cache_and_return({"weights": dict(w), "normalization": dict(n)})
         except Exception as exc:
             logger.warning("strategy_config.yaml (value_score) 読み込み失敗: %s", exc)
 
     # 2. 後方互換: strategy.toml フォールバック
-    toml_path = Path(__file__).resolve().parents[3] / "config" / "strategy.toml"
+    toml_path = _STRATEGY_CONFIG_PATH.parent / "strategy.toml"
     raw_toml: dict = {}
     if toml_path.exists():
         try:
@@ -302,12 +366,12 @@ def _load_value_config() -> dict:
         logger.warning(
             "value_score.weights が不正（負値または合計<=0）。デフォルトを使用"
         )
-        return _defaults()
+        return _cache_and_return(_defaults())
     if any(n.get(k, 0) <= 0 for k in ("per_mid", "pbr_mid", "div_yield_max")):
         logger.warning("value_score.normalization に 0 以下の値。デフォルトを使用")
-        return _defaults()
+        return _cache_and_return(_defaults())
 
-    return {"weights": dict(w), "normalization": dict(n)}
+    return _cache_and_return({"weights": dict(w), "normalization": dict(n)})
 
 
 def _compute_value_score(feat: dict[str, Any], config: dict) -> float | None:

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -80,6 +80,129 @@ _REENTRY_COOLDOWN_DAYS: int = (
 
 
 # ---------------------------------------------------------------------------
+# 設定ファイル読み込み
+# ---------------------------------------------------------------------------
+
+_STRATEGY_CONFIG_DEFAULTS: dict = {
+    "weights": {k: v for k, v in _DEFAULT_WEIGHTS.items()},
+    "threshold": _DEFAULT_THRESHOLD,
+    "stop_loss_rate": _STOP_LOSS_RATE,
+    "gap_up_threshold": _GAP_UP_THRESHOLD,
+    "gap_down_threshold": _GAP_DOWN_THRESHOLD,
+    "min_holding_days": _MIN_HOLDING_DAYS,
+    "max_holding_days": _MAX_HOLDING_DAYS,
+    "trailing_stop_atr_mult": _TRAILING_STOP_ATR_MULT,
+    "reentry_cooldown_days": _REENTRY_COOLDOWN_DAYS,
+}
+
+_STRATEGY_CONFIG_PATH = (
+    Path(__file__).resolve().parents[3] / "config" / "strategy_config.yaml"
+)
+
+
+def _load_strategy_config() -> dict:
+    """config/strategy_config.yaml から戦略パラメータを読み込む。
+
+    ファイルが存在しない・読み込み失敗の場合はデフォルト値にフォールバック。
+    各キーは個別に検証し、不正値のみデフォルトで補完する。
+
+    Returns:
+        {
+            "weights": dict[str, float],
+            "threshold": float,
+            "stop_loss_rate": float,
+            "gap_up_threshold": float,
+            "gap_down_threshold": float,
+            "min_holding_days": int,
+            "max_holding_days": int,
+            "trailing_stop_atr_mult": float,
+            "reentry_cooldown_days": int,
+        }
+    """
+    import yaml  # PyYAML（既存の依存パッケージ）
+
+    def _defaults() -> dict:
+        d = dict(_STRATEGY_CONFIG_DEFAULTS)
+        d["weights"] = dict(_STRATEGY_CONFIG_DEFAULTS["weights"])
+        return d
+
+    if not _STRATEGY_CONFIG_PATH.exists():
+        logger.debug(
+            "strategy_config.yaml が見つかりません。デフォルトを使用します: %s",
+            _STRATEGY_CONFIG_PATH,
+        )
+        return _defaults()
+
+    try:
+        with open(_STRATEGY_CONFIG_PATH, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except Exception as exc:
+        logger.warning("strategy_config.yaml 読み込み失敗: %s (デフォルトを使用)", exc)
+        return _defaults()
+
+    if not isinstance(data, dict):
+        logger.warning(
+            "strategy_config.yaml のトップレベルが dict ではありません。デフォルトを使用します"
+        )
+        return _defaults()
+
+    result = _defaults()
+    s = data.get("strategy")
+    if not isinstance(s, dict):
+        return result
+
+    # weights — 既知キーのみ受け付け、負値は無視、合計 0 以下ならデフォルト
+    raw_w = s.get("weights")
+    if isinstance(raw_w, dict):
+        merged: dict[str, float] = {}
+        for key in result["weights"]:
+            v = raw_w.get(key)
+            if (
+                v is not None
+                and isinstance(v, (int, float))
+                and not isinstance(v, bool)
+                and math.isfinite(float(v))
+                and float(v) >= 0
+            ):
+                merged[key] = float(v)
+            else:
+                merged[key] = result["weights"][key]
+        if sum(merged.values()) > 0:
+            result["weights"] = merged
+        else:
+            logger.warning(
+                "strategy_config.yaml: strategy.weights の合計が 0 以下。デフォルトを使用"
+            )
+
+    # float スカラーパラメータ
+    for key in (
+        "threshold",
+        "stop_loss_rate",
+        "gap_up_threshold",
+        "gap_down_threshold",
+        "trailing_stop_atr_mult",
+    ):
+        v = s.get(key)
+        if (
+            v is not None
+            and isinstance(v, (int, float))
+            and not isinstance(v, bool)
+            and math.isfinite(float(v))
+        ):
+            result[key] = float(v)
+
+    # int スカラーパラメータ（0 以上）
+    for key in ("min_holding_days", "max_holding_days", "reentry_cooldown_days"):
+        v = s.get(key)
+        if v is not None and isinstance(v, (int, float)) and not isinstance(v, bool):
+            iv = int(v)
+            if iv >= 0:
+                result[key] = iv
+
+    return result
+
+
+# ---------------------------------------------------------------------------
 # スコア計算ユーティリティ
 # ---------------------------------------------------------------------------
 
@@ -118,41 +241,71 @@ _VALUE_CONFIG_DEFAULTS: dict = {
 
 
 def _load_value_config() -> dict:
-    """config/strategy.toml からバリュースコア設定を読み込む。
+    """strategy_config.yaml の value_score セクションからバリュースコア設定を読み込む。
 
+    value_score セクションが存在しない場合は strategy.toml にフォールバック（後方互換）。
     ファイルが存在しない・読み込み失敗・不正値の場合はデフォルト値にフォールバック。
-    存在するキーのみファイル値でマージし、欠損キーはデフォルトで補完する。
-
-    Returns:
-        {"weights": {...}, "normalization": {...}} 形式の辞書。
     """
-    config_path = Path(__file__).resolve().parents[3] / "config" / "strategy.toml"
-    raw: dict = {}
-    if config_path.exists():
+    import yaml  # PyYAML
+
+    def _defaults() -> dict:
+        return {
+            "weights": dict(_VALUE_CONFIG_DEFAULTS["weights"]),
+            "normalization": dict(_VALUE_CONFIG_DEFAULTS["normalization"]),
+        }
+
+    # 1. strategy_config.yaml の value_score セクションを試みる
+    if _STRATEGY_CONFIG_PATH.exists():
         try:
-            with open(config_path, "rb") as f:
-                raw = tomllib.load(f).get("value_score", {})
+            with open(_STRATEGY_CONFIG_PATH, encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+            if isinstance(data, dict) and isinstance(data.get("value_score"), dict):
+                raw = data["value_score"]
+                w = {**_VALUE_CONFIG_DEFAULTS["weights"], **(raw.get("weights") or {})}
+                n = {
+                    **_VALUE_CONFIG_DEFAULTS["normalization"],
+                    **(raw.get("normalization") or {}),
+                }
+                if any(v < 0 for v in w.values()) or sum(w.values()) <= 0:
+                    logger.warning(
+                        "strategy_config.yaml: value_score.weights が不正。デフォルトを使用"
+                    )
+                    return _defaults()
+                if any(
+                    n.get(k, 0) <= 0 for k in ("per_mid", "pbr_mid", "div_yield_max")
+                ):
+                    logger.warning(
+                        "strategy_config.yaml: value_score.normalization に 0 以下の値。デフォルトを使用"
+                    )
+                    return _defaults()
+                return {"weights": dict(w), "normalization": dict(n)}
+        except Exception as exc:
+            logger.warning("strategy_config.yaml (value_score) 読み込み失敗: %s", exc)
+
+    # 2. 後方互換: strategy.toml フォールバック
+    toml_path = Path(__file__).resolve().parents[3] / "config" / "strategy.toml"
+    raw_toml: dict = {}
+    if toml_path.exists():
+        try:
+            with open(toml_path, "rb") as f:
+                raw_toml = tomllib.load(f).get("value_score", {})
         except Exception as exc:
             logger.warning("strategy.toml 読み込み失敗: %s (デフォルトを使用)", exc)
 
-    w = {**_VALUE_CONFIG_DEFAULTS["weights"], **(raw.get("weights") or {})}
-    n = {**_VALUE_CONFIG_DEFAULTS["normalization"], **(raw.get("normalization") or {})}
+    w = {**_VALUE_CONFIG_DEFAULTS["weights"], **(raw_toml.get("weights") or {})}
+    n = {
+        **_VALUE_CONFIG_DEFAULTS["normalization"],
+        **(raw_toml.get("normalization") or {}),
+    }
 
     if any(v < 0 for v in w.values()) or sum(w.values()) <= 0:
         logger.warning(
             "value_score.weights が不正（負値または合計<=0）。デフォルトを使用"
         )
-        return {
-            "weights": dict(_VALUE_CONFIG_DEFAULTS["weights"]),
-            "normalization": dict(_VALUE_CONFIG_DEFAULTS["normalization"]),
-        }
-
+        return _defaults()
     if any(n.get(k, 0) <= 0 for k in ("per_mid", "pbr_mid", "div_yield_max")):
         logger.warning("value_score.normalization に 0 以下の値。デフォルトを使用")
-        return {
-            "weights": dict(_VALUE_CONFIG_DEFAULTS["weights"]),
-            "normalization": dict(_VALUE_CONFIG_DEFAULTS["normalization"]),
-        }
+        return _defaults()
 
     return {"weights": dict(w), "normalization": dict(n)}
 

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -640,6 +640,7 @@ def _is_reentry_blocked(
     conn: duckdb.DuckDBPyConnection,
     code: str,
     target_date: date,
+    cooldown_days: int = _REENTRY_COOLDOWN_DAYS,
 ) -> bool:
     """最新の sell_date から target_date までの営業日数が _REENTRY_COOLDOWN_DAYS 未満なら True。
     sell_date が NULL またはレコードなしは False（制限なし）。
@@ -656,7 +657,7 @@ def _is_reentry_blocked(
         return False
     sell_date = row[0] if isinstance(row[0], date) else date.fromisoformat(str(row[0]))
     days = get_trading_days(conn, sell_date, target_date)
-    return (len(days) - 1) < _REENTRY_COOLDOWN_DAYS
+    return (len(days) - 1) < cooldown_days
 
 
 def _has_upcoming_earnings(
@@ -699,6 +700,7 @@ def _generate_sell_signals(
     min_holding_days: int = _MIN_HOLDING_DAYS,
     max_holding_days: int = _MAX_HOLDING_DAYS,
     trailing_stop_atr: float = _TRAILING_STOP_ATR_MULT,
+    stop_loss_rate: float = _STOP_LOSS_RATE,
 ) -> list[dict[str, Any]]:
     """保有ポジションに対してエグジット条件を判定し、SELL シグナルを返す。
 
@@ -720,6 +722,7 @@ def _generate_sell_signals(
         max_holding_days:    この営業日数以上保有した銘柄に time_exit SELL を発動（デフォルト: _MAX_HOLDING_DAYS）。
                              ストップロス・決算回避より低優先。min_holding_days は無視して発火する。
         trailing_stop_atr:   ATR 乗数。peak_close − N×ATR を下回ったら trailing_stop SELL（含み益ありの場合のみ）。
+        stop_loss_rate:      ストップロス閾値（デフォルト: _STOP_LOSS_RATE）。pnl_rate がこの値以下で SELL。
 
     Returns:
         [{"code": str, "score": float, "reason": str}, ...] のリスト。
@@ -779,7 +782,7 @@ def _generate_sell_signals(
 
         # 1. ストップロス（最優先・保有日数チェックをスキップ）
         pnl_rate = (close - avg_price) / avg_price
-        if pnl_rate <= _STOP_LOSS_RATE:
+        if pnl_rate <= stop_loss_rate:
             sell_signals.append(
                 {
                     "code": code,
@@ -886,13 +889,13 @@ def _generate_sell_signals(
 def generate_signals(
     conn: duckdb.DuckDBPyConnection,
     target_date: date,
-    threshold: float = _DEFAULT_THRESHOLD,
+    threshold: float | None = None,
     weights: dict[str, float] | None = None,
     event_dates: dict[date, str] | None = None,
     scope: BacktestScope | None = None,
-    min_holding_days: int = _MIN_HOLDING_DAYS,
-    max_holding_days: int = _MAX_HOLDING_DAYS,
-    trailing_stop_atr: float = _TRAILING_STOP_ATR_MULT,
+    min_holding_days: int | None = None,
+    max_holding_days: int | None = None,
+    trailing_stop_atr: float | None = None,
 ) -> int:
     """features テーブルを読み込み、売買シグナルを生成して signals テーブルへ書き込む。
 
@@ -901,22 +904,34 @@ def generate_signals(
     Args:
         conn:              DuckDB 接続。features / ai_scores / positions テーブルを参照する。
         target_date:       シグナル生成日。
-        threshold:         BUY シグナル生成の final_score 閾値（デフォルト 0.60）。
-        weights:           ファクター重みの辞書（デフォルトは StrategyModel.md Section 4.1 の値）。
+        threshold:         BUY シグナル生成の final_score 閾値（None の場合は config から読み込む）。
+        weights:           ファクター重みの辞書（None の場合は config から読み込む）。
         event_dates:       {event_date: event_name} の辞書。翌営業日がイベント日の場合、
                            BUY の size_multiplier を 0.5 に縮小する。省略時はイベントなし扱い。
         scope:             BacktestScope インスタンス。mode='manual_codes' かつ codes が指定されている場合、
                            features クエリを指定銘柄に絞る。省略時（None）は全銘柄が対象。
-        min_holding_days:  SELL を抑制する最低保有営業日数（デフォルト: _MIN_HOLDING_DAYS）。
+        min_holding_days:  SELL を抑制する最低保有営業日数（None の場合は config から読み込む）。
                            ストップロスと Bear レジーム時は保有日数に関わらず SELL が発生する。
-        max_holding_days:  この営業日数以上保有した銘柄に time_exit SELL を発動（デフォルト: _MAX_HOLDING_DAYS）。
+        max_holding_days:  この営業日数以上保有した銘柄に time_exit SELL を発動（None の場合は config から読み込む）。
                            1 以上を指定すること。
         trailing_stop_atr: ATR 乗数。peak_close − N×ATR を下回ったら trailing_stop SELL。
-                           正の値を指定すること（デフォルト: _TRAILING_STOP_ATR_MULT）。
+                           正の値を指定すること（None の場合は config から読み込む）。
 
     Returns:
         signals テーブルへ書き込んだシグナル数（BUY + SELL の合計）。
     """
+    _cfg = _load_strategy_config()
+    if threshold is None:
+        threshold = _cfg["threshold"]
+    if weights is None:
+        weights = _cfg["weights"]
+    if min_holding_days is None:
+        min_holding_days = _cfg["min_holding_days"]
+    if max_holding_days is None:
+        max_holding_days = _cfg["max_holding_days"]
+    if trailing_stop_atr is None:
+        trailing_stop_atr = _cfg["trailing_stop_atr_mult"]
+
     if min_holding_days < 0:
         raise ValueError(
             f"min_holding_days は 0 以上を指定してください: {min_holding_days}"
@@ -1113,6 +1128,8 @@ def generate_signals(
     score_map: dict[str, float] = {r["code"]: r["score"] for r in scored}
 
     # 6. BUY シグナル生成（Bear レジームまたは breadth_stop では抑制）
+    _gap_up = _cfg["gap_up_threshold"]
+    _gap_down = _cfg["gap_down_threshold"]
     buy_signals: list[dict] = []
     if not regime_is_bear and not breadth_stop:
         # 3c. ギャップ比率を一括取得（BUY 生成が必要な場合のみ実行）
@@ -1128,8 +1145,8 @@ def generate_signals(
                 continue
             gap = gap_ratios.get(r["code"])
             if gap is not None and (
-                gap > _GAP_UP_THRESHOLD + _GAP_THRESHOLD_EPSILON
-                or gap <= _GAP_DOWN_THRESHOLD + _GAP_THRESHOLD_EPSILON
+                gap > _gap_up + _GAP_THRESHOLD_EPSILON
+                or gap <= _gap_down + _GAP_THRESHOLD_EPSILON
             ):
                 logger.debug(
                     "gap filter: %s gap=%.2f%% — BUY を抑制 date=%s",
@@ -1151,7 +1168,7 @@ def generate_signals(
                 sector_suppressed += 1
                 continue
             # 再エントリー制限チェック
-            if _is_reentry_blocked(conn, r["code"], target_date):
+            if _is_reentry_blocked(conn, r["code"], target_date, cooldown_days=_cfg["reentry_cooldown_days"]):
                 logger.debug("reentry blocked: %s — date=%s", r["code"], target_date)
                 reentry_suppressed += 1
                 continue
@@ -1200,6 +1217,7 @@ def generate_signals(
         min_holding_days=min_holding_days,
         max_holding_days=max_holding_days,
         trailing_stop_atr=trailing_stop_atr,
+        stop_loss_rate=_cfg["stop_loss_rate"],
     )
 
     # SELL 対象銘柄は BUY から除外し、ランクを連番で再付与（SELL 優先ポリシー）

--- a/src/kabusys/validate_config.py
+++ b/src/kabusys/validate_config.py
@@ -235,6 +235,101 @@ def _check_risk_config_content(data: object) -> None:
             )
 
 
+_KNOWN_STRATEGY_WEIGHT_KEYS = frozenset(
+    {"momentum", "value", "volatility", "liquidity", "news"}
+)
+
+
+def _check_strategy_config_content(data: object) -> None:
+    """strategy_config.yaml のセマンティック検証。
+
+    _load_strategy_config() と同じルールを事前検証として適用する。
+    エラー・警告は _error / _warn に追記する（例外は送出しない）。
+    """
+    if not isinstance(data, dict):
+        _error("strategy_config.yaml のトップレベルが dict ではありません。")
+        return
+    s = data.get("strategy")
+    if not isinstance(s, dict):
+        _error("strategy_config.yaml に 'strategy' セクションがありません。")
+        return
+
+    # weights
+    raw_w = s.get("weights")
+    if not isinstance(raw_w, dict):
+        _error("strategy_config.yaml: strategy.weights が dict ではありません。")
+    else:
+        missing_w = _KNOWN_STRATEGY_WEIGHT_KEYS - set(raw_w)
+        for k in sorted(missing_w):
+            _warn(f"strategy_config.yaml: strategy.weights.{k} がありません（デフォルト値を使用）。")
+        for k, v in raw_w.items():
+            if isinstance(v, bool) or not isinstance(v, (int, float)):
+                _error(f"strategy_config.yaml: strategy.weights.{k} は数値で設定してください（現在値: {v!r}）。")
+            elif float(v) < 0:
+                _error(f"strategy_config.yaml: strategy.weights.{k} は 0 以上で設定してください（現在値: {v}）。")
+        valid_vals = [float(v) for k, v in raw_w.items()
+                      if not isinstance(v, bool) and isinstance(v, (int, float)) and float(v) >= 0]
+        if valid_vals and sum(valid_vals) <= 0:
+            _error("strategy_config.yaml: strategy.weights の合計が 0 以下です。")
+
+    # threshold
+    t = s.get("threshold")
+    if t is None:
+        _warn("strategy_config.yaml: strategy.threshold がありません（デフォルト値を使用）。")
+    elif isinstance(t, bool) or not isinstance(t, (int, float)):
+        _error(f"strategy_config.yaml: strategy.threshold は数値で設定してください（現在値: {t!r}）。")
+    elif not (0 < float(t) < 1):
+        _warn(f"strategy_config.yaml: strategy.threshold は (0, 1) の範囲が推奨です（現在値: {t}）。")
+
+    # stop_loss_rate
+    slr = s.get("stop_loss_rate")
+    if slr is None:
+        _warn("strategy_config.yaml: strategy.stop_loss_rate がありません（デフォルト値を使用）。")
+    elif isinstance(slr, bool) or not isinstance(slr, (int, float)):
+        _error(f"strategy_config.yaml: strategy.stop_loss_rate は数値で設定してください（現在値: {slr!r}）。")
+    elif float(slr) >= 0:
+        _error(f"strategy_config.yaml: strategy.stop_loss_rate は負の値で設定してください（現在値: {slr}）。")
+
+    # min_holding_days
+    mhd = s.get("min_holding_days")
+    if mhd is not None:
+        if isinstance(mhd, bool) or not isinstance(mhd, (int, float)):
+            _error(f"strategy_config.yaml: strategy.min_holding_days は整数で設定してください（現在値: {mhd!r}）。")
+        elif int(mhd) < 0:
+            _error(f"strategy_config.yaml: strategy.min_holding_days は 0 以上で設定してください（現在値: {mhd}）。")
+
+    # max_holding_days
+    xhd = s.get("max_holding_days")
+    if xhd is not None:
+        if isinstance(xhd, bool) or not isinstance(xhd, (int, float)):
+            _error(f"strategy_config.yaml: strategy.max_holding_days は整数で設定してください（現在値: {xhd!r}）。")
+        elif int(xhd) < 1:
+            _error(f"strategy_config.yaml: strategy.max_holding_days は 1 以上で設定してください（現在値: {xhd}）。")
+
+    # trailing_stop_atr_mult
+    tsa = s.get("trailing_stop_atr_mult")
+    if tsa is not None:
+        if isinstance(tsa, bool) or not isinstance(tsa, (int, float)):
+            _error(f"strategy_config.yaml: strategy.trailing_stop_atr_mult は数値で設定してください（現在値: {tsa!r}）。")
+        elif float(tsa) <= 0:
+            _error(f"strategy_config.yaml: strategy.trailing_stop_atr_mult は正の値で設定してください（現在値: {tsa}）。")
+
+    # gap thresholds
+    gut = s.get("gap_up_threshold")
+    if gut is not None:
+        if isinstance(gut, bool) or not isinstance(gut, (int, float)):
+            _error(f"strategy_config.yaml: strategy.gap_up_threshold は数値で設定してください（現在値: {gut!r}）。")
+        elif float(gut) <= 0:
+            _warn(f"strategy_config.yaml: strategy.gap_up_threshold は正の値が推奨です（現在値: {gut}）。")
+
+    gdt = s.get("gap_down_threshold")
+    if gdt is not None:
+        if isinstance(gdt, bool) or not isinstance(gdt, (int, float)):
+            _error(f"strategy_config.yaml: strategy.gap_down_threshold は数値で設定してください（現在値: {gdt!r}）。")
+        elif float(gdt) >= 0:
+            _warn(f"strategy_config.yaml: strategy.gap_down_threshold は負の値が推奨です（現在値: {gdt}）。")
+
+
 def _check_config_yaml_files() -> None:
     """config/*.yaml の存在・構文確認。risk_config.yaml はセマンティック検証も行う。"""
     try:
@@ -263,6 +358,8 @@ def _check_config_yaml_files() -> None:
                 _info(f"config/{filename}: syntax OK")
                 if filename == "risk_config.yaml":
                     _check_risk_config_content(data)
+                if filename == "strategy_config.yaml":
+                    _check_strategy_config_content(data)
             except Exception as e:
                 _error(f"config/{filename} のパースに失敗しました: {e}")
 

--- a/src/kabusys/validate_config.py
+++ b/src/kabusys/validate_config.py
@@ -279,7 +279,7 @@ def _check_strategy_config_content(data: object) -> None:
             if not isinstance(v, bool) and isinstance(v, (int, float)) and float(v) >= 0
         ]
         if valid_vals and sum(valid_vals) == 0:
-            _error("strategy_config.yaml: strategy.weights の合計が 0 以下です。")
+            _error("strategy_config.yaml: strategy.weights の合計が 0 です。")
 
     # threshold
     t = s.get("threshold")

--- a/src/kabusys/validate_config.py
+++ b/src/kabusys/validate_config.py
@@ -261,73 +261,114 @@ def _check_strategy_config_content(data: object) -> None:
     else:
         missing_w = _KNOWN_STRATEGY_WEIGHT_KEYS - set(raw_w)
         for k in sorted(missing_w):
-            _warn(f"strategy_config.yaml: strategy.weights.{k} がありません（デフォルト値を使用）。")
+            _warn(
+                f"strategy_config.yaml: strategy.weights.{k} がありません（デフォルト値を使用）。"
+            )
         for k, v in raw_w.items():
             if isinstance(v, bool) or not isinstance(v, (int, float)):
-                _error(f"strategy_config.yaml: strategy.weights.{k} は数値で設定してください（現在値: {v!r}）。")
+                _error(
+                    f"strategy_config.yaml: strategy.weights.{k} は数値で設定してください（現在値: {v!r}）。"
+                )
             elif float(v) < 0:
-                _error(f"strategy_config.yaml: strategy.weights.{k} は 0 以上で設定してください（現在値: {v}）。")
-        valid_vals = [float(v) for k, v in raw_w.items()
-                      if not isinstance(v, bool) and isinstance(v, (int, float)) and float(v) >= 0]
+                _error(
+                    f"strategy_config.yaml: strategy.weights.{k} は 0 以上で設定してください（現在値: {v}）。"
+                )
+        valid_vals = [
+            float(v)
+            for k, v in raw_w.items()
+            if not isinstance(v, bool) and isinstance(v, (int, float)) and float(v) >= 0
+        ]
         if valid_vals and sum(valid_vals) == 0:
             _error("strategy_config.yaml: strategy.weights の合計が 0 以下です。")
 
     # threshold
     t = s.get("threshold")
     if t is None:
-        _warn("strategy_config.yaml: strategy.threshold がありません（デフォルト値を使用）。")
+        _warn(
+            "strategy_config.yaml: strategy.threshold がありません（デフォルト値を使用）。"
+        )
     elif isinstance(t, bool) or not isinstance(t, (int, float)):
-        _error(f"strategy_config.yaml: strategy.threshold は数値で設定してください（現在値: {t!r}）。")
+        _error(
+            f"strategy_config.yaml: strategy.threshold は数値で設定してください（現在値: {t!r}）。"
+        )
     elif not (0 < float(t) < 1):
-        _warn(f"strategy_config.yaml: strategy.threshold は (0, 1) の範囲が推奨です（現在値: {t}）。")
+        _warn(
+            f"strategy_config.yaml: strategy.threshold は (0, 1) の範囲が推奨です（現在値: {t}）。"
+        )
 
     # stop_loss_rate
     slr = s.get("stop_loss_rate")
     if slr is None:
-        _warn("strategy_config.yaml: strategy.stop_loss_rate がありません（デフォルト値を使用）。")
+        _warn(
+            "strategy_config.yaml: strategy.stop_loss_rate がありません（デフォルト値を使用）。"
+        )
     elif isinstance(slr, bool) or not isinstance(slr, (int, float)):
-        _error(f"strategy_config.yaml: strategy.stop_loss_rate は数値で設定してください（現在値: {slr!r}）。")
+        _error(
+            f"strategy_config.yaml: strategy.stop_loss_rate は数値で設定してください（現在値: {slr!r}）。"
+        )
     elif float(slr) >= 0:
-        _error(f"strategy_config.yaml: strategy.stop_loss_rate は負の値で設定してください（現在値: {slr}）。")
+        _error(
+            f"strategy_config.yaml: strategy.stop_loss_rate は負の値で設定してください（現在値: {slr}）。"
+        )
 
     # min_holding_days
     mhd = s.get("min_holding_days")
     if mhd is not None:
         if isinstance(mhd, bool) or not isinstance(mhd, (int, float)):
-            _error(f"strategy_config.yaml: strategy.min_holding_days は整数で設定してください（現在値: {mhd!r}）。")
+            _error(
+                f"strategy_config.yaml: strategy.min_holding_days は整数で設定してください（現在値: {mhd!r}）。"
+            )
         elif int(mhd) < 0:
-            _error(f"strategy_config.yaml: strategy.min_holding_days は 0 以上で設定してください（現在値: {mhd}）。")
+            _error(
+                f"strategy_config.yaml: strategy.min_holding_days は 0 以上で設定してください（現在値: {mhd}）。"
+            )
 
     # max_holding_days
     xhd = s.get("max_holding_days")
     if xhd is not None:
         if isinstance(xhd, bool) or not isinstance(xhd, (int, float)):
-            _error(f"strategy_config.yaml: strategy.max_holding_days は整数で設定してください（現在値: {xhd!r}）。")
+            _error(
+                f"strategy_config.yaml: strategy.max_holding_days は整数で設定してください（現在値: {xhd!r}）。"
+            )
         elif int(xhd) < 1:
-            _error(f"strategy_config.yaml: strategy.max_holding_days は 1 以上で設定してください（現在値: {xhd}）。")
+            _error(
+                f"strategy_config.yaml: strategy.max_holding_days は 1 以上で設定してください（現在値: {xhd}）。"
+            )
 
     # trailing_stop_atr_mult
     tsa = s.get("trailing_stop_atr_mult")
     if tsa is not None:
         if isinstance(tsa, bool) or not isinstance(tsa, (int, float)):
-            _error(f"strategy_config.yaml: strategy.trailing_stop_atr_mult は数値で設定してください（現在値: {tsa!r}）。")
+            _error(
+                f"strategy_config.yaml: strategy.trailing_stop_atr_mult は数値で設定してください（現在値: {tsa!r}）。"
+            )
         elif float(tsa) <= 0:
-            _error(f"strategy_config.yaml: strategy.trailing_stop_atr_mult は正の値で設定してください（現在値: {tsa}）。")
+            _error(
+                f"strategy_config.yaml: strategy.trailing_stop_atr_mult は正の値で設定してください（現在値: {tsa}）。"
+            )
 
     # gap thresholds
     gut = s.get("gap_up_threshold")
     if gut is not None:
         if isinstance(gut, bool) or not isinstance(gut, (int, float)):
-            _error(f"strategy_config.yaml: strategy.gap_up_threshold は数値で設定してください（現在値: {gut!r}）。")
+            _error(
+                f"strategy_config.yaml: strategy.gap_up_threshold は数値で設定してください（現在値: {gut!r}）。"
+            )
         elif float(gut) <= 0:
-            _warn(f"strategy_config.yaml: strategy.gap_up_threshold は正の値が推奨です（現在値: {gut}）。")
+            _warn(
+                f"strategy_config.yaml: strategy.gap_up_threshold は正の値が推奨です（現在値: {gut}）。"
+            )
 
     gdt = s.get("gap_down_threshold")
     if gdt is not None:
         if isinstance(gdt, bool) or not isinstance(gdt, (int, float)):
-            _error(f"strategy_config.yaml: strategy.gap_down_threshold は数値で設定してください（現在値: {gdt!r}）。")
+            _error(
+                f"strategy_config.yaml: strategy.gap_down_threshold は数値で設定してください（現在値: {gdt!r}）。"
+            )
         elif float(gdt) >= 0:
-            _warn(f"strategy_config.yaml: strategy.gap_down_threshold は負の値が推奨です（現在値: {gdt}）。")
+            _warn(
+                f"strategy_config.yaml: strategy.gap_down_threshold は負の値が推奨です（現在値: {gdt}）。"
+            )
 
 
 def _check_config_yaml_files() -> None:

--- a/src/kabusys/validate_config.py
+++ b/src/kabusys/validate_config.py
@@ -269,7 +269,7 @@ def _check_strategy_config_content(data: object) -> None:
                 _error(f"strategy_config.yaml: strategy.weights.{k} は 0 以上で設定してください（現在値: {v}）。")
         valid_vals = [float(v) for k, v in raw_w.items()
                       if not isinstance(v, bool) and isinstance(v, (int, float)) and float(v) >= 0]
-        if valid_vals and sum(valid_vals) <= 0:
+        if valid_vals and sum(valid_vals) == 0:
             _error("strategy_config.yaml: strategy.weights の合計が 0 以下です。")
 
     # threshold
@@ -331,7 +331,7 @@ def _check_strategy_config_content(data: object) -> None:
 
 
 def _check_config_yaml_files() -> None:
-    """config/*.yaml の存在・構文確認。risk_config.yaml はセマンティック検証も行う。"""
+    """config/*.yaml の存在・構文確認。risk_config.yaml および strategy_config.yaml はセマンティック検証も行う。"""
     try:
         import yaml  # type: ignore[import]
 

--- a/src/kabusys/validate_config.py
+++ b/src/kabusys/validate_config.py
@@ -370,6 +370,32 @@ def _check_strategy_config_content(data: object) -> None:
                 f"strategy_config.yaml: strategy.gap_down_threshold は負の値が推奨です（現在値: {gdt}）。"
             )
 
+    # reentry_cooldown_days
+    rcd = s.get("reentry_cooldown_days")
+    if rcd is not None:
+        if isinstance(rcd, bool) or not isinstance(rcd, (int, float)):
+            _error(
+                f"strategy_config.yaml: strategy.reentry_cooldown_days は整数で設定してください（現在値: {rcd!r}）。"
+            )
+        elif int(rcd) < 0:
+            _error(
+                f"strategy_config.yaml: strategy.reentry_cooldown_days は 0 以上で設定してください（現在値: {rcd}）。"
+            )
+
+    # min/max 整合性チェック
+    mhd_valid = (
+        mhd is not None and not isinstance(mhd, bool) and isinstance(mhd, (int, float))
+    )
+    xhd_valid = (
+        xhd is not None and not isinstance(xhd, bool) and isinstance(xhd, (int, float))
+    )
+    if mhd_valid and xhd_valid and int(mhd) >= int(xhd):
+        _warn(
+            f"strategy_config.yaml: strategy.min_holding_days({int(mhd)}) >= "
+            f"max_holding_days({int(xhd)})。"
+            " time_exit が最低保有日数より先に発火するため、min_holding_days は実質的に無効になります。"
+        )
+
 
 def _check_config_yaml_files() -> None:
     """config/*.yaml の存在・構文確認。risk_config.yaml および strategy_config.yaml はセマンティック検証も行う。"""

--- a/tests/test_generate_signals_config.py
+++ b/tests/test_generate_signals_config.py
@@ -1,6 +1,7 @@
 """
 Tests that generate_signals() resolves None sentinels from strategy_config.yaml.
 """
+
 import textwrap
 from datetime import date
 from unittest.mock import patch
@@ -99,6 +100,7 @@ class TestGenerateSignalsConfigWeights:
         )
 
         from kabusys.strategy import signal_generator as sg
+
         with patch.object(sg, "_STRATEGY_CONFIG_PATH", cfg_path):
             count = sg.generate_signals(conn, target, weights=None)
 
@@ -148,12 +150,20 @@ class TestGenerateSignalsConfigWeights:
         )
 
         from kabusys.strategy import signal_generator as sg
+
         with patch.object(sg, "_STRATEGY_CONFIG_PATH", cfg_path):
             # Explicit weights: all volatility → low-volatility stock scores ~0.95 > threshold 0.50
             sg.generate_signals(
-                conn, target,
+                conn,
+                target,
                 threshold=0.50,
-                weights={"momentum": 0.0, "value": 0.0, "volatility": 1.0, "liquidity": 0.0, "news": 0.0},
+                weights={
+                    "momentum": 0.0,
+                    "value": 0.0,
+                    "volatility": 1.0,
+                    "liquidity": 0.0,
+                    "news": 0.0,
+                },
             )
         rows = conn.execute(
             "SELECT code, side FROM signals WHERE date = ?", [target]
@@ -204,6 +214,7 @@ class TestGenerateSignalsConfigThreshold:
         )
 
         from kabusys.strategy import signal_generator as sg
+
         with patch.object(sg, "_STRATEGY_CONFIG_PATH", cfg_path):
             # threshold=None → uses config threshold=0.99 → should produce 0 buy signals
             sg.generate_signals(conn, target)
@@ -251,6 +262,7 @@ class TestGenerateSignalsConfigThreshold:
         )
 
         from kabusys.strategy import signal_generator as sg
+
         with patch.object(sg, "_STRATEGY_CONFIG_PATH", cfg_path):
             # Explicit threshold=0.10 overrides config 0.99 → should produce buy signal
             sg.generate_signals(conn, target, threshold=0.10)
@@ -299,17 +311,15 @@ class TestGenerateSignalsConfigStopLoss:
         target = date(2025, 1, 6)
 
         # Position bought at 1000, now close=985 → -1.5% loss (exceeds -1% stop)
+        conn.execute("INSERT INTO positions VALUES (?, '1001', 100, 1000.0)", [target])
         conn.execute(
-            "INSERT INTO positions VALUES (?, '1001', 100, 1000.0)", [target]
+            "INSERT INTO prices_daily VALUES (?, '1001', 985.0, 990.0, 980.0, 985.0)",
+            [target],
         )
-        conn.execute(
-            "INSERT INTO prices_daily VALUES (?, '1001', 985.0, 990.0, 980.0, 985.0)", [target]
-        )
-        conn.execute(
-            "INSERT INTO trading_calendar VALUES (?)", [target]
-        )
+        conn.execute("INSERT INTO trading_calendar VALUES (?)", [target])
 
         from kabusys.strategy import signal_generator as sg
+
         with patch.object(sg, "_STRATEGY_CONFIG_PATH", cfg_path):
             sg.generate_signals(conn, target)
 
@@ -357,9 +367,11 @@ class TestGenerateSignalsNoneResolution:
         target = date(2025, 1, 6)
 
         from kabusys.strategy import signal_generator as sg
+
         with patch.object(sg, "_STRATEGY_CONFIG_PATH", cfg_path):
             count = sg.generate_signals(
-                conn, target,
+                conn,
+                target,
                 threshold=None,
                 weights=None,
                 min_holding_days=None,

--- a/tests/test_generate_signals_config.py
+++ b/tests/test_generate_signals_config.py
@@ -1,0 +1,369 @@
+"""
+Tests that generate_signals() resolves None sentinels from strategy_config.yaml.
+"""
+import textwrap
+from datetime import date
+from unittest.mock import patch
+
+import duckdb
+
+
+def _make_db():
+    """Create minimal in-memory DuckDB with required tables."""
+    conn = duckdb.connect()
+    conn.execute("""
+        CREATE TABLE features (
+            date DATE, code VARCHAR, momentum_20 DOUBLE, momentum_60 DOUBLE,
+            volatility_20 DOUBLE, volume_ratio DOUBLE, per DOUBLE, pbr DOUBLE,
+            div_yield DOUBLE, ma200_dev DOUBLE
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE ai_scores (date DATE, code VARCHAR, ai_score DOUBLE)
+    """)
+    conn.execute("""
+        CREATE TABLE signals (
+            date DATE, code VARCHAR, side VARCHAR, score DOUBLE,
+            signal_rank INTEGER, size_multiplier DOUBLE
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE positions (date DATE, code VARCHAR, position_size INTEGER, avg_price DOUBLE)
+    """)
+    conn.execute("""
+        CREATE TABLE position_entries (
+            code VARCHAR, entry_date DATE, sell_date DATE
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE prices_daily (date DATE, code VARCHAR, open DOUBLE, high DOUBLE, low DOUBLE, close DOUBLE)
+    """)
+    conn.execute("""
+        CREATE TABLE market_regime (date DATE, regime_label VARCHAR)
+    """)
+    conn.execute("""
+        CREATE TABLE market_breadth (date DATE, breadth_stop BOOLEAN)
+    """)
+    conn.execute("""
+        CREATE TABLE stocks (code VARCHAR, sector VARCHAR)
+    """)
+    conn.execute("""
+        CREATE TABLE earnings_calendar (code VARCHAR, announcement_date DATE)
+    """)
+    conn.execute("""
+        CREATE TABLE trading_calendar (date DATE)
+    """)
+    return conn
+
+
+class TestGenerateSignalsConfigWeights:
+    """When weights=None, config weights are used."""
+
+    def test_config_weights_used_when_none(self, tmp_path):
+        """Config momentum weight=0.99 should produce higher scores for momentum stocks."""
+        yaml_content = textwrap.dedent("""\
+            strategy:
+              weights:
+                momentum: 0.99
+                value: 0.00
+                volatility: 0.00
+                liquidity: 0.00
+                news: 0.01
+              threshold: 0.50
+              stop_loss_rate: -0.08
+              min_holding_days: 5
+              max_holding_days: 60
+              trailing_stop_atr_mult: 2.0
+              reentry_cooldown_days: 5
+              gap_up_threshold: 0.05
+              gap_down_threshold: -0.03
+            value_score:
+              weights:
+                per: 0.50
+                pbr: 0.30
+                div_yield: 0.20
+              normalization:
+                per_mid: 20.0
+                pbr_mid: 1.5
+                div_yield_max: 3.0
+        """)
+        cfg_path = tmp_path / "strategy_config.yaml"
+        cfg_path.write_text(yaml_content, encoding="utf-8")
+
+        conn = _make_db()
+        target = date(2025, 1, 6)
+        # Insert one stock with high momentum
+        conn.execute(
+            "INSERT INTO features VALUES (?, '1001', 3.0, 3.0, 0.0, 0.0, NULL, NULL, NULL, 0.0)",
+            [target],
+        )
+
+        from kabusys.strategy import signal_generator as sg
+        with patch.object(sg, "_STRATEGY_CONFIG_PATH", cfg_path):
+            count = sg.generate_signals(conn, target, weights=None)
+
+        rows = conn.execute(
+            "SELECT code, side FROM signals WHERE date = ?", [target]
+        ).fetchall()
+        assert count >= 1
+        assert any(r[0] == "1001" and r[1] == "buy" for r in rows)
+
+    def test_explicit_weights_override_config(self, tmp_path):
+        """Explicit weights parameter overrides config."""
+        yaml_content = textwrap.dedent("""\
+            strategy:
+              weights:
+                momentum: 0.99
+                value: 0.00
+                volatility: 0.00
+                liquidity: 0.00
+                news: 0.01
+              threshold: 0.90
+              stop_loss_rate: -0.08
+              min_holding_days: 5
+              max_holding_days: 60
+              trailing_stop_atr_mult: 2.0
+              reentry_cooldown_days: 5
+              gap_up_threshold: 0.05
+              gap_down_threshold: -0.03
+            value_score:
+              weights:
+                per: 0.50
+                pbr: 0.30
+                div_yield: 0.20
+              normalization:
+                per_mid: 20.0
+                pbr_mid: 1.5
+                div_yield_max: 3.0
+        """)
+        cfg_path = tmp_path / "strategy_config.yaml"
+        cfg_path.write_text(yaml_content, encoding="utf-8")
+
+        conn = _make_db()
+        target = date(2025, 1, 6)
+        # volatility_20 = -3.0 → low volatility (good) → _sigmoid(-(-3.0)) ≈ 0.95 > 0.50
+        conn.execute(
+            "INSERT INTO features VALUES (?, '1001', 0.0, 0.0, -3.0, 0.0, NULL, NULL, NULL, 0.0)",
+            [target],
+        )
+
+        from kabusys.strategy import signal_generator as sg
+        with patch.object(sg, "_STRATEGY_CONFIG_PATH", cfg_path):
+            # Explicit weights: all volatility → low-volatility stock scores ~0.95 > threshold 0.50
+            sg.generate_signals(
+                conn, target,
+                threshold=0.50,
+                weights={"momentum": 0.0, "value": 0.0, "volatility": 1.0, "liquidity": 0.0, "news": 0.0},
+            )
+        rows = conn.execute(
+            "SELECT code, side FROM signals WHERE date = ?", [target]
+        ).fetchall()
+        # With all-volatility weight and low volatility z-score, score should be above 0.5
+        assert any(r[0] == "1001" for r in rows)
+
+
+class TestGenerateSignalsConfigThreshold:
+    """When threshold=None, config threshold is used."""
+
+    def test_config_threshold_used_when_none(self, tmp_path):
+        yaml_content = textwrap.dedent("""\
+            strategy:
+              weights:
+                momentum: 0.20
+                value: 0.20
+                volatility: 0.20
+                liquidity: 0.20
+                news: 0.20
+              threshold: 0.99
+              stop_loss_rate: -0.08
+              min_holding_days: 5
+              max_holding_days: 60
+              trailing_stop_atr_mult: 2.0
+              reentry_cooldown_days: 5
+              gap_up_threshold: 0.05
+              gap_down_threshold: -0.03
+            value_score:
+              weights:
+                per: 0.50
+                pbr: 0.30
+                div_yield: 0.20
+              normalization:
+                per_mid: 20.0
+                pbr_mid: 1.5
+                div_yield_max: 3.0
+        """)
+        cfg_path = tmp_path / "strategy_config.yaml"
+        cfg_path.write_text(yaml_content, encoding="utf-8")
+
+        conn = _make_db()
+        target = date(2025, 1, 6)
+        # Insert stock with moderate score that would pass 0.60 but not 0.99
+        conn.execute(
+            "INSERT INTO features VALUES (?, '1001', 0.5, 0.5, 0.0, 0.0, NULL, NULL, NULL, 0.0)",
+            [target],
+        )
+
+        from kabusys.strategy import signal_generator as sg
+        with patch.object(sg, "_STRATEGY_CONFIG_PATH", cfg_path):
+            # threshold=None → uses config threshold=0.99 → should produce 0 buy signals
+            sg.generate_signals(conn, target)
+
+        rows = conn.execute(
+            "SELECT code, side FROM signals WHERE date = ? AND side='buy'", [target]
+        ).fetchall()
+        assert len(rows) == 0
+
+    def test_explicit_threshold_overrides_config(self, tmp_path):
+        yaml_content = textwrap.dedent("""\
+            strategy:
+              weights:
+                momentum: 0.20
+                value: 0.20
+                volatility: 0.20
+                liquidity: 0.20
+                news: 0.20
+              threshold: 0.99
+              stop_loss_rate: -0.08
+              min_holding_days: 5
+              max_holding_days: 60
+              trailing_stop_atr_mult: 2.0
+              reentry_cooldown_days: 5
+              gap_up_threshold: 0.05
+              gap_down_threshold: -0.03
+            value_score:
+              weights:
+                per: 0.50
+                pbr: 0.30
+                div_yield: 0.20
+              normalization:
+                per_mid: 20.0
+                pbr_mid: 1.5
+                div_yield_max: 3.0
+        """)
+        cfg_path = tmp_path / "strategy_config.yaml"
+        cfg_path.write_text(yaml_content, encoding="utf-8")
+
+        conn = _make_db()
+        target = date(2025, 1, 6)
+        conn.execute(
+            "INSERT INTO features VALUES (?, '1001', 3.0, 3.0, 0.0, 0.0, NULL, NULL, NULL, 0.0)",
+            [target],
+        )
+
+        from kabusys.strategy import signal_generator as sg
+        with patch.object(sg, "_STRATEGY_CONFIG_PATH", cfg_path):
+            # Explicit threshold=0.10 overrides config 0.99 → should produce buy signal
+            sg.generate_signals(conn, target, threshold=0.10)
+
+        rows = conn.execute(
+            "SELECT side FROM signals WHERE date = ? AND code='1001'", [target]
+        ).fetchall()
+        assert any(r[0] == "buy" for r in rows)
+
+
+class TestGenerateSignalsConfigStopLoss:
+    """Config stop_loss_rate is passed to _generate_sell_signals."""
+
+    def test_config_stop_loss_used(self, tmp_path):
+        """Very tight stop_loss (-0.01) should trigger SELL for small loss."""
+        yaml_content = textwrap.dedent("""\
+            strategy:
+              weights:
+                momentum: 0.20
+                value: 0.20
+                volatility: 0.20
+                liquidity: 0.20
+                news: 0.20
+              threshold: 0.60
+              stop_loss_rate: -0.01
+              min_holding_days: 5
+              max_holding_days: 60
+              trailing_stop_atr_mult: 2.0
+              reentry_cooldown_days: 5
+              gap_up_threshold: 0.05
+              gap_down_threshold: -0.03
+            value_score:
+              weights:
+                per: 0.50
+                pbr: 0.30
+                div_yield: 0.20
+              normalization:
+                per_mid: 20.0
+                pbr_mid: 1.5
+                div_yield_max: 3.0
+        """)
+        cfg_path = tmp_path / "strategy_config.yaml"
+        cfg_path.write_text(yaml_content, encoding="utf-8")
+
+        conn = _make_db()
+        target = date(2025, 1, 6)
+
+        # Position bought at 1000, now close=985 → -1.5% loss (exceeds -1% stop)
+        conn.execute(
+            "INSERT INTO positions VALUES (?, '1001', 100, 1000.0)", [target]
+        )
+        conn.execute(
+            "INSERT INTO prices_daily VALUES (?, '1001', 985.0, 990.0, 980.0, 985.0)", [target]
+        )
+        conn.execute(
+            "INSERT INTO trading_calendar VALUES (?)", [target]
+        )
+
+        from kabusys.strategy import signal_generator as sg
+        with patch.object(sg, "_STRATEGY_CONFIG_PATH", cfg_path):
+            sg.generate_signals(conn, target)
+
+        rows = conn.execute(
+            "SELECT code, side FROM signals WHERE date = ?", [target]
+        ).fetchall()
+        assert any(r[0] == "1001" and r[1] == "sell" for r in rows)
+
+
+class TestGenerateSignalsNoneResolution:
+    """All None params resolve from config without raising."""
+
+    def test_all_none_params_no_error(self, tmp_path):
+        """generate_signals() with all None params completes without error."""
+        yaml_content = textwrap.dedent("""\
+            strategy:
+              weights:
+                momentum: 0.40
+                value: 0.20
+                volatility: 0.15
+                liquidity: 0.15
+                news: 0.10
+              threshold: 0.60
+              stop_loss_rate: -0.08
+              min_holding_days: 5
+              max_holding_days: 60
+              trailing_stop_atr_mult: 2.0
+              reentry_cooldown_days: 5
+              gap_up_threshold: 0.05
+              gap_down_threshold: -0.03
+            value_score:
+              weights:
+                per: 0.50
+                pbr: 0.30
+                div_yield: 0.20
+              normalization:
+                per_mid: 20.0
+                pbr_mid: 1.5
+                div_yield_max: 3.0
+        """)
+        cfg_path = tmp_path / "strategy_config.yaml"
+        cfg_path.write_text(yaml_content, encoding="utf-8")
+
+        conn = _make_db()
+        target = date(2025, 1, 6)
+
+        from kabusys.strategy import signal_generator as sg
+        with patch.object(sg, "_STRATEGY_CONFIG_PATH", cfg_path):
+            count = sg.generate_signals(
+                conn, target,
+                threshold=None,
+                weights=None,
+                min_holding_days=None,
+                max_holding_days=None,
+                trailing_stop_atr=None,
+            )
+        assert count == 0  # no features/positions inserted, so 0 signals

--- a/tests/test_min_holding_days.py
+++ b/tests/test_min_holding_days.py
@@ -306,13 +306,10 @@ class TestMinHoldingDaysDefault:
             f"run_backtest の min_holding_days デフォルト値は 5 であるべき (got {param.default})"
         )
 
-    def test_generate_signals_and_run_backtest_defaults_match(self):
-        """`generate_signals` と `run_backtest` の min_holding_days デフォルト値が一致する。"""
+    def test_generate_signals_uses_none_sentinel_for_min_holding_days(self):
+        """`generate_signals` の min_holding_days デフォルト値は None（config-driven sentinel）であること。"""
         sig_gs = inspect.signature(generate_signals)
-        sig_rb = inspect.signature(run_backtest)
         default_gs = sig_gs.parameters["min_holding_days"].default
-        default_rb = sig_rb.parameters["min_holding_days"].default
-        assert default_gs == default_rb, (
-            f"generate_signals ({default_gs}) と run_backtest ({default_rb}) の "
-            "min_holding_days デフォルト値が一致すべき"
+        assert default_gs is None, (
+            f"generate_signals の min_holding_days デフォルト値は None (config-driven) であるべき (got {default_gs})"
         )

--- a/tests/test_strategy_config_load.py
+++ b/tests/test_strategy_config_load.py
@@ -1,0 +1,265 @@
+# tests/test_strategy_config_load.py
+"""_load_strategy_config() のユニットテスト。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _call_load(tmp_path: Path, yaml_content: str | None) -> dict:
+    from kabusys.strategy.signal_generator import _load_strategy_config
+
+    if yaml_content is None:
+        target = tmp_path / "nonexistent.yaml"
+    else:
+        target = tmp_path / "strategy_config.yaml"
+        target.write_text(yaml_content, encoding="utf-8")
+
+    with patch("kabusys.strategy.signal_generator._STRATEGY_CONFIG_PATH", target):
+        return _load_strategy_config()
+
+
+class TestLoadStrategyConfigMissingFile:
+    def test_returns_defaults_when_file_missing(self, tmp_path):
+        from kabusys.strategy.signal_generator import _STRATEGY_CONFIG_DEFAULTS
+
+        result = _call_load(tmp_path, None)
+        assert result["weights"] == _STRATEGY_CONFIG_DEFAULTS["weights"]
+        assert result["threshold"] == pytest.approx(
+            _STRATEGY_CONFIG_DEFAULTS["threshold"]
+        )
+
+    def test_returns_all_expected_keys(self, tmp_path):
+        result = _call_load(tmp_path, None)
+        expected_keys = {
+            "weights",
+            "threshold",
+            "stop_loss_rate",
+            "gap_up_threshold",
+            "gap_down_threshold",
+            "min_holding_days",
+            "max_holding_days",
+            "trailing_stop_atr_mult",
+            "reentry_cooldown_days",
+        }
+        assert expected_keys <= result.keys()
+
+
+class TestLoadStrategyConfigValidYaml:
+    def test_reads_weights_from_yaml(self, tmp_path):
+        content = """
+strategy:
+  weights:
+    momentum: 0.50
+    value: 0.25
+    volatility: 0.10
+    liquidity: 0.10
+    news: 0.05
+"""
+        result = _call_load(tmp_path, content)
+        assert result["weights"]["momentum"] == pytest.approx(0.50)
+        assert result["weights"]["value"] == pytest.approx(0.25)
+
+    def test_reads_threshold_from_yaml(self, tmp_path):
+        content = "strategy:\n  threshold: 0.75\n"
+        result = _call_load(tmp_path, content)
+        assert result["threshold"] == pytest.approx(0.75)
+
+    def test_reads_stop_loss_rate_from_yaml(self, tmp_path):
+        content = "strategy:\n  stop_loss_rate: -0.10\n"
+        result = _call_load(tmp_path, content)
+        assert result["stop_loss_rate"] == pytest.approx(-0.10)
+
+    def test_reads_min_holding_days_from_yaml(self, tmp_path):
+        content = "strategy:\n  min_holding_days: 10\n"
+        result = _call_load(tmp_path, content)
+        assert result["min_holding_days"] == 10
+
+    def test_reads_max_holding_days_from_yaml(self, tmp_path):
+        content = "strategy:\n  max_holding_days: 30\n"
+        result = _call_load(tmp_path, content)
+        assert result["max_holding_days"] == 30
+
+    def test_partial_weights_use_defaults_for_missing_keys(self, tmp_path):
+        """weights に momentum だけ指定 → 他のキーはデフォルト値を使う。"""
+        from kabusys.strategy.signal_generator import _STRATEGY_CONFIG_DEFAULTS
+
+        content = "strategy:\n  weights:\n    momentum: 0.60\n"
+        result = _call_load(tmp_path, content)
+        assert result["weights"]["momentum"] == pytest.approx(0.60)
+        assert result["weights"]["value"] == pytest.approx(
+            _STRATEGY_CONFIG_DEFAULTS["weights"]["value"]
+        )
+
+
+class TestLoadStrategyConfigInvalidValues:
+    def test_returns_default_weights_when_yaml_parse_fails(self, tmp_path):
+        from kabusys.strategy.signal_generator import _STRATEGY_CONFIG_DEFAULTS
+
+        result = _call_load(tmp_path, ": invalid: yaml: [[[")
+        assert result["weights"] == _STRATEGY_CONFIG_DEFAULTS["weights"]
+
+    def test_returns_default_weights_when_toplevel_not_dict(self, tmp_path):
+        from kabusys.strategy.signal_generator import _STRATEGY_CONFIG_DEFAULTS
+
+        result = _call_load(tmp_path, "- item1\n- item2\n")
+        assert result["weights"] == _STRATEGY_CONFIG_DEFAULTS["weights"]
+
+    def test_negative_weight_uses_default_for_that_key(self, tmp_path):
+        """個別の weight が負値 → そのキーだけデフォルトを使い、合計が正なら他は適用される。"""
+        from kabusys.strategy.signal_generator import _STRATEGY_CONFIG_DEFAULTS
+
+        content = """
+strategy:
+  weights:
+    momentum: -0.50
+    value: 0.25
+    volatility: 0.15
+    liquidity: 0.10
+    news: 0.10
+"""
+        result = _call_load(tmp_path, content)
+        # momentum は負なのでデフォルトを使う
+        assert result["weights"]["momentum"] == pytest.approx(
+            _STRATEGY_CONFIG_DEFAULTS["weights"]["momentum"]
+        )
+        # value は有効なのでそちらを使う
+        assert result["weights"]["value"] == pytest.approx(0.25)
+
+    def test_all_zero_weights_uses_defaults(self, tmp_path):
+        from kabusys.strategy.signal_generator import _STRATEGY_CONFIG_DEFAULTS
+
+        content = """
+strategy:
+  weights:
+    momentum: 0.0
+    value: 0.0
+    volatility: 0.0
+    liquidity: 0.0
+    news: 0.0
+"""
+        result = _call_load(tmp_path, content)
+        assert result["weights"] == _STRATEGY_CONFIG_DEFAULTS["weights"]
+
+    def test_bool_value_for_threshold_uses_default(self, tmp_path):
+        from kabusys.strategy.signal_generator import _STRATEGY_CONFIG_DEFAULTS
+
+        content = "strategy:\n  threshold: true\n"
+        result = _call_load(tmp_path, content)
+        assert result["threshold"] == pytest.approx(
+            _STRATEGY_CONFIG_DEFAULTS["threshold"]
+        )
+
+    def test_no_strategy_section_returns_defaults(self, tmp_path):
+        from kabusys.strategy.signal_generator import _STRATEGY_CONFIG_DEFAULTS
+
+        content = "value_score:\n  weights:\n    per: 0.5\n"
+        result = _call_load(tmp_path, content)
+        assert result["weights"] == _STRATEGY_CONFIG_DEFAULTS["weights"]
+        assert result["threshold"] == pytest.approx(
+            _STRATEGY_CONFIG_DEFAULTS["threshold"]
+        )
+
+
+class TestLoadValueConfigFromStrategyYaml:
+    def test_reads_value_score_from_strategy_config_yaml(self, tmp_path):
+        content = """
+strategy:
+  threshold: 0.60
+value_score:
+  weights:
+    per: 0.40
+    pbr: 0.40
+    div_yield: 0.20
+  normalization:
+    per_mid: 25.0
+    pbr_mid: 2.0
+    div_yield_max: 4.0
+"""
+        from kabusys.strategy.signal_generator import _load_value_config
+
+        target = tmp_path / "strategy_config.yaml"
+        target.write_text(content, encoding="utf-8")
+        with patch("kabusys.strategy.signal_generator._STRATEGY_CONFIG_PATH", target):
+            result = _load_value_config()
+        assert result["weights"]["per"] == pytest.approx(0.40)
+        assert result["normalization"]["per_mid"] == pytest.approx(25.0)
+
+    def test_falls_back_to_defaults_when_no_value_score_section(self, tmp_path):
+        """value_score セクションなし + strategy.toml もなし → デフォルト。"""
+        content = "strategy:\n  threshold: 0.60\n"
+        from kabusys.strategy.signal_generator import (
+            _load_value_config,
+        )
+
+        target = tmp_path / "strategy_config.yaml"
+        target.write_text(content, encoding="utf-8")
+
+        # strategy.toml の検索パスも tmp_path 内の存在しないファイルに向ける
+        fake_toml = tmp_path / "strategy.toml"  # 存在しない
+
+        with (
+            patch("kabusys.strategy.signal_generator._STRATEGY_CONFIG_PATH", target),
+            patch(
+                "kabusys.strategy.signal_generator.Path",
+                side_effect=lambda *a: (
+                    fake_toml if "strategy.toml" in str(a) else Path(*a)
+                ),
+            ),
+        ):
+            result = _load_value_config()
+
+        # 少なくとも必須キーが存在することを確認
+        assert "weights" in result
+        assert "normalization" in result
+
+    def test_value_score_invalid_weights_falls_back_to_defaults(self, tmp_path):
+        """value_score.weights が不正（負値）→ デフォルトを使用。"""
+        from kabusys.strategy.signal_generator import (
+            _load_value_config,
+            _VALUE_CONFIG_DEFAULTS,
+        )
+
+        content = """
+value_score:
+  weights:
+    per: -0.50
+    pbr: -0.30
+    div_yield: -0.20
+  normalization:
+    per_mid: 20.0
+    pbr_mid: 1.5
+    div_yield_max: 3.0
+"""
+        target = tmp_path / "strategy_config.yaml"
+        target.write_text(content, encoding="utf-8")
+        with patch("kabusys.strategy.signal_generator._STRATEGY_CONFIG_PATH", target):
+            result = _load_value_config()
+        assert result["weights"] == _VALUE_CONFIG_DEFAULTS["weights"]
+
+    def test_value_score_invalid_normalization_falls_back_to_defaults(self, tmp_path):
+        """value_score.normalization に 0 以下 → デフォルトを使用。"""
+        from kabusys.strategy.signal_generator import (
+            _load_value_config,
+            _VALUE_CONFIG_DEFAULTS,
+        )
+
+        content = """
+value_score:
+  weights:
+    per: 0.50
+    pbr: 0.30
+    div_yield: 0.20
+  normalization:
+    per_mid: 0.0
+    pbr_mid: 1.5
+    div_yield_max: 3.0
+"""
+        target = tmp_path / "strategy_config.yaml"
+        target.write_text(content, encoding="utf-8")
+        with patch("kabusys.strategy.signal_generator._STRATEGY_CONFIG_PATH", target):
+            result = _load_value_config()
+        assert result["normalization"] == _VALUE_CONFIG_DEFAULTS["normalization"]

--- a/tests/test_strategy_config_load.py
+++ b/tests/test_strategy_config_load.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import textwrap
 from pathlib import Path
 from unittest.mock import patch
 
@@ -263,3 +264,102 @@ value_score:
         with patch("kabusys.strategy.signal_generator._STRATEGY_CONFIG_PATH", target):
             result = _load_value_config()
         assert result["normalization"] == _VALUE_CONFIG_DEFAULTS["normalization"]
+
+
+class TestLoadStrategyConfigCache:
+    """mtime キャッシュのテスト。"""
+
+    def _reset_cache(self, sg):
+        sg._strategy_config_cache = None
+        sg._strategy_config_mtime = -1.0
+
+    def test_second_call_returns_same_result(self, tmp_path):
+        """同一ファイルの二回目の呼び出しはキャッシュから返す。"""
+        yaml_content = textwrap.dedent("""\
+            strategy:
+              weights:
+                momentum: 0.40
+                value: 0.20
+                volatility: 0.15
+                liquidity: 0.15
+                news: 0.10
+              threshold: 0.65
+              stop_loss_rate: -0.08
+              min_holding_days: 5
+              max_holding_days: 60
+              trailing_stop_atr_mult: 2.0
+              reentry_cooldown_days: 5
+              gap_up_threshold: 0.05
+              gap_down_threshold: -0.03
+        """)
+        cfg_path = tmp_path / "strategy_config.yaml"
+        cfg_path.write_text(yaml_content, encoding="utf-8")
+
+        from kabusys.strategy import signal_generator as sg
+
+        self._reset_cache(sg)
+        with patch("kabusys.strategy.signal_generator._STRATEGY_CONFIG_PATH", cfg_path):
+            result1 = sg._load_strategy_config()
+            result2 = sg._load_strategy_config()
+        assert result1 == result2
+        assert result1["threshold"] == pytest.approx(0.65)
+
+    def test_cache_invalidated_on_file_change(self, tmp_path):
+        """ファイル更新後は新しい値が返る（キャッシュ無効化）。"""
+        import os
+
+        cfg_path = tmp_path / "strategy_config.yaml"
+        cfg_path.write_text(
+            textwrap.dedent("""\
+            strategy:
+              weights:
+                momentum: 0.40
+                value: 0.20
+                volatility: 0.15
+                liquidity: 0.15
+                news: 0.10
+              threshold: 0.60
+              stop_loss_rate: -0.08
+              min_holding_days: 5
+              max_holding_days: 60
+              trailing_stop_atr_mult: 2.0
+              reentry_cooldown_days: 5
+              gap_up_threshold: 0.05
+              gap_down_threshold: -0.03
+        """),
+            encoding="utf-8",
+        )
+
+        from kabusys.strategy import signal_generator as sg
+
+        self._reset_cache(sg)
+        with patch("kabusys.strategy.signal_generator._STRATEGY_CONFIG_PATH", cfg_path):
+            result1 = sg._load_strategy_config()
+            assert result1["threshold"] == pytest.approx(0.60)
+
+            # ファイルを更新し mtime を変える
+            new_mtime = cfg_path.stat().st_mtime + 1.0
+            cfg_path.write_text(
+                textwrap.dedent("""\
+                strategy:
+                  weights:
+                    momentum: 0.40
+                    value: 0.20
+                    volatility: 0.15
+                    liquidity: 0.15
+                    news: 0.10
+                  threshold: 0.75
+                  stop_loss_rate: -0.08
+                  min_holding_days: 5
+                  max_holding_days: 60
+                  trailing_stop_atr_mult: 2.0
+                  reentry_cooldown_days: 5
+                  gap_up_threshold: 0.05
+                  gap_down_threshold: -0.03
+            """),
+                encoding="utf-8",
+            )
+            os.utime(str(cfg_path), (new_mtime, new_mtime))
+
+            result2 = sg._load_strategy_config()
+        assert result2["threshold"] == pytest.approx(0.75)

--- a/tests/test_time_exit.py
+++ b/tests/test_time_exit.py
@@ -302,9 +302,9 @@ class TestMaxHoldingDaysDefault:
         sig = inspect.signature(run_backtest)
         assert "max_holding_days" in sig.parameters
 
-    def test_generate_signals_default_is_60(self):
+    def test_generate_signals_default_is_none_sentinel(self):
         sig = inspect.signature(generate_signals)
-        assert sig.parameters["max_holding_days"].default == 60
+        assert sig.parameters["max_holding_days"].default is None
 
     def test_run_backtest_default_is_60(self):
         sig = inspect.signature(run_backtest)

--- a/tests/test_trailing_stop.py
+++ b/tests/test_trailing_stop.py
@@ -333,9 +333,9 @@ class TestTrailingStopDefault:
         sig = inspect.signature(run_backtest)
         assert "trailing_stop_atr" in sig.parameters
 
-    def test_generate_signals_default_is_2_0(self):
+    def test_generate_signals_default_is_none_sentinel(self):
         sig = inspect.signature(generate_signals)
-        assert sig.parameters["trailing_stop_atr"].default == pytest.approx(2.0)
+        assert sig.parameters["trailing_stop_atr"].default is None
 
     def test_run_backtest_default_is_2_0(self):
         sig = inspect.signature(run_backtest)

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -247,3 +247,134 @@ class TestPaperTradingCashValidation:
             config_dir=tmp_path,
         )
         assert not any("PAPER_TRADING_INITIAL_CASH" in e for e in errors)
+
+
+class TestCheckStrategyConfigContent:
+    """_check_strategy_config_content() のセマンティック検証テスト。"""
+
+    def _run_with_yaml(self, yaml_content: str, tmp_path):
+        """strategy_config.yaml に yaml_content を書いて validate() を実行する。"""
+        cfg_path = tmp_path / "strategy_config.yaml"
+        cfg_path.write_text(yaml_content, encoding="utf-8")
+        errors, warnings, _ = _run_validate(config_dir=tmp_path)
+        return errors, warnings
+
+    def test_valid_strategy_config_no_errors(self, tmp_path):
+        content = """\
+strategy:
+  weights:
+    momentum: 0.40
+    value: 0.20
+    volatility: 0.15
+    liquidity: 0.15
+    news: 0.10
+  threshold: 0.60
+  stop_loss_rate: -0.08
+  min_holding_days: 5
+  max_holding_days: 60
+  trailing_stop_atr_mult: 2.0
+  reentry_cooldown_days: 5
+  gap_up_threshold: 0.05
+  gap_down_threshold: -0.03
+value_score:
+  weights:
+    per: 0.50
+    pbr: 0.30
+    div_yield: 0.20
+  normalization:
+    per_mid: 20.0
+    pbr_mid: 1.5
+    div_yield_max: 3.0
+"""
+        errors, warnings = self._run_with_yaml(content, tmp_path)
+        strategy_errors = [e for e in errors if "strategy_config" in e]
+        assert strategy_errors == []
+
+    def test_missing_strategy_section_errors(self, tmp_path):
+        content = "other_key: value\n"
+        errors, _ = self._run_with_yaml(content, tmp_path)
+        assert any("strategy_config" in e and "strategy" in e for e in errors)
+
+    def test_negative_weight_errors(self, tmp_path):
+        content = """\
+strategy:
+  weights:
+    momentum: -0.10
+    value: 0.20
+    volatility: 0.15
+    liquidity: 0.15
+    news: 0.10
+  threshold: 0.60
+  stop_loss_rate: -0.08
+  min_holding_days: 5
+  max_holding_days: 60
+  trailing_stop_atr_mult: 2.0
+  reentry_cooldown_days: 5
+  gap_up_threshold: 0.05
+  gap_down_threshold: -0.03
+"""
+        errors, _ = self._run_with_yaml(content, tmp_path)
+        assert any("strategy_config" in e and "momentum" in e for e in errors)
+
+    def test_stop_loss_rate_non_negative_errors(self, tmp_path):
+        content = """\
+strategy:
+  weights:
+    momentum: 0.40
+    value: 0.20
+    volatility: 0.15
+    liquidity: 0.15
+    news: 0.10
+  threshold: 0.60
+  stop_loss_rate: 0.05
+  min_holding_days: 5
+  max_holding_days: 60
+  trailing_stop_atr_mult: 2.0
+  reentry_cooldown_days: 5
+  gap_up_threshold: 0.05
+  gap_down_threshold: -0.03
+"""
+        errors, _ = self._run_with_yaml(content, tmp_path)
+        assert any("strategy_config" in e and "stop_loss_rate" in e for e in errors)
+
+    def test_trailing_stop_non_positive_errors(self, tmp_path):
+        content = """\
+strategy:
+  weights:
+    momentum: 0.40
+    value: 0.20
+    volatility: 0.15
+    liquidity: 0.15
+    news: 0.10
+  threshold: 0.60
+  stop_loss_rate: -0.08
+  min_holding_days: 5
+  max_holding_days: 60
+  trailing_stop_atr_mult: -1.0
+  reentry_cooldown_days: 5
+  gap_up_threshold: 0.05
+  gap_down_threshold: -0.03
+"""
+        errors, _ = self._run_with_yaml(content, tmp_path)
+        assert any("strategy_config" in e and "trailing_stop_atr_mult" in e for e in errors)
+
+    def test_max_holding_days_zero_errors(self, tmp_path):
+        content = """\
+strategy:
+  weights:
+    momentum: 0.40
+    value: 0.20
+    volatility: 0.15
+    liquidity: 0.15
+    news: 0.10
+  threshold: 0.60
+  stop_loss_rate: -0.08
+  min_holding_days: 5
+  max_holding_days: 0
+  trailing_stop_atr_mult: 2.0
+  reentry_cooldown_days: 5
+  gap_up_threshold: 0.05
+  gap_down_threshold: -0.03
+"""
+        errors, _ = self._run_with_yaml(content, tmp_path)
+        assert any("strategy_config" in e and "max_holding_days" in e for e in errors)

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -380,3 +380,52 @@ strategy:
 """
         errors, _ = self._run_with_yaml(content, tmp_path)
         assert any("strategy_config" in e and "max_holding_days" in e for e in errors)
+
+    def test_negative_reentry_cooldown_errors(self, tmp_path):
+        content = """\
+strategy:
+  weights:
+    momentum: 0.40
+    value: 0.20
+    volatility: 0.15
+    liquidity: 0.15
+    news: 0.10
+  threshold: 0.60
+  stop_loss_rate: -0.08
+  min_holding_days: 5
+  max_holding_days: 60
+  trailing_stop_atr_mult: 2.0
+  reentry_cooldown_days: -1
+  gap_up_threshold: 0.05
+  gap_down_threshold: -0.03
+"""
+        errors, _ = self._run_with_yaml(content, tmp_path)
+        assert any(
+            "strategy_config" in e and "reentry_cooldown_days" in e for e in errors
+        )
+
+    def test_min_holding_days_gte_max_warns(self, tmp_path):
+        content = """\
+strategy:
+  weights:
+    momentum: 0.40
+    value: 0.20
+    volatility: 0.15
+    liquidity: 0.15
+    news: 0.10
+  threshold: 0.60
+  stop_loss_rate: -0.08
+  min_holding_days: 60
+  max_holding_days: 5
+  trailing_stop_atr_mult: 2.0
+  reentry_cooldown_days: 5
+  gap_up_threshold: 0.05
+  gap_down_threshold: -0.03
+"""
+        _, warnings = self._run_with_yaml(content, tmp_path)
+        assert any(
+            "strategy_config" in w
+            and "min_holding_days" in w
+            and "max_holding_days" in w
+            for w in warnings
+        )

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -356,7 +356,9 @@ strategy:
   gap_down_threshold: -0.03
 """
         errors, _ = self._run_with_yaml(content, tmp_path)
-        assert any("strategy_config" in e and "trailing_stop_atr_mult" in e for e in errors)
+        assert any(
+            "strategy_config" in e and "trailing_stop_atr_mult" in e for e in errors
+        )
 
     def test_max_holding_days_zero_errors(self, tmp_path):
         content = """\


### PR DESCRIPTION
## Summary

- `config/strategy_config.yaml` の全戦略パラメータ（重み・閾値・ストップロス・保有日数・ATR倍率・再エントリー制限・ギャップ閾値）を `_load_strategy_config()` で runtime 読み込みできるようにした
- `generate_signals()` のパラメータを `None` センチネルに変更し、`None` の場合は YAML から自動解決（コード変更不要で戦略調整が可能に）
- `_generate_sell_signals()` と `_is_reentry_blocked()` の内部定数参照を設定ファイル経由のパラメータに置換
- `scripts/generate_config.py` のテンプレートを実際の構造に合わせ更新
- `validate_config.py` に `strategy_config.yaml` のセマンティック検証を追加

## Test Plan

- [ ] `python -m pytest tests/ -x -q` で 1583 件全て PASS することを確認
- [ ] `python -m kabusys.validate_config` でエラーなく完了することを確認
- [ ] `config/strategy_config.yaml` の `threshold` を変更して `run_strategy_signal.py` を実行し、変更が反映されることを確認
- [ ] バックテストエンジンが明示的パラメータを渡す箇所の既存テストが通ることを確認（`test_min_holding_days.py`、`test_time_exit.py`、`test_trailing_stop.py`）

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)