### PR TITLE
feat: 夜間バッチレポートを運用フローに接続する (Issue #263)

### DIFF
--- a/scripts/run_ai_analysis.py
+++ b/scripts/run_ai_analysis.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 import sys
-from datetime import date
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 import duckdb
@@ -18,10 +18,14 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 from kabusys.config import Settings
 from kabusys.ai.news_nlp import score_news
 from kabusys.ai.regime_detector import score_regime
+from kabusys.operations.job_run_recorder import write_job_result
+from kabusys.operations.night_batch_report import JobRunResult
 from kabusys.utils.logging_setup import setup_logging
 
 setup_logging(app_name="ai_analysis")
 logger = logging.getLogger(__name__)
+
+_JOB_NAME = "ai_analysis_job"
 
 
 def main() -> None:
@@ -29,23 +33,52 @@ def main() -> None:
     conn = duckdb.connect(str(settings.duckdb_path))
     target_date = date.today()
     api_key = getattr(settings, "openai_api_key", None)
+    started_at = datetime.now(timezone.utc)
+    _failed = False
+    _errors: list[str] = []
+    _updated_rows: dict[str, int] = {}
 
     try:
         try:
             n_news = score_news(conn, target_date, api_key=api_key)
+            _updated_rows["ai_scores"] = n_news
             logger.info("score_news 完了: %d 件スコア (date=%s)", n_news, target_date)
-        except Exception:
+        except Exception as exc:
             logger.exception("score_news が失敗しました")
-            sys.exit(1)
+            _errors.append(f"score_news: {exc}")
+            _failed = True
 
-        try:
-            n_regime = score_regime(conn, target_date, api_key=api_key)
-            logger.info("score_regime 完了: %d 件 (date=%s)", n_regime, target_date)
-        except Exception:
-            logger.exception("score_regime が失敗しました")
-            sys.exit(1)
+        if not _failed:
+            try:
+                n_regime = score_regime(conn, target_date, api_key=api_key)
+                _updated_rows["market_regime"] = n_regime
+                logger.info("score_regime 完了: %d 件 (date=%s)", n_regime, target_date)
+            except Exception as exc:
+                logger.exception("score_regime が失敗しました")
+                _errors.append(f"score_regime: {exc}")
+                _failed = True
     finally:
         conn.close()
+
+    finished_at = datetime.now(timezone.utc)
+    try:
+        write_job_result(
+            JobRunResult(
+                job_name=_JOB_NAME,
+                status="failed" if _failed else "success",
+                started_at=started_at,
+                finished_at=finished_at,
+                duration_sec=(finished_at - started_at).total_seconds(),
+                updated_rows=_updated_rows,
+                warnings=[],
+                errors=_errors,
+            )
+        )
+    except Exception:
+        logger.warning("JobRunResult の書き出しに失敗しました", exc_info=True)
+
+    if _failed:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/run_ai_analysis.py
+++ b/scripts/run_ai_analysis.py
@@ -29,11 +29,11 @@ _JOB_NAME = "ai_analysis_job"
 
 
 def main() -> None:
+    started_at = datetime.now(timezone.utc)
     settings = Settings()
     conn = duckdb.connect(str(settings.duckdb_path))
     target_date = date.today()
     api_key = getattr(settings, "openai_api_key", None)
-    started_at = datetime.now(timezone.utc)
     _failed = False
     _errors: list[str] = []
     _updated_rows: dict[str, int] = {}

--- a/scripts/run_data_update.py
+++ b/scripts/run_data_update.py
@@ -28,10 +28,11 @@ _JOB_NAME = "data_update_job"
 
 
 def main() -> None:
+    started_at = datetime.now(timezone.utc)
     settings = Settings()
     conn = duckdb.connect(str(settings.duckdb_path))
-    started_at = datetime.now(timezone.utc)
     _failed = False
+    _has_warnings = False
     _errors: list[str] = []
     _updated_rows: dict[str, int] = {}
 
@@ -42,6 +43,7 @@ def main() -> None:
         if result.errors:
             logger.warning("ETL 完了（エラーあり）: %s", result.errors)
             _errors.extend(result.errors)
+            _has_warnings = True
         else:
             logger.info("ETL 完了")
 
@@ -69,7 +71,9 @@ def main() -> None:
         write_job_result(
             JobRunResult(
                 job_name=_JOB_NAME,
-                status="failed" if _failed else "success",
+                status="failed"
+                if _failed
+                else ("warning" if _has_warnings else "success"),
                 started_at=started_at,
                 finished_at=finished_at,
                 duration_sec=(finished_at - started_at).total_seconds(),

--- a/scripts/run_data_update.py
+++ b/scripts/run_data_update.py
@@ -51,6 +51,7 @@ def main() -> None:
         if max_date_row and max_date_row[0]:
             target_date = max_date_row[0]
             breadth_result = calc_and_save_breadth(conn, target_date)
+            _updated_rows["market_breadth"] = breadth_result
             if breadth_result == 1:
                 logger.info("breadth 挿入完了: date=%s", target_date)
             else:

--- a/scripts/run_data_update.py
+++ b/scripts/run_data_update.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 import duckdb
@@ -16,26 +17,34 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 from kabusys.config import Settings
 from kabusys.data.breadth import calc_and_save_breadth
 from kabusys.data.pipeline import run_daily_etl
+from kabusys.operations.job_run_recorder import write_job_result
+from kabusys.operations.night_batch_report import JobRunResult
 from kabusys.utils.logging_setup import setup_logging
 
 setup_logging(app_name="data_update")
 logger = logging.getLogger(__name__)
 
+_JOB_NAME = "data_update_job"
+
 
 def main() -> None:
     settings = Settings()
     conn = duckdb.connect(str(settings.duckdb_path))
+    started_at = datetime.now(timezone.utc)
+    _failed = False
+    _errors: list[str] = []
+    _updated_rows: dict[str, int] = {}
+
     try:
-        # ETL: 当日の価格データを取得して prices_daily に追加
         result = run_daily_etl(conn)
+        _updated_rows["prices_daily"] = result.prices_saved
+        _updated_rows["fundamentals"] = result.financials_saved
         if result.errors:
             logger.warning("ETL 完了（エラーあり）: %s", result.errors)
+            _errors.extend(result.errors)
         else:
             logger.info("ETL 完了")
 
-        # ETL で挿入された最新日付を target_date として breadth を計算
-        # （内部計算は WHERE date < target_date のため前日以前のデータを使用し、
-        #   計算結果は market_breadth.date = target_date（当日）として保存する）
         max_date_row = conn.execute("SELECT MAX(date) FROM prices_daily").fetchone()
         if max_date_row and max_date_row[0]:
             target_date = max_date_row[0]
@@ -48,11 +57,32 @@ def main() -> None:
                 )
         else:
             logger.warning("breadth 計算スキップ: prices_daily にデータなし")
-    except Exception:
+    except Exception as exc:
         logger.exception("data_update バッチが失敗しました")
-        sys.exit(1)
+        _errors.append(str(exc))
+        _failed = True
     finally:
         conn.close()
+
+    finished_at = datetime.now(timezone.utc)
+    try:
+        write_job_result(
+            JobRunResult(
+                job_name=_JOB_NAME,
+                status="failed" if _failed else "success",
+                started_at=started_at,
+                finished_at=finished_at,
+                duration_sec=(finished_at - started_at).total_seconds(),
+                updated_rows=_updated_rows,
+                warnings=[],
+                errors=_errors,
+            )
+        )
+    except Exception:
+        logger.warning("JobRunResult の書き出しに失敗しました", exc_info=True)
+
+    if _failed:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/run_feature_gen.py
+++ b/scripts/run_feature_gen.py
@@ -8,32 +8,63 @@ from __future__ import annotations
 
 import logging
 import sys
-from datetime import date
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 import duckdb
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 from kabusys.config import Settings
+from kabusys.operations.job_run_recorder import write_job_result
+from kabusys.operations.night_batch_report import JobRunResult
 from kabusys.strategy.feature_engineering import build_features
 from kabusys.utils.logging_setup import setup_logging
 
 setup_logging(app_name="feature_gen")
 logger = logging.getLogger(__name__)
 
+_JOB_NAME = "feature_generation_job"
+
 
 def main() -> None:
     settings = Settings()
     conn = duckdb.connect(str(settings.duckdb_path))
+    started_at = datetime.now(timezone.utc)
+    _failed = False
+    _errors: list[str] = []
+    _updated_rows: dict[str, int] = {}
+
     try:
         target_date = date.today()
         n = build_features(conn, target_date)
+        _updated_rows["features"] = n
         logger.info("特徴量生成完了: %d 件 (date=%s)", n, target_date)
-    except Exception:
+    except Exception as exc:
         logger.exception("build_features が失敗しました")
-        sys.exit(1)
+        _errors.append(str(exc))
+        _failed = True
     finally:
         conn.close()
+
+    finished_at = datetime.now(timezone.utc)
+    try:
+        write_job_result(
+            JobRunResult(
+                job_name=_JOB_NAME,
+                status="failed" if _failed else "success",
+                started_at=started_at,
+                finished_at=finished_at,
+                duration_sec=(finished_at - started_at).total_seconds(),
+                updated_rows=_updated_rows,
+                warnings=[],
+                errors=_errors,
+            )
+        )
+    except Exception:
+        logger.warning("JobRunResult の書き出しに失敗しました", exc_info=True)
+
+    if _failed:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/run_feature_gen.py
+++ b/scripts/run_feature_gen.py
@@ -27,9 +27,9 @@ _JOB_NAME = "feature_generation_job"
 
 
 def main() -> None:
+    started_at = datetime.now(timezone.utc)
     settings = Settings()
     conn = duckdb.connect(str(settings.duckdb_path))
-    started_at = datetime.now(timezone.utc)
     _failed = False
     _errors: list[str] = []
     _updated_rows: dict[str, int] = {}

--- a/scripts/run_night_batch_report.py
+++ b/scripts/run_night_batch_report.py
@@ -1,0 +1,223 @@
+"""scripts/run_night_batch_report.py
+
+夜間バッチ結果確認レポートの生成ランナー。
+
+artifacts/job_runs/{date}/ から JobRunResult を読み込み、
+DuckDB からカウントを取得してレポートを生成・保存する。
+Task Scheduler または手動実行で使用する。
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+import duckdb
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+from kabusys.config import Settings
+from kabusys.operations.job_run_recorder import read_job_results
+from kabusys.operations.night_batch_report import (
+    JobRunResult,
+    NextDaySummary,
+    UpdateCounts,
+    build_report,
+    format_cli_summary,
+    save_report,
+)
+from kabusys.utils.logging_setup import setup_logging
+
+setup_logging(app_name="night_batch_report")
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# ヘルパー関数
+# ---------------------------------------------------------------------------
+
+
+def load_job_results_or_empty(
+    run_date: date,
+    base_dir: Path | None = None,
+) -> list[JobRunResult]:
+    """read_job_results を呼び出し、例外が発生した場合は空リストを返す。"""
+    try:
+        return read_job_results(run_date, base_dir=base_dir)
+    except Exception:
+        logger.warning(
+            "JobRunResult の読み込みに失敗しました。空リストで続行します。",
+            exc_info=True,
+        )
+        return []
+
+
+def _count_table(
+    conn: duckdb.DuckDBPyConnection,
+    table: str,
+    run_date: date,
+) -> int:
+    """指定テーブルの run_date 行数を返す。テーブルが存在しない場合は 0 を返す。"""
+    try:
+        row = conn.execute(
+            f"SELECT COUNT(*) FROM {table} WHERE date = ?",  # noqa: S608
+            [run_date],
+        ).fetchone()
+        return int(row[0]) if row else 0
+    except Exception:
+        return 0
+
+
+def collect_update_counts(
+    conn: duckdb.DuckDBPyConnection,
+    run_date: date,
+) -> UpdateCounts:
+    """DB から各テーブルの run_date 行数を取得して UpdateCounts を返す。
+
+    存在しないテーブルへのクエリは 0 として扱う。
+    """
+    return UpdateCounts(
+        prices_daily=_count_table(conn, "prices_daily", run_date),
+        news_articles=_count_table(conn, "news_articles", run_date),
+        fundamentals=_count_table(conn, "fundamentals", run_date),
+        features=_count_table(conn, "features", run_date),
+        ai_scores=_count_table(conn, "ai_scores", run_date),
+        signals=_count_table(conn, "signals", run_date),
+        signal_queue=_count_table(conn, "signal_queue", run_date),
+    )
+
+
+def collect_next_day_summary(
+    conn: duckdb.DuckDBPyConnection,
+    run_date: date,
+) -> NextDaySummary:
+    """DB からシグナル情報を取得して NextDaySummary を返す。
+
+    buy/sell カウントは signals テーブルから取得する。
+    テーブルが存在しない場合は 0 として扱う。
+    """
+    buy_count = 0
+    sell_count = 0
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) FROM signals WHERE date = ? AND side = 'buy'",
+            [run_date],
+        ).fetchone()
+        buy_count = int(row[0]) if row else 0
+    except Exception:
+        pass
+
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) FROM signals WHERE date = ? AND side = 'sell'",
+            [run_date],
+        ).fetchone()
+        sell_count = int(row[0]) if row else 0
+    except Exception:
+        pass
+
+    return NextDaySummary(
+        buy_count=buy_count,
+        sell_count=sell_count,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI 引数パース
+# ---------------------------------------------------------------------------
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="夜間バッチ結果確認レポートを生成する。",
+    )
+    parser.add_argument(
+        "--db",
+        metavar="PATH",
+        default=None,
+        help="DuckDB ファイルのパス（省略時は Settings().duckdb_path）",
+    )
+    parser.add_argument(
+        "--date",
+        metavar="DATE",
+        default=None,
+        help="実行日（YYYY-MM-DD 形式、省略時は今日）",
+    )
+    parser.add_argument(
+        "--output-dir",
+        metavar="DIR",
+        default=None,
+        help="レポート JSON の保存先ディレクトリ（省略時: artifacts/reports）",
+    )
+    parser.add_argument(
+        "--job-runs-dir",
+        metavar="DIR",
+        default=None,
+        help="ジョブ実行 JSON の読み込み元ディレクトリ（省略時: artifacts/job_runs）",
+    )
+    return parser.parse_args()
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    args = _parse_args()
+
+    run_date = date.fromisoformat(args.date) if args.date else date.today()
+    logger.info("レポート生成開始: run_date=%s", run_date)
+
+    # --- JobRunResult 読み込み ---
+    job_runs_base = Path(args.job_runs_dir) if args.job_runs_dir else None
+    job_results = load_job_results_or_empty(run_date, base_dir=job_runs_base)
+    logger.info("JobRunResult 読み込み: %d 件", len(job_results))
+
+    # --- DB クエリ ---
+    db_path = args.db or str(Settings().duckdb_path)
+    conn = duckdb.connect(db_path)
+    try:
+        update_counts = collect_update_counts(conn, run_date)
+        next_day = collect_next_day_summary(conn, run_date)
+    finally:
+        conn.close()
+
+    # --- 翌営業日を特定（prices_daily の翌日以降の最小日付） ---
+    try:
+        conn2 = duckdb.connect(db_path)
+        try:
+            row = conn2.execute(
+                "SELECT MIN(date) FROM prices_daily WHERE date > ?", [run_date]
+            ).fetchone()
+            target_date: date = (
+                row[0] if row and row[0] else run_date + timedelta(days=1)
+            )
+        finally:
+            conn2.close()
+    except Exception:
+        logger.warning(
+            "翌営業日の取得に失敗しました。run_date+1 を使用します。", exc_info=True
+        )
+        target_date = run_date + timedelta(days=1)
+
+    # --- レポート構築・保存 ---
+    report = build_report(
+        job_results,
+        update_counts,
+        next_day,
+        run_date=run_date,
+        target_date=target_date,
+    )
+
+    output_dir = Path(args.output_dir) if args.output_dir else Path("artifacts/reports")
+    saved_path = save_report(report, output_dir)
+    logger.info("レポート保存: %s", saved_path)
+
+    print(format_cli_summary(report))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_night_batch_report.py
+++ b/scripts/run_night_batch_report.py
@@ -84,6 +84,7 @@ def collect_update_counts(
         fundamentals=_count_table(conn, "fundamentals", run_date),
         features=_count_table(conn, "features", run_date),
         ai_scores=_count_table(conn, "ai_scores", run_date),
+        market_regime=_count_table(conn, "market_regime", run_date),
         signals=_count_table(conn, "signals", run_date),
         signal_queue=_count_table(conn, "signal_queue", run_date),
     )
@@ -168,7 +169,16 @@ def _parse_args() -> argparse.Namespace:
 def main() -> None:
     args = _parse_args()
 
-    run_date = date.fromisoformat(args.date) if args.date else date.today()
+    if args.date:
+        try:
+            run_date = date.fromisoformat(args.date)
+        except ValueError:
+            logger.error(
+                "--date の形式が不正です: %s (YYYY-MM-DD が必要です)", args.date
+            )
+            sys.exit(1)
+    else:
+        run_date = date.today()
     logger.info("レポート生成開始: run_date=%s", run_date)
 
     # --- JobRunResult 読み込み ---
@@ -178,30 +188,23 @@ def main() -> None:
 
     # --- DB クエリ ---
     db_path = args.db or str(Settings().duckdb_path)
+    target_date: date = run_date + timedelta(days=1)
     conn = duckdb.connect(db_path)
     try:
         update_counts = collect_update_counts(conn, run_date)
         next_day = collect_next_day_summary(conn, run_date)
-    finally:
-        conn.close()
-
-    # --- 翌営業日を特定（prices_daily の翌日以降の最小日付） ---
-    try:
-        conn2 = duckdb.connect(db_path)
         try:
-            row = conn2.execute(
+            row = conn.execute(
                 "SELECT MIN(date) FROM prices_daily WHERE date > ?", [run_date]
             ).fetchone()
-            target_date: date = (
-                row[0] if row and row[0] else run_date + timedelta(days=1)
+            if row and row[0]:
+                target_date = row[0]
+        except Exception:
+            logger.warning(
+                "翌営業日の取得に失敗しました。run_date+1 を使用します。", exc_info=True
             )
-        finally:
-            conn2.close()
-    except Exception:
-        logger.warning(
-            "翌営業日の取得に失敗しました。run_date+1 を使用します。", exc_info=True
-        )
-        target_date = run_date + timedelta(days=1)
+    finally:
+        conn.close()
 
     # --- レポート構築・保存 ---
     report = build_report(

--- a/scripts/run_portfolio_construction.py
+++ b/scripts/run_portfolio_construction.py
@@ -16,7 +16,7 @@ import logging
 import os
 import sys
 import uuid
-from datetime import date
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 import duckdb
@@ -24,11 +24,13 @@ import duckdb
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from kabusys.config import Settings
+from kabusys.operations.job_run_recorder import write_job_result
 from kabusys.operations.line_reports import (
     format_evening_message,
     format_monthly_message,
     format_weekly_message,
 )
+from kabusys.operations.night_batch_report import JobRunResult
 from kabusys.operations.notifier import build_notifier
 from kabusys.operations.performance_collector import (
     collect_monthly_rows,
@@ -42,8 +44,9 @@ from kabusys.utils.logging_setup import setup_logging
 setup_logging(app_name="portfolio_construction")
 logger = logging.getLogger(__name__)
 
-_DEFAULT_PORTFOLIO_VALUE = 10_000_000  # 1000万円
+_DEFAULT_PORTFOLIO_VALUE = 10_000_000
 _MAX_UTILIZATION = 0.70
+_JOB_NAME = "portfolio_construction_job"
 
 
 def _get_today_return(
@@ -60,9 +63,13 @@ def _get_today_return(
 
 
 def main() -> None:
+    started_at = datetime.now(timezone.utc)
     settings = Settings()
     conn = duckdb.connect(str(settings.duckdb_path))
     target_date = date.today()
+    _failed = False
+    _errors: list[str] = []
+    _updated_rows: dict[str, int] = {}
 
     try:
         portfolio_value_str = os.environ.get(
@@ -80,7 +87,6 @@ def main() -> None:
         available_cash = portfolio_value * _MAX_UTILIZATION
         inserted = 0
 
-        # 1. 当日の BUY シグナルを取得
         cur = conn.execute(
             "SELECT code, side, score, signal_rank FROM signals WHERE date = ? AND side = 'buy'",
             [target_date],
@@ -90,19 +96,20 @@ def main() -> None:
 
         if not buy_signals:
             logger.info("本日の BUY シグナルが 0 件です。signal_queue を更新しません。")
+            _updated_rows["signal_queue"] = 0
         else:
-            # 2. 銘柄選定・重み計算（メモリ内）
             candidates = select_candidates(buy_signals)
             if not candidates:
                 logger.info("銘柄選定結果が 0 件です。signal_queue を更新しません。")
+                _updated_rows["signal_queue"] = 0
             else:
                 weights = calc_score_weights(candidates)
                 if not weights:
                     logger.info(
                         "重み計算結果が 0 件です。signal_queue を更新しません。"
                     )
+                    _updated_rows["signal_queue"] = 0
                 else:
-                    # 3. 最新終値を取得（直近の prices_daily から）
                     codes = [c["code"] for c in candidates]
                     code_params = ",".join(["?"] * len(codes))
                     price_cur = conn.execute(
@@ -124,7 +131,6 @@ def main() -> None:
                         if r[1] is not None
                     }
 
-                    # 4. 現在のポジション取得
                     pos_cur = conn.execute(
                         "SELECT code, size FROM positions WHERE code IN ("
                         + code_params
@@ -133,7 +139,6 @@ def main() -> None:
                     )
                     current_positions = {r[0]: int(r[1]) for r in pos_cur.fetchall()}
 
-                    # 5. ポジションサイズ計算
                     sizes = calc_position_sizes(
                         weights=weights,
                         candidates=candidates,
@@ -143,7 +148,6 @@ def main() -> None:
                         open_prices=close_prices,
                     )
 
-                    # 6. portfolio_targets / signal_queue をトランザクション内で更新
                     conn.execute("BEGIN")
                     try:
                         conn.execute(
@@ -157,7 +161,6 @@ def main() -> None:
                                 [target_date, code, weight, size],
                             )
 
-                        # 7. signal_queue を更新（当日の pending シグナルをクリアして再挿入）
                         conn.execute(
                             "DELETE FROM signal_queue WHERE date = ? AND status = 'pending'",
                             [target_date],
@@ -184,6 +187,7 @@ def main() -> None:
                         conn.execute("ROLLBACK")
                         raise
 
+                    _updated_rows["signal_queue"] = inserted
                     logger.info(
                         "ポートフォリオ構築完了: %d 銘柄を signal_queue に挿入 (date=%s)",
                         inserted,
@@ -248,11 +252,32 @@ def main() -> None:
         except Exception:
             logger.warning("LINE 通知に失敗しました", exc_info=True)
 
-    except Exception:
+    except Exception as exc:
         logger.exception("ポートフォリオ構築が失敗しました")
-        sys.exit(1)
+        _errors.append(str(exc))
+        _failed = True
     finally:
         conn.close()
+
+    finished_at = datetime.now(timezone.utc)
+    try:
+        write_job_result(
+            JobRunResult(
+                job_name=_JOB_NAME,
+                status="failed" if _failed else "success",
+                started_at=started_at,
+                finished_at=finished_at,
+                duration_sec=(finished_at - started_at).total_seconds(),
+                updated_rows=_updated_rows,
+                warnings=[],
+                errors=_errors,
+            )
+        )
+    except Exception:
+        logger.warning("JobRunResult の書き出しに失敗しました", exc_info=True)
+
+    if _failed:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/run_strategy_signal.py
+++ b/scripts/run_strategy_signal.py
@@ -8,32 +8,63 @@ from __future__ import annotations
 
 import logging
 import sys
-from datetime import date
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 import duckdb
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 from kabusys.config import Settings
+from kabusys.operations.job_run_recorder import write_job_result
+from kabusys.operations.night_batch_report import JobRunResult
 from kabusys.strategy.signal_generator import generate_signals
 from kabusys.utils.logging_setup import setup_logging
 
 setup_logging(app_name="strategy_signal")
 logger = logging.getLogger(__name__)
 
+_JOB_NAME = "strategy_signal_job"
+
 
 def main() -> None:
     settings = Settings()
     conn = duckdb.connect(str(settings.duckdb_path))
+    started_at = datetime.now(timezone.utc)
+    _failed = False
+    _errors: list[str] = []
+    _updated_rows: dict[str, int] = {}
+
     try:
         target_date = date.today()
         n = generate_signals(conn, target_date)
+        _updated_rows["signals"] = n
         logger.info("シグナル生成完了: %d 件 (date=%s)", n, target_date)
-    except Exception:
+    except Exception as exc:
         logger.exception("generate_signals が失敗しました")
-        sys.exit(1)
+        _errors.append(str(exc))
+        _failed = True
     finally:
         conn.close()
+
+    finished_at = datetime.now(timezone.utc)
+    try:
+        write_job_result(
+            JobRunResult(
+                job_name=_JOB_NAME,
+                status="failed" if _failed else "success",
+                started_at=started_at,
+                finished_at=finished_at,
+                duration_sec=(finished_at - started_at).total_seconds(),
+                updated_rows=_updated_rows,
+                warnings=[],
+                errors=_errors,
+            )
+        )
+    except Exception:
+        logger.warning("JobRunResult の書き出しに失敗しました", exc_info=True)
+
+    if _failed:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/run_strategy_signal.py
+++ b/scripts/run_strategy_signal.py
@@ -27,9 +27,9 @@ _JOB_NAME = "strategy_signal_job"
 
 
 def main() -> None:
+    started_at = datetime.now(timezone.utc)
     settings = Settings()
     conn = duckdb.connect(str(settings.duckdb_path))
-    started_at = datetime.now(timezone.utc)
     _failed = False
     _errors: list[str] = []
     _updated_rows: dict[str, int] = {}

--- a/scripts/setup_task_scheduler.ps1
+++ b/scripts/setup_task_scheduler.ps1
@@ -66,11 +66,12 @@ Register-KabuSysTask -TaskName "KabuSys_FeatureGen"            -Script "run_feat
 Register-KabuSysTask -TaskName "KabuSys_AiAnalysis"            -Script "run_ai_analysis.py"            -TriggerTime "18:00"
 Register-KabuSysTask -TaskName "KabuSys_StrategySignal"        -Script "run_strategy_signal.py"        -TriggerTime "20:00"
 Register-KabuSysTask -TaskName "KabuSys_PortfolioConstruction" -Script "run_portfolio_construction.py" -TriggerTime "21:00"
+Register-KabuSysTask -TaskName "KabuSys_NightBatchReport"      -Script "run_night_batch_report.py"      -TriggerTime "21:15"
 
 # System start jobs
 Register-KabuSysTask -TaskName "KabuSys_ExecutionStart"  -Script "start_system.py" -Arguments "--component execution"  -TriggerTime "08:30"
 Register-KabuSysTask -TaskName "KabuSys_MonitoringStart" -Script "start_system.py" -Arguments "--component monitoring" -TriggerTime "09:00"
 
 Write-Host ""
-Write-Host "8 件のジョブ登録が完了しました。"
+Write-Host "9 件のジョブ登録が完了しました。"
 Write-Host "確認: Get-ScheduledTask -TaskName 'KabuSys_*' | Select-Object TaskName, State"

--- a/src/kabusys/operations/job_run_recorder.py
+++ b/src/kabusys/operations/job_run_recorder.py
@@ -1,0 +1,84 @@
+"""JobRunResult を artifacts/job_runs/{date}/ に書き出す・読み込むヘルパー。"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date, datetime
+from pathlib import Path
+
+from kabusys.operations.night_batch_report import JobRunResult
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE = Path("artifacts") / "job_runs"
+
+
+def write_job_result(
+    result: JobRunResult,
+    base_dir: Path | None = None,
+    run_date: date | None = None,
+) -> Path:
+    """artifacts/job_runs/{run_date}/{job_name}.json に書き出す。
+
+    run_date 未指定時は date.today() を使用する。
+    同名ファイルが存在する場合は上書きする。
+
+    Returns:
+        書き出したファイルパス。
+    """
+    base = base_dir if base_dir is not None else _DEFAULT_BASE
+    d = (run_date or date.today()).isoformat()
+    out_dir = base / d
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    data = {
+        "job_name": result.job_name,
+        "status": result.status,
+        "started_at": result.started_at.isoformat(),
+        "finished_at": result.finished_at.isoformat(),
+        "duration_sec": result.duration_sec,
+        "updated_rows": result.updated_rows,
+        "warnings": result.warnings,
+        "errors": result.errors,
+    }
+    path = out_dir / f"{result.job_name}.json"
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    return path
+
+
+def read_job_results(
+    run_date: date,
+    base_dir: Path | None = None,
+) -> list[JobRunResult]:
+    """artifacts/job_runs/{run_date}/ の全 JSON を JobRunResult リストに変換して返す。
+
+    ディレクトリが存在しない場合・ファイルが 0 件の場合は空リストを返す。
+    読み込みに失敗した個別ファイルは警告ログを出してスキップする。
+    """
+    base = base_dir if base_dir is not None else _DEFAULT_BASE
+    run_dir = base / run_date.isoformat()
+    if not run_dir.exists():
+        return []
+
+    results: list[JobRunResult] = []
+    for path in sorted(run_dir.glob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            results.append(
+                JobRunResult(
+                    job_name=data["job_name"],
+                    status=data["status"],
+                    started_at=datetime.fromisoformat(data["started_at"]),
+                    finished_at=datetime.fromisoformat(data["finished_at"]),
+                    duration_sec=float(data["duration_sec"]),
+                    updated_rows=dict(data.get("updated_rows", {})),
+                    warnings=list(data.get("warnings", [])),
+                    errors=list(data.get("errors", [])),
+                )
+            )
+        except Exception:
+            logger.warning(
+                "job result JSON の読み込みに失敗しました: %s", path, exc_info=True
+            )
+    return results

--- a/src/kabusys/operations/job_run_recorder.py
+++ b/src/kabusys/operations/job_run_recorder.py
@@ -72,12 +72,16 @@ def read_job_results(
                     started_at=datetime.fromisoformat(data["started_at"]),
                     finished_at=datetime.fromisoformat(data["finished_at"]),
                     duration_sec=float(data["duration_sec"]),
-                    updated_rows=dict(data.get("updated_rows", {})),
+                    updated_rows={
+                        k: int(v) for k, v in data.get("updated_rows", {}).items()
+                    },
                     warnings=list(data.get("warnings", [])),
                     errors=list(data.get("errors", [])),
                 )
             )
-        except Exception:
+        except (
+            Exception
+        ):  # JSONDecodeError, KeyError, ValueError, or any future field change
             logger.warning(
                 "job result JSON の読み込みに失敗しました: %s", path, exc_info=True
             )

--- a/src/kabusys/operations/night_batch_report.py
+++ b/src/kabusys/operations/night_batch_report.py
@@ -51,6 +51,7 @@ class UpdateCounts:
     fundamentals: int = 0
     features: int = 0
     ai_scores: int = 0
+    market_regime: int = 0
     signals: int = 0
     signal_queue: int = 0
 
@@ -235,8 +236,8 @@ def format_cli_summary(report: NightBatchReport) -> str:
         "  Update Counts:",
         f"    prices_daily : {uc.prices_daily:>6}    features     : {uc.features:>6}",
         f"    news_articles: {uc.news_articles:>6}    ai_scores    : {uc.ai_scores:>6}",
-        f"    fundamentals : {uc.fundamentals:>6}    signals      : {uc.signals:>6}",
-        f"                              signal_queue : {uc.signal_queue:>6}",
+        f"    fundamentals : {uc.fundamentals:>6}    market_regime: {uc.market_regime:>6}",
+        f"    signals      : {uc.signals:>6}    signal_queue : {uc.signal_queue:>6}",
     ]
     lines.append(thin)
     nd = report.next_day_summary
@@ -333,6 +334,7 @@ def format_markdown(report: NightBatchReport) -> str:
         f"| fundamentals | {uc.fundamentals} |",
         f"| features | {uc.features} |",
         f"| ai_scores | {uc.ai_scores} |",
+        f"| market_regime | {uc.market_regime} |",
         f"| signals | {uc.signals} |",
         f"| signal_queue | {uc.signal_queue} |",
         "",

--- a/tests/test_job_run_recorder.py
+++ b/tests/test_job_run_recorder.py
@@ -1,0 +1,122 @@
+"""job_run_recorder モジュールのテスト"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timezone
+
+
+from kabusys.operations.night_batch_report import JobRunResult
+
+
+def _make_result(
+    job_name: str = "data_update_job",
+    status: str = "success",
+    started_at: datetime | None = None,
+) -> JobRunResult:
+    dt = started_at or datetime(2026, 5, 7, 15, 30, 0, tzinfo=timezone.utc)
+    return JobRunResult(
+        job_name=job_name,
+        status=status,
+        started_at=dt,
+        finished_at=datetime(2026, 5, 7, 15, 31, 0, tzinfo=timezone.utc),
+        duration_sec=60.0,
+        updated_rows={"prices_daily": 1850},
+        warnings=[],
+        errors=[],
+    )
+
+
+def test_write_creates_file(tmp_path):
+    from kabusys.operations.job_run_recorder import write_job_result
+
+    result = _make_result()
+    path = write_job_result(result, base_dir=tmp_path, run_date=date(2026, 5, 7))
+    assert path.exists()
+    assert path.name == "data_update_job.json"
+    assert path.parent.name == "2026-05-07"
+
+
+def test_write_json_content(tmp_path):
+    from kabusys.operations.job_run_recorder import write_job_result
+
+    result = _make_result()
+    path = write_job_result(result, base_dir=tmp_path, run_date=date(2026, 5, 7))
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["job_name"] == "data_update_job"
+    assert data["status"] == "success"
+    assert data["updated_rows"] == {"prices_daily": 1850}
+    assert data["duration_sec"] == 60.0
+    assert "started_at" in data
+    assert "finished_at" in data
+
+
+def test_read_empty_dir_returns_empty(tmp_path):
+    from kabusys.operations.job_run_recorder import read_job_results
+
+    results = read_job_results(date(2026, 5, 7), base_dir=tmp_path)
+    assert results == []
+
+
+def test_read_nonexistent_dir_returns_empty(tmp_path):
+    from kabusys.operations.job_run_recorder import read_job_results
+
+    results = read_job_results(date(2099, 1, 1), base_dir=tmp_path)
+    assert results == []
+
+
+def test_write_then_read_roundtrip(tmp_path):
+    from kabusys.operations.job_run_recorder import write_job_result, read_job_results
+
+    result = _make_result(status="failed")
+    result.errors.append("something went wrong")
+    write_job_result(result, base_dir=tmp_path, run_date=date(2026, 5, 7))
+    loaded = read_job_results(date(2026, 5, 7), base_dir=tmp_path)
+    assert len(loaded) == 1
+    assert loaded[0].job_name == "data_update_job"
+    assert loaded[0].status == "failed"
+    assert loaded[0].errors == ["something went wrong"]
+    assert loaded[0].updated_rows == {"prices_daily": 1850}
+
+
+def test_read_multiple_jobs(tmp_path):
+    from kabusys.operations.job_run_recorder import write_job_result, read_job_results
+
+    for job_name in [
+        "data_update_job",
+        "feature_generation_job",
+        "strategy_signal_job",
+    ]:
+        write_job_result(
+            _make_result(job_name=job_name),
+            base_dir=tmp_path,
+            run_date=date(2026, 5, 7),
+        )
+    loaded = read_job_results(date(2026, 5, 7), base_dir=tmp_path)
+    assert len(loaded) == 3
+    names = {r.job_name for r in loaded}
+    assert names == {"data_update_job", "feature_generation_job", "strategy_signal_job"}
+
+
+def test_read_skips_malformed_json(tmp_path):
+    from kabusys.operations.job_run_recorder import write_job_result, read_job_results
+
+    write_job_result(_make_result(), base_dir=tmp_path, run_date=date(2026, 5, 7))
+    bad = tmp_path / "2026-05-07" / "broken_job.json"
+    bad.write_text("not valid json", encoding="utf-8")
+    loaded = read_job_results(date(2026, 5, 7), base_dir=tmp_path)
+    assert len(loaded) == 1
+
+
+def test_write_overwrites_same_job(tmp_path):
+    from kabusys.operations.job_run_recorder import write_job_result, read_job_results
+
+    write_job_result(
+        _make_result(status="failed"), base_dir=tmp_path, run_date=date(2026, 5, 7)
+    )
+    write_job_result(
+        _make_result(status="success"), base_dir=tmp_path, run_date=date(2026, 5, 7)
+    )
+    loaded = read_job_results(date(2026, 5, 7), base_dir=tmp_path)
+    assert len(loaded) == 1
+    assert loaded[0].status == "success"

--- a/tests/test_night_batch_runner.py
+++ b/tests/test_night_batch_runner.py
@@ -1,0 +1,229 @@
+"""tests/test_night_batch_runner.py
+
+run_night_batch_report.py のヘルパー関数のユニットテスト。
+スクリプトを直接インポートして検証する。
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import duckdb
+
+# scripts/ ディレクトリを sys.path に追加してスクリプトをインポートする
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+from run_night_batch_report import (  # noqa: E402
+    collect_next_day_summary,
+    collect_update_counts,
+    load_job_results_or_empty,
+)
+
+
+# ---------------------------------------------------------------------------
+# DB セットアップヘルパー
+# ---------------------------------------------------------------------------
+
+
+def _setup_db(conn: duckdb.DuckDBPyConnection) -> None:
+    """テスト用の最小スキーマを作成する。"""
+    conn.execute("CREATE TABLE prices_daily (date DATE, code VARCHAR, close DOUBLE)")
+    conn.execute(
+        "CREATE TABLE signals (date DATE, code VARCHAR, side VARCHAR, score DOUBLE, signal_rank INT)"
+    )
+    conn.execute("CREATE TABLE signal_queue (date DATE, code VARCHAR, status VARCHAR)")
+
+
+# ---------------------------------------------------------------------------
+# load_job_results_or_empty のテスト
+# ---------------------------------------------------------------------------
+
+
+def test_load_job_results_or_empty_nonexistent_dir(tmp_path: Path) -> None:
+    """存在しないディレクトリを指定した場合は空リストを返す。"""
+    nonexistent = tmp_path / "no_such_dir"
+    result = load_job_results_or_empty(date(2026, 5, 7), base_dir=nonexistent)
+    assert result == []
+
+
+def test_load_job_results_or_empty_with_results(tmp_path: Path) -> None:
+    """JSON ファイルが存在する場合に JobRunResult リストを返す。"""
+    run_date = date(2026, 5, 7)
+    job_dir = tmp_path / run_date.isoformat()
+    job_dir.mkdir(parents=True)
+
+    now = datetime.now(timezone.utc)
+    job_data = {
+        "job_name": "data_update_job",
+        "status": "success",
+        "started_at": now.isoformat(),
+        "finished_at": now.isoformat(),
+        "duration_sec": 12.5,
+        "updated_rows": {"prices_daily": 100},
+        "warnings": [],
+        "errors": [],
+    }
+    (job_dir / "data_update_job.json").write_text(
+        json.dumps(job_data), encoding="utf-8"
+    )
+
+    result = load_job_results_or_empty(run_date, base_dir=tmp_path)
+    assert len(result) == 1
+    assert result[0].job_name == "data_update_job"
+    assert result[0].status == "success"
+    assert result[0].duration_sec == 12.5
+
+
+def test_load_job_results_or_empty_handles_error(tmp_path: Path) -> None:
+    """base_dir にファイルを渡してもエラーを返さず空リストを返す。"""
+    # tmp_path にファイルを作成し、それをディレクトリとして渡す
+    bogus_file = tmp_path / "not_a_dir.txt"
+    bogus_file.write_text("content", encoding="utf-8")
+
+    # not_a_dir.txt/{date} は存在しないので空リストを返すべき
+    result = load_job_results_or_empty(date(2026, 5, 7), base_dir=bogus_file)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# collect_update_counts のテスト
+# ---------------------------------------------------------------------------
+
+
+def test_collect_update_counts_empty_tables() -> None:
+    """空テーブルのみ存在する場合、全カウントが 0 になる。"""
+    conn = duckdb.connect(":memory:")
+    _setup_db(conn)
+    try:
+        counts = collect_update_counts(conn, date(2026, 5, 7))
+        assert counts.prices_daily == 0
+        assert counts.signals == 0
+        assert counts.signal_queue == 0
+        assert counts.fundamentals == 0
+        assert counts.ai_scores == 0
+        assert counts.features == 0
+        assert counts.news_articles == 0
+    finally:
+        conn.close()
+
+
+def test_collect_update_counts_with_data() -> None:
+    """データを挿入した場合に正しいカウントを返す。"""
+    conn = duckdb.connect(":memory:")
+    _setup_db(conn)
+    run_date = date(2026, 5, 7)
+    try:
+        conn.execute("INSERT INTO prices_daily VALUES (?, '1301', 100.0)", [run_date])
+        conn.execute("INSERT INTO prices_daily VALUES (?, '1302', 200.0)", [run_date])
+        conn.execute(
+            "INSERT INTO signals VALUES (?, '1301', 'buy', 0.8, 1)", [run_date]
+        )
+        conn.execute(
+            "INSERT INTO signal_queue VALUES (?, '1301', 'pending')", [run_date]
+        )
+
+        counts = collect_update_counts(conn, run_date)
+        assert counts.prices_daily == 2
+        assert counts.signals == 1
+        assert counts.signal_queue == 1
+    finally:
+        conn.close()
+
+
+def test_collect_update_counts_missing_tables_return_zero() -> None:
+    """存在しないテーブル（fundamentals, ai_scores, features 等）はカウント 0 を返す。"""
+    conn = duckdb.connect(":memory:")
+    # prices_daily と signals のみ作成、他は作らない
+    conn.execute("CREATE TABLE prices_daily (date DATE, code VARCHAR, close DOUBLE)")
+    conn.execute(
+        "CREATE TABLE signals (date DATE, code VARCHAR, side VARCHAR, score DOUBLE, signal_rank INT)"
+    )
+    # signal_queue は作らない
+    try:
+        counts = collect_update_counts(conn, date(2026, 5, 7))
+        assert counts.fundamentals == 0
+        assert counts.ai_scores == 0
+        assert counts.features == 0
+        assert counts.news_articles == 0
+        assert counts.signal_queue == 0
+    finally:
+        conn.close()
+
+
+def test_collect_update_counts_prices_daily_count() -> None:
+    """run_date の行のみカウントされ、他の日付の行は含まれない。"""
+    conn = duckdb.connect(":memory:")
+    _setup_db(conn)
+    run_date = date(2026, 5, 7)
+    other_date = date(2026, 5, 6)
+    try:
+        conn.execute("INSERT INTO prices_daily VALUES (?, '1301', 100.0)", [run_date])
+        conn.execute("INSERT INTO prices_daily VALUES (?, '1302', 200.0)", [run_date])
+        conn.execute("INSERT INTO prices_daily VALUES (?, '1303', 300.0)", [run_date])
+        conn.execute("INSERT INTO prices_daily VALUES (?, '1304', 400.0)", [other_date])
+
+        counts = collect_update_counts(conn, run_date)
+        assert counts.prices_daily == 3
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# collect_next_day_summary のテスト
+# ---------------------------------------------------------------------------
+
+
+def test_collect_next_day_summary_with_future_data() -> None:
+    """prices_daily に翌日データが存在する場合、next_trading_day が正しく設定される。"""
+    conn = duckdb.connect(":memory:")
+    _setup_db(conn)
+    run_date = date(2026, 5, 7)
+    next_day = date(2026, 5, 8)
+    try:
+        conn.execute("INSERT INTO prices_daily VALUES (?, '1301', 100.0)", [next_day])
+
+        summary = collect_next_day_summary(conn, run_date)
+        assert summary.buy_count == 0
+        assert summary.sell_count == 0
+    finally:
+        conn.close()
+
+
+def test_collect_next_day_summary_no_future_data() -> None:
+    """将来データがない場合でもクラッシュせず、デフォルト値を返す。"""
+    conn = duckdb.connect(":memory:")
+    _setup_db(conn)
+    run_date = date(2026, 5, 7)
+    try:
+        # prices_daily は空
+        summary = collect_next_day_summary(conn, run_date)
+        # 例外が起きないことと、buy/sell カウントが 0 であることを確認
+        assert summary.buy_count == 0
+        assert summary.sell_count == 0
+    finally:
+        conn.close()
+
+
+def test_collect_next_day_summary_signal_counts() -> None:
+    """buy/sell シグナルを挿入すると、対応するカウントが返る。"""
+    conn = duckdb.connect(":memory:")
+    _setup_db(conn)
+    run_date = date(2026, 5, 7)
+    try:
+        conn.execute(
+            "INSERT INTO signals VALUES (?, '1301', 'buy', 0.9, 1)", [run_date]
+        )
+        conn.execute(
+            "INSERT INTO signals VALUES (?, '1302', 'buy', 0.8, 2)", [run_date]
+        )
+        conn.execute(
+            "INSERT INTO signals VALUES (?, '1303', 'sell', 0.7, 3)", [run_date]
+        )
+
+        summary = collect_next_day_summary(conn, run_date)
+        assert summary.buy_count == 2
+        assert summary.sell_count == 1
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

- `job_run_recorder.py` を新規追加 — `JobRunResult` を `artifacts/job_runs/{date}/{job_name}.json` に書き出し・読み込みするヘルパー
- 5 つの夜間バッチスクリプト（`run_data_update.py` / `run_feature_gen.py` / `run_ai_analysis.py` / `run_strategy_signal.py` / `run_portfolio_construction.py`）を修正し、成功・失敗いずれの場合も `JobRunResult` を書き出すよう接続
- `scripts/run_night_batch_report.py` を新規追加 — job run 結果を読み込み、DB からカウントを収集して夜間レポートを生成・保存・CLI 出力するランナー
- `setup_task_scheduler.ps1` に `KabuSys_NightBatchReport`（21:15 起動）を追加（登録ジョブ数 8 → 9）

## Test Plan

- [ ] `python -m pytest` — 1605 tests passing
- [ ] `scripts/setup_task_scheduler.ps1` 実行後、`Get-ScheduledTask -TaskName 'KabuSys_*'` で 9 件のタスクが表示されることを確認
- [ ] 夜間バッチ実行後、`artifacts/job_runs/{date}/` に各ジョブの JSON が生成されることを確認
- [ ] `python scripts/run_night_batch_report.py` を実行し、CLI サマリーが標準出力に表示されることを確認

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)