### PR TITLE
feat: LINE 定期レポート送信を実装 (Issue #256)

### DIFF
--- a/docs/superpowers/plans/2026-05-07-line-periodic-reports.md
+++ b/docs/superpowers/plans/2026-05-07-line-periodic-reports.md
@@ -1,0 +1,669 @@
+# LINE 定期レポート送信 実装プラン
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `LineNotifier` 基盤を活用し、Execution 起動時（朝）と portfolio_construction 完了後（夜）に定期 LINE 通知を送信する。金曜夜に週次、月末夜に月次のサマリも送る。
+
+**Architecture:** メッセージ生成関数を `src/kabusys/operations/line_reports.py` に純粋関数として集約しテスト容易にする。`run_execution.py`（朝通知）と `scripts/run_portfolio_construction.py`（夜/週次/月次通知）に `build_notifier()` を追加して送信する。`LINE_NOTIFY_ENABLED=false` では `NullNotifier.send()` が呼ばれるだけで Core 機能に影響しない。
+
+**Tech Stack:** Python 3.10+, 既存 `LineNotifier` / `NullNotifier` / `build_notifier()` (`operations/notifier.py`), `performance_collector.py`, `execution_startup_report.py`
+
+---
+
+## ファイル構成
+
+| 操作 | パス | 役割 |
+|---|---|---|
+| Create | `src/kabusys/operations/line_reports.py` | LINE メッセージ文字列生成（純粋関数 4 本） |
+| Create | `tests/test_line_reports.py` | line_reports.py のユニットテスト |
+| Modify | `src/kabusys/run_execution.py` | 起動後 Startup Summary を元に朝通知を送信 |
+| Modify | `scripts/run_portfolio_construction.py` | 完了後に夜通知・金曜週次・月末月次を送信 |
+
+---
+
+### Task 1: `line_reports.py` — メッセージ生成関数
+
+**Files:**
+- Create: `src/kabusys/operations/line_reports.py`
+- Create: `tests/test_line_reports.py`
+
+- [ ] **Step 1: テストを書く**
+
+`tests/test_line_reports.py` を新規作成する:
+
+```python
+"""tests/test_line_reports.py — LINE 定期レポートメッセージ生成テスト"""
+
+from __future__ import annotations
+
+from kabusys.operations.line_reports import (
+    format_evening_message,
+    format_monthly_message,
+    format_morning_message,
+    format_weekly_message,
+)
+
+
+class TestFormatMorningMessage:
+    def test_ready_with_pending(self):
+        msg = format_morning_message(
+            status="READY",
+            orders_no_status=0,
+            pending_count=3,
+            report_date="2026-05-07",
+        )
+        assert "2026-05-07" in msg
+        assert "READY" in msg
+        assert "3" in msg
+
+    def test_blocked_shows_orders_no_status(self):
+        msg = format_morning_message(
+            status="BLOCKED",
+            orders_no_status=2,
+            pending_count=0,
+            report_date="2026-05-07",
+        )
+        assert "BLOCKED" in msg
+        assert "2" in msg
+
+    def test_ready_with_warnings(self):
+        msg = format_morning_message(
+            status="READY_WITH_WARNINGS",
+            orders_no_status=0,
+            pending_count=1,
+            report_date="2026-05-07",
+        )
+        assert "READY_WITH_WARNINGS" in msg
+
+    def test_zero_pending(self):
+        msg = format_morning_message(
+            status="READY",
+            orders_no_status=0,
+            pending_count=0,
+            report_date="2026-05-07",
+        )
+        assert "0" in msg
+
+
+class TestFormatEveningMessage:
+    def test_with_daily_return(self):
+        msg = format_evening_message(
+            inserted=4,
+            report_date="2026-05-07",
+            daily_return=0.032,
+        )
+        assert "2026-05-07" in msg
+        assert "4" in msg
+        assert "3.2" in msg
+
+    def test_negative_daily_return(self):
+        msg = format_evening_message(
+            inserted=2,
+            report_date="2026-05-07",
+            daily_return=-0.015,
+        )
+        assert "-1.5" in msg
+
+    def test_no_daily_return(self):
+        msg = format_evening_message(
+            inserted=0,
+            report_date="2026-05-07",
+            daily_return=None,
+        )
+        assert "2026-05-07" in msg
+        assert "0" in msg
+
+    def test_return_is_string(self):
+        msg = format_evening_message(
+            inserted=3,
+            report_date="2026-05-07",
+            daily_return=0.01,
+        )
+        assert isinstance(msg, str)
+        assert len(msg) > 0
+
+
+class TestFormatWeeklyMessage:
+    def test_with_full_summary(self):
+        summary = {
+            "cumulative_return": 0.032,
+            "max_drawdown": -0.015,
+            "win_rate": 0.6,
+            "equity_start": 10_000_000,
+            "equity_end": 10_320_000,
+        }
+        msg = format_weekly_message(
+            summary=summary,
+            from_date="2026-04-28",
+            to_date="2026-05-02",
+        )
+        assert "2026-04-28" in msg
+        assert "2026-05-02" in msg
+        assert "3.2" in msg
+        assert "60.0" in msg
+
+    def test_with_none_values(self):
+        summary = {
+            "cumulative_return": None,
+            "max_drawdown": None,
+            "win_rate": None,
+            "equity_start": None,
+            "equity_end": None,
+        }
+        msg = format_weekly_message(
+            summary=summary,
+            from_date="2026-04-28",
+            to_date="2026-05-02",
+        )
+        assert isinstance(msg, str)
+        assert len(msg) > 0
+
+
+class TestFormatMonthlyMessage:
+    def test_with_full_summary(self):
+        summary = {
+            "cumulative_return": 0.058,
+            "max_drawdown": -0.023,
+            "win_rate": 0.553,
+            "equity_start": 10_000_000,
+            "equity_end": 10_580_000,
+        }
+        msg = format_monthly_message(
+            summary=summary,
+            from_date="2026-04-01",
+            to_date="2026-04-30",
+        )
+        assert "2026-04-01" in msg
+        assert "5.8" in msg
+        assert "55.3" in msg
+
+    def test_with_none_values(self):
+        summary = {
+            "cumulative_return": None,
+            "max_drawdown": None,
+            "win_rate": None,
+            "equity_start": None,
+            "equity_end": None,
+        }
+        msg = format_monthly_message(
+            summary=summary,
+            from_date="2026-04-01",
+            to_date="2026-04-30",
+        )
+        assert isinstance(msg, str)
+        assert len(msg) > 0
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```
+python -m pytest tests/test_line_reports.py -v
+```
+
+Expected: `ImportError: cannot import name 'format_morning_message' from 'kabusys.operations.line_reports'`
+
+- [ ] **Step 3: `line_reports.py` を実装**
+
+`src/kabusys/operations/line_reports.py` を新規作成する:
+
+```python
+"""line_reports.py — LINE 定期レポートのメッセージ文字列生成。
+
+すべて純粋関数。送信は呼び出し元（run_execution.py 等）が行う。
+"""
+
+from __future__ import annotations
+
+
+def _fmt_rate(value: float | None) -> str:
+    if value is None:
+        return "N/A"
+    return f"{value * 100:+.1f}%"
+
+
+def _fmt_yen(value: float | None) -> str:
+    if value is None:
+        return "N/A"
+    return f"{value:,.0f} 円"
+
+
+def format_morning_message(
+    *,
+    status: str,
+    orders_no_status: int,
+    pending_count: int,
+    report_date: str,
+) -> str:
+    """Execution 起動完了時の朝通知メッセージを生成する。
+
+    Args:
+        status:           READY / READY_WITH_WARNINGS / BLOCKED
+        orders_no_status: ステータス不明の注文件数
+        pending_count:    当日 signal_queue の pending 件数
+        report_date:      YYYY-MM-DD
+    """
+    lines = [
+        f"【KabuSys 朝】{report_date}",
+        f"ステータス: {status}",
+        f"pending シグナル: {pending_count} 件",
+    ]
+    if orders_no_status > 0:
+        lines.append(f"⚠ ステータス不明の注文: {orders_no_status} 件（要確認）")
+    return "\n".join(lines)
+
+
+def format_evening_message(
+    *,
+    inserted: int,
+    report_date: str,
+    daily_return: float | None = None,
+) -> str:
+    """portfolio_construction 完了後の夜通知メッセージを生成する。
+
+    Args:
+        inserted:     signal_queue に挿入した件数
+        report_date:  YYYY-MM-DD
+        daily_return: 当日の日次リターン（0.032 = +3.2%）、取得できない場合は None
+    """
+    lines = [
+        f"【KabuSys 夜】{report_date}",
+        f"翌日シグナル: {inserted} 件",
+        f"当日リターン: {_fmt_rate(daily_return)}",
+    ]
+    return "\n".join(lines)
+
+
+def format_weekly_message(
+    *,
+    summary: dict,
+    from_date: str,
+    to_date: str,
+) -> str:
+    """週次サマリ通知メッセージを生成する。
+
+    Args:
+        summary:   PerformanceReport.summary dict
+        from_date: YYYY-MM-DD（週の開始日）
+        to_date:   YYYY-MM-DD（週の終了日）
+    """
+    lines = [
+        f"【KabuSys 週次】{from_date} 〜 {to_date}",
+        f"累積リターン: {_fmt_rate(summary.get('cumulative_return'))}",
+        f"最大ドローダウン: {_fmt_rate(summary.get('max_drawdown'))}",
+        f"勝率: {_fmt_rate(summary.get('win_rate'))}",
+        f"期末資産: {_fmt_yen(summary.get('equity_end'))}",
+    ]
+    return "\n".join(lines)
+
+
+def format_monthly_message(
+    *,
+    summary: dict,
+    from_date: str,
+    to_date: str,
+) -> str:
+    """月次サマリ通知メッセージを生成する。
+
+    Args:
+        summary:   PerformanceReport.summary dict
+        from_date: YYYY-MM-DD（月初）
+        to_date:   YYYY-MM-DD（月末）
+    """
+    lines = [
+        f"【KabuSys 月次】{from_date} 〜 {to_date}",
+        f"累積リターン: {_fmt_rate(summary.get('cumulative_return'))}",
+        f"最大ドローダウン: {_fmt_rate(summary.get('max_drawdown'))}",
+        f"勝率: {_fmt_rate(summary.get('win_rate'))}",
+        f"期末資産: {_fmt_yen(summary.get('equity_end'))}",
+    ]
+    return "\n".join(lines)
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+```
+python -m pytest tests/test_line_reports.py -v
+```
+
+Expected: 13 passed
+
+- [ ] **Step 5: ruff チェック**
+
+```
+python -m ruff check src/kabusys/operations/line_reports.py tests/test_line_reports.py
+python -m ruff format --check src/kabusys/operations/line_reports.py tests/test_line_reports.py
+```
+
+Expected: `All checks passed!` / `N files already formatted`
+
+- [ ] **Step 6: コミット**
+
+```
+git add src/kabusys/operations/line_reports.py tests/test_line_reports.py
+git commit -m "feat: LINE 定期レポートメッセージ生成関数を追加 (Issue #256)"
+```
+
+---
+
+### Task 2: `run_execution.py` に朝通知を追加
+
+**Files:**
+- Modify: `src/kabusys/run_execution.py:32-36`（imports）、`src/kabusys/run_execution.py:278-291`（report 生成後）
+
+- [ ] **Step 1: テストを書く**
+
+`tests/test_line_reports.py` の末尾に追加する:
+
+```python
+# run_execution の朝通知ヘルパーのテスト
+from unittest.mock import MagicMock, patch
+
+
+class TestCountPendingSignals:
+    def test_returns_count_from_db(self):
+        from kabusys.run_execution import _count_pending_signals
+        from datetime import date
+
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (5,)
+        result = _count_pending_signals(conn, date(2026, 5, 7))
+        assert result == 5
+
+    def test_returns_zero_when_no_rows(self):
+        from kabusys.run_execution import _count_pending_signals
+        from datetime import date
+
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (0,)
+        result = _count_pending_signals(conn, date(2026, 5, 7))
+        assert result == 0
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```
+python -m pytest tests/test_line_reports.py::TestCountPendingSignals -v
+```
+
+Expected: `ImportError: cannot import name '_count_pending_signals' from 'kabusys.run_execution'`
+
+- [ ] **Step 3: `run_execution.py` を修正**
+
+`src/kabusys/run_execution.py` の import セクション（line 32 付近）に追加:
+
+```python
+from kabusys.operations.line_reports import format_morning_message  # noqa: E402
+from kabusys.operations.notifier import build_notifier  # noqa: E402
+```
+
+同ファイルに `_count_pending_signals` 関数を追加（`_load_risk_config` の直前付近、line 44 付近）:
+
+```python
+def _count_pending_signals(conn, target_date: date) -> int:
+    row = conn.execute(
+        "SELECT COUNT(*) FROM signal_queue WHERE date = ? AND status = 'pending'",
+        [target_date],
+    ).fetchone()
+    return int(row[0]) if row else 0
+```
+
+同ファイルの Execution Startup Summary 生成ブロック（line 278-291）を以下に置き換える:
+
+```python
+        # 起動時リコンシリエーション + Execution Startup Summary 生成
+        today = date.today()
+        reconcile_result = reconciler.run()
+        _report = None
+        try:
+            _report = build_report(
+                reconcile_result=reconcile_result, startup_date=today
+            )
+            print(format_cli_summary(_report))
+            save_report(_report)
+        except Exception:
+            logger.warning(
+                "Execution Startup Summary の生成に失敗しました（起動を続行します）",
+                exc_info=True,
+            )
+
+        # 朝の LINE 通知（失敗しても起動を継続する）
+        try:
+            notifier = build_notifier(settings)
+            pending_count = _count_pending_signals(duckdb_conn, today)
+            status = _report.status if _report is not None else "UNKNOWN"
+            orders_no_status = _report.orders_no_status if _report is not None else 0
+            msg = format_morning_message(
+                status=status,
+                orders_no_status=orders_no_status,
+                pending_count=pending_count,
+                report_date=today.isoformat(),
+            )
+            notifier.send(msg)
+        except Exception:
+            logger.warning("朝の LINE 通知に失敗しました（起動を続行します）", exc_info=True)
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+```
+python -m pytest tests/test_line_reports.py::TestCountPendingSignals -v
+```
+
+Expected: 2 passed
+
+- [ ] **Step 5: 全テスト回帰確認**
+
+```
+python -m pytest tests/test_line_reports.py tests/test_notifier.py -v
+```
+
+Expected: 全テスト pass
+
+- [ ] **Step 6: ruff チェック**
+
+```
+python -m ruff check src/kabusys/run_execution.py
+python -m ruff format --check src/kabusys/run_execution.py
+```
+
+Expected: `All checks passed!`
+
+- [ ] **Step 7: コミット**
+
+```
+git add src/kabusys/run_execution.py tests/test_line_reports.py
+git commit -m "feat: run_execution.py に朝の LINE 通知を追加 (Issue #256)"
+```
+
+---
+
+### Task 3: `run_portfolio_construction.py` に夜/週次/月次通知を追加
+
+**Files:**
+- Modify: `scripts/run_portfolio_construction.py`
+
+- [ ] **Step 1: テストを書く**
+
+`tests/test_line_reports.py` の末尾に追加する:
+
+```python
+class TestGetTodayReturn:
+    def test_returns_float_when_row_exists(self):
+        from scripts.run_portfolio_construction import _get_today_return
+        from datetime import date
+
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (0.032,)
+        result = _get_today_return(conn, date(2026, 5, 7))
+        assert result == 0.032
+
+    def test_returns_none_when_no_row(self):
+        from scripts.run_portfolio_construction import _get_today_return
+        from datetime import date
+
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = None
+        result = _get_today_return(conn, date(2026, 5, 7))
+        assert result is None
+
+    def test_returns_none_when_value_is_null(self):
+        from scripts.run_portfolio_construction import _get_today_return
+        from datetime import date
+
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (None,)
+        result = _get_today_return(conn, date(2026, 5, 7))
+        assert result is None
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```
+python -m pytest tests/test_line_reports.py::TestGetTodayReturn -v
+```
+
+Expected: `ImportError: cannot import name '_get_today_return' from 'scripts.run_portfolio_construction'`
+
+- [ ] **Step 3: `run_portfolio_construction.py` を修正**
+
+import セクションの末尾（`from kabusys.utils.logging_setup import setup_logging` の後）に追加:
+
+```python
+import calendar
+
+from kabusys.operations.line_reports import (
+    format_evening_message,
+    format_monthly_message,
+    format_weekly_message,
+)
+from kabusys.operations.notifier import build_notifier
+from kabusys.operations.performance_collector import (
+    collect_monthly_rows,
+    collect_weekly_rows,
+)
+from kabusys.operations.performance_report import build_report
+```
+
+`main()` 関数の直前に `_get_today_return` ヘルパーを追加:
+
+```python
+def _get_today_return(conn, target_date: date) -> float | None:
+    row = conn.execute(
+        "SELECT daily_return FROM portfolio_performance"
+        " WHERE date = ? AND env = 'live' LIMIT 1",
+        [target_date],
+    ).fetchone()
+    if row is None or row[0] is None:
+        return None
+    return float(row[0])
+```
+
+`main()` 関数の `conn.execute("COMMIT")` の直後（`logger.info("ポートフォリオ構築完了...")`の後）に追加:
+
+```python
+        logger.info(
+            "ポートフォリオ構築完了: %d 銘柄を signal_queue に挿入 (date=%s)",
+            inserted,
+            target_date,
+        )
+
+        # LINE 通知（失敗しても例外を伝播させない）
+        try:
+            notifier = build_notifier(settings)
+
+            # 夜の日次通知
+            daily_return = _get_today_return(conn, target_date)
+            notifier.send(
+                format_evening_message(
+                    inserted=inserted,
+                    report_date=target_date.isoformat(),
+                    daily_return=daily_return,
+                )
+            )
+
+            # 週次通知（金曜日: weekday == 4）
+            if target_date.weekday() == 4:
+                week_start = date.fromisocalendar(
+                    target_date.isocalendar()[0],
+                    target_date.isocalendar()[1],
+                    1,
+                )
+                weekly_rows = collect_weekly_rows(conn, "live", week_start, target_date)
+                weekly_report = build_report(
+                    weekly_rows,
+                    report_type="weekly",
+                    env="live",
+                    from_date=week_start,
+                    to_date=target_date,
+                )
+                notifier.send(
+                    format_weekly_message(
+                        summary=weekly_report.summary,
+                        from_date=week_start.isoformat(),
+                        to_date=target_date.isoformat(),
+                    )
+                )
+
+            # 月次通知（月末）
+            last_day = calendar.monthrange(target_date.year, target_date.month)[1]
+            if target_date.day == last_day:
+                month_start = target_date.replace(day=1)
+                monthly_rows = collect_monthly_rows(conn, "live", month_start, target_date)
+                monthly_report = build_report(
+                    monthly_rows,
+                    report_type="monthly",
+                    env="live",
+                    from_date=month_start,
+                    to_date=target_date,
+                )
+                notifier.send(
+                    format_monthly_message(
+                        summary=monthly_report.summary,
+                        from_date=month_start.isoformat(),
+                        to_date=target_date.isoformat(),
+                    )
+                )
+
+        except Exception:
+            logger.warning("LINE 通知に失敗しました", exc_info=True)
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+```
+python -m pytest tests/test_line_reports.py::TestGetTodayReturn -v
+```
+
+Expected: 3 passed
+
+- [ ] **Step 5: 全テスト回帰確認**
+
+```
+python -m pytest tests/test_line_reports.py -v
+```
+
+Expected: 全テスト pass (18 件)
+
+- [ ] **Step 6: ruff チェック**
+
+```
+python -m ruff check scripts/run_portfolio_construction.py
+python -m ruff format --check scripts/run_portfolio_construction.py
+```
+
+Expected: `All checks passed!`
+
+- [ ] **Step 7: 全テスト回帰確認（全体）**
+
+```
+python -m pytest --tb=short -q
+```
+
+Expected: 全テスト pass（回帰なし）
+
+- [ ] **Step 8: コミット**
+
+```
+git add scripts/run_portfolio_construction.py tests/test_line_reports.py
+git commit -m "feat: portfolio_construction 完了後に夜・週次・月次 LINE 通知を追加 (Issue #256)"
+```

--- a/documents/05_Backtest/BacktestFramework.md
+++ b/documents/05_Backtest/BacktestFramework.md
@@ -1,268 +1,235 @@
-# Backtest Framework (バックテスト・検証基盤)
+# Backtest Framework
 
-- 対象: AIスコア、クオンツ戦略のリサーチおよびバックテストパイプライン
-- 版数: v2.0
+- 対象: KabuSys のバックテスト実行基盤
+- 更新: 実装済み仕様ベース
 
 ---
 
 ## 1. 目的
 
-システムに実装する「戦略（Strategy）」や「AIモデルのスコアリング」が、**「本当に利益を生む優位性があるか（Alpha）」**を過去のデータを用いて検証する枠組み。
-
-「本番環境（Production）」と「テスト環境（Backtest）」のコードベース（ロジック）を完全に共通化し、バックテストで利益が出たのに本番で損をする「乖離（オーバーフィッティング等）」を最小限にとどめることを目的とする。
-
-**対象戦略**: 日足スイング戦略（想定保有期間: 数営業日〜数週間、最大 60 営業日）。夜間バッチでシグナル生成し翌営業日寄付き執行する設計を前提とする。以下の制御ルールがバックテスト本番で共通適用される。
-
-| 制御ルール | 実装箇所 |
-|-----------|---------|
-| ギャップリスクフィルタ（始値 +5%超 / -3%以下でBUY見送り） | `generate_signals()` |
-| 決算回避（決算前日のBUY禁止・決算前強制SELL） | `generate_signals()` |
-| 主要イベント前BUYサイズ縮小（50%） | `generate_signals()` |
-| セクター相対強弱フィルタ（下位25%セクターBUY禁止） | `generate_signals()` |
-| 最低保有日数（5営業日、ストップロス・決算回避を除く） | `_generate_sell_signals()` |
-| 再エントリー制限（SELL後5営業日同一銘柄BUY禁止） | `generate_signals()` |
+KabuSys のバックテストは、実運用で使っている `generate_signals()` と同じロジックを再利用しながら、専用のインメモリ DB 上で安全に検証するための仕組みです。  
+`paper_trading` や `live` と乖離しないことを優先し、シグナル生成・保有制御・地合い判定をできるだけ共通化しています。
 
 ---
 
-## 2. Research Environment ワークフロー
+## 2. 位置づけ
 
-新しい戦略やAIスコアは、以下の厳格なステップを踏んで本番へ導入される。
-
-1. **Research (探索・分析)**
-   - Jupyter Notebook等でJ-Quantsのヒストリカルデータやニュース履歴を分析。
-   - 特徴量の相関や、AIニューススコアの統計的優位性を仮説立て・探索。
-2. **Backtest (ヒストリカル・シミュレーション)**
-   - 過去数年分（Bull/Bearの両相場を含む期間）のデータに取引ロジックを流し込み、スリッページや売買手数料を考慮した詳細なパフォーマンス測定を実施。
-3. **Forward Test (ペーパー取引 / シミュレーション実行)**
-   - バックテストで合格したロジックを、本番と**全く同じExecution System**のまま `MockBrokerClient` を使ってリアルタイム稼働させる。
-   - 環境変数 `KABUSYS_ENV=paper_trading` で Paper Trading モードに切り替わり、`BrokerClientFactory` が自動的に `MockBrokerClient` を選択する。
-   - データは `data/paper_trading.db` に保存され、本番 DB（`data/monitoring.db`）とは完全分離される。
-   - `PAPER_FILL_MODE` 環境変数で約定シミュレーション方式を制御（`instant` / `partial` / `never` / `reject`、デフォルト: `instant`）。
-   - ここで、APIの速度や、リアルタイムの気配値更新特有の遅延（レイテンシ）の影響を評価。
-4. **Production (本番稼働)**
-   - Forward Testで想定通りの乖離率に収まり、システム安定性が確認された場合のみ、通常のロット（資金）を投下して本番運用を開始。
+1. Research
+   Notebook や分析コードで仮説を作る
+2. Backtest
+   共通ロジックで過去検証する
+3. Paper Trading
+   模擬約定で運用フローを確認する
+4. Live
+   実口座で日次運用する
 
 ---
 
-## 3. レポート評価指標（Metrics）
+## 3. 主な評価指標
 
-バックテストの結果は、単なる「最終利益」だけでなく、いかに安定して資産を増やせるかというリスク調整後リターンで評価する。
+- CAGR
+- Sharpe Ratio
+- Max Drawdown
+- Win Rate
+- Payoff Ratio
+- Profit Factor
+- Annual Volatility
+- Calmar Ratio
+- Avg Holding Days
 
-| 指標 | 定義 | 合格ライン |
-|------|------|-----------|
-| **CAGR (年平均成長率)** | `(最終資産/初期資産)^(1/年数) - 1` | — |
-| **Sharpe Ratio** | `年次化超過リターン / 年次化標準偏差`（無リスク金利=0） | ≥ 1.0（理想 1.5） |
-| **Max Drawdown** | `max(1 - 評価額 / 過去ピーク)` | ≤ 20% |
-| **Win Rate / Payoff Ratio** | 勝ちトレード数 / 全クローズトレード数、平均利益 / 平均損失 | — |
-
-**税金は計算対象外**（確定申告ルール・NISA・損失繰越が複雑なため）。手数料のみ適用する。
+集計は `src/kabusys/backtest/metrics.py` と `src/kabusys/backtest/report.py` で行う。
 
 ---
 
-## 4. ルックアヘッド・バイアス（未来情報漏洩）の完全防止策
+## 4. 実行モデル
 
-バックテストにおける最大の罠は「その時点で知り得ない未来（翌日や来週）のデータを使って今日の売買判断をしてしまうこと」である。これをフレームワークレベルで厳粛に防ぐ。
+1 営業日ごとに次を繰り返す。
 
-### 4.1 財務情報・ニュースの反映タイミング
+1. 前営業日に作った注文を当日寄りで約定させる
+2. 当日の `positions` をインメモリ DB に反映する
+3. 当日終値で時価評価する
+4. 当日データで `generate_signals()` を実行する
+5. 翌営業日寄りで執行する注文キューを組む
 
-「決算発表日」や「大引け後（15:00以降）のニュース」のデータは、その日の取引が終わった後にしか市場に反映されない前提とする。これらがシグナル生成に使えるのは、厳密に「翌営業日の寄付き（または夜間バッチ）」からである。
-
-### 4.2 本番用とバックテスト用クロック（時計）の共通化
-
-`Strategy` 層などからはサーバーの現在時刻 (`datetime.now()`) を直接見ず、フレームワークから注入される `Current Simulated Time` インターフェースに依存するように設計する。
-これにより、同じコードを時計の針だけ任意に進めてループ実行することで、未来のデータへの参照を物理的にブロックする。
-
-実装上は `engine.py` のループ変数 `trading_day` がそのまま Simulated Time として機能する。
-既存の `generate_signals(conn, target_date)` は引数で日付を受け取る設計のため、`datetime.now()` に依存しない。
-
-| 処理 | 使うデータ | 根拠 |
-|------|-----------|------|
-| シグナル生成（day T） | `date < T` の価格・特徴量 | `generate_signals()` の SQL が `WHERE date = T` でバインド |
-| SELL 判定（day T） | `date <= T` の prices_daily | `_generate_sell_signals()` の SQL が `WHERE date <= T` でバインド |
-| 約定（day T+1） | day T+1 の始値 | シグナルは常に翌営業日の始値で執行 |
-| 最低保有日数判定（day T） | `position_entries.entry_date` | バックテスト用インメモリ DB で管理（本番と同一ロジック） |
-| 再エントリー制限判定（day T） | `position_entries.sell_date` | 同上 |
-| 決算回避判定（day T） | `earnings_calendar.announcement_date` | インメモリ DB にコピー済み |
-
-さらに、インメモリ DB には `end_date` 以降のデータを含まないため、物理的に未来参照が不可能。
-
-`position_entries` テーブルはバックテスト開始時に空で初期化され、`simulator.py` が BUY/SELL 約定のたびに書き込む。`earnings_calendar` は本番 DB から `end_date` までのデータをコピーして使用する。
-
-### 4.3 スリッページと手数料の厳密なモデリング
-
-シグナルが出た翌日の「始値（Open）」で約定すると仮定する。さらに、売買手数料を必ず差し引く設定をデフォルトとする。
-
-| パラメータ | デフォルト値 | 説明 |
-|-----------|------------|------|
-| `slippage_rate` | 0.001 (0.1%) | BUY: `open × (1 + slippage_rate)` / SELL: `open × (1 - slippage_rate)` |
-| `commission_rate` | 0.00055 (0.055%) | 国内証券の標準的な手数料率 |
-| `max_position_pct` | 0.20 (20%) | 1銘柄あたりの最大ポートフォリオ比率（RiskManagement.md 準拠） |
+これにより、シグナル生成は当日終値ベース、執行は翌営業日寄りという運用系と同じ前提で評価する。
 
 ---
 
 ## 5. モジュール構成
 
-```
+```text
 src/kabusys/backtest/
 ├── __init__.py
-├── clock.py       # SimulatedClock（将来の拡張用薄いデータクラス）
-├── simulator.py   # PortfolioSimulator — 擬似約定・ポートフォリオ状態管理
-├── metrics.py     # calc_metrics() — CAGR / Sharpe / MaxDD / WinRate
-├── engine.py      # run_backtest() — 全体を統合するエントリポイント
-└── run.py         # CLI エントリポイント
+├── clock.py
+├── simulator.py
+├── metrics.py
+├── engine.py
+├── report.py
+└── run.py
 
 tests/
-└── test_backtest_framework.py
+├── test_backtest_framework.py
+├── test_backtest_scope.py
+├── test_backtest_report.py
+└── test_min_holding_days.py
 ```
 
 ---
 
 ## 6. 公開 API
 
-### `engine.py`
+### `run_backtest()`
 
 ```python
-def run_backtest(
-    conn: duckdb.DuckDBPyConnection,
-    start_date: date,
-    end_date: date,
-    initial_cash: float = 10_000_000,
-    slippage_rate: float = 0.001,
-    commission_rate: float = 0.00055,
-    max_position_pct: float = 0.20,
-) -> BacktestResult:
-    ...
-
-@dataclass
-class BacktestResult:
-    history: list[DailySnapshot]   # 日次ポートフォリオ履歴
-    trades: list[TradeRecord]      # 全約定履歴
-    metrics: BacktestMetrics       # 計算済みメトリクス
+run_backtest(
+    conn,
+    start_date,
+    end_date,
+    initial_cash=10_000_000,
+    slippage_rate=0.001,
+    commission_rate=0.00055,
+    max_position_pct=0.10,
+    allocation_method="risk_based",
+    max_utilization=0.70,
+    max_positions=10,
+    risk_pct=0.005,
+    stop_loss_pct=0.08,
+    lot_size=100,
+    backtest_scope=None,
+    min_holding_days=5,
+    max_holding_days=60,
+    trailing_stop_atr=2.0,
+)
 ```
 
-### CLI
+### `BacktestScope`
+
+```python
+BacktestScope(
+    mode="default_universe" | "manual_codes",
+    codes=None,
+    preserve_universe_filters=True,
+)
+```
+
+### `BacktestResult`
+
+`BacktestResult` には次のメタデータが入る。
+
+- `history`
+- `trades`
+- `metrics`
+- `scope_mode`
+- `scope_codes`
+- `effective_universe_size`
+- `excluded_codes`
+- `preserve_universe_filters`
+
+---
+
+## 7. CLI
+
+基本実行:
 
 ```bash
 python -m kabusys.backtest.run \
-    --start 2023-01-01 --end 2024-12-31 \
+    --start 2023-01-01 \
+    --end 2024-12-31 \
     --cash 10000000 \
-    --db path/to/kabusys.duckdb
+    --db data/kabusys.duckdb
 ```
 
-**前提条件**: 指定 DB ファイルに `prices_daily`, `features`, `ai_scores`, `market_regime`, `market_breadth`, `market_calendar`, `earnings_calendar` が入力済みであること。`position_entries` はバックテスト開始時に自動で空テーブルとして初期化される。
+主なオプション:
+
+- `--scope-mode default_universe|manual_codes`
+- `--codes 7203 9984 ...`
+- `--no-preserve-universe-filters`
+- `--min-holding-days 5`
+- `--max-holding-days 60`
+- `--trailing-stop-atr 2.0`
+- `--output-format summary|json|markdown|all`
+- `--output-dir artifacts/backtests/...`
+
+`manual_codes` を使うと対象銘柄を限定した targeted backtest を実行できる。
 
 ---
 
-## 7. インメモリ DB 分離（本番 DB 汚染防止）
+## 8. インメモリ DB 分離
 
-`generate_signals()` は `signals` テーブルに書き込み、`_generate_sell_signals()` は `positions` テーブルを読み取る。これらを本番 DB に直接書くと本番データを汚染する。
+バックテストは本番 DB 汚染を防ぐため、毎回 `:memory:` の DuckDB を作って必要データだけをコピーして実行する。
 
-**方針**: バックテストは専用のインメモリ DuckDB を使用する。
+概念的には次の流れ。
 
-```
-_build_backtest_conn(source_conn, start_date, end_date):
-  1. ":memory:" で新規 DuckDB を作成しスキーマを初期化
-  2. source_conn から以下のデータをコピー:
-     - prices_daily     (start_date - 300日 〜 end_date)
-     - features         (同範囲)
-     - ai_scores        (同範囲)
-     - market_regime    (同範囲)
-     - market_calendar  (全件)
-     - stocks           (全件。セクターフィルタ用)
-     - earnings_calendar (end_date までの全件。未来参照防止のため end_date でカット)
-  3. インメモリ conn を返す
+```text
+_build_backtest_conn(source_conn, start_date, end_date)
+  1. :memory: DB を作成
+  2. 必要テーブルを source_conn からコピー
+  3. prices_daily から market_breadth を再計算
+  4. positions / signals / position_entries をバックテスト用に使う
 ```
 
-> **注意（未対応）**: `market_breadth` はバックテスト用インメモリ DB にコピーされていない。
-> このため `_is_breadth_stop()` は常に `False`（BUY 許可・安全側）を返し、
-> バックテストでは breadth_stop フィルタが機能しない。
-> 対応は別 Issue で実装予定。
+コピーまたは再構成する主なテーブル:
+
+- `prices_daily`
+- `features`
+- `ai_scores`
+- `market_regime`
+- `market_calendar`
+- `stocks`
+- `earnings_calendar`
+- `market_breadth`（コピーではなく再計算）
+
+重要:
+
+- `market_breadth` は未対応ではなく、現在はバックテスト用 DB で再計算される
+- そのため `breadth_stop` フィルタはバックテストでも有効
+- `manual_codes` 指定時でも `market_regime` / `market_breadth` は市場全体ベースで判定する
 
 ---
 
-## 8. 実行フロー（1日のループ）
+## 9. 実装済みの保有制御
 
-```
-# 初期化
-bt_conn = _build_backtest_conn(conn, start_date, end_date)
-simulator = PortfolioSimulator(cash=initial_cash, ...)
-signals_prev = []
+バックテストで評価できる主な保有制御:
 
-for trading_day in get_trading_days(bt_conn, start_date, end_date):
+- `min_holding_days`
+- `max_holding_days` による `time_exit`
+- `trailing_stop_atr`
+- Bear regime による BUY 抑制
+- `breadth_stop` による BUY 抑制
+- 決算回避
+- ストップロス
 
-    1. 前日シグナルを当日 open 価格で約定
-       → open_prices = _fetch_open_prices(bt_conn, trading_day)
-       → simulator.execute_orders(signals_prev, open_prices,
-                                  slippage_rate, commission_rate)
-          ※ shares = floor(alloc / (open * (1 + slippage_rate)))  for BUY
-          ※ 約定価格 = open * (1 - slippage_rate)               for SELL
-
-    2. positions テーブルに書き戻し（generate_signals の SELL 判定に必要）
-       → _write_positions(bt_conn, trading_day,
-                          simulator.positions, simulator.cost_basis)
-          ※ DELETE WHERE date = trading_day → INSERT（冪等）
-          ※ market_value は NULL（nullable カラム、SELL 判定では参照されない）
-
-    3. 当日終値で時価評価・スナップショット記録
-       → close_prices = _fetch_close_prices(bt_conn, trading_day)
-       → simulator.mark_to_market(trading_day, close_prices)
-
-    4. 翌日用シグナルを生成
-       → generate_signals(bt_conn, target_date=trading_day)
-          ※ 戻り値は int（書き込み件数）。シグナル内容は signals テーブルをクエリ
-
-    5. 翌日の発注リストを組み立て（ポジションサイジング）
-       → buy_signals  = SELECT code, signal_rank FROM signals
-                         WHERE date = trading_day AND side = 'buy'
-                         ORDER BY signal_rank
-       → sell_signals = SELECT code FROM signals
-                         WHERE date = trading_day AND side = 'sell'
-       → prior_pv = simulator.history[-1].portfolio_value
-                    if simulator.history else initial_cash
-       → alloc = min(prior_pv * max_position_pct,
-                     simulator.cash / len(buy_signals))   # buy なし時はスキップ
-       → signals_prev = [{"code": s.code, "side": "buy", "alloc": alloc}
-                          for s in buy_signals] +
-                         [{"code": s.code, "side": "sell"}
-                          for s in sell_signals]
-```
+`min_holding_days` は通常 SELL を抑制するが、ストップロス・決算回避・time exit・一部の優先 SELL 条件はバイパスされる。
 
 ---
 
-## 9. データ構造
+## 10. レポート出力
 
-```python
-@dataclass
-class DailySnapshot:
-    date: date
-    cash: float
-    positions: dict[str, int]   # code → 株数
-    portfolio_value: float      # cash + 時価評価額
+`src/kabusys/backtest/report.py` でバックテスト結果をレポート化できる。
 
-@dataclass
-class TradeRecord:
-    date: date
-    code: str
-    side: str                   # "buy" | "sell"
-    shares: int
-    price: float                # 約定価格（スリッページ適用後）
-    commission: float
-    realized_pnl: float | None  # SELL 時のみ（取得原価との差分）
+出力形式:
 
-@dataclass
-class PortfolioSimulator:
-    cash: float
-    positions: dict[str, int]
-    cost_basis: dict[str, float]  # code → 平均取得単価
-    history: list[DailySnapshot]
-    trades: list[TradeRecord]
+- CLI summary
+- JSON
+- Markdown
+- 保存一式
 
-@dataclass
-class BacktestMetrics:
-    cagr: float
-    sharpe_ratio: float
-    max_drawdown: float
-    win_rate: float
-    payoff_ratio: float
-    total_trades: int
-```
+`--output-format all` を指定すると、既定で `artifacts/backtests/{run_id}/` に次を保存する。
+
+- `summary.json`
+- `report.md`
+- `trades.csv`
+- `daily_equity.csv`
+- `warnings.json`
+
+targeted backtest の場合は `report_type = targeted_backtest` となり、スコープ情報と警告がレポートへ反映される。
+
+---
+
+## 11. 関連
+
+- `documents/02_Strategy/StrategyModel.md`
+- `documents/06_RiskManagement/RiskManagement.md`
+- `documents/Archive/TODO_TargetedBacktest.md`
+- `documents/Archive/TODO_BacktestReporting.md`
+- `documents/Archive/TODO_MinHoldingDaysBacktestComparison.md`

--- a/documents/08_Operations/TradingRunbook.md
+++ b/documents/08_Operations/TradingRunbook.md
@@ -1,380 +1,238 @@
-# TradingRunbook.md
+# Trading Runbook
 
-## 1. 目的
-
-本ドキュメントは、日本株自動売買システムの **日次運用手順（Trading Runbook）** を定義する。
-
-目的:
-
-- 日々の運用作業の標準化
-- 手動確認ポイントの整理
-- アラート発生時の対応フローの明確化
-- 安定した自動売買運用
-
-対象環境:
-
-- Single Windows PC（KabuSys 稼働ノード）
-- Python 自動売買システム
-- kabuステーション API
-- J-Quants データ
+- 対象: KabuSys の日次運用
+- 前提: Single Windows Node / kabuステーション API / J-Quants
 
 ---
 
-## 2. 日次運用タイムライン
+## 1. 日次タイムライン
 
-```
-07:50  PC・kabuステーション起動確認
-08:00  Pre-Market Checklist（手動確認）
-08:30  Execution 起動（Task Scheduler 自動）
-09:00  Monitoring 起動（Task Scheduler 自動） / 前場オープン
-09:00-11:30  前場取引監視
-11:30-12:30  昼休み（注文受付停止）
-12:30-15:00  後場取引監視
-15:00  市場クローズ（現物株）/ Market Close 確認
-15:30  data_update バッチ（Task Scheduler 自動）
-16:00  feature_gen バッチ（Task Scheduler 自動）
-18:00  ai_analysis バッチ（Task Scheduler 自動）
-20:00  strategy_signal バッチ（Task Scheduler 自動）
-21:00  portfolio_construction バッチ（Task Scheduler 自動）
-21:30  夜間バッチ結果確認（手動）
+```text
+07:50  PC / kabuステーション起動確認
+08:00  Pre-Market Checklist
+08:30  Execution 起動
+09:00  Monitoring 起動・前場監視
+11:30  昼休み確認
+12:30  後場監視
+15:00  Market Close 確認
+15:30  data_update
+16:00  feature_gen
+18:00  ai_analysis
+20:00  strategy_signal
+21:00  portfolio_construction
+21:30  Night Batch 確認
 ```
 
 ---
 
-## 3. Pre-Market Checklist（08:00）
+## 2. Pre-Market（08:00）
 
-市場オープン前に以下を確認する。
+確認項目:
 
-| 項目 | 確認内容 | 確認方法 |
-|------|---------|---------|
-| PC 状態 | Windows 稼働・スリープ解除済み | 目視 |
-| kabuステーション | 起動・ログイン済み | 画面確認 |
-| API 接続 | kabuステーション API 応答あり | kabuステーション 画面の接続状態 |
-| J-Quants データ | 前日分データが DuckDB に入っていること | `data_update` バッチのログ確認 |
-| Signal Queue | 本日の `pending` シグナルが存在すること | SQLite / DuckDB 確認 |
-| ポジション | DB のポジションと証券口座が一致していること | `run_position_reconciliation_report` コマンドで確認 |
-| 停止フラグ | `data/stop_requested.flag` が存在しないこと | エクスプローラーで確認 |
-| Task Scheduler | KabuSys_* タスクが `Ready` 状態であること | タスクスケジューラ画面 |
+- Windows PC が正常
+- kabuステーションが起動済み
+- API 接続が正常
+- `data/stop_requested.flag` が存在しない
+- `signal_queue` の `pending` が残っている
+- Task Scheduler の `KabuSys_*` が `Ready`
+- DB と口座のポジション差分が許容範囲
 
-**ポジション確認コマンド（手動実行）:**
+主要コマンド:
 
 ```cmd
+python -m kabusys.run_pre_market_report --save
+python -m kabusys.run_signal_queue_report
 python -m kabusys.run_position_reconciliation_report
 ```
 
-`CLEAN` が表示されれば一致。`DISCREPANCY` が表示された場合は差分銘柄・数量を確認し、必要に応じて手動調整すること。
+判定:
 
-**Task Scheduler 確認コマンド:**
+- `READY`: 執行開始可
+- `READY_WITH_WARNINGS`: 警告確認の上で開始判断
+- `BLOCKED`: 自動執行を開始しない
 
-```powershell
-Get-ScheduledTask -TaskName "KabuSys_*" | Select-Object TaskName, State
-```
+出力先:
 
-問題があれば Execution 起動前に解消すること。
+- `artifacts/pre_market/{date}/report.md`
 
 ---
 
-## 4. Execution 起動（08:30）
-
-Task Scheduler が自動実行する。手動起動が必要な場合は以下を使用する。
-
-**手動起動:**
+## 3. Execution 起動（08:30）
 
 ```cmd
-cd C:\path\to\KabuSys
+python scripts\start_system.py --dry-run
 python scripts\start_system.py --component execution
 ```
 
-**両コンポーネント一括起動:**
+起動直後の確認:
 
-```cmd
-python scripts\start_system.py
-```
+- `data/execution.pid` が生成されている
+- `orders_no_status = 0`
+- `position_discrepancies` が許容範囲
 
-**起動確認:**
+補足:
 
-```cmd
-# PID ファイルが作成されていることを確認
-type data\execution.pid
-```
-
-起動時の自動処理（`run_execution.py` 内）:
-
-1. 停止フラグ（`data/stop_requested.flag`）が存在しない場合のみ起動
-2. 自動リコンシリエーション実行
-   - `OrderSent` 状態の注文をブローカーと突合・同期
-   - ポジション差分をログに記録
-3. Signal Queue の `pending` シグナルを読み込み発注開始
-
-> `orders_no_status > 0` または `position_discrepancies > 0` がログに出た場合は手動確認を実施すること。  
-> 詳細: `FailureRecovery.md` §5「PC 再起動後のリコンシリエーション」
-
-**手動停止（緊急時）:**
-
-```cmd
-python scripts\stop_system.py
-```
+- `python -m kabusys.run_execution` 実行時に Execution Startup Summary が自動生成される
+- 保存先: `artifacts/execution_startup/{date}/report.md`
 
 ---
 
-## 5. 市場中の監視（前場 09:00-11:30 / 後場 12:30-15:00）
+## 4. ザラ場監視（09:00-15:00）
 
-> **TSE 現物株の取引時間**: 前場 09:00-11:30、後場 12:30-15:00。昼休み（11:30-12:30）は注文受付停止。15:00 以降は API での新規発注不可。
+見るもの:
 
-### 5.1 システム処理（自動）
+- `execution_service`
+- `monitoring_service`
+- 注文エラー
+- API エラー
+- ドローダウン
+- Kill Switch
+- ポジション差分
 
-- シグナル取得・発注（前場・後場）
-- 約定確認・ポジション更新
-- リスクチェック（ドローダウン監視）
-- Kill Switch 判定（DD 上限超過 / API 断絶）
+主要コマンド:
 
-### 5.2 監視項目
-
-| 項目 | 監視内容 | 判断基準 |
-|------|---------|---------|
-| 注文エラー | `rejected` 注文の有無 | 3 件以上連続で手動確認 |
-| API 接続 | kabuステーション 接続状態 | 5 分以上切断で手動対応 |
-| ドローダウン | 日次 DD | 10% 超過で Kill Switch 検討 |
-| Execution プロセス | PID ファイル存在確認 | `data/execution.pid` が消えたら再起動 |
-| Monitoring プロセス | PID ファイル存在確認 | `data/monitoring.pid` が消えたら再起動 |
-| ポジション差分 | DB とブローカーのポジション一致確認 | `run_position_reconciliation_report --watch` で定期確認 |
-
-### 5.3 ログ確認
-
-各プロセス・スクリプトは `kabusys.utils.logging_setup.setup_logging` を使用して統一されたログ設定を行う。  
-ログは **stdout（コンソール）** と **ファイル（日次ローテーション）** の2か所に出力される。  
-フォーマット: `%(asctime)s %(levelname)-8s %(name)s: %(message)s`（`datefmt="%Y-%m-%dT%H:%M:%S"` によるローカル時刻・タイムゾーンなし。例: `2026-04-18T09:00:00`）
-
-**アプリケーションログファイル（`logs\` ディレクトリ、自動ローテーション）:**
-
-| プロセス / スクリプト | ログファイル | ローテーション |
-|---------------------|------------|--------------|
-| ExecutionEngine | `logs\execution.log` | 日次・30日保持 |
-| MonitoringEngine | `logs\monitoring.log` | 日次・30日保持 |
-| data_update バッチ | `logs\data_update.log` | 日次・30日保持 |
-| feature_gen バッチ | `logs\feature_gen.log` | 日次・30日保持 |
-| ai_analysis バッチ | `logs\ai_analysis.log` | 日次・30日保持 |
-| strategy_signal バッチ | `logs\strategy_signal.log` | 日次・30日保持 |
-| portfolio_construction バッチ | `logs\portfolio_construction.log` | 日次・30日保持 |
-
-> ログファイルは日次（深夜0時）に自動ローテーションされ、30日分保持される。手動アーカイブは不要。  
-> ログディレクトリは `LOG_DIR` 環境変数で変更可能（未設定時はプロセス起動時のカレントディレクトリ配下の `logs/`）。  
-> Task Scheduler から起動した場合は `LOG_DIR` を絶対パスで設定すること（例: `C:\KabuSys\logs`）。
-
-**ログ確認コマンド（PowerShell）:**
+```cmd
+python -m kabusys.run_intraday_monitor --watch
+```
 
 ```powershell
-# 直近50行を確認
 Get-Content logs\execution.log -Tail 50
-
-# ERROR / CRITICAL のみ抽出
 Select-String -Path logs\*.log -Pattern "ERROR|CRITICAL"
-
-# 過去ローテーションファイルの確認（例: execution.log.2026-04-17）
-Get-ChildItem logs\execution.log* | Sort-Object LastWriteTime -Descending
 ```
 
-主要なログキーワード:
-
-| キーワード | 意味 |
-|-----------|------|
-| `停止フラグを検知` | グレースフル停止が開始された |
-| `Kill Switch` | 緊急停止が発動された |
-| `position_discrepancies` | ポジション不整合が検出された |
-| `orders_no_status` | 状態不明の注文がある（リコンシリエーション要） |
-| `CIRCUIT_BREAKER_OPEN` | サーキットブレーカが発動 |
-| `ERROR` / `CRITICAL` | 即時確認が必要 |
-
----
-
-## 6. アラート対応フロー
-
-### 6.1 アラートの種類と優先度
-
-| アラート | 優先度 | 初動対応 |
-|---------|--------|---------|
-| Max Drawdown 超過 | 🔴 最高 | 即時 Kill Switch → 手動確認 |
-| API 接続断 | 🔴 最高 | kabuステーション 再起動 → 再接続確認 |
-| Execution プロセス停止 | 🔴 高 | `start_system.py --component execution` |
-| `rejected` 注文多発 | 🟡 中 | 注文ログ確認 → 原因特定 |
-| Night Batch 失敗 | 🟡 中 | ログ確認 → 手動再実行 |
-| Signal Queue 空 | 🟡 中 | `portfolio_construction` バッチ再実行 |
-| Monitoring プロセス停止 | 🟢 低 | `start_system.py --component monitoring` |
-
-### 6.2 共通対応フロー
-
-```
-1. ログ確認
-   └─ ERROR / CRITICAL メッセージを特定
-
-2. 状態確認
-   ├─ PID ファイル確認（data/*.pid）
-   ├─ 停止フラグ確認（data/stop_requested.flag）
-   └─ DB 整合性（signal_queue, positions）
-
-3. 判断
-   ├─ 軽微 → ログに記録して継続監視
-   ├─ 中程度 → 該当コンポーネント再起動
-   └─ 重大 → Kill Switch 発動（§8 参照）
-
-4. 復旧後確認
-   └─ FailureRecovery.md §11「復旧確認チェックリスト」に従う
-```
-
----
-
-## 7. Market Close 確認（15:00）
-
-市場クローズ後に以下を確認する。
-
-| 項目 | 確認内容 |
-|------|---------|
-| 未約定注文 | `signal_queue` に `pending` が残っていないか |
-| ポジション更新 | `positions` テーブルが最新状態か |
-| 日次損益 | `portfolio_performance` テーブルに本日分が記録されているか |
-| Execution 停止 | 取引時間外は不要なので `stop_system.py` で停止しても良い |
-
-**手動でポジション更新を確認する場合（DuckDB）:**
+Streamlit を使う場合:
 
 ```cmd
-duckdb data\kabusys.duckdb "SELECT * FROM positions ORDER BY code"
+streamlit run src/kabusys/monitoring/streamlit_dashboard.py -- --db data/monitoring.db
 ```
 
-> 15:00 以降に `start_system.py` を実行しても、kabuステーション API が注文受付外のため発注は行われない。
+利用ページ:
+
+- `Home`
+- `WebManual`
+- `Signal Queue`
+- `Performance`
+- `Strategy Lab`
 
 ---
 
-## 8. 緊急停止（Kill Switch）
+## 5. 障害時の基本対応
 
-### 8.1 自動発動条件
+1. ログ確認
+2. PID / stop flag / DB 状態確認
+3. 必要なら Kill Switch
+4. 再起動前に reconciliation
 
-ExecutionEngine が以下を検知した場合に自動発動:
-
-- 最大ドローダウン（`max_drawdown`）超過
-- API 接続断（`circuit_breaker` 発動）
-- `circuit_breaker_errors` 件以上の連続エラー
-
-### 8.2 手動発動
+停止:
 
 ```cmd
 python scripts\stop_system.py
 ```
 
-停止フラグ（`data/stop_requested.flag`）を作成し、Execution / Monitoring がグレースフルに終了する（最大 10 秒）。  
-10 秒以内に終了しない場合は強制終了（`psutil.Process(pid).kill()`）される。
-
-再起動する際は停止フラグが残っているため、`--clear-stop-flag` を明示指定する必要がある。
+再開前確認:
 
 ```cmd
-python scripts\start_system.py --clear-stop-flag
-```
-
-#### 再開前の状態確認（推奨）
-
-`--clear-stop-flag` で本起動する前に、`--dry-run` で発注なしの状態確認を実施することを推奨する。
-
-```cmd
-:: 発注なしで DB 状態を確認（プロセス起動なし、停止フラグも変更しない）
 python scripts\start_system.py --dry-run
 ```
 
-出力例:
+---
 
-```
-[DRY-RUN] 停止フラグ: あり (data\stop_requested.flag)
-[DRY-RUN] signal_queue: pending=3 件, processing=0 件（リコンシリエーション対象）
-[DRY-RUN] positions: 5 件
-[DRY-RUN] 発注は行いません。通常起動は --clear-stop-flag を指定してください。
+## 6. Market Close（15:00）
+
+確認項目:
+
+- `signal_queue` に未処理 `pending` がない
+- `positions` が更新済み
+- `portfolio_performance` に当日分が記録済み
+
+主要コマンド:
+
+```cmd
+python -m kabusys.run_market_close_report --save
+python -m kabusys.run_performance_report --type daily --save
 ```
 
-### 8.3 発動後の確認
+判定:
 
-```
-1. ログで Kill Switch 発動の原因を確認
-2. ポジションを証券口座で直接確認（手動）
-3. python scripts\start_system.py --dry-run で pending シグナル数とポジションを確認
-4. 原因が解消したら FailureRecovery.md §9 に従い復旧
-5. 翌日の Runbook を通常通り実行
-```
+- `OK`: 夜間バッチへ進行可
+- `BLOCKED`: warning 解消まで進めない
+
+出力先:
+
+- `artifacts/market_close/{date}/report.md`
+- `artifacts/performance/live/daily/{date}/report.md`
 
 ---
 
-## 9. 夜間処理確認（21:30〜）
+## 7. 夜間バッチ（15:30-21:00）
 
-以下の Task Scheduler ジョブが正常完了したかを確認する。
+ジョブ:
 
-| ジョブ名 | 実行時刻 | スクリプト | 確認内容 |
-|---------|---------|----------|---------|
-| KabuSys_DataUpdate | 15:30 | `run_data_update.py` | DuckDB に当日データが追加されているか |
-| KabuSys_FeatureGen | 16:00 | `run_feature_gen.py` | `features` テーブルが更新されているか |
-| KabuSys_AiAnalysis | 18:00 | `run_ai_analysis.py` | `news_scores`, `regime_scores` が更新されているか |
-| KabuSys_StrategySignal | 20:00 | `run_strategy_signal.py` | `signals` テーブルに本日の BUY シグナルがあるか |
-| KabuSys_PortfolioConstruction | 21:00 | `run_portfolio_construction.py` | `signal_queue` に `pending` シグナルが入っているか |
+- `run_data_update.py`
+- `run_feature_gen.py`
+- `run_ai_analysis.py`
+- `run_strategy_signal.py`
+- `run_portfolio_construction.py`
 
-**Task Scheduler の実行履歴確認（PowerShell）:**
+Task Scheduler 確認:
 
 ```powershell
 Get-ScheduledTask -TaskName "KabuSys_*" | Get-ScheduledTaskInfo | Select-Object TaskName, LastRunTime, LastTaskResult
 ```
 
-`LastTaskResult = 0` が正常終了。それ以外はログファイルを確認すること。
+---
 
-```powershell
-# 例: AiAnalysis のエラー確認
-Get-Content logs\KabuSys_AiAnalysis.log -Tail 100 | Select-String "ERROR|CRITICAL"
-```
+## 8. Night Batch 判定（21:30）
 
-**夜間バッチ手動再実行（異常時）:**
+主要コマンド:
 
 ```cmd
-# 例: portfolio_construction を手動再実行
-python scripts\run_portfolio_construction.py
+python -m kabusys.run_signal_queue_report
 ```
+
+確認項目:
+
+- 必須ジョブ成功
+- `signals` が生成されている
+- 翌営業日の `signal_queue` が作られている
+- 必要なら warning を確認する
+
+判定の考え方:
+
+- `READY`: 必須ジョブ成功かつ翌営業日の `signal_queue` が作成済み
+- `READY_WITH_WARNINGS`: warning はあるが翌営業日の準備は完了
+- `BLOCKED`: 必須ジョブ失敗または翌営業日の発注準備が未完了
+
+補足:
+
+- 判定ロジック自体は `src/kabusys/operations/night_batch_report.py` に実装済み
+- 現行ツリーでは独立 CLI よりも Task Scheduler 結果確認と `run_signal_queue_report` を運用導線にしている
 
 ---
 
-## 10. 日次レポート確認
-
-Market Close 後（または翌朝）に確認する。
-
-`run_performance_report` で成績サマリーを出力する:
+## 9. 成績レポート
 
 ```cmd
 python -m kabusys.run_performance_report --type daily --save
-```
-
-週次・月次レポートは必要に応じて:
-
-```cmd
 python -m kabusys.run_performance_report --type weekly --save
 python -m kabusys.run_performance_report --type monthly --save
 ```
 
-`paper_trading` 環境の成績を確認する場合:
+Paper 環境:
 
 ```cmd
 python -m kabusys.run_performance_report --type daily --env paper_trading
 ```
 
-レポートは `artifacts/performance/{env}/{type}/{period}/report.md` に保存される。
+出力先:
 
-| 項目 | 確認方法 |
-|------|---------|
-| 日次リターン・累積リターン | `run_performance_report --type daily` |
-| ドローダウン | `run_performance_report --type daily`（サマリー内） |
-| 週次成績 | `run_performance_report --type weekly` |
-| ポジション一覧（詳細） | `positions` テーブル（直接参照） |
-| 取引履歴（詳細） | `orders` テーブル（SQLite、直接参照） |
+- `artifacts/performance/{env}/{type}/{period}/report.md`
 
 ---
 
-## 11. まとめ
+## 10. 参考
 
-このRunbookにより **安定した自動売買運用を実現する。**
-
-関連ドキュメント:
-
-- `FailureRecovery.md` — 障害発生時の詳細復旧手順
-- `Monitoring.md` — 監視基盤の設計
-- `documents/09_Deployment/` — デプロイメント構成
-- `documents/10_Runtime/` — ジョブスケジュール定義
+- `documents/08_Operations/FailureRecovery.md`
+- `documents/08_Operations/Monitoring.md`
+- `documents/10_Runtime/RuntimeJobSchedule.md`
+- `documents/WebManual/D_LiveOperation.md`

--- a/documents/10_Runtime/RuntimeJobSchedule.md
+++ b/documents/10_Runtime/RuntimeJobSchedule.md
@@ -1,428 +1,216 @@
-# RuntimeJobSchedule.md
+# Runtime Job Schedule
 
-## 1. 目的
+- 対象: KabuSys の日次ジョブ構成
+- 前提: Single Windows Node / Windows Task Scheduler
 
-本ドキュメントは、日本株自動売買システムの
-**日次運用スケジュール（Runtime Job Schedule）** を定義する。
+---
 
-目的:
+## 1. 全体像
 
--   夜間バッチ処理の順序定義
--   ザラ場処理の安全運用
--   Execution 環境の保護
--   Windows Task Scheduler の設定指針
+KabuSys は、夜間バッチで翌営業日のシグナルと発注キューを作り、翌朝に Execution / Monitoring を起動してザラ場を監視する構成です。
 
-本システムは **Single Windows Node** で稼働するため、
-処理負荷を時間帯で分離する。
+```text
+15:30  data_update
+16:00  feature_gen
+18:00  ai_analysis
+20:00  strategy_signal
+21:00  portfolio_construction
+21:30  night batch status confirmation
+08:00  pre_market_report
+08:30  execution start
+09:00  monitoring start
+15:00  market_close_report
+```
 
-**本スケジュールは日足スイング戦略専用の設計である。**
-夜間バッチでシグナルを生成し、翌営業日の寄付きで執行する。ザラ場中はシグナル生成を行わない（Execution と Monitoring のみ稼働）。デイトレードやザラ場リバランスには対応しない。
+---
 
-------------------------------------------------------------------------
+## 2. Night Batch
 
-# 2. 日次運用タイムライン
+### 2.1 data_update（15:30）
 
-    15:30  Market Close
-       ↓
-    Night Batch Processing
-       ↓
-    Signal Generation
-       ↓
-    Portfolio Construction
-       ↓
-    Execution Preparation
-       ↓
-    09:00  Market Open
-       ↓
-    Execution Monitoring
-       ↓
-    15:30  Market Close
+役割:
 
-------------------------------------------------------------------------
+- J-Quants 日次データ取得
+- ニュース原文保存
+- DuckDB 更新
 
-# 3. 夜間バッチ（Night Batch）
+主なテーブル:
 
-夜間バッチは **重い計算処理を行う時間帯**。
+- `prices_daily`
+- `fundamentals`
+- `raw_news`
 
-対象処理:
+### 2.2 feature_gen（16:00）
 
--   データ更新
--   特徴量計算
--   AI分析
--   戦略シグナル生成
--   ポートフォリオ構築
+役割:
 
-------------------------------------------------------------------------
+- モメンタム
+- ボラティリティ
+- 流動性
+- その他特徴量
 
-## 3.1 データ更新
+主なテーブル:
 
-**時刻**
+- `features`
 
-    15:30
+### 2.3 ai_analysis（18:00）
 
-ジョブ
+役割:
 
-    data_update_job
+- ニュース sentiment
+- 市場 regime 判定
 
-処理
+主なテーブル:
 
--   J-Quants から株価・財務・銘柄マスタを取得（市場・財務データの唯一の基盤データ源）
--   Yahoo News から補助ニュース記事を取得（RSS、売買判断の主役にしない）
--   データ保存
+- `ai_scores`
+- `market_regime`
 
-更新対象
+### 2.4 strategy_signal（20:00）
 
-    prices_daily
-    news_articles
-    fundamentals
+役割:
 
-------------------------------------------------------------------------
+- BUY / SELL シグナル生成
+- Bear regime / breadth_stop / 決算回避反映
+- `min_holding_days` / `time_exit` / `trailing_stop` を考慮
 
-## 3.1b 適時開示収集（Issue #198 / #199）
+主なテーブル:
 
-> ⚠️ **オプション機能** — `ENABLE_TDNET=true`（`.env`）のときのみ実行されます。デフォルトはスキップ。
+- `signals`
 
-**時刻**
+### 2.5 portfolio_construction（21:00）
 
-    15:35（TDnet） / 15:40（EDINET）
+役割:
 
-ジョブ
+- ポジションサイズ計算
+- 翌営業日発注キュー生成
 
-    tdnet_collection_job
-    edinet_collection_job
+主なテーブル:
 
-処理
+- `signal_queue`
 
--   適時開示情報閲覧サービス (TDnet) から当日の開示一覧を全件取得（先に全件保存・後から参照する方式）
--   EDINET API から有報・四半期報告・大量保有等の法定開示を補完取得
--   開示情報を `raw_disclosures` に保存（冪等: ON CONFLICT DO NOTHING）
+---
 
-更新対象
+## 3. Night Batch 状態確認（21:30）
 
-    raw_disclosures（source='tdnet' / 'edinet'）
+現行運用では、Task Scheduler の結果確認と `signal_queue` の確認を組み合わせて翌営業日の準備完了を判断する。
 
-注意
+```powershell
+Get-ScheduledTask -TaskName "KabuSys_*" | Get-ScheduledTaskInfo | Select-Object TaskName, LastRunTime, LastTaskResult
+```
 
--   `ENABLE_TDNET=false`（デフォルト）の場合、`run_tdnet_collection.py` は即座にスキップされ Core 機能に影響しない
--   TDnet 閲覧サービスには31日掲載制限がある。毎日差分取得で取りこぼしを防ぐ
--   開示分類（`disclosure_events`）は別ジョブ（17:00）で実施する
+```cmd
+python -m kabusys.run_signal_queue_report
+```
 
-------------------------------------------------------------------------
+判定の考え方:
 
-## 3.2 特徴量生成
+- `READY`: 必須ジョブ成功かつ翌営業日の `signal_queue` が作成済み
+- `READY_WITH_WARNINGS`: warning はあるが翌営業日の準備は完了
+- `BLOCKED`: 必須ジョブ失敗または翌営業日の発注準備が未完了
 
-**時刻**
+補足:
 
-    16:00
+- 判定ロジック自体は `src/kabusys/operations/night_batch_report.py` に実装済み
+- 現行ツリーでは独立 CLI よりも Task Scheduler と queue 確認が導線
 
-ジョブ
+---
 
-    feature_generation_job
+## 4. Pre-Market（08:00）
 
-処理
+```cmd
+python -m kabusys.run_pre_market_report --save
+```
 
--   モメンタム
--   ボラティリティ
--   出来高指標
+判定:
 
-保存
+- `READY`
+- `READY_WITH_WARNINGS`
+- `BLOCKED`
 
-    features
+確認対象:
 
-------------------------------------------------------------------------
+- stop flag
+- Task Scheduler readiness
+- Signal Queue
+- ポジション差分
+- データ鮮度
 
-## 3.2b 開示イベント分類
+出力先:
 
-> ⚠️ **オプション機能** — `ENABLE_TDNET=true`（`.env`）のときのみ実行されます。デフォルトはスキップ。
+- `artifacts/pre_market/{date}/report.md`
 
-**時刻**
+---
 
-    17:00
+## 5. Execution / Monitoring
 
-ジョブ
+### 5.1 Execution Start（08:30）
 
-    disclosure_classification_job
+```cmd
+python scripts\start_system.py --component execution
+```
 
-処理
+補足:
 
--   `raw_disclosures` の当日分を表題ベースの分類ルールで評価
--   `event_type`（決算短信/業績修正上方・下方/自己株取得/増資/M&A/訴訟不祥事等）を付与
--   `event_score`（+1.0 / 0.0 / -1.0）・`buy_caution` / `hold_caution` / `review_required` フラグを付与
--   `disclosure_events` に UPSERT
+- `python -m kabusys.run_execution` 実行時に Execution Startup Summary が自動保存される
+- 保存先: `artifacts/execution_startup/{date}/report.md`
 
-更新対象
+### 5.2 Monitoring Start（09:00）
 
-    disclosure_events
+```cmd
+python scripts\start_system.py --component monitoring
+```
 
-------------------------------------------------------------------------
+ザラ場では `execution_service` と `monitoring_service` が動作し、注文・ポジション・リスク状態を監視する。
 
-## 3.3 AI分析
+---
 
-**時刻**
+## 6. Market Close（15:00）
 
-    18:00
+```cmd
+python -m kabusys.run_market_close_report --save
+python -m kabusys.run_performance_report --type daily --save
+```
 
-ジョブ
+判定:
 
-    ai_analysis_job
+- `OK`
+- `BLOCKED`
 
-処理
+出力先:
 
--   ニュースセンチメント分析: score_news(conn, target_date)
-    - raw_news + news_symbols → gpt-4o-mini → 銘柄ごとの sentiment_score
--   市場レジーム判定: score_regime(conn, target_date)
-    - ETF1321の200日MA乖離（70%）+ マクロニュースLLM（30%）→ regime_score / regime_label
+- `artifacts/market_close/{date}/report.md`
+- `artifacts/performance/live/daily/{date}/report.md`
 
-保存
+---
 
-    ai_scores      （sentiment_score: 銘柄単位）
-    market_regime  （regime_score / regime_label: 日次1行）
+## 7. Task Scheduler
 
-------------------------------------------------------------------------
+登録スクリプト:
 
-## 3.4 売買シグナル生成
+- `scripts/setup_task_scheduler.ps1`
 
-**時刻**
+標準ジョブ:
 
-    20:00
+- `KabuSys_DataUpdate`
+- `KabuSys_FeatureGen`
+- `KabuSys_AiAnalysis`
+- `KabuSys_StrategySignal`
+- `KabuSys_PortfolioConstruction`
+- `KabuSys_ExecutionStart`
+- `KabuSys_MonitoringStart`
 
-ジョブ
+---
 
-    strategy_signal_job
+## 8. 補足
 
-処理
+- `market_breadth` は data update / breadth 計算で日次更新される
+- バックテストでは `prices_daily` から再計算して `breadth_stop` を評価する
+- Streamlit ダッシュボードから `WebManual` を参照できる
 
--   戦略スコア算出（モメンタム / バリュー / ボラティリティ / AIスコア統合）
--   セクター相対強弱フィルタ適用
--   ギャップリスクフィルタ適用
--   決算回避・主要イベント縮小判定（`earnings_calendar` / `config/event_calendar.md` 参照）
--   最低保有日数・再エントリー制限判定（`position_entries` テーブル参照）
--   breadth_stop フィルタ適用（`market_breadth` テーブル参照）
--   銘柄ランキング・シグナル書き込み
+---
 
-保存
+## 9. 参考
 
-    signals（side, score, signal_rank, size_multiplier）
-
-------------------------------------------------------------------------
-
-## 3.5 ポートフォリオ生成
-
-**時刻**
-
-    21:00
-
-ジョブ
-
-    portfolio_construction_job
-
-処理
-
--   ポジションサイズ計算
--   リスク制御適用
-
-保存
-
-    signal_queue
-
-------------------------------------------------------------------------
-
-# 4. プレマーケット処理
-
-市場開始前に Execution を起動する。
-
-**時刻**
-
-    08:30
-
-ジョブ
-
-    execution_start
-
-処理
-
--   Execution Engine 起動
--   Signal Queue 読み込み
--   API接続確認
-
-------------------------------------------------------------------------
-
-# 5. ザラ場処理（Market Hours）
-
-ザラ場では **重い処理は禁止**。
-
-稼働プロセス
-
-    execution_service
-    monitoring_service
-
-------------------------------------------------------------------------
-
-## 5.1 Execution Loop
-
-    execution_loop
-
-処理
-
--   pending signal取得
--   発注
--   約定確認
--   ポジション更新
-
-------------------------------------------------------------------------
-
-## 5.2 Monitoring Loop
-
-    monitoring_loop
-
-監視
-
--   Executionプロセス
--   API接続
--   ドローダウン
--   注文エラー
-
-異常時
-
-    LINE Alert
-    Kill Switch
-
-------------------------------------------------------------------------
-
-# 6. Market Close処理
-
-**時刻**
-
-    15:30
-
-ジョブ
-
-    market_close_job
-
-処理
-
--   ポジション更新
--   当日ログ保存
--   パフォーマンス計算
-
-更新テーブル
-
-    positions
-    portfolio_performance
-
-------------------------------------------------------------------------
-
-# 7. Windows Task Scheduler 設定
-
-登録スクリプト: `scripts/setup_task_scheduler.ps1`
-
-  時刻    タスク名                             実行スクリプト
-  ------- ------------------------------------ -----------------------------------------------
-  15:30   KabuSys_DataUpdate                   scripts\run_data_update.py
-  15:33   KabuSys_YahooNewsCollection          scripts\run_yahoonews_collection.py    ※ オプション (ENABLE_YAHOONEWS=true 時のみ実行)
-  15:35   KabuSys_TDnetCollection              scripts\run_tdnet_collection.py        ※ オプション (ENABLE_TDNET=true 時のみ実行)
-  15:40   KabuSys_EdinetCollection             scripts\run_edinet_collection.py       ※ オプション (ENABLE_EDINET=true 時のみ実行)
-  16:00   KabuSys_FeatureGen                   scripts\run_feature_gen.py
-  17:00   KabuSys_DisclosureClassification     scripts\run_disclosure_classification.py ※ オプション (ENABLE_TDNET=true 時のみ実行)
-  18:00   KabuSys_AiAnalysis                   scripts\run_ai_analysis.py
-  20:00   KabuSys_StrategySignal               scripts\run_strategy_signal.py
-  21:00   KabuSys_PortfolioConstruction        scripts\run_portfolio_construction.py
-  08:30   KabuSys_ExecutionStart               scripts\start_system.py --component execution
-  09:00   KabuSys_MonitoringStart              scripts\start_system.py --component monitoring
-
-登録コマンド（プロジェクトルートで実行）:
-
-    powershell -File scripts\setup_task_scheduler.ps1
-
-既存ジョブは `-Force` で上書き登録される。
-
-------------------------------------------------------------------------
-
-# 8. プロセス優先度
-
-Execution環境を保護する。
-
-  プロセス             優先度     起動スクリプト
-  -------------------- -------- -------------------------------------------
-  execution_service    High     scripts\start_system.py --component execution
-  monitoring_service   High     scripts\start_system.py --component monitoring
-  strategy_service     Normal   ライブラリ（夜間バッチから呼び出し）
-  ai_service           Low      ライブラリ（夜間バッチから呼び出し）
-
-各起動スクリプトは `src/kabusys/utils/process_priority.set_process_priority("high")` を
-先頭で呼び出し、OS優先度を設定してからエンジンを初期化する。
-Windows では管理者権限推奨（権限不足時は WARNING ログで続行）。
-
-------------------------------------------------------------------------
-
-# 8.1 停止・制御スクリプト
-
-  スクリプト                     用途
-  ------------------------------ ----------------------------------------------------
-  scripts\start_system.py        execution / monitoring プロセスを起動（PIDファイル書き込み）
-  scripts\stop_system.py         グレースフル停止（10秒タイムアウト後に強制終了）
-  scripts\rebuild_features.py    prices_daily のデータ確認後に特徴量を再計算
-  scripts\reset_signals.py       signal_queue をクリア（未処理シグナルを削除）
-
-停止フラグファイル: `data/stop_requested.flag`
-
-- `stop_system.py` が作成し、`start_system.py` が次回起動時にクリアする。
-- `run_execution.py` と `run_monitoring.py` はメインループでこのフラグを監視してグレースフルに終了する。
-
-PIDファイル:
-
-  プロセス           PIDファイル
-  ------------------ ----------------------
-  execution_service  data/execution.pid
-  monitoring_service data/monitoring.pid
-
-------------------------------------------------------------------------
-
-# 9. 休日・祝日処理
-
-JPXカレンダーを参照する。
-
-    market_calendar
-
-チェック
-
--   is_trading_day
--   is_half_day
--   is_sq_day
-
-非取引日は **Night Batch のみ実行**。
-
-------------------------------------------------------------------------
-
-# 10. 障害対応
-
-異常フロー
-
-    Monitoring
-       ↓
-    Alert
-       ↓
-    Execution Stop
-       ↓
-    Manual Investigation
-
-------------------------------------------------------------------------
-
-# 11. まとめ
-
-Runtime Job Schedule は以下で構成される。
-
-    Night Batch
-       ↓
-    Signal Generation
-       ↓
-    Portfolio Construction
-       ↓
-    Execution Preparation
-       ↓
-    Market Execution
-       ↓
-    Monitoring
-
-このスケジュールにより **Single Windows Node
-環境でも安全で安定した自動売買運用**を実現する。
+- `documents/08_Operations/TradingRunbook.md`
+- `documents/WebManual/A_OperationsCycle.md`
+- `documents/10_Runtime/TODO_OperationsInterfaces.md`

--- a/documents/WebManual/A_Overview.md
+++ b/documents/WebManual/A_Overview.md
@@ -1,132 +1,113 @@
-# A. システム説明・特徴 — WebManual
+# A. 概要・全体像
 
-- **対象**: KabuSys を初めて知る方・利用を検討している方
-- **想定読者**: 運用者・管理者・全員（初読向け）
-- **目的**: KabuSys が何をするシステムなのか、どんなことができるのかを理解する
+- 対象: KabuSys を初めて使う運用者
+- 目的: 何ができるか、どの順で読めばよいかを短く把握する
 
 ---
 
 ## A-1. KabuSys とは何か
 
-KabuSys（カブシス）は、**日本株の自動売買を行う個人向けの自動化システム**です。
+KabuSys は、日本株の日次運用を前提にした自動売買支援システムです。  
+夜間バッチで翌営業日の候補を作り、朝に運用可否を確認し、ザラ場で注文と監視を行い、引け後に結果を記録します。
 
-株の「買い」「売り」の判断から、証券会社への発注・約定確認・リスク管理・日々の運用レポートまで、**すべての工程をプログラムが自動的に行います**。
+前提:
 
-### どんな人のためのシステムか
-
-- 日中は仕事があって株価を見続けられないが、株式投資を自動化したい人
-- 感情的な売買判断をなくし、ルールベースで一貫したトレードを実現したい人
-- 定量的な分析（データ・数値に基づく判断）で売買を行いたい人
-
-### どんな環境で動くか
-
-| 項目 | 内容 |
-|---|---|
-| OS | Windows（kabuステーションAPIがWindows専用のため） |
-| 証券会社 | auカブコム証券（kabuステーションAPI利用） |
-| 市場データ | J-Quants API（日本取引所グループ公式データ） |
-| 実行環境 | 1台のWindows PC（常時起動が前提） |
-
-> ⚠️ KabuSys を使うには、**auカブコム証券の口座**と**kabuステーション®のインストール**が必要です。
+- Windows
+- kabuステーション API
+- J-Quants
 
 ---
 
-## A-2. このシステムで何ができるか（機能一覧）
+## A-2. このシステムで何ができるか
 
-### Core 機能（基本機能）
+Core 機能:
 
-| 機能 | 概要 |
-|---|---|
-| **自動発注** | シグナルに基づき、ザラ場中に自動で買い・売りを発注する |
-| **リスク管理** | ドローダウン超過・資金上限超えなどの危険な状態を検知し、自動で発注を止める |
-| **Kill Switch（緊急停止）** | 異常発生時に即座にすべての自動発注を停止する |
-| **夜間バッチ処理** | 引け後〜翌朝にかけて、翌日の売買シグナルを自動的に計算・準備する |
-| **ペーパートレード** | 実際の資金を使わず、仮想売買でシステムをテストできる |
-| **運用レポート** | 日次・週次・月次の損益・約定履歴・シグナル一覧をレポートとして出力する |
-| **設定検証** | 起動前に設定ファイルの異常を自動チェックする（`validate_config`） |
+- 日次データ更新
+- 特徴量生成
+- AI によるニュース / regime 補助判定
+- 売買シグナル生成
+- ポートフォリオ構築
+- 自動執行
+- リスク管理と Kill Switch
+- 日次 / 週次 / 月次レポート
 
-### オプション機能（有効化で使える機能）
+運用インターフェース:
 
-| 機能 | 概要 | 必要な設定 |
-|---|---|---|
-| **AI センチメント分析** | ニュース記事の内容を AI が読み取り、売買判断スコアに加味する | OpenAI API キー + `ENABLE_AI_SENTIMENT=true` |
-| **LINE 通知** | 発注・約定・エラーなどのイベントを LINE メッセージで通知する | LINE Messaging API + `LINE_NOTIFY_ENABLED=true` |
+- CLI レポート
+- Streamlit ダッシュボード
+- Streamlit 内 WebManual ビュー
 
-> オプション機能は無効（デフォルト）のままでも Core 機能は正常に動作します。
+Streamlit で確認できる主なページ:
 
----
-
-## A-3. どのように売買を決めているか
-
-詳細は [A_StrategyFlow.md](./A_StrategyFlow.md) を参照してください。
-
-要約すると、KabuSys は次の手順で売買を決定します。
-
-1. **スクリーニング** — 対象銘柄（ユニバース）を絞り込む
-2. **スコアリング** — 各銘柄にモメンタム・出来高・財務などの要素で点数をつける
-3. **地合い判定** — 市場全体の地合いが悪いときは新規買いを停止する
-4. **ポジションサイジング** — 点数の高い銘柄を、リスク管理の範囲内で資金配分する
-5. **売り判断** — 保有銘柄の損切り・利確条件を毎日確認し、条件を満たせば売却シグナルを出す
+- `Home`
+- `WebManual`
+- `Signal Queue`
+- `Performance`
+- `Strategy Lab`
 
 ---
 
-## A-4. 1日の動き方（運用サイクル）
+## A-3. 読む順番
 
-詳細は [A_OperationsCycle.md](./A_OperationsCycle.md) を参照してください。
+1. [B_CoreSetup.md](./B_CoreSetup.md)
+2. [A_OperationsCycle.md](./A_OperationsCycle.md)
+3. [C_PaperTrading.md](./C_PaperTrading.md)
+4. [D_LiveOperation.md](./D_LiveOperation.md)
+5. [E_FailureRecovery.md](./E_FailureRecovery.md)
+6. [A_StrategyFlow.md](./A_StrategyFlow.md) — 売買判断の詳細フロー（深掘り用）
 
-要約すると、1日のシステムの動きは以下のとおりです。
+---
 
-```
-【夜間・引け後】
-15:30 〜  市場データ更新（夜間バッチ自動実行）
-16:00 〜  特徴量計算
-18:00 〜  AI ニュース分析（オプション）
-20:00 〜  売買シグナル生成
-21:00 〜  ポートフォリオ構築・翌日の発注候補確定
+## A-4. 1日の流れ
 
-【朝・ザラ場中】
-08:00     Pre-Market チェック（手動確認）
-08:30     Execution Engine 起動（自動発注開始）
-09:00     Monitoring 起動（監視開始）
-09:00〜15:00  ザラ場中の発注・約定確認・監視
-15:00     市場クローズ → 引け後レポート確認
-21:30     夜間バッチ結果確認（手動）
+```text
+15:30  data_update
+16:00  feature_gen
+18:00  ai_analysis
+20:00  strategy_signal
+21:00  portfolio_construction
+21:30  Night Batch 状態確認
+08:00  pre_market_report
+08:30  execution start
+09:00  monitoring start
+15:00  market_close_report
 ```
 
----
+運用判断は、個別ログだけでなく次のレポートで行う。
 
-## A-5. システム全体の構成図
-
-```
-【夜間バッチ処理】
-  J-Quants API → データ更新
-               → 特徴量計算
-  Yahoo News   → AI センチメント分析（オプション）
-               ↓
-          シグナルキュー（DuckDB）
-
-【ザラ場中の自動売買】
-  シグナルキュー
-       ↓（Pull 型）
-  Execution Engine（発注管理）
-       ↓
-  kabuステーション API
-       ↓
-  証券会社（自動発注・約定）
-
-【常時監視】
-  Monitoring System（独立プロセス）
-       ↓
-  異常検知 → LINE 通知（オプション）/ Kill Switch（緊急停止）
-```
-
-> **重要な設計方針**: AI はシグナルを「補助的に」加味するだけであり、発注の最終判断はルールベースのロジックが行います。これにより AI の暴走リスクを防止しています。
+- `run_pre_market_report`
+- Execution Startup Summary（`run_execution.py` 実行時に自動保存）
+- `run_market_close_report`
+- Night Batch 状態確認（Task Scheduler + Signal Queue）
+- `run_performance_report`
 
 ---
 
-## 関連ドキュメント
+## A-5. 画面で見るか、CLI で見るか
 
-- [A_StrategyFlow.md](./A_StrategyFlow.md) — 売買判断の詳細な流れ
-- [A_OperationsCycle.md](./A_OperationsCycle.md) — 1日の運用サイクルの詳細
-- [C_PaperTrading.md](./C_PaperTrading.md) — ペーパートレード（テスト運用）の始め方
-- [B_CoreSetup.md](./B_CoreSetup.md) — 初期導入手順
+CLI が向くもの:
+
+- バッチ結果の明示確認
+- 障害時の詳細確認
+- スクリプト再実行
+
+Streamlit が向くもの:
+
+- 日中監視
+- Signal Queue / Performance の可視化
+- WebManual の横断参照
+
+方針:
+
+- 実処理は CLI / service 側
+- Streamlit は表示と導線
+
+---
+
+## A-6. 関連
+
+- [A_OperationsCycle.md](./A_OperationsCycle.md)
+- [B_CoreSetup.md](./B_CoreSetup.md)
+- [C_PaperTrading.md](./C_PaperTrading.md)
+- [D_LiveOperation.md](./D_LiveOperation.md)
+- [E_FailureRecovery.md](./E_FailureRecovery.md)

--- a/documents/WebManual/D_LiveOperation.md
+++ b/documents/WebManual/D_LiveOperation.md
@@ -1,212 +1,192 @@
-# D. 本番運用 — WebManual
+# D. 本番運用
 
-- **対象**: KabuSys を実際の資金で自動売買として運用する方
-- **想定読者**: ペーパートレードで検証済みの運用者
-- **目的**: 本番環境での日次運用を、毎日の定型手順として安全に実施できるようにする
-
-> ⚠️ **本番運用を開始する前に、必ずペーパートレード（[C_PaperTrading.md](./C_PaperTrading.md)）で動作確認を行ってください。**
+- 対象: `live` 環境で KabuSys を運用する担当者
+- 前提: Paper Trading で一通り確認済み
 
 ---
 
-## D-1. 本番運用を始める前のチェックリスト
+## D-1. 本番切替前チェック
 
-以下がすべて完了していることを確認してください。
-
-- [ ] ペーパートレードで数日間、一連の運用フロー（夜間バッチ→発注→約定確認）が正常に動作している
-- [ ] `.env` の `KABUSYS_ENV` を `paper_trading` から `live` に変更した
-- [ ] `python -m kabusys.validate_config` が `live` 環境でエラーなく完了する
-- [ ] kabuステーション® が本番用パスワード（ポート 18080）でログインできている
-- [ ] `config/risk_config.yaml` のリスクパラメータを実際の運用資金に合わせて設定している
-- [ ] Task Scheduler の全バッチジョブが `Ready` 状態になっている
+- `.env` の `KABUSYS_ENV=live`
+- `python -m kabusys.validate_config`
+- kabuステーション API 接続確認
+- `config/risk_config.yaml` の再確認
+- Task Scheduler の `KabuSys_*` が `Ready`
 
 ---
 
-## D-2. 1日の運用タイムライン
+## D-2. 1日の流れ
 
-```
-07:50  PC・kabuステーション起動確認（手動）
-08:00  Pre-Market Checklist 確認（手動）
-08:30  Execution Engine 起動（Task Scheduler 自動）
-09:00  Monitoring 起動（Task Scheduler 自動）
-       ─────── 前場（09:00〜11:30）───────
-       自動発注・約定確認・リスク監視
-       ─────── 昼休み（11:30〜12:30）─────
-       注文受付停止
-       ─────── 後場（12:30〜15:00）───────
-       自動発注・約定確認・リスク監視
-15:00  市場クローズ → Market Close 確認（手動）
-15:30  市場データ更新バッチ（Task Scheduler 自動）
-16:00  特徴量計算バッチ（Task Scheduler 自動）
-18:00  AI 分析バッチ（Task Scheduler 自動・オプション）
-20:00  売買シグナル生成バッチ（Task Scheduler 自動）
-21:00  ポートフォリオ構築バッチ（Task Scheduler 自動）
-21:30  夜間バッチ結果確認（手動）
+```text
+08:00  Pre-Market
+08:30  Execution 起動
+09:00  Monitoring 起動
+09:00-15:00  ザラ場監視
+15:00  Market Close
+15:30-21:00  夜間バッチ
+21:30  Night Batch 状態確認
 ```
 
 ---
 
-## D-3. 朝の確認（08:00 — Pre-Market Checklist）
+## D-3. 朝の確認（08:00）
 
-市場オープン前に、以下を **すべて** 確認してから Execution を起動します。
+主要コマンド:
 
-| 確認項目 | 内容 | 確認方法 |
-|---|---|---|
-| PC 状態 | スリープ解除済み・正常動作 | 目視 |
-| kabuステーション | 起動・ログイン済み（本番ポート 18080） | 画面確認 |
-| API 接続 | kabuステーション の接続状態 = 正常 | kabuステーション 画面 |
-| 夜間データ | 前日分データが DuckDB に入っている | `data_update` ログ確認 |
-| Signal Queue | 本日の `pending` シグナルが存在する | 下記コマンド |
-| ポジション整合 | DB と証券口座のポジションが一致 | 下記コマンド |
-| 停止フラグ | `data/stop_requested.flag` が存在しない | エクスプローラー確認 |
-| Task Scheduler | 全バッチジョブが `Ready` 状態 | 下記コマンド |
-
-**Signal Queue 確認:**
 ```cmd
+python -m kabusys.run_pre_market_report --save
 python -m kabusys.run_signal_queue_report
-```
-
-**ポジション整合確認:**
-```cmd
 python -m kabusys.run_position_reconciliation_report
 ```
-→ `CLEAN` が表示されれば問題なし。`DISCREPANCY` が出た場合は Execution 起動前に確認すること。
 
-**Task Scheduler 状態確認:**
-```powershell
-Get-ScheduledTask -TaskName "KabuSys_*" | Select-Object TaskName, State
-```
+判定:
+
+- `READY`
+- `READY_WITH_WARNINGS`
+- `BLOCKED`
+
+`BLOCKED` の場合は Execution を開始しない。
+
+出力先:
+
+- `artifacts/pre_market/{date}/report.md`
 
 ---
 
-## D-4. Execution の起動と停止（08:30）
+## D-4. Execution 起動（08:30）
 
-Task Scheduler が自動起動します。手動での起動・停止が必要な場合は以下を使用します。
-
-**手動起動（Execution + Monitoring まとめて）:**
 ```cmd
-python scripts\start_system.py
-```
-
-**Execution のみ起動:**
-```cmd
+python scripts\start_system.py --dry-run
 python scripts\start_system.py --component execution
 ```
 
-**起動前の安全確認（`--dry-run`）:**
-```cmd
-python scripts\start_system.py --dry-run
-```
-発注は行わず、Signal Queue とポジションの状態のみ確認できます。
+補足:
 
-**停止（グレースフルシャットダウン）:**
-```cmd
-python scripts\stop_system.py
-```
+- `python -m kabusys.run_execution` 実行時に Execution Startup Summary が自動保存される
+- 保存先: `artifacts/execution_startup/{date}/report.md`
+
+`orders_no_status > 0` は執行継続不可の扱いにする。
 
 ---
 
-## D-5. ザラ場中の監視（09:00〜15:00）
+## D-5. ザラ場監視（09:00-15:00）
 
-ザラ場中は以下の項目を定期的に目視確認します。
+見るもの:
 
-| 監視項目 | 確認内容 | 異常時の対応 |
-|---|---|---|
-| 注文エラー | `rejected` 注文が連続していないか | ログ確認 → [E. 障害対応](./E_FailureRecovery.md) |
-| API 接続 | kabuステーション の接続状態 | kabuステーション 再起動 |
-| ドローダウン | 日次損失が閾値に近づいていないか | Kill Switch 検討 |
-| Execution プロセス | `data/execution.pid` が存在するか | `start_system.py --component execution` |
+- 注文エラー
+- API エラー
+- ドローダウン
+- Kill Switch
+- ポジション差分
 
-**ログのリアルタイム確認:**
-```powershell
-# Execution ログの直近50行
-Get-Content logs\execution.log -Tail 50
+CLI:
 
-# ERROR / CRITICAL のみ抽出
-Select-String -Path logs\*.log -Pattern "ERROR|CRITICAL"
+```cmd
+python -m kabusys.run_intraday_monitor --watch
 ```
 
-**主要なログキーワード:**
+Streamlit:
 
-| キーワード | 意味 | 対応 |
-|---|---|---|
-| `停止フラグを検知` | グレースフル停止開始 | 正常停止を確認する |
-| `Kill Switch` | 緊急停止発動 | [E-2. 緊急停止](./E_FailureRecovery.md#e-2) を参照 |
-| `position_discrepancies` | ポジション不整合 | [E-4. ポジション不整合](./E_FailureRecovery.md#e-4) を参照 |
-| `CIRCUIT_BREAKER_OPEN` | サーキットブレーカー発動 | [E-3. API 障害](./E_FailureRecovery.md#e-3) を参照 |
+```cmd
+streamlit run src/kabusys/monitoring/streamlit_dashboard.py -- --db data/monitoring.db
+```
+
+使うページ:
+
+- `Home`
+- `WebManual`
+- `Signal Queue`
+- `Performance`
+- `Strategy Lab`
 
 ---
 
-## D-6. 引け後の確認（15:00 — Market Close）
-
-市場クローズ後に以下を確認します。
-
-| 確認項目 | 確認内容 |
-|---|---|
-| 未約定注文 | `signal_queue` に `pending` が残っていないか |
-| ポジション更新 | `positions` テーブルが最新状態か |
-| 当日損益 | `portfolio_performance` に本日分が記録されているか |
+## D-6. 引け後の確認（15:00）
 
 ```cmd
-:: ポジション確認
-duckdb data\kabusys.duckdb "SELECT * FROM positions ORDER BY code"
-
-:: 日次レポート生成（artifacts/ に保存）
+python -m kabusys.run_market_close_report --save
 python -m kabusys.run_performance_report --type daily --save
-
-:: Market Close レポート
-python -m kabusys.run_market_close_report
 ```
+
+判定:
+
+- `OK`: 夜間バッチへ進む
+- `BLOCKED`: warning 解消まで進まない
+
+出力先:
+
+- `artifacts/market_close/{date}/report.md`
+- `artifacts/performance/live/daily/{date}/report.md`
 
 ---
 
 ## D-7. 夜間バッチの確認（21:30）
 
-夜間バッチが正常完了したかを確認します。
-
 ```powershell
-# Task Scheduler の実行結果を一覧表示
 Get-ScheduledTask -TaskName "KabuSys_*" | Get-ScheduledTaskInfo | Select-Object TaskName, LastRunTime, LastTaskResult
 ```
 
-`LastTaskResult = 0` が正常終了です。
-
-| ジョブ名 | 実行時刻 | 確認内容 |
-|---|---|---|
-| KabuSys_DataUpdate | 15:30 | DuckDB に当日の株価データが追加されている |
-| KabuSys_FeatureGen | 16:00 | `features` テーブルが更新されている |
-| KabuSys_AiAnalysis | 18:00 | `news_scores`, `regime_scores` が更新されている（オプション） |
-| KabuSys_StrategySignal | 20:00 | `signals` テーブルに本日の BUY シグナルがある |
-| KabuSys_PortfolioConstruction | 21:00 | `signal_queue` に `pending` シグナルが入っている |
-
-**signal_queue に pending がない場合（翌日の発注候補ゼロ）:**
 ```cmd
 python -m kabusys.run_signal_queue_report
-:: → pending = 0 なら翌日は発注なし（戦略上の条件不成立）
 ```
+
+確認項目:
+
+- 必須ジョブ成功
+- `signals` 生成済み
+- 翌営業日の `signal_queue` 作成済み
+- warning の有無
+
+判定の考え方:
+
+- `READY`: 必須ジョブ成功かつ翌営業日の `signal_queue` が作成済み
+- `READY_WITH_WARNINGS`: warning はあるが翌営業日の準備は完了
+- `BLOCKED`: 必須ジョブ失敗または翌営業日の発注準備が未完了
+
+補足:
+
+- 判定ロジック自体は `src/kabusys/operations/night_batch_report.py` に実装済み
+- 現行ツリーでは独立 CLI よりも Task Scheduler と queue 確認が導線
 
 ---
 
-## D-8. 成績レポートの確認（日次・週次・月次）
-
-成績レポートはいつでも生成できます。
+## D-8. 成績レポート
 
 ```cmd
-:: 日次レポート
 python -m kabusys.run_performance_report --type daily --save
-
-:: 週次レポート
 python -m kabusys.run_performance_report --type weekly --save
-
-:: 月次レポート
 python -m kabusys.run_performance_report --type monthly --save
 ```
 
-レポートは `artifacts/performance/live/` 配下に保存されます。
+保存先:
+
+- `artifacts/performance/live/daily/...`
+- `artifacts/performance/live/weekly/...`
+- `artifacts/performance/live/monthly/...`
 
 ---
 
-## 関連ドキュメント
+## D-9. 異常時
 
-- `documents/08_Operations/TradingRunbook.md` — 日次運用の詳細手順（エンジニア向け完全版）
-- [E_FailureRecovery.md](./E_FailureRecovery.md) — 異常が起きたときの対応
-- [C_PaperTrading.md](./C_PaperTrading.md) — ペーパートレードへの切り替え方
+停止:
+
+```cmd
+python scripts\stop_system.py
+```
+
+再開前:
+
+```cmd
+python scripts\start_system.py --dry-run
+```
+
+詳細は [E_FailureRecovery.md](./E_FailureRecovery.md) を参照。
+
+---
+
+## 関連
+
+- [A_OperationsCycle.md](./A_OperationsCycle.md)
+- [C_PaperTrading.md](./C_PaperTrading.md)
+- [E_FailureRecovery.md](./E_FailureRecovery.md)
+- [documents/08_Operations/TradingRunbook.md](../08_Operations/TradingRunbook.md)

--- a/scripts/run_portfolio_construction.py
+++ b/scripts/run_portfolio_construction.py
@@ -47,12 +47,12 @@ _MAX_UTILIZATION = 0.70
 
 
 def _get_today_return(
-    conn: duckdb.DuckDBPyConnection, target_date: date
+    conn: duckdb.DuckDBPyConnection, target_date: date, env: str
 ) -> float | None:
     row = conn.execute(
         "SELECT daily_return FROM portfolio_performance"
-        " WHERE date = ? AND env = 'live' LIMIT 1",
-        [target_date],
+        " WHERE date = ? AND env = ? LIMIT 1",
+        [target_date, env],
     ).fetchone()
     if row is None or row[0] is None:
         return None
@@ -193,9 +193,10 @@ def main() -> None:
         # LINE 通知（失敗しても例外を伝播させない）
         try:
             notifier = build_notifier(settings)
+            env = settings.env
 
             # 夜の日次通知
-            daily_return = _get_today_return(conn, target_date)
+            daily_return = _get_today_return(conn, target_date, env)
             notifier.send(
                 format_evening_message(
                     inserted=inserted,
@@ -208,11 +209,11 @@ def main() -> None:
             if target_date.weekday() == 4:
                 iso = target_date.isocalendar()
                 week_start = date.fromisocalendar(iso.year, iso.week, 1)
-                weekly_rows = collect_weekly_rows(conn, "live", week_start, target_date)
+                weekly_rows = collect_weekly_rows(conn, env, week_start, target_date)
                 weekly_report = build_report(
                     weekly_rows,
                     report_type="weekly",
-                    env="live",
+                    env=env,
                     from_date=week_start,
                     to_date=target_date,
                 )
@@ -229,12 +230,12 @@ def main() -> None:
             if target_date.day == last_day:
                 month_start = target_date.replace(day=1)
                 monthly_rows = collect_monthly_rows(
-                    conn, "live", month_start, target_date
+                    conn, env, month_start, target_date
                 )
                 monthly_report = build_report(
                     monthly_rows,
                     report_type="monthly",
-                    env="live",
+                    env=env,
                     from_date=month_start,
                     to_date=target_date,
                 )

--- a/scripts/run_portfolio_construction.py
+++ b/scripts/run_portfolio_construction.py
@@ -11,6 +11,7 @@ signals テーブルから当日の BUY シグナルを読み込み、
 
 from __future__ import annotations
 
+import calendar
 import logging
 import os
 import sys
@@ -21,7 +22,19 @@ from pathlib import Path
 import duckdb
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
 from kabusys.config import Settings
+from kabusys.operations.line_reports import (
+    format_evening_message,
+    format_monthly_message,
+    format_weekly_message,
+)
+from kabusys.operations.notifier import build_notifier
+from kabusys.operations.performance_collector import (
+    collect_monthly_rows,
+    collect_weekly_rows,
+)
+from kabusys.operations.performance_report import build_report
 from kabusys.portfolio.portfolio_builder import calc_score_weights, select_candidates
 from kabusys.portfolio.position_sizing import calc_position_sizes
 from kabusys.utils.logging_setup import setup_logging
@@ -31,6 +44,19 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_PORTFOLIO_VALUE = 10_000_000  # 1000万円
 _MAX_UTILIZATION = 0.70
+
+
+def _get_today_return(
+    conn: duckdb.DuckDBPyConnection, target_date: date
+) -> float | None:
+    row = conn.execute(
+        "SELECT daily_return FROM portfolio_performance"
+        " WHERE date = ? AND env = 'live' LIMIT 1",
+        [target_date],
+    ).fetchone()
+    if row is None or row[0] is None:
+        return None
+    return float(row[0])
 
 
 def main() -> None:
@@ -52,6 +78,7 @@ def main() -> None:
             )
             portfolio_value = float(_DEFAULT_PORTFOLIO_VALUE)
         available_cash = portfolio_value * _MAX_UTILIZATION
+        inserted = 0
 
         # 1. 当日の BUY シグナルを取得
         cur = conn.execute(
@@ -63,98 +90,164 @@ def main() -> None:
 
         if not buy_signals:
             logger.info("本日の BUY シグナルが 0 件です。signal_queue を更新しません。")
-            return
+        else:
+            # 2. 銘柄選定・重み計算（メモリ内）
+            candidates = select_candidates(buy_signals)
+            if not candidates:
+                logger.info("銘柄選定結果が 0 件です。signal_queue を更新しません。")
+            else:
+                weights = calc_score_weights(candidates)
+                if not weights:
+                    logger.info(
+                        "重み計算結果が 0 件です。signal_queue を更新しません。"
+                    )
+                else:
+                    # 3. 最新終値を取得（直近の prices_daily から）
+                    codes = [c["code"] for c in candidates]
+                    code_params = ",".join(["?"] * len(codes))
+                    price_cur = conn.execute(
+                        f"""
+                        SELECT p.code, p.close
+                        FROM prices_daily p
+                        INNER JOIN (
+                            SELECT code, MAX(date) AS max_date
+                            FROM prices_daily
+                            WHERE code IN ({code_params})
+                            GROUP BY code
+                        ) latest ON p.code = latest.code AND p.date = latest.max_date
+                        """,
+                        codes,
+                    )
+                    close_prices = {
+                        r[0]: float(r[1])
+                        for r in price_cur.fetchall()
+                        if r[1] is not None
+                    }
 
-        # 2. 銘柄選定・重み計算（メモリ内）
-        candidates = select_candidates(buy_signals)
-        if not candidates:
-            logger.info("銘柄選定結果が 0 件です。signal_queue を更新しません。")
-            return
+                    # 4. 現在のポジション取得
+                    pos_cur = conn.execute(
+                        "SELECT code, size FROM positions WHERE code IN ("
+                        + code_params
+                        + ")",
+                        codes,
+                    )
+                    current_positions = {r[0]: int(r[1]) for r in pos_cur.fetchall()}
 
-        weights = calc_score_weights(candidates)
-        if not weights:
-            logger.info("重み計算結果が 0 件です。signal_queue を更新しません。")
-            return
+                    # 5. ポジションサイズ計算
+                    sizes = calc_position_sizes(
+                        weights=weights,
+                        candidates=candidates,
+                        portfolio_value=portfolio_value,
+                        available_cash=available_cash,
+                        current_positions=current_positions,
+                        open_prices=close_prices,
+                    )
 
-        # 3. 最新終値を取得（直近の prices_daily から）
-        codes = [c["code"] for c in candidates]
-        code_params = ",".join(["?"] * len(codes))
-        price_cur = conn.execute(
-            f"""
-            SELECT p.code, p.close
-            FROM prices_daily p
-            INNER JOIN (
-                SELECT code, MAX(date) AS max_date
-                FROM prices_daily
-                WHERE code IN ({code_params})
-                GROUP BY code
-            ) latest ON p.code = latest.code AND p.date = latest.max_date
-            """,
-            codes,
-        )
-        close_prices = {
-            r[0]: float(r[1]) for r in price_cur.fetchall() if r[1] is not None
-        }
+                    # 6. portfolio_targets / signal_queue をトランザクション内で更新
+                    conn.execute("BEGIN")
+                    try:
+                        conn.execute(
+                            "DELETE FROM portfolio_targets WHERE date = ?",
+                            [target_date],
+                        )
+                        for code, weight in weights.items():
+                            size = sizes.get(code, 0)
+                            conn.execute(
+                                "INSERT INTO portfolio_targets (date, code, target_weight, target_size) VALUES (?,?,?,?)",
+                                [target_date, code, weight, size],
+                            )
 
-        # 4. 現在のポジション取得
-        pos_cur = conn.execute(
-            "SELECT code, size FROM positions WHERE code IN (" + code_params + ")",
-            codes,
-        )
-        current_positions = {r[0]: int(r[1]) for r in pos_cur.fetchall()}
+                        # 7. signal_queue を更新（当日の pending シグナルをクリアして再挿入）
+                        conn.execute(
+                            "DELETE FROM signal_queue WHERE date = ? AND status = 'pending'",
+                            [target_date],
+                        )
+                        for code, shares in sizes.items():
+                            if shares <= 0:
+                                continue
+                            price = close_prices.get(code)
+                            if price is None:
+                                logger.warning(
+                                    "価格不明のため銘柄 %s をスキップします。", code
+                                )
+                                continue
+                            conn.execute(
+                                """INSERT INTO signal_queue
+                                   (signal_id, date, code, side, size, order_type, price, status)
+                                   VALUES (?, ?, ?, 'buy', ?, 'market', ?, 'pending')""",
+                                [str(uuid.uuid4()), target_date, code, shares, price],
+                            )
+                            inserted += 1
 
-        # 5. ポジションサイズ計算
-        sizes = calc_position_sizes(
-            weights=weights,
-            candidates=candidates,
-            portfolio_value=portfolio_value,
-            available_cash=available_cash,
-            current_positions=current_positions,
-            open_prices=close_prices,
-        )
+                        conn.execute("COMMIT")
+                    except Exception:
+                        conn.execute("ROLLBACK")
+                        raise
 
-        # 6. portfolio_targets / signal_queue をトランザクション内で更新
-        conn.execute("BEGIN")
+                    logger.info(
+                        "ポートフォリオ構築完了: %d 銘柄を signal_queue に挿入 (date=%s)",
+                        inserted,
+                        target_date,
+                    )
+
+        # LINE 通知（失敗しても例外を伝播させない）
         try:
-            conn.execute("DELETE FROM portfolio_targets WHERE date = ?", [target_date])
-            for code, weight in weights.items():
-                size = sizes.get(code, 0)
-                conn.execute(
-                    "INSERT INTO portfolio_targets (date, code, target_weight, target_size) VALUES (?,?,?,?)",
-                    [target_date, code, weight, size],
-                )
+            notifier = build_notifier(settings)
 
-            # 7. signal_queue を更新（当日の pending シグナルをクリアして再挿入）
-            conn.execute(
-                "DELETE FROM signal_queue WHERE date = ? AND status = 'pending'",
-                [target_date],
+            # 夜の日次通知
+            daily_return = _get_today_return(conn, target_date)
+            notifier.send(
+                format_evening_message(
+                    inserted=inserted,
+                    report_date=target_date.isoformat(),
+                    daily_return=daily_return,
+                )
             )
-            inserted = 0
-            for code, shares in sizes.items():
-                if shares <= 0:
-                    continue
-                price = close_prices.get(code)
-                if price is None:
-                    logger.warning("価格不明のため銘柄 %s をスキップします。", code)
-                    continue
-                conn.execute(
-                    """INSERT INTO signal_queue
-                       (signal_id, date, code, side, size, order_type, price, status)
-                       VALUES (?, ?, ?, 'buy', ?, 'market', ?, 'pending')""",
-                    [str(uuid.uuid4()), target_date, code, shares, price],
+
+            # 週次通知（金曜日: weekday == 4）
+            if target_date.weekday() == 4:
+                iso = target_date.isocalendar()
+                week_start = date.fromisocalendar(iso.year, iso.week, 1)
+                weekly_rows = collect_weekly_rows(conn, "live", week_start, target_date)
+                weekly_report = build_report(
+                    weekly_rows,
+                    report_type="weekly",
+                    env="live",
+                    from_date=week_start,
+                    to_date=target_date,
                 )
-                inserted += 1
+                notifier.send(
+                    format_weekly_message(
+                        summary=weekly_report.summary,
+                        from_date=week_start.isoformat(),
+                        to_date=target_date.isoformat(),
+                    )
+                )
 
-            conn.execute("COMMIT")
+            # 月次通知（月末）
+            last_day = calendar.monthrange(target_date.year, target_date.month)[1]
+            if target_date.day == last_day:
+                month_start = target_date.replace(day=1)
+                monthly_rows = collect_monthly_rows(
+                    conn, "live", month_start, target_date
+                )
+                monthly_report = build_report(
+                    monthly_rows,
+                    report_type="monthly",
+                    env="live",
+                    from_date=month_start,
+                    to_date=target_date,
+                )
+                notifier.send(
+                    format_monthly_message(
+                        summary=monthly_report.summary,
+                        from_date=month_start.isoformat(),
+                        to_date=target_date.isoformat(),
+                    )
+                )
+
         except Exception:
-            conn.execute("ROLLBACK")
-            raise
-
-        logger.info(
-            "ポートフォリオ構築完了: %d 銘柄を signal_queue に挿入 (date=%s)",
-            inserted,
-            target_date,
-        )
+            logger.warning("LINE 通知に失敗しました", exc_info=True)
 
     except Exception:
         logger.exception("ポートフォリオ構築が失敗しました")

--- a/src/kabusys/operations/line_reports.py
+++ b/src/kabusys/operations/line_reports.py
@@ -1,0 +1,92 @@
+"""line_reports.py — LINE 定期レポートのメッセージ文字列生成。
+
+すべて純粋関数。送信は呼び出し元（run_execution.py 等）が行う。
+"""
+
+from __future__ import annotations
+
+
+def _fmt_rate(value: float | None) -> str:
+    if value is None:
+        return "N/A"
+    return f"{value * 100:+.1f}%"
+
+
+def _fmt_yen(value: float | None) -> str:
+    if value is None:
+        return "N/A"
+    return f"{value:,.0f} 円"
+
+
+def format_morning_message(
+    *,
+    status: str,
+    orders_no_status: int,
+    pending_count: int,
+    report_date: str,
+) -> str:
+    """Execution 起動完了時の朝通知メッセージを生成する。"""
+    lines = [
+        f"【KabuSys 朝】{report_date}",
+        f"ステータス: {status}",
+        f"pending シグナル: {pending_count} 件",
+    ]
+    if orders_no_status > 0:
+        lines.append(f"⚠ ステータス不明の注文: {orders_no_status} 件（要確認）")
+    return "\n".join(lines)
+
+
+def format_evening_message(
+    *,
+    inserted: int,
+    report_date: str,
+    daily_return: float | None = None,
+) -> str:
+    """portfolio_construction 完了後の夜通知メッセージを生成する。"""
+    lines = [
+        f"【KabuSys 夜】{report_date}",
+        f"翌日シグナル: {inserted} 件",
+        f"当日リターン: {_fmt_rate(daily_return)}",
+    ]
+    return "\n".join(lines)
+
+
+def _format_periodic_message(
+    label: str,
+    *,
+    summary: dict[str, float | None],
+    from_date: str,
+    to_date: str,
+) -> str:
+    lines = [
+        f"【KabuSys {label}】{from_date} 〜 {to_date}",
+        f"累積リターン: {_fmt_rate(summary.get('cumulative_return'))}",
+        f"最大ドローダウン: {_fmt_rate(summary.get('max_drawdown'))}",
+        f"勝率: {_fmt_rate(summary.get('win_rate'))}",
+        f"期末資産: {_fmt_yen(summary.get('equity_end'))}",
+    ]
+    return "\n".join(lines)
+
+
+def format_weekly_message(
+    *,
+    summary: dict[str, float | None],
+    from_date: str,
+    to_date: str,
+) -> str:
+    """週次サマリ通知メッセージを生成する。"""
+    return _format_periodic_message(
+        "週次", summary=summary, from_date=from_date, to_date=to_date
+    )
+
+
+def format_monthly_message(
+    *,
+    summary: dict[str, float | None],
+    from_date: str,
+    to_date: str,
+) -> str:
+    """月次サマリ通知メッセージを生成する。"""
+    return _format_periodic_message(
+        "月次", summary=summary, from_date=from_date, to_date=to_date
+    )

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -35,10 +35,20 @@ from kabusys.operations.execution_startup_report import (  # noqa: E402
     save_report,
 )
 from kabusys.monitoring.monitoring_db import init_monitoring_db  # noqa: E402
+from kabusys.operations.line_reports import format_morning_message  # noqa: E402
+from kabusys.operations.notifier import build_notifier  # noqa: E402
 from kabusys.utils.logging_setup import setup_logging  # noqa: E402
 from kabusys.utils.process_priority import set_process_priority  # noqa: E402
 
 logger = logging.getLogger(__name__)
+
+
+def _count_pending_signals(conn: duckdb.DuckDBPyConnection, target_date: date) -> int:
+    row = conn.execute(
+        "SELECT COUNT(*) FROM signal_queue WHERE date = ? AND status = 'pending'",
+        [target_date],
+    ).fetchone()
+    return int(row[0]) if row else 0
 
 
 def _load_risk_config(path: Path, initial_portfolio_value: float) -> RiskConfig:
@@ -278,6 +288,7 @@ def main() -> None:
         # 起動時リコンシリエーション + Execution Startup Summary 生成
         today = date.today()
         reconcile_result = reconciler.run()
+        _report = None
         try:
             _report = build_report(
                 reconcile_result=reconcile_result, startup_date=today
@@ -288,6 +299,24 @@ def main() -> None:
             logger.warning(
                 "Execution Startup Summary の生成に失敗しました（起動を続行します）",
                 exc_info=True,
+            )
+
+        # 朝の LINE 通知（失敗しても起動を継続する）
+        try:
+            notifier = build_notifier(settings)
+            pending_count = _count_pending_signals(duckdb_conn, today)
+            status = _report.status if _report is not None else "UNKNOWN"
+            orders_no_status = _report.orders_no_status if _report is not None else 0
+            msg = format_morning_message(
+                status=status,
+                orders_no_status=orders_no_status,
+                pending_count=pending_count,
+                report_date=today.isoformat(),
+            )
+            notifier.send(msg)
+        except Exception:
+            logger.warning(
+                "朝の LINE 通知に失敗しました（起動を続行します）", exc_info=True
             )
 
         # 5. ExecutionEngine 起動（reconciliation は上で完了済みのため reconciler=None）

--- a/tests/test_line_reports.py
+++ b/tests/test_line_reports.py
@@ -184,3 +184,38 @@ class TestCountPendingSignals:
         conn.execute.return_value.fetchone.return_value = (0,)
         result = _count_pending_signals(conn, date(2026, 5, 7))
         assert result == 0
+
+
+class TestGetTodayReturn:
+    def test_returns_float_when_row_exists(self):
+        from datetime import date
+        from unittest.mock import MagicMock
+
+        from scripts.run_portfolio_construction import _get_today_return
+
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (0.032,)
+        result = _get_today_return(conn, date(2026, 5, 7))
+        assert result == 0.032
+
+    def test_returns_none_when_no_row(self):
+        from datetime import date
+        from unittest.mock import MagicMock
+
+        from scripts.run_portfolio_construction import _get_today_return
+
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = None
+        result = _get_today_return(conn, date(2026, 5, 7))
+        assert result is None
+
+    def test_returns_none_when_value_is_null(self):
+        from datetime import date
+        from unittest.mock import MagicMock
+
+        from scripts.run_portfolio_construction import _get_today_return
+
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (None,)
+        result = _get_today_return(conn, date(2026, 5, 7))
+        assert result is None

--- a/tests/test_line_reports.py
+++ b/tests/test_line_reports.py
@@ -158,3 +158,29 @@ class TestFormatMonthlyMessage:
         )
         assert isinstance(msg, str)
         assert len(msg) > 0
+
+
+# run_execution の朝通知ヘルパーのテスト
+from unittest.mock import MagicMock
+
+
+class TestCountPendingSignals:
+    def test_returns_count_from_db(self):
+        from datetime import date
+
+        from kabusys.run_execution import _count_pending_signals
+
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (5,)
+        result = _count_pending_signals(conn, date(2026, 5, 7))
+        assert result == 5
+
+    def test_returns_zero_when_no_rows(self):
+        from datetime import date
+
+        from kabusys.run_execution import _count_pending_signals
+
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (0,)
+        result = _count_pending_signals(conn, date(2026, 5, 7))
+        assert result == 0

--- a/tests/test_line_reports.py
+++ b/tests/test_line_reports.py
@@ -1,0 +1,160 @@
+"""tests/test_line_reports.py — LINE 定期レポートメッセージ生成テスト"""
+
+from __future__ import annotations
+
+from kabusys.operations.line_reports import (
+    format_evening_message,
+    format_monthly_message,
+    format_morning_message,
+    format_weekly_message,
+)
+
+
+class TestFormatMorningMessage:
+    def test_ready_with_pending(self):
+        msg = format_morning_message(
+            status="READY",
+            orders_no_status=0,
+            pending_count=3,
+            report_date="2026-05-07",
+        )
+        assert "2026-05-07" in msg
+        assert "READY" in msg
+        assert "3" in msg
+
+    def test_blocked_shows_orders_no_status(self):
+        msg = format_morning_message(
+            status="BLOCKED",
+            orders_no_status=2,
+            pending_count=0,
+            report_date="2026-05-07",
+        )
+        assert "BLOCKED" in msg
+        assert "2" in msg
+
+    def test_ready_with_warnings(self):
+        msg = format_morning_message(
+            status="READY_WITH_WARNINGS",
+            orders_no_status=0,
+            pending_count=1,
+            report_date="2026-05-07",
+        )
+        assert "READY_WITH_WARNINGS" in msg
+
+    def test_zero_pending(self):
+        msg = format_morning_message(
+            status="READY",
+            orders_no_status=0,
+            pending_count=0,
+            report_date="2026-05-07",
+        )
+        assert "0" in msg
+
+
+class TestFormatEveningMessage:
+    def test_with_daily_return(self):
+        msg = format_evening_message(
+            inserted=4,
+            report_date="2026-05-07",
+            daily_return=0.032,
+        )
+        assert "2026-05-07" in msg
+        assert "4" in msg
+        assert "3.2" in msg
+
+    def test_negative_daily_return(self):
+        msg = format_evening_message(
+            inserted=2,
+            report_date="2026-05-07",
+            daily_return=-0.015,
+        )
+        assert "-1.5" in msg
+
+    def test_no_daily_return(self):
+        msg = format_evening_message(
+            inserted=0,
+            report_date="2026-05-07",
+            daily_return=None,
+        )
+        assert "2026-05-07" in msg
+        assert "0" in msg
+
+    def test_return_is_string(self):
+        msg = format_evening_message(
+            inserted=3,
+            report_date="2026-05-07",
+            daily_return=0.01,
+        )
+        assert isinstance(msg, str)
+        assert len(msg) > 0
+
+
+class TestFormatWeeklyMessage:
+    def test_with_full_summary(self):
+        summary = {
+            "cumulative_return": 0.032,
+            "max_drawdown": -0.015,
+            "win_rate": 0.6,
+            "equity_start": 10_000_000,
+            "equity_end": 10_320_000,
+        }
+        msg = format_weekly_message(
+            summary=summary,
+            from_date="2026-04-28",
+            to_date="2026-05-02",
+        )
+        assert "2026-04-28" in msg
+        assert "2026-05-02" in msg
+        assert "3.2" in msg
+        assert "60.0" in msg
+
+    def test_with_none_values(self):
+        summary = {
+            "cumulative_return": None,
+            "max_drawdown": None,
+            "win_rate": None,
+            "equity_start": None,
+            "equity_end": None,
+        }
+        msg = format_weekly_message(
+            summary=summary,
+            from_date="2026-04-28",
+            to_date="2026-05-02",
+        )
+        assert isinstance(msg, str)
+        assert len(msg) > 0
+
+
+class TestFormatMonthlyMessage:
+    def test_with_full_summary(self):
+        summary = {
+            "cumulative_return": 0.058,
+            "max_drawdown": -0.023,
+            "win_rate": 0.553,
+            "equity_start": 10_000_000,
+            "equity_end": 10_580_000,
+        }
+        msg = format_monthly_message(
+            summary=summary,
+            from_date="2026-04-01",
+            to_date="2026-04-30",
+        )
+        assert "2026-04-01" in msg
+        assert "5.8" in msg
+        assert "55.3" in msg
+
+    def test_with_none_values(self):
+        summary = {
+            "cumulative_return": None,
+            "max_drawdown": None,
+            "win_rate": None,
+            "equity_start": None,
+            "equity_end": None,
+        }
+        msg = format_monthly_message(
+            summary=summary,
+            from_date="2026-04-01",
+            to_date="2026-04-30",
+        )
+        assert isinstance(msg, str)
+        assert len(msg) > 0

--- a/tests/test_line_reports.py
+++ b/tests/test_line_reports.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from datetime import date
+from unittest.mock import MagicMock
+
 from kabusys.operations.line_reports import (
     format_evening_message,
     format_monthly_message,
@@ -161,13 +164,8 @@ class TestFormatMonthlyMessage:
 
 
 # run_execution の朝通知ヘルパーのテスト
-from unittest.mock import MagicMock
-
-
 class TestCountPendingSignals:
     def test_returns_count_from_db(self):
-        from datetime import date
-
         from kabusys.run_execution import _count_pending_signals
 
         conn = MagicMock()
@@ -176,8 +174,6 @@ class TestCountPendingSignals:
         assert result == 5
 
     def test_returns_zero_when_no_rows(self):
-        from datetime import date
-
         from kabusys.run_execution import _count_pending_signals
 
         conn = MagicMock()
@@ -188,9 +184,6 @@ class TestCountPendingSignals:
 
 class TestGetTodayReturn:
     def test_returns_float_when_row_exists(self):
-        from datetime import date
-        from unittest.mock import MagicMock
-
         from scripts.run_portfolio_construction import _get_today_return
 
         conn = MagicMock()
@@ -199,9 +192,6 @@ class TestGetTodayReturn:
         assert result == 0.032
 
     def test_returns_none_when_no_row(self):
-        from datetime import date
-        from unittest.mock import MagicMock
-
         from scripts.run_portfolio_construction import _get_today_return
 
         conn = MagicMock()
@@ -210,9 +200,6 @@ class TestGetTodayReturn:
         assert result is None
 
     def test_returns_none_when_value_is_null(self):
-        from datetime import date
-        from unittest.mock import MagicMock
-
         from scripts.run_portfolio_construction import _get_today_return
 
         conn = MagicMock()

--- a/tests/test_line_reports.py
+++ b/tests/test_line_reports.py
@@ -181,6 +181,14 @@ class TestCountPendingSignals:
         result = _count_pending_signals(conn, date(2026, 5, 7))
         assert result == 0
 
+    def test_returns_zero_when_fetchone_is_none(self):
+        from kabusys.run_execution import _count_pending_signals
+
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = None
+        result = _count_pending_signals(conn, date(2026, 5, 7))
+        assert result == 0
+
 
 class TestGetTodayReturn:
     def test_returns_float_when_row_exists(self):
@@ -188,7 +196,7 @@ class TestGetTodayReturn:
 
         conn = MagicMock()
         conn.execute.return_value.fetchone.return_value = (0.032,)
-        result = _get_today_return(conn, date(2026, 5, 7))
+        result = _get_today_return(conn, date(2026, 5, 7), "live")
         assert result == 0.032
 
     def test_returns_none_when_no_row(self):
@@ -196,7 +204,7 @@ class TestGetTodayReturn:
 
         conn = MagicMock()
         conn.execute.return_value.fetchone.return_value = None
-        result = _get_today_return(conn, date(2026, 5, 7))
+        result = _get_today_return(conn, date(2026, 5, 7), "live")
         assert result is None
 
     def test_returns_none_when_value_is_null(self):
@@ -204,5 +212,5 @@ class TestGetTodayReturn:
 
         conn = MagicMock()
         conn.execute.return_value.fetchone.return_value = (None,)
-        result = _get_today_return(conn, date(2026, 5, 7))
+        result = _get_today_return(conn, date(2026, 5, 7), "live")
         assert result is None


### PR DESCRIPTION
## Summary

- `src/kabusys/operations/line_reports.py` を新規作成 — 朝/夜/週次/月次の LINE メッセージを生成する純粋関数 4 本
- `src/kabusys/run_execution.py` に朝通知を追加 — 起動時に `_count_pending_signals()` でシグナル件数を取得し、エンジンステータスと合わせて LINE 送信
- `scripts/run_portfolio_construction.py` に夜通知・週次通知・月次通知を追加 — 完了後に当日リターンを含む夜通知を毎日送信、金曜日に週次サマリ、月末に月次サマリを送信

## Details

- `LineNotifier` / `NullNotifier` / `build_notifier()` は Issue #196 で実装済みの基盤を活用
- `LINE_NOTIFY_ENABLED=false` のとき `NullNotifier.send()` が呼ばれるだけで Core 機能に影響しない
- すべての通知呼び出しは `try/except Exception` でラップし、通知失敗でも Core 処理が継続する
- 0 シグナル日でも夜通知は送信される（`inserted=0` として通知）

## Test Plan

- [x] `tests/test_line_reports.py` 17 件新規追加（メッセージ生成関数 12 件 + ヘルパー 5 件）
- [x] 全テスト 1604 件通過
- [x] ruff check / ruff format — all clean

Closes #256