### PR TITLE
feat: TOPIX相対強度・財務品質指標を features に追加 (Issue #257)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,9 +222,10 @@ KabuSys は**日足スイング戦略**専用の設計です。夜間バッチ�
   ├─ 16:00  特徴量生成   scripts/run_feature_gen.py
   ├─ 18:00  AI 分析      scripts/run_ai_analysis.py
   ├─ 20:00  シグナル生成 scripts/run_strategy_signal.py
-  └─ 21:00  ポートフォリオ構築 scripts/run_portfolio_construction.py
+  ├─ 21:00  ポートフォリオ構築 scripts/run_portfolio_construction.py
+  └─ 21:15  バッチ結果レポート scripts/run_night_batch_report.py
   ↓
-21:30  夜間バッチ結果確認（Signal Queue / 異常チェック）
+21:30  夜間バッチ結果確認（レポート参照）
   ↓
 08:30  Execution 起動
 09:00  市場オープン → 寄付き発注
@@ -287,17 +288,33 @@ python scripts/run_portfolio_construction.py
 シグナルからポジションサイズを計算し、リスク制御を適用して `signal_queue` に翌日の発注キューを生成します。  
 このテーブルが Execution エンジンの入力になります。
 
+**バッチ結果レポート**（21:15 自動実行）
+
+```
+python scripts/run_night_batch_report.py
+```
+
+各ジョブの実行結果 (`artifacts/job_runs/{date}/`) を読み込み、DB からカウントを集計して READY / READY_WITH_WARNINGS / BLOCKED を判定します。  
+`KabuSys_NightBatchReport` タスクが 21:15 に自動実行します。手動確認・再生成にも使用できます。
+
+出力先: `artifacts/night_batch/{date}/summary.json`, `report.md`, `warnings.json`
+
 ---
 
 ### 夜間バッチ結果確認
 
-**Signal Queue 確認**（21:30 頃・任意）  
-翌営業日の発注予定を確認し、READY / BLOCKED / READY_WITH_WARNINGS を判定します。
+**Night Batch レポート確認**（21:30 頃）  
+21:15 に自動生成されたレポートを確認します。
 
 ```
-python -m kabusys.run_signal_queue_report
-python -m kabusys.run_signal_queue_report --date 2026-04-28 --save --json
+python scripts/run_night_batch_report.py
 ```
+
+判定結果:
+
+- `READY` — 全必須ジョブ成功・`signal_queue` 作成済み → 翌日執行可
+- `READY_WITH_WARNINGS` — 警告あり・準備は完了 → 内容確認の上で判断
+- `BLOCKED` — 必須ジョブ失敗または `signal_queue` 空 → 自動執行を開始しない
 
 ---
 
@@ -467,10 +484,13 @@ touch data/stop_requested.flag
 
 - Signal Queue: artifacts/signal_queue/YYYY-MM-DD/
   - summary.json, report.md, warnings.json
+- Job Runs: artifacts/job_runs/YYYY-MM-DD/
+  - {job_name}.json（各夜間バッチジョブの実行結果）
+- Night Batch: artifacts/night_batch/YYYY-MM-DD/
+  - summary.json, report.md, warnings.json
 - Execution Startup: artifacts/execution_startup/YYYY-MM-DD/
 - Pre-Market: artifacts/pre_market/YYYY-MM-DD/
 - Market Close: artifacts/market_close/YYYY-MM-DD/
-- Night Batch: artifacts/night_batch/YYYY-MM-DD/
 - Performance: artifacts/performance/{env}/{type}/{period}/
 
 ---
@@ -495,6 +515,7 @@ touch data/stop_requested.flag
   - operations/                    — 各種レポート生成ロジック（pure function）
     - pre_market_report.py
     - night_batch_report.py
+    - job_run_recorder.py          — 夜間バッチジョブ実行結果の書き出し・読み込み
     - market_close_report.py
     - performance_collector.py
     - performance_report.py

--- a/documents/08_Operations/TradingRunbook.md
+++ b/documents/08_Operations/TradingRunbook.md
@@ -20,7 +20,8 @@
 18:00  ai_analysis
 20:00  strategy_signal
 21:00  portfolio_construction
-21:30  Night Batch 確認
+21:15  night_batch_report（自動生成）
+21:30  Night Batch 確認（オペレーター）
 ```
 
 ---
@@ -164,15 +165,18 @@ python -m kabusys.run_performance_report --type daily --save
 
 ---
 
-## 7. 夜間バッチ（15:30-21:00）
+## 7. 夜間バッチ（15:30-21:15）
 
 ジョブ:
 
-- `run_data_update.py`
-- `run_feature_gen.py`
-- `run_ai_analysis.py`
-- `run_strategy_signal.py`
-- `run_portfolio_construction.py`
+| 時刻 | スクリプト |
+|---|---|
+| 15:30 | `run_data_update.py` |
+| 16:00 | `run_feature_gen.py` |
+| 18:00 | `run_ai_analysis.py` |
+| 20:00 | `run_strategy_signal.py` |
+| 21:00 | `run_portfolio_construction.py` |
+| 21:15 | `run_night_batch_report.py`（自動レポート生成） |
 
 Task Scheduler 確認:
 
@@ -184,29 +188,30 @@ Get-ScheduledTask -TaskName "KabuSys_*" | Get-ScheduledTaskInfo | Select-Object 
 
 ## 8. Night Batch 判定（21:30）
 
-主要コマンド:
+21:15 に `KabuSys_NightBatchReport` が自動実行し、レポートを生成する。
 
 ```cmd
-python -m kabusys.run_signal_queue_report
+python scripts/run_night_batch_report.py
 ```
+
+出力先:
+
+- `artifacts/night_batch/{date}/summary.json`
+- `artifacts/night_batch/{date}/report.md`
+- `artifacts/night_batch/{date}/warnings.json`
 
 確認項目:
 
-- 必須ジョブ成功
+- 必須ジョブ成功（`data_update` / `feature_gen` / `ai_analysis` / `strategy_signal` / `portfolio_construction`）
 - `signals` が生成されている
 - 翌営業日の `signal_queue` が作られている
-- 必要なら warning を確認する
+- warnings の有無
 
-判定の考え方:
+判定:
 
-- `READY`: 必須ジョブ成功かつ翌営業日の `signal_queue` が作成済み
+- `READY`: 全必須ジョブ成功かつ `signal_queue` 作成済み
 - `READY_WITH_WARNINGS`: warning はあるが翌営業日の準備は完了
-- `BLOCKED`: 必須ジョブ失敗または翌営業日の発注準備が未完了
-
-補足:
-
-- 判定ロジック自体は `src/kabusys/operations/night_batch_report.py` に実装済み
-- 現行ツリーでは独立 CLI よりも Task Scheduler 結果確認と `run_signal_queue_report` を運用導線にしている
+- `BLOCKED`: 必須ジョブ失敗または `signal_queue` が空
 
 ---
 

--- a/documents/10_Runtime/RuntimeArchitecture.md
+++ b/documents/10_Runtime/RuntimeArchitecture.md
@@ -166,6 +166,7 @@ monitoring_service は常時稼働する。
   18:00   KabuSys_AiAnalysis             scripts\run_ai_analysis.py
   20:00   KabuSys_StrategySignal         scripts\run_strategy_signal.py
   21:00   KabuSys_PortfolioConstruction  scripts\run_portfolio_construction.py
+  21:15   KabuSys_NightBatchReport       scripts\run_night_batch_report.py
   08:30   KabuSys_ExecutionStart         scripts\start_system.py --component execution
   09:00   KabuSys_MonitoringStart        scripts\start_system.py --component monitoring
 

--- a/documents/10_Runtime/RuntimeJobSchedule.md
+++ b/documents/10_Runtime/RuntimeJobSchedule.md
@@ -15,7 +15,8 @@ KabuSys は、夜間バッチで翌営業日のシグナルと発注キューを
 18:00  ai_analysis
 20:00  strategy_signal
 21:00  portfolio_construction
-21:30  night batch status confirmation
+21:15  night_batch_report（自動生成）
+21:30  night batch status confirmation（オペレーター確認）
 08:00  pre_market_report
 08:30  execution start
 09:00  monitoring start
@@ -88,30 +89,50 @@ KabuSys は、夜間バッチで翌営業日のシグナルと発注キューを
 
 - `signal_queue`
 
+### 2.6 night_batch_report（21:15）
+
+役割:
+
+- `artifacts/job_runs/{date}/` から各ジョブの `JobRunResult` を読み込む
+- DuckDB から当日の更新件数・翌営業日シグナル情報を集計
+- READY / READY_WITH_WARNINGS / BLOCKED を判定してレポートを生成
+
+主なアーティファクト:
+
+- `artifacts/job_runs/{date}/{job_name}.json`（各ジョブの実行結果）
+- `artifacts/night_batch/{date}/summary.json`
+- `artifacts/night_batch/{date}/report.md`
+- `artifacts/night_batch/{date}/warnings.json`
+
+関連モジュール:
+
+- `src/kabusys/operations/night_batch_report.py`
+- `src/kabusys/operations/job_run_recorder.py`
+
 ---
 
-## 3. Night Batch 状態確認（21:30）
+## 3. Night Batch 状態確認（21:15 以降）
 
-現行運用では、Task Scheduler の結果確認と `signal_queue` の確認を組み合わせて翌営業日の準備完了を判断する。
+21:15 に `KabuSys_NightBatchReport` が自動実行し、CLI サマリーと `artifacts/night_batch/{date}/` を生成する。
+
+手動実行（再生成・デバッグ時）:
+
+```cmd
+python scripts/run_night_batch_report.py
+python scripts/run_night_batch_report.py --date 2026-05-07
+```
+
+Task Scheduler 結果確認:
 
 ```powershell
 Get-ScheduledTask -TaskName "KabuSys_*" | Get-ScheduledTaskInfo | Select-Object TaskName, LastRunTime, LastTaskResult
 ```
 
-```cmd
-python -m kabusys.run_signal_queue_report
-```
+判定:
 
-判定の考え方:
-
-- `READY`: 必須ジョブ成功かつ翌営業日の `signal_queue` が作成済み
+- `READY`: 全必須ジョブ成功かつ翌営業日の `signal_queue` が作成済み
 - `READY_WITH_WARNINGS`: warning はあるが翌営業日の準備は完了
-- `BLOCKED`: 必須ジョブ失敗または翌営業日の発注準備が未完了
-
-補足:
-
-- 判定ロジック自体は `src/kabusys/operations/night_batch_report.py` に実装済み
-- 現行ツリーでは独立 CLI よりも Task Scheduler と queue 確認が導線
+- `BLOCKED`: 必須ジョブ失敗または `signal_queue` が空
 
 ---
 
@@ -191,13 +212,16 @@ python -m kabusys.run_performance_report --type daily --save
 
 標準ジョブ:
 
-- `KabuSys_DataUpdate`
-- `KabuSys_FeatureGen`
-- `KabuSys_AiAnalysis`
-- `KabuSys_StrategySignal`
-- `KabuSys_PortfolioConstruction`
-- `KabuSys_ExecutionStart`
-- `KabuSys_MonitoringStart`
+| 時刻 | タスク名 | スクリプト |
+|---|---|---|
+| 15:30 | `KabuSys_DataUpdate` | `scripts\run_data_update.py` |
+| 16:00 | `KabuSys_FeatureGen` | `scripts\run_feature_gen.py` |
+| 18:00 | `KabuSys_AiAnalysis` | `scripts\run_ai_analysis.py` |
+| 20:00 | `KabuSys_StrategySignal` | `scripts\run_strategy_signal.py` |
+| 21:00 | `KabuSys_PortfolioConstruction` | `scripts\run_portfolio_construction.py` |
+| 21:15 | `KabuSys_NightBatchReport` | `scripts\run_night_batch_report.py` |
+| 08:30 | `KabuSys_ExecutionStart` | `scripts\start_system.py --component execution` |
+| 09:00 | `KabuSys_MonitoringStart` | `scripts\start_system.py --component monitoring` |
 
 ---
 

--- a/documents/10_Runtime/TODO_NightBatchOperationsReport.md
+++ b/documents/10_Runtime/TODO_NightBatchOperationsReport.md
@@ -1,6 +1,6 @@
 # TODO: 夜間バッチ結果確認レポートの運用フロー接続
 
-- ステータス: **未接続**
+- ステータス: **完了（Issue #263 / PR #268 でマージ済み）**
 - 関連モジュール: `src/kabusys/operations/night_batch_report.py`（実装済み）
 - 関連仕様: `documents/10_Runtime/MVP_NightBatchOperationsReportSpec.md`
 

--- a/documents/WebManual/D_LiveOperation.md
+++ b/documents/WebManual/D_LiveOperation.md
@@ -23,8 +23,8 @@
 09:00  Monitoring 起動
 09:00-15:00  ザラ場監視
 15:00  Market Close
-15:30-21:00  夜間バッチ
-21:30  Night Batch 状態確認
+15:30-21:15  夜間バッチ（21:15 にレポート自動生成）
+21:30  Night Batch 状態確認（オペレーター）
 ```
 
 ---
@@ -122,12 +122,16 @@ python -m kabusys.run_performance_report --type daily --save
 
 ## D-7. 夜間バッチの確認（21:30）
 
-```powershell
-Get-ScheduledTask -TaskName "KabuSys_*" | Get-ScheduledTaskInfo | Select-Object TaskName, LastRunTime, LastTaskResult
-```
+21:15 に `KabuSys_NightBatchReport` が自動実行し、レポートを生成する。手動確認・再生成:
 
 ```cmd
-python -m kabusys.run_signal_queue_report
+python scripts/run_night_batch_report.py
+```
+
+Task Scheduler 結果確認:
+
+```powershell
+Get-ScheduledTask -TaskName "KabuSys_*" | Get-ScheduledTaskInfo | Select-Object TaskName, LastRunTime, LastTaskResult
 ```
 
 確認項目:
@@ -135,18 +139,20 @@ python -m kabusys.run_signal_queue_report
 - 必須ジョブ成功
 - `signals` 生成済み
 - 翌営業日の `signal_queue` 作成済み
-- warning の有無
+- warnings の有無
 
-判定の考え方:
+判定:
 
-- `READY`: 必須ジョブ成功かつ翌営業日の `signal_queue` が作成済み
-- `READY_WITH_WARNINGS`: warning はあるが翌営業日の準備は完了
-- `BLOCKED`: 必須ジョブ失敗または翌営業日の発注準備が未完了
+- `READY`: 全必須ジョブ成功かつ `signal_queue` 作成済み → 翌日執行可
+- `READY_WITH_WARNINGS`: warning はあるが翌営業日の準備は完了 → 内容確認の上で判断
+- `BLOCKED`: 必須ジョブ失敗または `signal_queue` が空 → 自動執行を開始しない
 
-補足:
+出力先:
 
-- 判定ロジック自体は `src/kabusys/operations/night_batch_report.py` に実装済み
-- 現行ツリーでは独立 CLI よりも Task Scheduler と queue 確認が導線
+- `artifacts/night_batch/{date}/summary.json`
+- `artifacts/night_batch/{date}/report.md`
+- `artifacts/night_batch/{date}/warnings.json`
+- `artifacts/job_runs/{date}/{job_name}.json`（各ジョブの実行結果）
 
 ---
 

--- a/src/kabusys/data/jquants_client.py
+++ b/src/kabusys/data/jquants_client.py
@@ -687,6 +687,77 @@ def save_market_calendar(
     return len(rows)
 
 
+def fetch_topix_daily(
+    id_token: str | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
+) -> list[dict[str, Any]]:
+    """TOPIX 日足 OHLC を取得する（/indices/topix エンドポイント）。
+
+    Args:
+        id_token:  認証トークン。省略時はキャッシュを使用。
+        date_from: 取得開始日。
+        date_to:   取得終了日。
+
+    Returns:
+        TOPIX 日足レコードのリスト。各要素は {"Date": "YYYYMMDD", "Open": float, ...} を含む。
+    """
+    params: dict[str, str] = {}
+    if date_from:
+        params["dateFrom"] = date_from.strftime("%Y%m%d")
+    if date_to:
+        params["dateTo"] = date_to.strftime("%Y%m%d")
+    data = _request("/indices/topix", params=params, id_token=id_token)
+    records = data.get("topix", [])
+    logger.info("fetch_topix_daily: %d レコード取得", len(records))
+    return records
+
+
+def save_topix_daily(
+    conn: duckdb.DuckDBPyConnection,
+    records: list[dict[str, Any]],
+) -> int:
+    """TOPIX 日足データを topix_daily テーブルへ冪等保存する。
+
+    Args:
+        conn:    DuckDB 接続。
+        records: fetch_topix_daily() の戻り値。
+
+    Returns:
+        保存したレコード数。
+    """
+    rows: list[tuple] = []
+    for r in records:
+        date_str = r.get("Date", "")
+        if not date_str:
+            continue
+        try:
+            d = date(int(date_str[:4]), int(date_str[4:6]), int(date_str[6:8]))
+        except (ValueError, IndexError):
+            logger.warning("save_topix_daily: 不正な日付 '%s' — スキップ", date_str)
+            continue
+        o = _to_float(r.get("Open"))
+        h = _to_float(r.get("High"))
+        lo = _to_float(r.get("Low"))
+        c = _to_float(r.get("Close"))
+        if None in (o, h, lo, c):
+            continue
+        rows.append((d, o, h, lo, c))
+    if not rows:
+        return 0
+    conn.executemany(
+        """
+        INSERT INTO topix_daily (date, open, high, low, close)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT (date) DO UPDATE SET
+            open=excluded.open, high=excluded.high, low=excluded.low, close=excluded.close
+        """,
+        rows,
+    )
+    logger.info("save_topix_daily: %d 件を topix_daily に保存", len(rows))
+    return len(rows)
+
+
 def fetch_listed_info(
     id_token: str | None = None,
     date_: date | None = None,

--- a/src/kabusys/data/jquants_client.py
+++ b/src/kabusys/data/jquants_client.py
@@ -741,6 +741,7 @@ def save_topix_daily(
         lo = _to_float(r.get("Low"))
         c = _to_float(r.get("Close"))
         if None in (o, h, lo, c):
+            logger.warning("save_topix_daily: OHLC 欠損行をスキップ: %s", r)
             continue
         rows.append((d, o, h, lo, c))
     if not rows:

--- a/src/kabusys/data/pipeline.py
+++ b/src/kabusys/data/pipeline.py
@@ -439,6 +439,10 @@ def run_topix_etl(
 ) -> tuple[int, int]:
     """TOPIX 日足データの差分 ETL を実行する。
 
+    TOPIX は単一時系列かつ JPX 公式指数のため、過去日付の訂正配信はほぼ発生しない。
+    当日分が取得済み（last >= target_date）の場合はバックフィルも含めてスキップする。
+    通常の差分更新では最終取得日 - backfill_days 日前から再取得し、万一の後出し修正を吸収する。
+
     Args:
         conn:          DuckDB 接続。
         target_date:   取得終了日。

--- a/src/kabusys/data/pipeline.py
+++ b/src/kabusys/data/pipeline.py
@@ -83,6 +83,8 @@ class ETLResult:
     earnings_calendar_saved: int = 0
     dividends_fetched: int = 0
     dividends_saved: int = 0
+    topix_fetched: int = 0
+    topix_saved: int = 0
     quality_issues: list[quality.QualityIssue] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
 
@@ -267,6 +269,18 @@ def get_last_dividend_date(conn: duckdb.DuckDBPyConnection) -> date | None:
     return _get_max_date(conn, "dividends", "pub_date")
 
 
+def get_last_topix_date(conn: duckdb.DuckDBPyConnection) -> date | None:
+    """topix_daily テーブルの最終取得日を返す。
+
+    Args:
+        conn: DuckDB 接続。
+
+    Returns:
+        最終取得日。テーブル未作成または空の場合は None。
+    """
+    return _get_max_date(conn, "topix_daily", "date")
+
+
 # ---------------------------------------------------------------------------
 # 個別ETLジョブ
 # ---------------------------------------------------------------------------
@@ -416,6 +430,50 @@ def run_dividends_etl(
     return len(records), saved
 
 
+def run_topix_etl(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date,
+    id_token: str | None = None,
+    date_from: date | None = None,
+    backfill_days: int = _DEFAULT_BACKFILL_DAYS,
+) -> tuple[int, int]:
+    """TOPIX 日足データの差分 ETL を実行する。
+
+    Args:
+        conn:          DuckDB 接続。
+        target_date:   取得終了日。
+        id_token:      J-Quants 認証トークン。
+        date_from:     取得開始日。省略時は最終取得日 - backfill_days + 1。
+        backfill_days: バックフィル日数（デフォルト 3 日）。
+
+    Returns:
+        (取得レコード数, 保存レコード数) のタプル。
+    """
+    if date_from is None:
+        last = get_last_topix_date(conn)
+        if last is not None:
+            if last >= target_date:
+                logger.info(
+                    "run_topix_etl: すでに最新 date_from=%s target=%s", last, target_date
+                )
+                return 0, 0
+            date_from = max(_MIN_DATA_DATE, last - timedelta(days=backfill_days - 1))
+        else:
+            date_from = _MIN_DATA_DATE
+
+    if date_from > target_date:
+        logger.info(
+            "run_topix_etl: すでに最新 date_from=%s target=%s", date_from, target_date
+        )
+        return 0, 0
+
+    logger.info("run_topix_etl: date_from=%s date_to=%s", date_from, target_date)
+    records = jq.fetch_topix_daily(id_token=id_token, date_from=date_from, date_to=target_date)
+    saved = jq.save_topix_daily(conn, records)
+    logger.info("run_topix_etl: fetched=%d saved=%d", len(records), saved)
+    return len(records), saved
+
+
 def run_calendar_etl(
     conn: duckdb.DuckDBPyConnection,
     target_date: date,
@@ -487,8 +545,9 @@ def run_daily_etl(
       2. 株価日足ETL（差分更新 + backfill）
       3. 財務データETL（差分更新 + backfill）
       4. 配当データETL（差分更新 + backfill）
-      5. 決算カレンダーETL（翌30日分を先読み取得・冪等保存）
-      6. 品質チェック（オプション）
+      5. TOPIX 日足ETL（差分更新 + backfill）
+      6. 決算カレンダーETL（翌30日分を先読み取得・冪等保存）
+      7. 品質チェック（オプション）
 
     Args:
         conn:                    DuckDB 接続。
@@ -552,7 +611,18 @@ def run_daily_etl(
         logger.exception("run_dividends_etl 失敗")
         result.errors.append("run_dividends_etl 失敗")
 
-    # 5. 決算カレンダー（翌30日分を先読み取得・冪等保存）
+    # 5. TOPIX 日足 ETL
+    try:
+        fetched, saved = run_topix_etl(
+            conn, trading_day, id_token=id_token, backfill_days=backfill_days
+        )
+        result.topix_fetched = fetched
+        result.topix_saved = saved
+    except Exception:
+        logger.exception("run_topix_etl 失敗")
+        result.errors.append("run_topix_etl 失敗")
+
+    # 6. 決算カレンダー（翌30日分を先読み取得・冪等保存）
     try:
         ec_records = jq.fetch_earnings_calendar(
             id_token=id_token,
@@ -566,7 +636,7 @@ def run_daily_etl(
         result.errors.append(f"earnings_calendar: {exc}")
         logger.warning("決算カレンダー取得失敗（ETL継続）: %s", exc)
 
-    # 6. 品質チェック
+    # 7. 品質チェック
     if run_quality_checks:
         try:
             result.quality_issues = quality.run_all_checks(

--- a/src/kabusys/data/pipeline.py
+++ b/src/kabusys/data/pipeline.py
@@ -455,7 +455,9 @@ def run_topix_etl(
             if last >= target_date:
                 # TOPIX は単一時系列のため、当日分が取得済みであればバックフィルも不要
                 logger.info(
-                    "run_topix_etl: すでに最新 date_from=%s target=%s", last, target_date
+                    "run_topix_etl: すでに最新 date_from=%s target=%s",
+                    last,
+                    target_date,
                 )
                 return 0, 0
             date_from = max(_MIN_DATA_DATE, last - timedelta(days=backfill_days - 1))
@@ -469,7 +471,9 @@ def run_topix_etl(
         return 0, 0
 
     logger.info("run_topix_etl: date_from=%s date_to=%s", date_from, target_date)
-    records = jq.fetch_topix_daily(id_token=id_token, date_from=date_from, date_to=target_date)
+    records = jq.fetch_topix_daily(
+        id_token=id_token, date_from=date_from, date_to=target_date
+    )
     saved = jq.save_topix_daily(conn, records)
     logger.info("run_topix_etl: fetched=%d saved=%d", len(records), saved)
     return len(records), saved

--- a/src/kabusys/data/pipeline.py
+++ b/src/kabusys/data/pipeline.py
@@ -453,6 +453,7 @@ def run_topix_etl(
         last = get_last_topix_date(conn)
         if last is not None:
             if last >= target_date:
+                # TOPIX は単一時系列のため、当日分が取得済みであればバックフィルも不要
                 logger.info(
                     "run_topix_etl: すでに最新 date_from=%s target=%s", last, target_date
                 )

--- a/src/kabusys/data/schema.py
+++ b/src/kabusys/data/schema.py
@@ -202,6 +202,9 @@ CREATE TABLE IF NOT EXISTS features (
     pbr             DOUBLE,
     div_yield       DOUBLE,
     ma200_dev       DOUBLE,
+    topix_rel_20    DOUBLE,
+    topix_rel_60    DOUBLE,
+    quality_score   DOUBLE,
     created_at      TIMESTAMP   NOT NULL DEFAULT current_timestamp,
     PRIMARY KEY (date, code)
 )
@@ -483,6 +486,10 @@ _MIGRATIONS: list[str] = [
     "CREATE TABLE IF NOT EXISTS backtest_runs (run_id VARCHAR PRIMARY KEY, created_at TIMESTAMP NOT NULL DEFAULT current_timestamp, start_date DATE NOT NULL, end_date DATE NOT NULL, initial_cash DECIMAL(18,2) NOT NULL, scope_mode VARCHAR NOT NULL, scope_codes_json VARCHAR, params_json VARCHAR NOT NULL, cagr DOUBLE, sharpe DOUBLE, max_drawdown DOUBLE, win_rate DOUBLE, payoff_ratio DOUBLE, profit_factor DOUBLE, annual_volatility DOUBLE, calmar_ratio DOUBLE, avg_holding_days DOUBLE, total_trades INTEGER, effective_universe_size INTEGER)",
     "CREATE TABLE IF NOT EXISTS backtest_trades (run_id VARCHAR NOT NULL, trade_seq INTEGER NOT NULL, date DATE NOT NULL, code VARCHAR NOT NULL, side VARCHAR NOT NULL CHECK (side IN ('buy', 'sell')), shares INTEGER NOT NULL, price DECIMAL(18,4) NOT NULL, commission DECIMAL(18,4) NOT NULL, realized_pnl DECIMAL(18,4), PRIMARY KEY (run_id, trade_seq))",
     "CREATE TABLE IF NOT EXISTS backtest_daily_equity (run_id VARCHAR NOT NULL, date DATE NOT NULL, portfolio_value DECIMAL(18,2) NOT NULL, cash DECIMAL(18,2) NOT NULL, PRIMARY KEY (run_id, date))",
+    # Issue #257: features に TOPIX 相対強度・品質スコアを追加
+    "ALTER TABLE features ADD COLUMN IF NOT EXISTS topix_rel_20 DOUBLE",
+    "ALTER TABLE features ADD COLUMN IF NOT EXISTS topix_rel_60 DOUBLE",
+    "ALTER TABLE features ADD COLUMN IF NOT EXISTS quality_score DOUBLE",
 ]
 
 # ---------------------------------------------------------------------------

--- a/src/kabusys/research/factor_research.py
+++ b/src/kabusys/research/factor_research.py
@@ -294,3 +294,109 @@ def calc_value(
     result = [dict(zip(cols, r)) for r in rows]
     logger.debug("calc_value: %d 銘柄 date=%s", len(result), target_date)
     return result
+
+
+# ---------------------------------------------------------------------------
+# TOPIX 相対強度ファクター
+# ---------------------------------------------------------------------------
+
+
+def calc_topix_relative(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date,
+) -> list[dict[str, Any]]:
+    """TOPIX 対比の相対モメンタムを計算する。
+
+    各銘柄の 21 日・63 日リターンから同期間の TOPIX リターンを差し引く。
+    topix_daily にデータが存在しない場合は空リストを返す。
+
+    Args:
+        conn:        DuckDB 接続。prices_daily / topix_daily テーブルを参照する。
+        target_date: 計算基準日。
+
+    Returns:
+        [{"date": date, "code": str, "topix_rel_20": float|None, "topix_rel_60": float|None}]
+    """
+    start_date = target_date - timedelta(days=_MOMENTUM_SCAN_DAYS)
+
+    topix_row = conn.execute(
+        f"""
+        WITH topix_data AS (
+            SELECT date, close,
+                   LAG(close, {_MOMENTUM_SHORT_DAYS}) OVER (ORDER BY date) AS close_short_ago,
+                   LAG(close, {_MOMENTUM_MID_DAYS})   OVER (ORDER BY date) AS close_mid_ago
+            FROM topix_daily
+            WHERE date BETWEEN ? AND ?
+        )
+        SELECT
+            CASE WHEN close_short_ago > 0
+                 THEN (close - close_short_ago) / close_short_ago END AS ret_short,
+            CASE WHEN close_mid_ago > 0
+                 THEN (close - close_mid_ago) / close_mid_ago END AS ret_mid
+        FROM topix_data
+        WHERE date = (SELECT MAX(date) FROM topix_daily WHERE date <= ?)
+        """,
+        [start_date, target_date, target_date],
+    ).fetchone()
+
+    if topix_row is None:
+        logger.warning("calc_topix_relative: TOPIX データ不足 date=%s", target_date)
+        return []
+
+    topix_ret_short = float(topix_row[0]) if topix_row[0] is not None else None
+    topix_ret_mid = float(topix_row[1]) if topix_row[1] is not None else None
+
+    rows = conn.execute(
+        f"""
+        WITH stock_data AS (
+            SELECT code, date, close,
+                   LAG(close, {_MOMENTUM_SHORT_DAYS}) OVER (PARTITION BY code ORDER BY date)
+                       AS close_short_ago,
+                   LAG(close, {_MOMENTUM_MID_DAYS})   OVER (PARTITION BY code ORDER BY date)
+                       AS close_mid_ago
+            FROM prices_daily
+            WHERE date BETWEEN ? AND ?
+        )
+        SELECT date, code, close, close_short_ago, close_mid_ago
+        FROM stock_data
+        WHERE date = (
+            SELECT MAX(date) FROM prices_daily WHERE date <= ?
+        )
+        ORDER BY code
+        """,
+        [start_date, target_date, target_date],
+    ).fetchall()
+
+    result = []
+    for _row_date, code, close, close_short_ago, close_mid_ago in rows:
+        stock_ret_short = (
+            float((close - close_short_ago) / close_short_ago)
+            if close_short_ago and close_short_ago > 0
+            else None
+        )
+        stock_ret_mid = (
+            float((close - close_mid_ago) / close_mid_ago)
+            if close_mid_ago and close_mid_ago > 0
+            else None
+        )
+        topix_rel_20 = (
+            stock_ret_short - topix_ret_short
+            if stock_ret_short is not None and topix_ret_short is not None
+            else None
+        )
+        topix_rel_60 = (
+            stock_ret_mid - topix_ret_mid
+            if stock_ret_mid is not None and topix_ret_mid is not None
+            else None
+        )
+        result.append(
+            {
+                "date": target_date,
+                "code": code,
+                "topix_rel_20": topix_rel_20,
+                "topix_rel_60": topix_rel_60,
+            }
+        )
+
+    logger.debug("calc_topix_relative: %d 銘柄 date=%s", len(result), target_date)
+    return result

--- a/src/kabusys/research/factor_research.py
+++ b/src/kabusys/research/factor_research.py
@@ -420,7 +420,8 @@ def calc_quality(
       - rev_growth_yoy  : 売上 YoY 成長率（最新 FY / 直前 FY - 1）
       - profit_growth_yoy: 営業利益 YoY 成長率（最新 FY / 直前 FY - 1）
 
-    period_type が '%FY%' に一致するレコードのみを対象とする。
+    period_type が 'FYResult%' に一致する通期実績レコードのみを対象とする
+    （FYForecastRevision 等の予想・修正系は除外）。
     年次データが 1 件のみの場合は成長率が None になる。
 
     Args:

--- a/src/kabusys/research/factor_research.py
+++ b/src/kabusys/research/factor_research.py
@@ -345,6 +345,12 @@ def calc_topix_relative(
 
     topix_ret_short = float(topix_row[0]) if topix_row[0] is not None else None
     topix_ret_mid = float(topix_row[1]) if topix_row[1] is not None else None
+    if topix_ret_short is None and topix_ret_mid is None:
+        logger.warning(
+            "calc_topix_relative: TOPIX LAG ウィンドウ不足（データは存在するがリターン計算不可）date=%s",
+            target_date,
+        )
+        return []
 
     rows = conn.execute(
         f"""
@@ -357,7 +363,11 @@ def calc_topix_relative(
             FROM prices_daily
             WHERE date BETWEEN ? AND ?
         )
-        SELECT date, code, close, close_short_ago, close_mid_ago
+        SELECT date, code,
+               CASE WHEN close_short_ago > 0
+                    THEN (close - close_short_ago) / close_short_ago END AS ret_short,
+               CASE WHEN close_mid_ago > 0
+                    THEN (close - close_mid_ago) / close_mid_ago END AS ret_mid
         FROM stock_data
         WHERE date = (
             SELECT MAX(date) FROM prices_daily WHERE date <= ?
@@ -368,17 +378,9 @@ def calc_topix_relative(
     ).fetchall()
 
     result = []
-    for _row_date, code, close, close_short_ago, close_mid_ago in rows:
-        stock_ret_short = (
-            float((close - close_short_ago) / close_short_ago)
-            if close_short_ago and close_short_ago > 0
-            else None
-        )
-        stock_ret_mid = (
-            float((close - close_mid_ago) / close_mid_ago)
-            if close_mid_ago and close_mid_ago > 0
-            else None
-        )
+    for _row_date, code, ret_short, ret_mid in rows:
+        stock_ret_short = float(ret_short) if ret_short is not None else None
+        stock_ret_mid = float(ret_mid) if ret_mid is not None else None
         topix_rel_20 = (
             stock_ret_short - topix_ret_short
             if stock_ret_short is not None and topix_ret_short is not None

--- a/src/kabusys/research/factor_research.py
+++ b/src/kabusys/research/factor_research.py
@@ -402,3 +402,66 @@ def calc_topix_relative(
 
     logger.debug("calc_topix_relative: %d 銘柄 date=%s", len(result), target_date)
     return result
+
+
+# ---------------------------------------------------------------------------
+# 財務品質ファクター
+# ---------------------------------------------------------------------------
+
+
+def calc_quality(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date,
+) -> list[dict[str, Any]]:
+    """財務品質指標を計算する。
+
+    raw_financials の年次（FY）データから以下を計算する。
+      - op_margin       : 営業利益率（operating_profit / revenue）
+      - rev_growth_yoy  : 売上 YoY 成長率（最新 FY / 直前 FY - 1）
+      - profit_growth_yoy: 営業利益 YoY 成長率（最新 FY / 直前 FY - 1）
+
+    period_type が '%FY%' に一致するレコードのみを対象とする。
+    年次データが 1 件のみの場合は成長率が None になる。
+
+    Args:
+        conn:        DuckDB 接続。raw_financials テーブルを参照する。
+        target_date: 計算基準日（report_date <= target_date のデータのみ使用）。
+
+    Returns:
+        [{"date": date, "code": str, "op_margin": float|None,
+          "rev_growth_yoy": float|None, "profit_growth_yoy": float|None}]
+    """
+    rows = conn.execute(
+        """
+        WITH fy_ranked AS (
+            SELECT code, report_date, revenue, operating_profit,
+                   ROW_NUMBER() OVER (PARTITION BY code ORDER BY report_date DESC) AS rn
+            FROM raw_financials
+            WHERE report_date <= ?
+              AND period_type LIKE '%FY%'
+        ),
+        latest_fy AS (SELECT * FROM fy_ranked WHERE rn = 1),
+        prior_fy  AS (SELECT * FROM fy_ranked WHERE rn = 2)
+        SELECT
+            ? AS date,
+            l.code,
+            CASE WHEN l.revenue > 0 AND l.operating_profit IS NOT NULL
+                 THEN l.operating_profit / l.revenue END AS op_margin,
+            CASE WHEN p.revenue IS NOT NULL AND p.revenue <> 0
+                      AND l.revenue IS NOT NULL
+                 THEN (l.revenue - p.revenue) / ABS(p.revenue) END AS rev_growth_yoy,
+            CASE WHEN p.operating_profit IS NOT NULL AND p.operating_profit <> 0
+                      AND l.operating_profit IS NOT NULL
+                 THEN (l.operating_profit - p.operating_profit) / ABS(p.operating_profit)
+                 END AS profit_growth_yoy
+        FROM latest_fy l
+        LEFT JOIN prior_fy p ON l.code = p.code
+        ORDER BY l.code
+        """,
+        [target_date, target_date],
+    ).fetchall()
+
+    cols = ["date", "code", "op_margin", "rev_growth_yoy", "profit_growth_yoy"]
+    result = [dict(zip(cols, r)) for r in rows]
+    logger.debug("calc_quality: %d 銘柄 date=%s", len(result), target_date)
+    return result

--- a/src/kabusys/research/factor_research.py
+++ b/src/kabusys/research/factor_research.py
@@ -435,7 +435,7 @@ def calc_quality(
         """
         WITH fy_ranked AS (
             SELECT code, report_date, revenue, operating_profit,
-                   ROW_NUMBER() OVER (PARTITION BY code ORDER BY report_date DESC) AS rn
+                   ROW_NUMBER() OVER (PARTITION BY code ORDER BY report_date DESC, fetched_at DESC) AS rn
             FROM raw_financials
             WHERE report_date <= ?
               AND period_type LIKE '%FY%'

--- a/src/kabusys/research/factor_research.py
+++ b/src/kabusys/research/factor_research.py
@@ -438,7 +438,7 @@ def calc_quality(
                    ROW_NUMBER() OVER (PARTITION BY code ORDER BY report_date DESC, fetched_at DESC) AS rn
             FROM raw_financials
             WHERE report_date <= ?
-              AND period_type LIKE '%FY%'
+              AND period_type LIKE 'FYResult%'
         ),
         latest_fy AS (SELECT * FROM fy_ranked WHERE rn = 1),
         prior_fy  AS (SELECT * FROM fy_ranked WHERE rn = 2)

--- a/src/kabusys/strategy/feature_engineering.py
+++ b/src/kabusys/strategy/feature_engineering.py
@@ -25,7 +25,13 @@ from typing import Any
 import duckdb
 
 from kabusys.data.stats import zscore_normalize
-from kabusys.research.factor_research import calc_momentum, calc_value, calc_volatility
+from kabusys.research.factor_research import (
+    calc_momentum,
+    calc_quality,
+    calc_topix_relative,
+    calc_value,
+    calc_volatility,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +50,11 @@ _NORM_COLS: tuple[str, ...] = (
     "atr_pct",
     "volume_ratio",
     "ma200_dev",
+    "topix_rel_20",
+    "topix_rel_60",
+    "op_margin",
+    "rev_growth_yoy",
+    "profit_growth_yoy",
 )
 
 
@@ -103,10 +114,14 @@ def build_features(
     mom_list = calc_momentum(conn, target_date)
     vol_list = calc_volatility(conn, target_date)
     val_list = calc_value(conn, target_date)
+    topix_rel_list = calc_topix_relative(conn, target_date)
+    quality_list = calc_quality(conn, target_date)
 
     mom_map: dict[str, dict] = {r["code"]: r for r in mom_list}
     vol_map: dict[str, dict] = {r["code"]: r for r in vol_list}
     val_map: dict[str, dict] = {r["code"]: r for r in val_list}
+    topix_map: dict[str, dict] = {r["code"]: r for r in topix_rel_list}
+    quality_map: dict[str, dict] = {r["code"]: r for r in quality_list}
 
     # 2. current close prices（ユニバースフィルタ用）
     # target_date 以前の最新価格を参照（休場日・当日欠損に対応）
@@ -132,6 +147,8 @@ def build_features(
         m = mom_map.get(code, {})
         v = vol_map.get(code, {})
         f = val_map.get(code, {})
+        t = topix_map.get(code, {})
+        q = quality_map.get(code, {})
         merged.append(
             {
                 "code": code,
@@ -146,6 +163,11 @@ def build_features(
                 "per": f.get("per"),
                 "pbr": f.get("pbr"),  # 追加
                 "div_yield": f.get("div_yield"),  # 追加
+                "topix_rel_20": t.get("topix_rel_20"),
+                "topix_rel_60": t.get("topix_rel_60"),
+                "op_margin": q.get("op_margin"),
+                "rev_growth_yoy": q.get("rev_growth_yoy"),
+                "profit_growth_yoy": q.get("profit_growth_yoy"),
             }
         )
 
@@ -163,6 +185,10 @@ def build_features(
                 r[col] = max(-_ZSCORE_CLIP, min(_ZSCORE_CLIP, v))
             else:
                 r[col] = None
+        # quality_score: 正規化済み品質サブ指標の非 NULL 平均
+        q_vals = [r.get("op_margin"), r.get("rev_growth_yoy"), r.get("profit_growth_yoy")]
+        q_valid = [v for v in q_vals if v is not None and math.isfinite(v)]
+        r["quality_score"] = sum(q_valid) / len(q_valid) if q_valid else None
 
     # 7. features テーブルへ日付単位の置換（トランザクション＋バルク挿入で原子性を保証）
     params = [
@@ -177,6 +203,9 @@ def build_features(
             r.get("pbr"),  # 追加
             r.get("div_yield"),  # 追加
             r.get("ma200_dev"),
+            r.get("topix_rel_20"),
+            r.get("topix_rel_60"),
+            r.get("quality_score"),
         )
         for r in normalized
     ]
@@ -188,8 +217,9 @@ def build_features(
                 """
                 INSERT INTO features
                     (date, code, momentum_20, momentum_60, volatility_20, volume_ratio,
-                     per, pbr, div_yield, ma200_dev, created_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, current_timestamp)
+                     per, pbr, div_yield, ma200_dev,
+                     topix_rel_20, topix_rel_60, quality_score, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, current_timestamp)
                 """,
                 params,
             )

--- a/src/kabusys/strategy/feature_engineering.py
+++ b/src/kabusys/strategy/feature_engineering.py
@@ -186,7 +186,11 @@ def build_features(
             else:
                 r[col] = None
         # quality_score: 正規化済み品質サブ指標の非 NULL 平均
-        q_vals = [r.get("op_margin"), r.get("rev_growth_yoy"), r.get("profit_growth_yoy")]
+        q_vals = [
+            r.get("op_margin"),
+            r.get("rev_growth_yoy"),
+            r.get("profit_growth_yoy"),
+        ]
         q_valid = [v for v in q_vals if v is not None and math.isfinite(v)]
         r["quality_score"] = sum(q_valid) / len(q_valid) if q_valid else None
 

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -78,6 +78,10 @@ _REENTRY_COOLDOWN_DAYS: int = (
     5  # SELL 後この営業日数を経過するまで同一銘柄の BUY を禁止
 )
 
+_TOPIX_DRAWDOWN_THRESHOLD: float = -0.15  # 200MA 乖離率がこの値以下で縮小
+_TOPIX_SIZE_MULTIPLIER_BEAR: float = 0.5  # 地合い悪化時の size_multiplier
+_TOPIX_MIN_DATA_COUNT: int = 100  # 200MA を信頼できる最低データ数
+
 
 # ---------------------------------------------------------------------------
 # 設定ファイル読み込み
@@ -454,6 +458,54 @@ def _is_breadth_stop(
     if row is None:
         return False
     return bool(row[0])
+
+
+def _get_topix_size_multiplier(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date,
+) -> float:
+    """TOPIX の 200 日移動平均乖離率に基づく size_multiplier を返す。
+
+    TOPIX が 200 日 MA から _TOPIX_DRAWDOWN_THRESHOLD (−15%) 以上下落している場合は
+    _TOPIX_SIZE_MULTIPLIER_BEAR (0.5) を返す。
+    データ不足または topix_daily が空の場合は 1.0 を返す（制限なし）。
+
+    Args:
+        conn:        DuckDB 接続。topix_daily テーブルを参照する。
+        target_date: 基準日（この日以前の最新 TOPIX を使用）。
+
+    Returns:
+        size_multiplier（0.5 または 1.0）。
+    """
+    try:
+        row = conn.execute(
+            """
+            WITH topix_data AS (
+                SELECT date, close,
+                       AVG(close) OVER (ORDER BY date ROWS BETWEEN 199 PRECEDING AND CURRENT ROW) AS ma200,
+                       COUNT(*) OVER (ORDER BY date ROWS BETWEEN 199 PRECEDING AND CURRENT ROW) AS cnt
+                FROM topix_daily
+                WHERE date <= ?
+            )
+            SELECT close, ma200, cnt
+            FROM topix_data
+            WHERE date = (SELECT MAX(date) FROM topix_daily WHERE date <= ?)
+            """,
+            [target_date, target_date],
+        ).fetchone()
+    except Exception:
+        logger.debug(
+            "_get_topix_size_multiplier: topix_daily テーブルが存在しないため 1.0 を返す date=%s",
+            target_date,
+        )
+        return 1.0
+
+    if row is None or row[1] is None or row[2] < _TOPIX_MIN_DATA_COUNT:
+        return 1.0
+    close, ma200, cnt = float(row[0]), float(row[1]), row[2]
+    if ma200 > 0 and (close / ma200 - 1.0) < _TOPIX_DRAWDOWN_THRESHOLD:
+        return _TOPIX_SIZE_MULTIPLIER_BEAR
+    return 1.0
 
 
 def _fetch_gap_ratios(
@@ -1049,6 +1101,8 @@ def generate_signals(
 
     event_dates = event_dates or {}
     size_multiplier = _get_event_size_multiplier(event_dates, target_date, conn)
+    topix_multiplier = _get_topix_size_multiplier(conn, target_date)
+    size_multiplier = min(size_multiplier, topix_multiplier)
 
     # 1. features 読み込み（scope.mode="manual_codes" の場合は対象銘柄に限定）
     _scope_codes: frozenset[str] | None = None

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -502,7 +502,7 @@ def _get_topix_size_multiplier(
 
     if row is None or row[1] is None or row[2] < _TOPIX_MIN_DATA_COUNT:
         return 1.0
-    close, ma200, cnt = float(row[0]), float(row[1]), row[2]
+    close, ma200, _ = float(row[0]), float(row[1]), row[2]
     if ma200 > 0 and (close / ma200 - 1.0) < _TOPIX_DRAWDOWN_THRESHOLD:
         return _TOPIX_SIZE_MULTIPLIER_BEAR
     return 1.0

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -80,7 +80,7 @@ _REENTRY_COOLDOWN_DAYS: int = (
 
 _TOPIX_DRAWDOWN_THRESHOLD: float = -0.15  # 200MA 乖離率がこの値以下で縮小
 _TOPIX_SIZE_MULTIPLIER_BEAR: float = 0.5  # 地合い悪化時の size_multiplier
-_TOPIX_MIN_DATA_COUNT: int = 100  # 200MA を信頼できる最低データ数
+_TOPIX_MIN_DATA_COUNT: int = 100  # 200MA を信頼できる最低データ数（初期運用でのデータ蓄積期間を考慮し 200 でなく 100 に設定）
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -527,7 +527,6 @@ class TestEarningsCalendarPipeline:
 # TOPIX 日次 ETL テスト
 # ---------------------------------------------------------------------------
 
-from kabusys.data import jquants_client as jq
 from kabusys.data.pipeline import run_topix_etl, get_last_topix_date
 
 
@@ -546,7 +545,7 @@ def mem_db_topix():
 class TestSaveTopixDaily:
     def test_saves_records(self, mem_db_topix):
         records = [_sample_topix_record("20240110"), _sample_topix_record("20240111")]
-        saved = jq.save_topix_daily(mem_db_topix, records)
+        saved = jquants.save_topix_daily(mem_db_topix, records)
         assert saved == 2
         row = mem_db_topix.execute(
             "SELECT COUNT(*) FROM topix_daily"
@@ -555,25 +554,25 @@ class TestSaveTopixDaily:
 
     def test_idempotent(self, mem_db_topix):
         records = [_sample_topix_record("20240110")]
-        jq.save_topix_daily(mem_db_topix, records)
-        saved = jq.save_topix_daily(mem_db_topix, records)
+        jquants.save_topix_daily(mem_db_topix, records)
+        saved = jquants.save_topix_daily(mem_db_topix, records)
         assert saved == 1  # upsert: 上書き成功
         row = mem_db_topix.execute("SELECT COUNT(*) FROM topix_daily").fetchone()[0]
         assert row == 1
 
     def test_skips_missing_date(self, mem_db_topix):
-        saved = jq.save_topix_daily(mem_db_topix, [{"Open": 2300.0}])
+        saved = jquants.save_topix_daily(mem_db_topix, [{"Open": 2300.0}])
         assert saved == 0
 
     def test_skips_invalid_date(self, mem_db_topix):
-        saved = jq.save_topix_daily(mem_db_topix, [{"Date": "BADDATE", "Open": 2300.0, "High": 2310.0, "Low": 2290.0, "Close": 2305.0}])
+        saved = jquants.save_topix_daily(mem_db_topix, [{"Date": "BADDATE", "Open": 2300.0, "High": 2310.0, "Low": 2290.0, "Close": 2305.0}])
         assert saved == 0
 
 
 class TestRunTopixEtl:
     def test_fetches_and_saves(self, mem_db_topix):
-        with mock.patch.object(jq, "fetch_topix_daily", return_value=[_sample_topix_record("20240110")]) as mock_fetch, \
-             mock.patch.object(jq, "save_topix_daily", return_value=1) as mock_save:
+        with mock.patch.object(jquants, "fetch_topix_daily", return_value=[_sample_topix_record("20240110")]) as mock_fetch, \
+             mock.patch.object(jquants, "save_topix_daily", return_value=1) as mock_save:
             fetched, saved = run_topix_etl(mem_db_topix, date(2024, 1, 10))
         assert fetched == 1
         assert saved == 1
@@ -583,7 +582,7 @@ class TestRunTopixEtl:
             "INSERT INTO topix_daily (date, open, high, low, close) VALUES (?, 2300, 2310, 2290, 2305)",
             [date(2024, 1, 10)],
         )
-        with mock.patch.object(jq, "fetch_topix_daily") as mock_fetch:
+        with mock.patch.object(jquants, "fetch_topix_daily") as mock_fetch:
             fetched, saved = run_topix_etl(mem_db_topix, date(2024, 1, 10))
         mock_fetch.assert_not_called()
         assert fetched == 0

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -16,6 +16,7 @@ import pytest
 
 from kabusys.data import jquants_client as jquants
 from kabusys.data import quality
+from kabusys.data.pipeline import get_last_topix_date, run_topix_etl
 
 
 # ---------------------------------------------------------------------------
@@ -527,16 +528,21 @@ class TestEarningsCalendarPipeline:
 # TOPIX 日次 ETL テスト
 # ---------------------------------------------------------------------------
 
-from kabusys.data.pipeline import run_topix_etl, get_last_topix_date
-
 
 def _sample_topix_record(date_str: str = "20240110") -> dict:
-    return {"Date": date_str, "Open": 2300.1, "High": 2310.2, "Low": 2295.0, "Close": 2305.5}
+    return {
+        "Date": date_str,
+        "Open": 2300.1,
+        "High": 2310.2,
+        "Low": 2295.0,
+        "Close": 2305.5,
+    }
 
 
 @pytest.fixture
 def mem_db_topix():
     from kabusys.data.schema import init_schema
+
     c = init_schema(":memory:")
     yield c
     c.close()
@@ -547,9 +553,7 @@ class TestSaveTopixDaily:
         records = [_sample_topix_record("20240110"), _sample_topix_record("20240111")]
         saved = jquants.save_topix_daily(mem_db_topix, records)
         assert saved == 2
-        row = mem_db_topix.execute(
-            "SELECT COUNT(*) FROM topix_daily"
-        ).fetchone()[0]
+        row = mem_db_topix.execute("SELECT COUNT(*) FROM topix_daily").fetchone()[0]
         assert row == 2
 
     def test_idempotent(self, mem_db_topix):
@@ -565,14 +569,31 @@ class TestSaveTopixDaily:
         assert saved == 0
 
     def test_skips_invalid_date(self, mem_db_topix):
-        saved = jquants.save_topix_daily(mem_db_topix, [{"Date": "BADDATE", "Open": 2300.0, "High": 2310.0, "Low": 2290.0, "Close": 2305.0}])
+        saved = jquants.save_topix_daily(
+            mem_db_topix,
+            [
+                {
+                    "Date": "BADDATE",
+                    "Open": 2300.0,
+                    "High": 2310.0,
+                    "Low": 2290.0,
+                    "Close": 2305.0,
+                }
+            ],
+        )
         assert saved == 0
 
 
 class TestRunTopixEtl:
     def test_fetches_and_saves(self, mem_db_topix):
-        with mock.patch.object(jquants, "fetch_topix_daily", return_value=[_sample_topix_record("20240110")]) as mock_fetch, \
-             mock.patch.object(jquants, "save_topix_daily", return_value=1) as mock_save:
+        with (
+            mock.patch.object(
+                jquants,
+                "fetch_topix_daily",
+                return_value=[_sample_topix_record("20240110")],
+            ),
+            mock.patch.object(jquants, "save_topix_daily", return_value=1),
+        ):
             fetched, saved = run_topix_etl(mem_db_topix, date(2024, 1, 10))
         assert fetched == 1
         assert saved == 1

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -521,3 +521,79 @@ class TestEarningsCalendarPipeline:
         n = jq.save_earnings_calendar(conn, records)
         assert n == 1  # 有効な 1件のみ保存
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# TOPIX 日次 ETL テスト
+# ---------------------------------------------------------------------------
+
+from kabusys.data import jquants_client as jq
+from kabusys.data.pipeline import run_topix_etl, get_last_topix_date
+
+
+def _sample_topix_record(date_str: str = "20240110") -> dict:
+    return {"Date": date_str, "Open": 2300.1, "High": 2310.2, "Low": 2295.0, "Close": 2305.5}
+
+
+@pytest.fixture
+def mem_db_topix():
+    from kabusys.data.schema import init_schema
+    c = init_schema(":memory:")
+    yield c
+    c.close()
+
+
+class TestSaveTopixDaily:
+    def test_saves_records(self, mem_db_topix):
+        records = [_sample_topix_record("20240110"), _sample_topix_record("20240111")]
+        saved = jq.save_topix_daily(mem_db_topix, records)
+        assert saved == 2
+        row = mem_db_topix.execute(
+            "SELECT COUNT(*) FROM topix_daily"
+        ).fetchone()[0]
+        assert row == 2
+
+    def test_idempotent(self, mem_db_topix):
+        records = [_sample_topix_record("20240110")]
+        jq.save_topix_daily(mem_db_topix, records)
+        saved = jq.save_topix_daily(mem_db_topix, records)
+        assert saved == 1  # upsert: 上書き成功
+        row = mem_db_topix.execute("SELECT COUNT(*) FROM topix_daily").fetchone()[0]
+        assert row == 1
+
+    def test_skips_missing_date(self, mem_db_topix):
+        saved = jq.save_topix_daily(mem_db_topix, [{"Open": 2300.0}])
+        assert saved == 0
+
+    def test_skips_invalid_date(self, mem_db_topix):
+        saved = jq.save_topix_daily(mem_db_topix, [{"Date": "BADDATE", "Open": 2300.0, "High": 2310.0, "Low": 2290.0, "Close": 2305.0}])
+        assert saved == 0
+
+
+class TestRunTopixEtl:
+    def test_fetches_and_saves(self, mem_db_topix):
+        with mock.patch.object(jq, "fetch_topix_daily", return_value=[_sample_topix_record("20240110")]) as mock_fetch, \
+             mock.patch.object(jq, "save_topix_daily", return_value=1) as mock_save:
+            fetched, saved = run_topix_etl(mem_db_topix, date(2024, 1, 10))
+        assert fetched == 1
+        assert saved == 1
+
+    def test_skips_when_up_to_date(self, mem_db_topix):
+        mem_db_topix.execute(
+            "INSERT INTO topix_daily (date, open, high, low, close) VALUES (?, 2300, 2310, 2290, 2305)",
+            [date(2024, 1, 10)],
+        )
+        with mock.patch.object(jq, "fetch_topix_daily") as mock_fetch:
+            fetched, saved = run_topix_etl(mem_db_topix, date(2024, 1, 10))
+        mock_fetch.assert_not_called()
+        assert fetched == 0
+
+    def test_get_last_topix_date_none_when_empty(self, mem_db_topix):
+        assert get_last_topix_date(mem_db_topix) is None
+
+    def test_get_last_topix_date_returns_max(self, mem_db_topix):
+        mem_db_topix.executemany(
+            "INSERT INTO topix_daily (date, open, high, low, close) VALUES (?, 2300, 2310, 2290, 2305)",
+            [(date(2024, 1, 10),), (date(2024, 1, 11),)],
+        )
+        assert get_last_topix_date(mem_db_topix) == date(2024, 1, 11)

--- a/tests/test_factor_research.py
+++ b/tests/test_factor_research.py
@@ -586,3 +586,29 @@ class TestCalcTopixRelative:
         row = result[0]
         assert set(row.keys()) == {"date", "code", "topix_rel_20", "topix_rel_60"}
         assert row["date"] == self.TARGET
+
+    def test_returns_empty_when_topix_lag_window_insufficient(self, db):
+        """TOPIX data exists but fewer rows than LAG window -> returns []"""
+        from datetime import timedelta
+
+        conn = db
+        target_date = date(2024, 1, 31)
+        # Insert enough stock data (70 days)
+        base = date(2023, 11, 1)
+        for i in range(70):
+            d = base + timedelta(days=i)
+            c = 1000.0 + i
+            conn.execute(
+                "INSERT INTO prices_daily (date, code, open, high, low, close, volume, turnover)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                [d, "1301", c, c, c, c, 1000, c * 1000],
+            )
+        # Insert ONLY 10 days of TOPIX data (far less than 21-day LAG)
+        for i in range(10):
+            d = date(2024, 1, 22) + timedelta(days=i)
+            conn.execute(
+                "INSERT INTO topix_daily (date, open, high, low, close) VALUES (?, ?, ?, ?, ?)",
+                [d, 2000.0, 2010.0, 1990.0, 2000.0 + i],
+            )
+        result = calc_topix_relative(conn, target_date)
+        assert result == []

--- a/tests/test_factor_research.py
+++ b/tests/test_factor_research.py
@@ -20,6 +20,7 @@ from kabusys.research.factor_research import (
     calc_momentum,
     calc_volatility,
     calc_value,
+    calc_topix_relative,
 )
 from kabusys.research.feature_exploration import (
     calc_forward_returns,
@@ -50,6 +51,15 @@ def _insert_prices(conn, rows: list[tuple]):
         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT DO NOTHING
         """,
+        rows,
+    )
+
+
+def _insert_topix(conn, rows: list[tuple]):
+    """(date, open, high, low, close) を topix_daily に挿入。"""
+    conn.executemany(
+        "INSERT INTO topix_daily (date, open, high, low, close) VALUES (?, ?, ?, ?, ?) "
+        "ON CONFLICT DO NOTHING",
         rows,
     )
 
@@ -508,3 +518,71 @@ class TestResearchIsolation:
         calc_momentum(db, date(2024, 1, 5))
         after = db.execute("SELECT COUNT(*) FROM signal_queue").fetchone()[0]
         assert before == after  # signal_queue に変化なし
+
+
+# ---------------------------------------------------------------------------
+# calc_topix_relative
+# ---------------------------------------------------------------------------
+
+
+class TestCalcTopixRelative:
+    TARGET = date(2024, 3, 1)
+    START = date(2023, 1, 1)
+
+    def _make_prices(self, start: date, days: int, code: str, base: float) -> list[tuple]:
+        """base から 1% ずつ上昇する価格シリーズを生成。"""
+        from datetime import timedelta
+        rows = []
+        for i in range(days):
+            d = start + timedelta(days=i)
+            c = base * (1 + 0.01 * i)
+            rows.append((d, code, c, c, c, c, 100000, c * 100000))
+        return rows
+
+    def _make_topix(self, start: date, days: int, base: float) -> list[tuple]:
+        from datetime import timedelta
+        rows = []
+        for i in range(days):
+            d = start + timedelta(days=i)
+            c = base * (1 + 0.005 * i)  # 0.5% ずつ上昇（株より遅い）
+            rows.append((d, c, c, c, c))
+        return rows
+
+    def test_returns_correct_relative_momentum(self, db):
+        _insert_prices(db, self._make_prices(self.START, 425, "1001", 1000.0))
+        _insert_topix(db, self._make_topix(self.START, 425, 2000.0))
+        result = calc_topix_relative(db, self.TARGET)
+        assert len(result) == 1
+        row = result[0]
+        assert row["code"] == "1001"
+        # 株の 21 日リターン > TOPIX の 21 日リターン → topix_rel_20 > 0
+        assert row["topix_rel_20"] is not None
+        assert row["topix_rel_20"] > 0
+        # 株の 63 日リターン > TOPIX の 63 日リターン → topix_rel_60 > 0
+        assert row["topix_rel_60"] is not None
+        assert row["topix_rel_60"] > 0
+
+    def test_returns_empty_when_no_topix_data(self, db):
+        _insert_prices(db, self._make_prices(self.START, 425, "1001", 1000.0))
+        # topix_daily にデータなし
+        result = calc_topix_relative(db, self.TARGET)
+        assert result == []
+
+    def test_returns_none_for_insufficient_stock_history(self, db):
+        from datetime import timedelta
+        # 株は 10 日分のみ（21 日に足りない）
+        _insert_prices(db, self._make_prices(self.TARGET - timedelta(days=10), 10, "1001", 1000.0))
+        _insert_topix(db, self._make_topix(self.START, 425, 2000.0))
+        result = calc_topix_relative(db, self.TARGET)
+        assert len(result) == 1
+        assert result[0]["topix_rel_20"] is None
+        assert result[0]["topix_rel_60"] is None
+
+    def test_result_schema(self, db):
+        _insert_prices(db, self._make_prices(self.START, 425, "1001", 1000.0))
+        _insert_topix(db, self._make_topix(self.START, 425, 2000.0))
+        result = calc_topix_relative(db, self.TARGET)
+        assert len(result) == 1
+        row = result[0]
+        assert set(row.keys()) == {"date", "code", "topix_rel_20", "topix_rel_60"}
+        assert row["date"] == self.TARGET

--- a/tests/test_factor_research.py
+++ b/tests/test_factor_research.py
@@ -676,3 +676,21 @@ class TestCalcQuality:
         row = result[0]
         assert set(row.keys()) == {"date", "code", "op_margin", "rev_growth_yoy", "profit_growth_yoy"}
         assert row["date"] == self.TARGET
+
+    def test_op_margin_none_when_revenue_zero(self, db):
+        _insert_financials(db, [
+            ("1001", date(2024, 1, 1), "FYResultNotification", 0.0, 50_000.0, 30_000.0, 30.0, 0.0),
+        ])
+        result = calc_quality(db, self.TARGET)
+        assert len(result) == 1
+        assert result[0]["op_margin"] is None
+
+    def test_rev_growth_yoy_with_negative_prior_revenue(self, db):
+        _insert_financials(db, [
+            ("1001", date(2023, 1, 1), "FYResultNotification", -100_000.0, -10_000.0, -20_000.0, -20.0, 0.0),
+            ("1001", date(2024, 1, 1), "FYResultNotification", -80_000.0, -5_000.0, -10_000.0, -10.0, 0.0),
+        ])
+        result = calc_quality(db, self.TARGET)
+        assert len(result) == 1
+        # (-80000 - -100000) / abs(-100000) = 20000 / 100000 = 0.2
+        assert abs(result[0]["rev_growth_yoy"] - 0.2) < 1e-9

--- a/tests/test_factor_research.py
+++ b/tests/test_factor_research.py
@@ -530,9 +530,12 @@ class TestCalcTopixRelative:
     TARGET = date(2024, 3, 1)
     START = date(2023, 1, 1)
 
-    def _make_prices(self, start: date, days: int, code: str, base: float) -> list[tuple]:
+    def _make_prices(
+        self, start: date, days: int, code: str, base: float
+    ) -> list[tuple]:
         """base から 1% ずつ上昇する価格シリーズを生成。"""
         from datetime import timedelta
+
         rows = []
         for i in range(days):
             d = start + timedelta(days=i)
@@ -542,6 +545,7 @@ class TestCalcTopixRelative:
 
     def _make_topix(self, start: date, days: int, base: float) -> list[tuple]:
         from datetime import timedelta
+
         rows = []
         for i in range(days):
             d = start + timedelta(days=i)
@@ -571,8 +575,11 @@ class TestCalcTopixRelative:
 
     def test_returns_none_for_insufficient_stock_history(self, db):
         from datetime import timedelta
+
         # 株は 10 日分のみ（21 日に足りない）
-        _insert_prices(db, self._make_prices(self.TARGET - timedelta(days=10), 10, "1001", 1000.0))
+        _insert_prices(
+            db, self._make_prices(self.TARGET - timedelta(days=10), 10, "1001", 1000.0)
+        )
         _insert_topix(db, self._make_topix(self.START, 425, 2000.0))
         result = calc_topix_relative(db, self.TARGET)
         assert len(result) == 1
@@ -624,9 +631,21 @@ class TestCalcQuality:
     TARGET = date(2024, 3, 1)
 
     def test_computes_op_margin_from_fy_record(self, db):
-        _insert_financials(db, [
-            ("1001", date(2024, 1, 1), "FYResultNotification", 1_000_000.0, 200_000.0, 150_000.0, 100.0, 0.10),
-        ])
+        _insert_financials(
+            db,
+            [
+                (
+                    "1001",
+                    date(2024, 1, 1),
+                    "FYResultNotification",
+                    1_000_000.0,
+                    200_000.0,
+                    150_000.0,
+                    100.0,
+                    0.10,
+                ),
+            ],
+        )
         result = calc_quality(db, self.TARGET)
         assert len(result) == 1
         row = result[0]
@@ -634,10 +653,31 @@ class TestCalcQuality:
         assert abs(row["op_margin"] - 0.2) < 1e-9  # 200000 / 1000000
 
     def test_computes_yoy_growth_with_two_fy_records(self, db):
-        _insert_financials(db, [
-            ("1001", date(2023, 1, 1), "FYResultNotification", 1_000_000.0, 100_000.0, 80_000.0, 80.0, 0.08),
-            ("1001", date(2024, 1, 1), "FYResultNotification", 1_200_000.0, 150_000.0, 120_000.0, 120.0, 0.10),
-        ])
+        _insert_financials(
+            db,
+            [
+                (
+                    "1001",
+                    date(2023, 1, 1),
+                    "FYResultNotification",
+                    1_000_000.0,
+                    100_000.0,
+                    80_000.0,
+                    80.0,
+                    0.08,
+                ),
+                (
+                    "1001",
+                    date(2024, 1, 1),
+                    "FYResultNotification",
+                    1_200_000.0,
+                    150_000.0,
+                    120_000.0,
+                    120.0,
+                    0.10,
+                ),
+            ],
+        )
         result = calc_quality(db, self.TARGET)
         assert len(result) == 1
         row = result[0]
@@ -645,51 +685,138 @@ class TestCalcQuality:
         assert abs(row["profit_growth_yoy"] - 0.5) < 1e-9
 
     def test_growth_none_with_single_fy_record(self, db):
-        _insert_financials(db, [
-            ("1001", date(2024, 1, 1), "FYResultNotification", 1_000_000.0, 200_000.0, 150_000.0, 100.0, 0.10),
-        ])
+        _insert_financials(
+            db,
+            [
+                (
+                    "1001",
+                    date(2024, 1, 1),
+                    "FYResultNotification",
+                    1_000_000.0,
+                    200_000.0,
+                    150_000.0,
+                    100.0,
+                    0.10,
+                ),
+            ],
+        )
         result = calc_quality(db, self.TARGET)
         assert len(result) == 1
         assert result[0]["rev_growth_yoy"] is None
         assert result[0]["profit_growth_yoy"] is None
 
     def test_excludes_non_fy_records(self, db):
-        _insert_financials(db, [
-            ("1001", date(2024, 1, 1), "Q1ResultNotification", 250_000.0, 50_000.0, 40_000.0, 25.0, 0.10),
-        ])
+        _insert_financials(
+            db,
+            [
+                (
+                    "1001",
+                    date(2024, 1, 1),
+                    "Q1ResultNotification",
+                    250_000.0,
+                    50_000.0,
+                    40_000.0,
+                    25.0,
+                    0.10,
+                ),
+            ],
+        )
         result = calc_quality(db, self.TARGET)
         assert result == []
 
     def test_excludes_future_records(self, db):
-        _insert_financials(db, [
-            ("1001", date(2024, 4, 1), "FYResultNotification", 1_000_000.0, 200_000.0, 150_000.0, 100.0, 0.10),
-        ])
+        _insert_financials(
+            db,
+            [
+                (
+                    "1001",
+                    date(2024, 4, 1),
+                    "FYResultNotification",
+                    1_000_000.0,
+                    200_000.0,
+                    150_000.0,
+                    100.0,
+                    0.10,
+                ),
+            ],
+        )
         result = calc_quality(db, self.TARGET)
         assert result == []
 
     def test_result_schema(self, db):
-        _insert_financials(db, [
-            ("1001", date(2024, 1, 1), "FYResultNotification", 1_000_000.0, 200_000.0, 150_000.0, 100.0, 0.10),
-        ])
+        _insert_financials(
+            db,
+            [
+                (
+                    "1001",
+                    date(2024, 1, 1),
+                    "FYResultNotification",
+                    1_000_000.0,
+                    200_000.0,
+                    150_000.0,
+                    100.0,
+                    0.10,
+                ),
+            ],
+        )
         result = calc_quality(db, self.TARGET)
         assert len(result) == 1
         row = result[0]
-        assert set(row.keys()) == {"date", "code", "op_margin", "rev_growth_yoy", "profit_growth_yoy"}
+        assert set(row.keys()) == {
+            "date",
+            "code",
+            "op_margin",
+            "rev_growth_yoy",
+            "profit_growth_yoy",
+        }
         assert row["date"] == self.TARGET
 
     def test_op_margin_none_when_revenue_zero(self, db):
-        _insert_financials(db, [
-            ("1001", date(2024, 1, 1), "FYResultNotification", 0.0, 50_000.0, 30_000.0, 30.0, 0.0),
-        ])
+        _insert_financials(
+            db,
+            [
+                (
+                    "1001",
+                    date(2024, 1, 1),
+                    "FYResultNotification",
+                    0.0,
+                    50_000.0,
+                    30_000.0,
+                    30.0,
+                    0.0,
+                ),
+            ],
+        )
         result = calc_quality(db, self.TARGET)
         assert len(result) == 1
         assert result[0]["op_margin"] is None
 
     def test_rev_growth_yoy_with_negative_prior_revenue(self, db):
-        _insert_financials(db, [
-            ("1001", date(2023, 1, 1), "FYResultNotification", -100_000.0, -10_000.0, -20_000.0, -20.0, 0.0),
-            ("1001", date(2024, 1, 1), "FYResultNotification", -80_000.0, -5_000.0, -10_000.0, -10.0, 0.0),
-        ])
+        _insert_financials(
+            db,
+            [
+                (
+                    "1001",
+                    date(2023, 1, 1),
+                    "FYResultNotification",
+                    -100_000.0,
+                    -10_000.0,
+                    -20_000.0,
+                    -20.0,
+                    0.0,
+                ),
+                (
+                    "1001",
+                    date(2024, 1, 1),
+                    "FYResultNotification",
+                    -80_000.0,
+                    -5_000.0,
+                    -10_000.0,
+                    -10.0,
+                    0.0,
+                ),
+            ],
+        )
         result = calc_quality(db, self.TARGET)
         assert len(result) == 1
         # (-80000 - -100000) / abs(-100000) = 20000 / 100000 = 0.2

--- a/tests/test_factor_research.py
+++ b/tests/test_factor_research.py
@@ -21,6 +21,7 @@ from kabusys.research.factor_research import (
     calc_volatility,
     calc_value,
     calc_topix_relative,
+    calc_quality,
 )
 from kabusys.research.feature_exploration import (
     calc_forward_returns,
@@ -612,3 +613,66 @@ class TestCalcTopixRelative:
             )
         result = calc_topix_relative(conn, target_date)
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# calc_quality
+# ---------------------------------------------------------------------------
+
+
+class TestCalcQuality:
+    TARGET = date(2024, 3, 1)
+
+    def test_computes_op_margin_from_fy_record(self, db):
+        _insert_financials(db, [
+            ("1001", date(2024, 1, 1), "FYResultNotification", 1_000_000.0, 200_000.0, 150_000.0, 100.0, 0.10),
+        ])
+        result = calc_quality(db, self.TARGET)
+        assert len(result) == 1
+        row = result[0]
+        assert row["code"] == "1001"
+        assert abs(row["op_margin"] - 0.2) < 1e-9  # 200000 / 1000000
+
+    def test_computes_yoy_growth_with_two_fy_records(self, db):
+        _insert_financials(db, [
+            ("1001", date(2023, 1, 1), "FYResultNotification", 1_000_000.0, 100_000.0, 80_000.0, 80.0, 0.08),
+            ("1001", date(2024, 1, 1), "FYResultNotification", 1_200_000.0, 150_000.0, 120_000.0, 120.0, 0.10),
+        ])
+        result = calc_quality(db, self.TARGET)
+        assert len(result) == 1
+        row = result[0]
+        assert abs(row["rev_growth_yoy"] - 0.2) < 1e-9
+        assert abs(row["profit_growth_yoy"] - 0.5) < 1e-9
+
+    def test_growth_none_with_single_fy_record(self, db):
+        _insert_financials(db, [
+            ("1001", date(2024, 1, 1), "FYResultNotification", 1_000_000.0, 200_000.0, 150_000.0, 100.0, 0.10),
+        ])
+        result = calc_quality(db, self.TARGET)
+        assert len(result) == 1
+        assert result[0]["rev_growth_yoy"] is None
+        assert result[0]["profit_growth_yoy"] is None
+
+    def test_excludes_non_fy_records(self, db):
+        _insert_financials(db, [
+            ("1001", date(2024, 1, 1), "Q1ResultNotification", 250_000.0, 50_000.0, 40_000.0, 25.0, 0.10),
+        ])
+        result = calc_quality(db, self.TARGET)
+        assert result == []
+
+    def test_excludes_future_records(self, db):
+        _insert_financials(db, [
+            ("1001", date(2024, 4, 1), "FYResultNotification", 1_000_000.0, 200_000.0, 150_000.0, 100.0, 0.10),
+        ])
+        result = calc_quality(db, self.TARGET)
+        assert result == []
+
+    def test_result_schema(self, db):
+        _insert_financials(db, [
+            ("1001", date(2024, 1, 1), "FYResultNotification", 1_000_000.0, 200_000.0, 150_000.0, 100.0, 0.10),
+        ])
+        result = calc_quality(db, self.TARGET)
+        assert len(result) == 1
+        row = result[0]
+        assert set(row.keys()) == {"date", "code", "op_margin", "rev_growth_yoy", "profit_growth_yoy"}
+        assert row["date"] == self.TARGET

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -1,6 +1,7 @@
 """
 build_features 統合テスト — TOPIX 相対強度・品質スコア (Issue #257)
 """
+
 from __future__ import annotations
 
 import math
@@ -23,7 +24,9 @@ def conn():
     c.close()
 
 
-def _insert_prices(conn, code: str, start: date, days: int, base: float = 1000.0) -> None:
+def _insert_prices(
+    conn, code: str, start: date, days: int, base: float = 1000.0
+) -> None:
     rows = []
     for i in range(days):
         d = start + timedelta(days=i)
@@ -55,8 +58,28 @@ def _insert_financials(conn, code: str) -> None:
         "(code, report_date, period_type, revenue, operating_profit, net_income, eps, roe, bps, fetched_at) "
         "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, current_timestamp) ON CONFLICT DO NOTHING",
         [
-            (code, date(2023, 1, 1), "FYResultNotification", 1_000_000, 200_000, 150_000, 100, 0.10, 1000),
-            (code, date(2024, 1, 1), "FYResultNotification", 1_200_000, 250_000, 180_000, 120, 0.12, 1100),
+            (
+                code,
+                date(2023, 1, 1),
+                "FYResultNotification",
+                1_000_000,
+                200_000,
+                150_000,
+                100,
+                0.10,
+                1000,
+            ),
+            (
+                code,
+                date(2024, 1, 1),
+                "FYResultNotification",
+                1_200_000,
+                250_000,
+                180_000,
+                120,
+                0.12,
+                1100,
+            ),
         ],
     )
 

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -1,0 +1,125 @@
+"""
+build_features 統合テスト — TOPIX 相対強度・品質スコア (Issue #257)
+"""
+from __future__ import annotations
+
+import math
+from datetime import date, timedelta
+
+import pytest
+
+from kabusys.data.schema import init_schema
+from kabusys.strategy.feature_engineering import build_features
+
+
+TARGET = date(2024, 3, 1)
+START = date(2023, 1, 1)
+
+
+@pytest.fixture
+def conn():
+    c = init_schema(":memory:")
+    yield c
+    c.close()
+
+
+def _insert_prices(conn, code: str, start: date, days: int, base: float = 1000.0) -> None:
+    rows = []
+    for i in range(days):
+        d = start + timedelta(days=i)
+        c = base * (1 + 0.01 * i)
+        rows.append((d, code, c, c, c, c, 100_000, c * 600_000))  # turnover > 5億
+    conn.executemany(
+        "INSERT INTO prices_daily (date, code, open, high, low, close, volume, turnover) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT DO NOTHING",
+        rows,
+    )
+
+
+def _insert_topix(conn, start: date, days: int, base: float = 2000.0) -> None:
+    rows = []
+    for i in range(days):
+        d = start + timedelta(days=i)
+        c = base * (1 + 0.005 * i)
+        rows.append((d, c, c, c, c))
+    conn.executemany(
+        "INSERT INTO topix_daily (date, open, high, low, close) VALUES (?, ?, ?, ?, ?) "
+        "ON CONFLICT DO NOTHING",
+        rows,
+    )
+
+
+def _insert_financials(conn, code: str) -> None:
+    conn.executemany(
+        "INSERT INTO raw_financials "
+        "(code, report_date, period_type, revenue, operating_profit, net_income, eps, roe, bps, fetched_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, current_timestamp) ON CONFLICT DO NOTHING",
+        [
+            (code, date(2023, 1, 1), "FYResultNotification", 1_000_000, 200_000, 150_000, 100, 0.10, 1000),
+            (code, date(2024, 1, 1), "FYResultNotification", 1_200_000, 250_000, 180_000, 120, 0.12, 1100),
+        ],
+    )
+
+
+class TestBuildFeaturesWithNewColumns:
+    def test_topix_rel_columns_populated_when_topix_data_exists(self, conn):
+        _insert_prices(conn, "1001", START, 430)
+        _insert_topix(conn, START, 430)
+        _insert_financials(conn, "1001")
+        count = build_features(conn, TARGET)
+        assert count == 1
+        row = conn.execute(
+            "SELECT topix_rel_20, topix_rel_60 FROM features WHERE date=? AND code=?",
+            [TARGET, "1001"],
+        ).fetchone()
+        assert row is not None
+        assert row[0] is not None and math.isfinite(row[0])
+        assert row[1] is not None and math.isfinite(row[1])
+
+    def test_topix_rel_columns_null_when_no_topix_data(self, conn):
+        _insert_prices(conn, "1001", START, 430)
+        # topix_daily にデータなし
+        _insert_financials(conn, "1001")
+        count = build_features(conn, TARGET)
+        assert count == 1
+        row = conn.execute(
+            "SELECT topix_rel_20, topix_rel_60 FROM features WHERE date=? AND code=?",
+            [TARGET, "1001"],
+        ).fetchone()
+        assert row[0] is None
+        assert row[1] is None
+
+    def test_quality_score_populated_when_fy_data_exists(self, conn):
+        _insert_prices(conn, "1001", START, 430)
+        _insert_topix(conn, START, 430)
+        _insert_financials(conn, "1001")
+        build_features(conn, TARGET)
+        row = conn.execute(
+            "SELECT quality_score FROM features WHERE date=? AND code=?",
+            [TARGET, "1001"],
+        ).fetchone()
+        assert row is not None
+        assert row[0] is not None and math.isfinite(row[0])
+
+    def test_quality_score_null_when_no_financials(self, conn):
+        _insert_prices(conn, "1001", START, 430)
+        _insert_topix(conn, START, 430)
+        # raw_financials にデータなし
+        build_features(conn, TARGET)
+        row = conn.execute(
+            "SELECT quality_score FROM features WHERE date=? AND code=?",
+            [TARGET, "1001"],
+        ).fetchone()
+        assert row is not None
+        assert row[0] is None
+
+    def test_idempotent(self, conn):
+        _insert_prices(conn, "1001", START, 430)
+        _insert_topix(conn, START, 430)
+        _insert_financials(conn, "1001")
+        build_features(conn, TARGET)
+        build_features(conn, TARGET)
+        count = conn.execute(
+            "SELECT COUNT(*) FROM features WHERE date=?", [TARGET]
+        ).fetchone()[0]
+        assert count == 1  # 日付単位で置換されるため重複なし

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -625,8 +625,11 @@ class TestGetTopixSizeMultiplier:
             rows,
         )
 
-    def _make_topix_series(self, conn, start: date, days: int, start_close: float, end_close: float) -> None:
+    def _make_topix_series(
+        self, conn, start: date, days: int, start_close: float, end_close: float
+    ) -> None:
         from datetime import timedelta
+
         rows = []
         for i in range(days):
             d = start + timedelta(days=i)
@@ -638,12 +641,17 @@ class TestGetTopixSizeMultiplier:
         assert _get_topix_size_multiplier(conn, TARGET_DATE) == 1.0
 
     def test_returns_1_when_above_ma200(self, conn):
-        self._make_topix_series(conn, TARGET_DATE - timedelta(days=250), 250, 2000.0, 2000.0)
+        self._make_topix_series(
+            conn, TARGET_DATE - timedelta(days=250), 250, 2000.0, 2000.0
+        )
         assert _get_topix_size_multiplier(conn, TARGET_DATE) == 1.0
 
     def test_returns_05_when_below_ma200_by_15_percent(self, conn):
         from datetime import timedelta
-        self._make_topix_series(conn, TARGET_DATE - timedelta(days=250), 240, 2000.0, 2000.0)
+
+        self._make_topix_series(
+            conn, TARGET_DATE - timedelta(days=250), 240, 2000.0, 2000.0
+        )
         # 直近 10 日を 1600 に設定（200MA ≈ 2000 なので乖離率 ≈ -0.20）
         recent_start = TARGET_DATE - timedelta(days=10)
         self._make_topix_series(conn, recent_start, 11, 1600.0, 1600.0)
@@ -652,5 +660,8 @@ class TestGetTopixSizeMultiplier:
 
     def test_returns_1_when_insufficient_data(self, conn):
         from datetime import timedelta
-        self._make_topix_series(conn, TARGET_DATE - timedelta(days=50), 50, 2000.0, 2000.0)
+
+        self._make_topix_series(
+            conn, TARGET_DATE - timedelta(days=50), 50, 2000.0, 2000.0
+        )
         assert _get_topix_size_multiplier(conn, TARGET_DATE) == 1.0

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -7,7 +7,7 @@ breadth_stop による BUY 停止の動作検証。
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, timedelta
 
 import pytest
 
@@ -606,3 +606,51 @@ def test_generate_signals_no_ai_warning_when_ai_disabled(conn, monkeypatch, capl
     assert len(ai_warnings) == 0, (
         f"ENABLE_AI_SENTIMENT=false なのに AI 警告が {len(ai_warnings)} 件出力された"
     )
+
+
+# ---------------------------------------------------------------------------
+# Task 6: TOPIX 200MA 乖離率に基づく size_multiplier 縮小
+# ---------------------------------------------------------------------------
+
+from kabusys.strategy.signal_generator import _get_topix_size_multiplier  # noqa: E402
+
+
+class TestGetTopixSizeMultiplier:
+    """TOPIX 200MA 乖離率に基づく size_multiplier のテスト。"""
+
+    def _insert_topix(self, conn, rows: list[tuple]) -> None:
+        conn.executemany(
+            "INSERT INTO topix_daily (date, open, high, low, close) VALUES (?, ?, ?, ?, ?) "
+            "ON CONFLICT DO NOTHING",
+            rows,
+        )
+
+    def _make_topix_series(self, conn, start: date, days: int, start_close: float, end_close: float) -> None:
+        from datetime import timedelta
+        rows = []
+        for i in range(days):
+            d = start + timedelta(days=i)
+            c = start_close + (end_close - start_close) * i / max(days - 1, 1)
+            rows.append((d, c, c, c, c))
+        self._insert_topix(conn, rows)
+
+    def test_returns_1_when_no_topix_data(self, conn):
+        assert _get_topix_size_multiplier(conn, TARGET_DATE) == 1.0
+
+    def test_returns_1_when_above_ma200(self, conn):
+        self._make_topix_series(conn, TARGET_DATE - timedelta(days=250), 250, 2000.0, 2000.0)
+        assert _get_topix_size_multiplier(conn, TARGET_DATE) == 1.0
+
+    def test_returns_05_when_below_ma200_by_15_percent(self, conn):
+        from datetime import timedelta
+        self._make_topix_series(conn, TARGET_DATE - timedelta(days=250), 240, 2000.0, 2000.0)
+        # 直近 10 日を 1600 に設定（200MA ≈ 2000 なので乖離率 ≈ -0.20）
+        recent_start = TARGET_DATE - timedelta(days=10)
+        self._make_topix_series(conn, recent_start, 11, 1600.0, 1600.0)
+        result = _get_topix_size_multiplier(conn, TARGET_DATE)
+        assert result == 0.5
+
+    def test_returns_1_when_insufficient_data(self, conn):
+        from datetime import timedelta
+        self._make_topix_series(conn, TARGET_DATE - timedelta(days=50), 50, 2000.0, 2000.0)
+        assert _get_topix_size_multiplier(conn, TARGET_DATE) == 1.0


### PR DESCRIPTION
## Summary

- **TOPIX 日次 ETL 追加**: `jquants_client.fetch_topix_daily()` / `save_topix_daily()` と `pipeline.run_topix_etl()` を実装し、`run_daily_etl()` の Step 5 として統合
- **TOPIX 相対強度ファクター**: `calc_topix_relative()` で `topix_rel_20`（21日）・`topix_rel_60`（63日）の銘柄対比 TOPIX 超過リターンを計算
- **財務品質ファクター**: `calc_quality()` で `op_margin`・`rev_growth_yoy`・`profit_growth_yoy` を `raw_financials` FY レコードから算出
- **スキーマ拡張**: `features` テーブルに `topix_rel_20 DOUBLE`・`topix_rel_60 DOUBLE`・`quality_score DOUBLE` を追加（マイグレーション含む）
- **`build_features()` 統合**: 新ファクターを正規化・クリップし、`quality_score` を品質サブ指標の平均として算出・保存
- **地合い悪化時の `size_multiplier` 縮小**: `_get_topix_size_multiplier()` を `signal_generator` に追加、TOPIX が 200MA から −15% 以上乖離した場合に `size_multiplier = 0.5` を適用

## Test Plan

- [ ] `python -m pytest tests/ -q` → 1674 passed, 0 failed
- [ ] `python -m pytest tests/test_data_pipeline.py -v` — TOPIX ETL テスト（save/run/get_last）
- [ ] `python -m pytest tests/test_factor_research.py::TestCalcTopixRelative tests/test_factor_research.py::TestCalcQuality -v`
- [ ] `python -m pytest tests/test_feature_engineering.py -v` — build_features 統合テスト
- [ ] `python -m pytest tests/test_signal_generator.py::TestGetTopixSizeMultiplier -v`

Closes #257