### PR TITLE
refactor: signal_generator / backtest の AI 依存を RegimeProvider で抽象化し Core-only モードを定義する (Issue #271)

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,8 +547,9 @@ touch data/stop_requested.flag
     - monitoring_engine.py         — 各 Monitor を統括するポーリングエンジン
     - system_monitor.py            — CPU / メモリ / プロセス監視
     - streamlit_dashboard.py       — Streamlit Home ページ（SQLite 参照）
-    - dashboard_data.py            — 全ページ共通データロード関数（DuckDB / SQLite）
+    - dashboard_data.py            — Core 運用ページ向けデータロード関数（DuckDB / SQLite）
     - operations_data.py           — 運用フローページ向けデータロード関数（SQLite / Streamlit 非依存）
+    - strategy_lab_data.py         — Strategy Lab ページ（AI Addon）専用データロード関数（DuckDB）
     - pages/
       - 2_Initial_Setup.py         — 環境変数・設定・DB・Task Scheduler 確認
       - 3_Pre_Market.py            — 朝の READY/BLOCKED 判定・データ鮮度確認

--- a/docs/superpowers/plans/2026-05-08-regime-provider-core-only-mode.md
+++ b/docs/superpowers/plans/2026-05-08-regime-provider-core-only-mode.md
@@ -1,0 +1,572 @@
+# RegimeProvider と Core-only モード定義 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `signal_generator.py` と `backtest/engine.py` の `market_regime` / `ai_scores` 直参照を `RegimeProvider` プロトコルで抽象化し、`ENABLE_AI_SENTIMENT=false` + AI テーブル空の状態で Core 売買フロー・バックテストが明示的に正常動作するようにする（Issue #271）。
+
+**Architecture:** `src/kabusys/core/interfaces/regime.py` に `RegimeProvider` Protocol・`NullRegimeProvider`（常に 'bull'）・`DatabaseRegimeProvider`（DB 参照）を定義する。`signal_generator._is_bear_regime()` を廃止して `regime_provider.get_regime()` に差し替え、AI スコアクエリを `enable_ai_sentiment` フラグでガードする。`backtest/engine._fetch_regime()` も同様に置き換える。
+
+**Tech Stack:** Python 3.10+, typing.Protocol, DuckDB, pytest
+
+---
+
+## ファイル構成
+
+```
+新規作成:
+  src/kabusys/core/__init__.py
+  src/kabusys/core/interfaces/__init__.py
+  src/kabusys/core/interfaces/regime.py
+  tests/test_regime_provider.py
+
+変更:
+  src/kabusys/strategy/signal_generator.py
+    - _is_bear_regime() を削除
+    - generate_signals() に regime_provider 引数追加 + AI スコアフラグガード
+
+  src/kabusys/backtest/engine.py
+    - _fetch_regime() を削除
+    - _build_backtest_conn() の AI テーブルコピーを条件化
+    - run_backtest() 内で regime_provider を構築して直接使用
+```
+
+---
+
+## Task 1: `RegimeProvider` インターフェースと実装を定義する
+
+**Files:**
+- Create: `src/kabusys/core/__init__.py`
+- Create: `src/kabusys/core/interfaces/__init__.py`
+- Create: `src/kabusys/core/interfaces/regime.py`
+- Test: `tests/test_regime_provider.py`
+
+- [ ] **Step 1: テストファイルを作成する（失敗確認用）**
+
+`tests/test_regime_provider.py` を以下の内容で作成:
+
+```python
+"""tests/test_regime_provider.py — RegimeProvider 実装の単体テスト"""
+from datetime import date
+
+import pytest
+
+from kabusys.core.interfaces import build_regime_provider
+from kabusys.core.interfaces.regime import DatabaseRegimeProvider, NullRegimeProvider
+
+
+@pytest.fixture
+def duck_conn():
+    from kabusys.data.schema import init_schema
+
+    conn = init_schema(":memory:")
+    yield conn
+    conn.close()
+
+
+def test_null_regime_provider_always_bull():
+    p = NullRegimeProvider()
+    assert p.get_regime(date.today()) == "bull"
+
+
+def test_null_regime_provider_any_date():
+    p = NullRegimeProvider()
+    assert p.get_regime(date(2020, 1, 1)) == "bull"
+
+
+def test_db_regime_provider_empty_table_returns_bull(duck_conn):
+    p = DatabaseRegimeProvider(duck_conn)
+    assert p.get_regime(date.today()) == "bull"
+
+
+def test_db_regime_provider_returns_stored_label(duck_conn):
+    duck_conn.execute(
+        "INSERT INTO market_regime (date, regime_score, regime_label, ma200_ratio, macro_sentiment)"
+        " VALUES ('2024-09-01', 0.8, 'neutral', 1.05, 0.1)"
+    )
+    p = DatabaseRegimeProvider(duck_conn)
+    assert p.get_regime(date(2024, 9, 1)) == "neutral"
+
+
+def test_db_regime_provider_bear(duck_conn):
+    duck_conn.execute(
+        "INSERT INTO market_regime (date, regime_score, regime_label, ma200_ratio, macro_sentiment)"
+        " VALUES ('2024-09-02', -0.5, 'bear', 0.88, -0.4)"
+    )
+    p = DatabaseRegimeProvider(duck_conn)
+    assert p.get_regime(date(2024, 9, 2)) == "bear"
+
+
+def test_build_regime_provider_disabled_returns_null(duck_conn):
+    p = build_regime_provider(duck_conn, enabled=False)
+    assert isinstance(p, NullRegimeProvider)
+
+
+def test_build_regime_provider_enabled_returns_db(duck_conn):
+    p = build_regime_provider(duck_conn, enabled=True)
+    assert isinstance(p, DatabaseRegimeProvider)
+```
+
+- [ ] **Step 2: テスト実行（失敗確認）**
+
+```bash
+pytest tests/test_regime_provider.py -v
+```
+
+期待: `ModuleNotFoundError: No module named 'kabusys.core'`
+
+- [ ] **Step 3: `src/kabusys/core/__init__.py` を作成（空ファイル）**
+
+```python
+```
+
+（ファイルを空で作成する）
+
+- [ ] **Step 4: `src/kabusys/core/interfaces/regime.py` を作成**
+
+```python
+"""regime.py — RegimeProvider プロトコルと Core 実装。
+
+Core-only モード（AI Addon 未導入時）は NullRegimeProvider を使う。
+AI Addon 有効時は DatabaseRegimeProvider が market_regime テーブルを参照する。
+"""
+from __future__ import annotations
+
+from datetime import date
+from typing import Protocol
+
+import duckdb
+
+
+class RegimeProvider(Protocol):
+    """市場レジームラベルを返すインターフェース。"""
+
+    def get_regime(self, target_date: date) -> str:
+        """レジームラベルを返す。データなし時は 'bull' を返す。"""
+        ...
+
+
+class NullRegimeProvider:
+    """AI Addon 未導入時のフォールバック。常に 'bull' を返す。"""
+
+    def get_regime(self, target_date: date) -> str:
+        return "bull"
+
+
+class DatabaseRegimeProvider:
+    """market_regime テーブルからレジームを取得する Core 実装。"""
+
+    def __init__(self, conn: duckdb.DuckDBPyConnection) -> None:
+        self._conn = conn
+
+    def get_regime(self, target_date: date) -> str:
+        row = self._conn.execute(
+            "SELECT regime_label FROM market_regime WHERE date = ?",
+            [target_date],
+        ).fetchone()
+        return row[0] if row else "bull"
+```
+
+- [ ] **Step 5: `src/kabusys/core/interfaces/__init__.py` を作成**
+
+```python
+"""core/interfaces — Core が Addon に公開する接続点の定義。"""
+from __future__ import annotations
+
+import duckdb
+
+from kabusys.core.interfaces.regime import (
+    DatabaseRegimeProvider,
+    NullRegimeProvider,
+    RegimeProvider,
+)
+
+__all__ = [
+    "RegimeProvider",
+    "NullRegimeProvider",
+    "DatabaseRegimeProvider",
+    "build_regime_provider",
+]
+
+
+def build_regime_provider(
+    conn: duckdb.DuckDBPyConnection,
+    enabled: bool,
+) -> RegimeProvider:
+    """ENABLE_AI_SENTIMENT フラグに基づいて RegimeProvider を返す。"""
+    if enabled:
+        return DatabaseRegimeProvider(conn)
+    return NullRegimeProvider()
+```
+
+- [ ] **Step 6: テスト実行（パス確認）**
+
+```bash
+pytest tests/test_regime_provider.py -v
+```
+
+期待: 7 件 PASSED
+
+- [ ] **Step 7: ruff チェック**
+
+```bash
+python -m ruff check src/kabusys/core/ tests/test_regime_provider.py
+python -m ruff format --check src/kabusys/core/ tests/test_regime_provider.py
+```
+
+期待: エラーなし
+
+- [ ] **Step 8: コミット**
+
+```bash
+git add src/kabusys/core/ tests/test_regime_provider.py
+git commit -m "feat: RegimeProvider プロトコルと Core 実装を追加 (Issue #271)"
+```
+
+---
+
+## Task 2: `signal_generator.py` を `RegimeProvider` に移行する
+
+**Files:**
+- Modify: `src/kabusys/strategy/signal_generator.py`
+- Test: `tests/test_signal_generator.py`（既存テストのリグレッション確認）
+
+- [ ] **Step 1: ベースラインを確認する**
+
+```bash
+pytest tests/test_signal_generator.py -v --tb=short -q
+```
+
+期待: 全件 PASSED（件数を記録しておく）
+
+- [ ] **Step 2: `signal_generator.py` のインポートに `RegimeProvider` 関連を追加する**
+
+ファイル先頭の `from kabusys.data.calendar_management import ...` の行（line 39 付近）の直後に追加:
+
+```python
+from kabusys.core.interfaces import RegimeProvider, build_regime_provider
+```
+
+- [ ] **Step 3: `_is_bear_regime()` 関数を削除する**
+
+以下のブロックをファイルから削除する（line 428-442 付近）:
+
+```python
+def _is_bear_regime(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date,
+) -> bool:
+    """market_regime テーブルの regime_label を参照し、Bear 相場か否かを判定する。
+
+    データが存在しない場合は False（安全側：BUY を許可）を返す。
+    """
+    row = conn.execute(
+        "SELECT regime_label FROM market_regime WHERE date = ?",
+        [target_date],
+    ).fetchone()
+    if row is None:
+        return False
+    return row[0] == "bear"
+```
+
+- [ ] **Step 4: `generate_signals()` のシグネチャに `regime_provider` を追加する**
+
+変更前（line 1005-1015 付近）:
+
+```python
+def generate_signals(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date,
+    threshold: float | None = None,
+    weights: dict[str, float] | None = None,
+    event_dates: dict[date, str] | None = None,
+    scope: BacktestScope | None = None,
+    min_holding_days: int | None = None,
+    max_holding_days: int | None = None,
+    trailing_stop_atr: float | None = None,
+) -> int:
+```
+
+変更後:
+
+```python
+def generate_signals(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date,
+    threshold: float | None = None,
+    weights: dict[str, float] | None = None,
+    event_dates: dict[date, str] | None = None,
+    scope: BacktestScope | None = None,
+    min_holding_days: int | None = None,
+    max_holding_days: int | None = None,
+    trailing_stop_atr: float | None = None,
+    *,
+    regime_provider: RegimeProvider | None = None,
+) -> int:
+```
+
+- [ ] **Step 5: `generate_signals()` 内の `from kabusys.config import Settings` と `ai_enabled` を移動する**
+
+関数内の以下の 2 行（line 1191-1194 付近）を削除する:
+
+```python
+    from kabusys.config import Settings
+
+    value_config = _load_value_config()
+    ai_enabled = Settings().enable_ai_sentiment
+```
+
+削除後、同じ位置に以下を書く（`value_config` の読み込みはそのまま残す）:
+
+```python
+    from kabusys.config import Settings
+
+    ai_enabled = Settings().enable_ai_sentiment
+    if regime_provider is None:
+        regime_provider = build_regime_provider(conn, ai_enabled)
+    value_config = _load_value_config()
+```
+
+- [ ] **Step 6: AI スコアクエリをフラグガード化する**
+
+変更前（line 1156-1161 付近）:
+
+```python
+    # 2. AI スコア読み込み（センチメントスコアのみ使用）
+    ai_rows = conn.execute(
+        "SELECT code, ai_score FROM ai_scores WHERE date = ?",
+        [target_date],
+    ).fetchall()
+    ai_map: dict[str, dict] = {code: {"ai_score": ai} for code, ai in ai_rows}
+```
+
+変更後:
+
+```python
+    # 2. AI スコア読み込み（ENABLE_AI_SENTIMENT=false 時はスキップ）
+    ai_map: dict[str, dict]
+    if ai_enabled:
+        ai_rows = conn.execute(
+            "SELECT code, ai_score FROM ai_scores WHERE date = ?",
+            [target_date],
+        ).fetchall()
+        ai_map = {code: {"ai_score": ai} for code, ai in ai_rows}
+    else:
+        ai_map = {}
+```
+
+- [ ] **Step 7: `_is_bear_regime()` の呼び出しを `regime_provider.get_regime()` に置き換える**
+
+変更前（line 1163-1169 付近）:
+
+```python
+    # 3. Bear レジーム判定（market_regime テーブルから取得）
+    regime_is_bear = _is_bear_regime(conn, target_date)
+    if regime_is_bear:
+        logger.info(
+            "generate_signals: Bear レジーム検知 — BUY シグナル抑制 date=%s",
+            target_date,
+        )
+```
+
+変更後:
+
+```python
+    # 3. Bear レジーム判定
+    regime_is_bear = regime_provider.get_regime(target_date) == "bear"
+    if regime_is_bear:
+        logger.info(
+            "generate_signals: Bear レジーム検知 — BUY シグナル抑制 date=%s",
+            target_date,
+        )
+```
+
+- [ ] **Step 8: テスト実行**
+
+```bash
+pytest tests/test_signal_generator.py -v --tb=short -q
+```
+
+期待: Step 1 と同件数 PASSED
+
+- [ ] **Step 9: ruff チェック**
+
+```bash
+python -m ruff check src/kabusys/strategy/signal_generator.py
+python -m ruff format --check src/kabusys/strategy/signal_generator.py
+```
+
+期待: エラーなし
+
+- [ ] **Step 10: コミット**
+
+```bash
+git add src/kabusys/strategy/signal_generator.py
+git commit -m "refactor: signal_generator を RegimeProvider に移行し AI スコアをフラグガード化 (Issue #271)"
+```
+
+---
+
+## Task 3: `backtest/engine.py` を `RegimeProvider` に移行する
+
+**Files:**
+- Modify: `src/kabusys/backtest/engine.py`
+- Test: `tests/test_backtest_engine.py`（既存テストのリグレッション確認）
+
+- [ ] **Step 1: ベースラインを確認する**
+
+```bash
+pytest tests/test_backtest_engine.py -v --tb=short -q
+```
+
+期待: 全件 PASSED（件数を記録しておく）
+
+- [ ] **Step 2: `engine.py` のインポートに `RegimeProvider` 関連を追加する**
+
+`from kabusys.portfolio import ...` ブロック（line 19-26 付近）の直後に追加:
+
+```python
+from kabusys.core.interfaces import RegimeProvider, build_regime_provider
+```
+
+- [ ] **Step 3: `_fetch_regime()` 関数を削除する**
+
+以下のブロックをファイルから削除する（line 340-355 付近）:
+
+```python
+def _fetch_regime(conn: duckdb.DuckDBPyConnection, trading_day: date) -> str:
+    """market_regime テーブルから当日レジームを返す。データなしなら 'bull' でフォールバック。
+
+    schema.py の market_regime テーブルのレジーム列名は `regime_label`。
+    """
+    row = conn.execute(
+        "SELECT regime_label FROM market_regime WHERE date = ?", [trading_day]
+    ).fetchone()
+    if row is None:
+        # バックテスト序盤などでレジームデータが未整備の場合は通常の運用。INFO に留める。
+        logger.info(
+            "_fetch_regime: %s のレジームが取得できません。'bull' でフォールバック。",
+            trading_day,
+        )
+        return "bull"
+    return row[0]
+```
+
+- [ ] **Step 4: `_build_backtest_conn()` の AI テーブルコピーを条件化する**
+
+変更前（line 92 付近）:
+
+```python
+    date_filtered_tables = ("prices_daily", "features", "ai_scores", "market_regime")
+```
+
+変更後:
+
+```python
+    from kabusys.config import Settings
+
+    _ai_enabled = Settings().enable_ai_sentiment
+    _core_tables: tuple[str, ...] = ("prices_daily", "features", "market_regime")
+    _ai_tables: tuple[str, ...] = ("ai_scores",) if _ai_enabled else ()
+    date_filtered_tables = _core_tables + _ai_tables
+```
+
+- [ ] **Step 5: `run_backtest()` 内で `regime_provider` を構築する**
+
+`run_backtest()` 関数内の `bt_conn = _build_backtest_conn(...)` 呼び出し（line 483 付近）の直後に追加:
+
+```python
+    from kabusys.config import Settings
+
+    _regime_provider: RegimeProvider = build_regime_provider(
+        bt_conn, Settings().enable_ai_sentiment
+    )
+```
+
+- [ ] **Step 6: `_fetch_regime()` の呼び出しを `_regime_provider.get_regime()` に置き換える**
+
+変更前（line 567 付近）:
+
+```python
+            regime = _fetch_regime(bt_conn, trading_day)
+```
+
+変更後:
+
+```python
+            regime = _regime_provider.get_regime(trading_day)
+```
+
+- [ ] **Step 7: テスト実行**
+
+```bash
+pytest tests/test_backtest_engine.py -v --tb=short -q
+```
+
+期待: Step 1 と同件数 PASSED
+
+- [ ] **Step 8: ruff チェック**
+
+```bash
+python -m ruff check src/kabusys/backtest/engine.py
+python -m ruff format --check src/kabusys/backtest/engine.py
+```
+
+期待: エラーなし
+
+- [ ] **Step 9: コミット**
+
+```bash
+git add src/kabusys/backtest/engine.py
+git commit -m "refactor: backtest/engine を RegimeProvider に移行し AI テーブルコピーをフラグ条件化 (Issue #271)"
+```
+
+---
+
+## Task 4: 全体テストと設計書更新
+
+**Files:**
+- Test: 全テストスイート
+- Modify: `documents/00_Architecture/TODO_CoreAddonImportBoundaryAudit.md`
+
+- [ ] **Step 1: 全テストを実行する**
+
+```bash
+pytest --tb=short -q
+```
+
+期待: 全件 PASSED（リグレッションなし）
+
+- [ ] **Step 2: `TODO_CoreAddonImportBoundaryAudit.md` の Section 2.1 を更新する**
+
+Section 2.1（AI — 判定）の以下の行を変更する:
+
+変更前:
+```markdown
+- データ境界: `未分離`
+```
+
+変更後:
+```markdown
+- データ境界: `✅ 分離済み（Issue #271）`
+```
+
+- [ ] **Step 3: `TODO_CoreAddonImportBoundaryAudit.md` の Section 5 を更新する**
+
+変更前:
+```markdown
+1. `signal_generator.py` の `ai_scores` / `market_regime` 参照を抽象化する
+2. `backtest` の `Core-only` 入力要件を定義する
+```
+
+変更後:
+```markdown
+1. ~~`signal_generator.py` の `ai_scores` / `market_regime` 参照を抽象化する~~ ✅ 完了（Issue #271）
+2. ~~`backtest` の `Core-only` 入力要件を定義する~~ ✅ 完了（Issue #271）
+```
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add documents/00_Architecture/TODO_CoreAddonImportBoundaryAudit.md
+git commit -m "docs: Core-only モード定義の完了を設計書に反映 (Issue #271)"
+```

--- a/docs/superpowers/specs/2026-05-08-regime-provider-core-only-mode-design.md
+++ b/docs/superpowers/specs/2026-05-08-regime-provider-core-only-mode-design.md
@@ -1,0 +1,513 @@
+# RegimeProvider と Core-only モード定義 実装設計
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `signal_generator.py` と `backtest/engine.py` が `market_regime` テーブルを直接前提にする結合を `RegimeProvider` プロトコルで抽象化し、`ENABLE_AI_SENTIMENT=false` かつ AI テーブルが空の状態で Core の売買フローとバックテストが明示的に正常動作するようにする（Issue #271）。
+
+**Architecture:** `src/kabusys/core/interfaces/regime.py` に `RegimeProvider` Protocol・`NullRegimeProvider`・`DatabaseRegimeProvider` を定義する。`signal_generator.py` の `_is_bear_regime()` を廃止して `regime_provider.get_regime()` に置き換え、AI スコアクエリを `enable_ai_sentiment` フラグでガードする。`backtest/engine.py` の `_get_daily_regime()` も同様に置き換える。
+
+**Tech Stack:** Python 3.10+, typing.Protocol, DuckDB, pytest
+
+---
+
+## ファイル構成
+
+### 新規作成
+
+| ファイル | 役割 |
+|---|---|
+| `src/kabusys/core/__init__.py` | `core` パッケージ初期化（空） |
+| `src/kabusys/core/interfaces/__init__.py` | `interfaces` パッケージ初期化・`build_regime_provider` 公開 |
+| `src/kabusys/core/interfaces/regime.py` | `RegimeProvider` Protocol・`NullRegimeProvider`・`DatabaseRegimeProvider` |
+| `tests/test_regime_provider.py` | `RegimeProvider` 実装の単体テスト |
+
+### 変更
+
+| ファイル | 変更内容 |
+|---|---|
+| `src/kabusys/strategy/signal_generator.py` | `_is_bear_regime()` 廃止、`generate_signals()` に `regime_provider` 引数追加、AI スコアフラグガード追加 |
+| `src/kabusys/backtest/engine.py` | `_get_daily_regime()` 廃止、`regime_provider` 注入、AI テーブルコピーを条件化 |
+
+### 変更なし
+
+- `src/kabusys/portfolio/risk_adjustment.py` — `calc_regime_multiplier(regime: str)` はすでに文字列受け取りで抽象化済み
+
+---
+
+## Task 1: `RegimeProvider` インターフェースを定義する
+
+**Files:**
+- Create: `src/kabusys/core/__init__.py`
+- Create: `src/kabusys/core/interfaces/__init__.py`
+- Create: `src/kabusys/core/interfaces/regime.py`
+- Test: `tests/test_regime_provider.py`
+
+- [ ] **Step 1: テストを書く（失敗確認用）**
+
+```python
+# tests/test_regime_provider.py
+"""tests/test_regime_provider.py — RegimeProvider 実装の単体テスト"""
+from datetime import date
+import duckdb
+import pytest
+
+from kabusys.core.interfaces import build_regime_provider
+from kabusys.core.interfaces.regime import (
+    DatabaseRegimeProvider,
+    NullRegimeProvider,
+)
+
+
+@pytest.fixture
+def duck_conn():
+    import duckdb
+    from kabusys.data.schema import init_schema
+    conn = init_schema(":memory:")
+    yield conn
+    conn.close()
+
+
+# --- NullRegimeProvider ---
+
+def test_null_regime_provider_always_bull():
+    p = NullRegimeProvider()
+    assert p.get_regime(date.today()) == "bull"
+
+
+def test_null_regime_provider_any_date():
+    p = NullRegimeProvider()
+    assert p.get_regime(date(2020, 1, 1)) == "bull"
+
+
+# --- DatabaseRegimeProvider ---
+
+def test_db_regime_provider_empty_table_returns_bull(duck_conn):
+    p = DatabaseRegimeProvider(duck_conn)
+    assert p.get_regime(date.today()) == "bull"
+
+
+def test_db_regime_provider_returns_stored_label(duck_conn):
+    duck_conn.execute(
+        "INSERT INTO market_regime (date, regime_score, regime_label, ma200_ratio, macro_sentiment)"
+        " VALUES ('2024-09-01', 0.8, 'neutral', 1.05, 0.1)"
+    )
+    p = DatabaseRegimeProvider(duck_conn)
+    assert p.get_regime(date(2024, 9, 1)) == "neutral"
+
+
+def test_db_regime_provider_bear(duck_conn):
+    duck_conn.execute(
+        "INSERT INTO market_regime (date, regime_score, regime_label, ma200_ratio, macro_sentiment)"
+        " VALUES ('2024-09-02', -0.5, 'bear', 0.88, -0.4)"
+    )
+    p = DatabaseRegimeProvider(duck_conn)
+    assert p.get_regime(date(2024, 9, 2)) == "bear"
+
+
+# --- build_regime_provider factory ---
+
+def test_build_regime_provider_disabled_returns_null(duck_conn):
+    p = build_regime_provider(duck_conn, enabled=False)
+    assert isinstance(p, NullRegimeProvider)
+
+
+def test_build_regime_provider_enabled_returns_db(duck_conn):
+    p = build_regime_provider(duck_conn, enabled=True)
+    assert isinstance(p, DatabaseRegimeProvider)
+```
+
+- [ ] **Step 2: テスト実行（失敗確認）**
+
+```bash
+pytest tests/test_regime_provider.py -v
+```
+
+期待: `ModuleNotFoundError: No module named 'kabusys.core'`
+
+- [ ] **Step 3: `src/kabusys/core/__init__.py` を作成**
+
+```python
+```
+（空ファイル）
+
+- [ ] **Step 4: `src/kabusys/core/interfaces/regime.py` を作成**
+
+```python
+"""regime.py — RegimeProvider プロトコルと Core 実装。
+
+Core-only モード（AI Addon 未導入時）は NullRegimeProvider を使う。
+AI Addon 有効時は DatabaseRegimeProvider が market_regime テーブルを参照する。
+"""
+from __future__ import annotations
+
+from datetime import date
+from typing import Protocol
+
+import duckdb
+
+
+class RegimeProvider(Protocol):
+    """市場レジームラベルを返すインターフェース。"""
+
+    def get_regime(self, target_date: date) -> str:
+        """レジームラベルを返す。データなし時は 'bull' を返す。"""
+        ...
+
+
+class NullRegimeProvider:
+    """AI Addon 未導入時のフォールバック。常に 'bull' を返す。"""
+
+    def get_regime(self, target_date: date) -> str:
+        return "bull"
+
+
+class DatabaseRegimeProvider:
+    """market_regime テーブルからレジームを取得する Core 実装。"""
+
+    def __init__(self, conn: duckdb.DuckDBPyConnection) -> None:
+        self._conn = conn
+
+    def get_regime(self, target_date: date) -> str:
+        row = self._conn.execute(
+            "SELECT regime_label FROM market_regime WHERE date = ?",
+            [target_date],
+        ).fetchone()
+        return row[0] if row else "bull"
+```
+
+- [ ] **Step 5: `src/kabusys/core/interfaces/__init__.py` を作成**
+
+```python
+"""core/interfaces — Core が Addon に公開する接続点の定義。"""
+from __future__ import annotations
+
+import duckdb
+
+from kabusys.core.interfaces.regime import (
+    DatabaseRegimeProvider,
+    NullRegimeProvider,
+    RegimeProvider,
+)
+
+__all__ = [
+    "RegimeProvider",
+    "NullRegimeProvider",
+    "DatabaseRegimeProvider",
+    "build_regime_provider",
+]
+
+
+def build_regime_provider(
+    conn: duckdb.DuckDBPyConnection,
+    enabled: bool,
+) -> RegimeProvider:
+    """ENABLE_AI_SENTIMENT フラグに基づいて RegimeProvider を返す。"""
+    if enabled:
+        return DatabaseRegimeProvider(conn)
+    return NullRegimeProvider()
+```
+
+- [ ] **Step 6: テスト実行（パス確認）**
+
+```bash
+pytest tests/test_regime_provider.py -v
+```
+
+期待: 8 件 PASSED
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add src/kabusys/core/ tests/test_regime_provider.py
+git commit -m "feat: RegimeProvider プロトコルと Core 実装を追加 (Issue #271)"
+```
+
+---
+
+## Task 2: `signal_generator.py` を `RegimeProvider` に移行する
+
+**Files:**
+- Modify: `src/kabusys/strategy/signal_generator.py`
+- Test: `tests/test_signal_generator.py` （既存テストがパスすることを確認）
+
+- [ ] **Step 1: 既存テストを実行してベースラインを確認**
+
+```bash
+pytest tests/test_signal_generator.py -v --tb=short
+```
+
+期待: 全件 PASSED（件数を記録する）
+
+- [ ] **Step 2: `signal_generator.py` のインポートを追加**
+
+`signal_generator.py` の先頭 import 群に追加:
+
+```python
+from kabusys.core.interfaces import RegimeProvider, build_regime_provider
+```
+
+- [ ] **Step 3: `_is_bear_regime()` 関数を削除する**
+
+以下の関数ブロックを丸ごと削除:
+
+```python
+def _is_bear_regime(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date,
+) -> bool:
+    """market_regime テーブルの regime_label を参照し、Bear 相場か否かを判定する。
+
+    データが存在しない場合は False（安全側：BUY を許可）を返す。
+    """
+    row = conn.execute(
+        "SELECT regime_label FROM market_regime WHERE date = ?",
+        [target_date],
+    ).fetchone()
+    if row is None:
+        return False
+    return row[0] == "bear"
+```
+
+- [ ] **Step 4: `generate_signals()` シグネチャに `regime_provider` を追加**
+
+変更前:
+```python
+def generate_signals(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date,
+) -> list[dict[str, Any]]:
+```
+
+変更後:
+```python
+def generate_signals(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date,
+    *,
+    regime_provider: RegimeProvider | None = None,
+) -> list[dict[str, Any]]:
+```
+
+- [ ] **Step 5: `generate_signals()` 内の AI スコアと regime 参照を書き換える**
+
+`generate_signals()` 関数の先頭付近（weights 取得の直後、features クエリの前）に追加:
+
+```python
+    ai_enabled = Settings().enable_ai_sentiment
+    if regime_provider is None:
+        regime_provider = build_regime_provider(conn, ai_enabled)
+```
+
+AI スコアのクエリ部分（`# 2. AI スコア読み込み` セクション）を書き換え:
+
+```python
+    # 2. AI スコア読み込み（ENABLE_AI_SENTIMENT=false 時はスキップ）
+    if ai_enabled:
+        ai_rows = conn.execute(
+            "SELECT code, ai_score FROM ai_scores WHERE date = ?",
+            [target_date],
+        ).fetchall()
+        ai_map: dict[str, dict] = {code: {"ai_score": ai} for code, ai in ai_rows}
+    else:
+        ai_map = {}
+```
+
+Bear レジーム判定部分（`# 3. Bear レジーム判定` セクション）を書き換え:
+
+```python
+    # 3. Bear レジーム判定
+    regime_is_bear = regime_provider.get_regime(target_date) == "bear"
+    if regime_is_bear:
+        logger.info(
+            "generate_signals: Bear レジーム検知 — BUY シグナル抑制 date=%s",
+            target_date,
+        )
+```
+
+ループ前に既存の `ai_enabled = Settings().enable_ai_sentiment` が 1 行あるので削除する（Step 4 で上方に移動済みのため重複となる）。
+
+- [ ] **Step 6: テスト実行**
+
+```bash
+pytest tests/test_signal_generator.py -v --tb=short
+```
+
+期待: Step 1 と同件数 PASSED
+
+- [ ] **Step 7: ruff チェック**
+
+```bash
+python -m ruff check src/kabusys/strategy/signal_generator.py
+python -m ruff format --check src/kabusys/strategy/signal_generator.py
+```
+
+期待: エラーなし
+
+- [ ] **Step 8: コミット**
+
+```bash
+git add src/kabusys/strategy/signal_generator.py
+git commit -m "refactor: signal_generator を RegimeProvider に移行し AI スコアをフラグガード化 (Issue #271)"
+```
+
+---
+
+## Task 3: `backtest/engine.py` を `RegimeProvider` に移行する
+
+**Files:**
+- Modify: `src/kabusys/backtest/engine.py`
+- Test: `tests/test_backtest_engine.py` （既存テストがパスすることを確認）
+
+- [ ] **Step 1: 既存テストを実行してベースラインを確認**
+
+```bash
+pytest tests/test_backtest_engine.py -v --tb=short
+```
+
+期待: 全件 PASSED（件数を記録する）
+
+- [ ] **Step 2: `engine.py` のインポートを追加**
+
+`engine.py` の先頭 import 群に追加:
+
+```python
+from kabusys.core.interfaces import RegimeProvider, build_regime_provider
+```
+
+- [ ] **Step 3: `_get_daily_regime()` 関数を削除する**
+
+以下の関数ブロックを丸ごと削除:
+
+```python
+def _get_daily_regime(
+    conn: duckdb.DuckDBPyConnection,
+    trading_day: date,
+) -> str:
+    """market_regime テーブルから当日レジームを返す。データなしなら 'bull' でフォールバック。
+
+    schema.py の market_regime テーブルのレジーム列名は `regime_label`。
+    """
+    row = conn.execute(
+        "SELECT regime_label FROM market_regime WHERE date = ?", [trading_day]
+    ).fetchone()
+    return row[0] if row else "bull"
+```
+
+- [ ] **Step 4: `_build_backtest_conn()` の AI テーブルコピーを条件化**
+
+変更前:
+```python
+    date_filtered_tables = ("prices_daily", "features", "ai_scores", "market_regime")
+```
+
+変更後:
+```python
+    from kabusys.config import Settings
+    ai_enabled = Settings().enable_ai_sentiment
+    core_tables: tuple[str, ...] = ("prices_daily", "features", "market_regime")
+    ai_tables: tuple[str, ...] = ("ai_scores",) if ai_enabled else ()
+    date_filtered_tables = core_tables + ai_tables
+```
+
+- [ ] **Step 5: `_run_backtest_loop()` に `regime_provider` を注入する**
+
+`_run_backtest_loop()` のシグネチャに `regime_provider` を追加し、`_get_daily_regime()` の呼び出しを置き換える。
+
+変更前のシグネチャ:
+```python
+def _run_backtest_loop(
+    conn: duckdb.DuckDBPyConnection,
+    ...
+) -> BacktestResult:
+```
+
+変更後のシグネチャ:
+```python
+def _run_backtest_loop(
+    conn: duckdb.DuckDBPyConnection,
+    ...,
+    regime_provider: RegimeProvider,
+) -> BacktestResult:
+```
+
+`_get_daily_regime(conn, trading_day)` の呼び出し箇所を:
+```python
+    regime = regime_provider.get_regime(trading_day)
+```
+に置き換える。
+
+- [ ] **Step 6: `run_backtest()` から `regime_provider` を構築して渡す**
+
+`run_backtest()` 内の `_run_backtest_loop()` 呼び出し前に追加:
+
+```python
+    from kabusys.config import Settings
+    regime_provider = build_regime_provider(bt_conn, Settings().enable_ai_sentiment)
+```
+
+`_run_backtest_loop()` の呼び出しに `regime_provider=regime_provider` を追加する。
+
+- [ ] **Step 7: テスト実行**
+
+```bash
+pytest tests/test_backtest_engine.py -v --tb=short
+```
+
+期待: Step 1 と同件数 PASSED
+
+- [ ] **Step 8: ruff チェック**
+
+```bash
+python -m ruff check src/kabusys/backtest/engine.py
+python -m ruff format --check src/kabusys/backtest/engine.py
+```
+
+期待: エラーなし
+
+- [ ] **Step 9: コミット**
+
+```bash
+git add src/kabusys/backtest/engine.py
+git commit -m "refactor: backtest/engine を RegimeProvider に移行し AI テーブルコピーをフラグ条件化 (Issue #271)"
+```
+
+---
+
+## Task 4: 全体テストとドキュメント更新
+
+**Files:**
+- Test: 全テストスイート
+- Modify: `documents/00_Architecture/TODO_CoreAddonImportBoundaryAudit.md`
+
+- [ ] **Step 1: 全テストを実行**
+
+```bash
+pytest --tb=short -q
+```
+
+期待: 全件 PASSED（リグレッションなし）
+
+- [ ] **Step 2: `ENABLE_AI_SENTIMENT=false` での動作確認**
+
+```bash
+pytest tests/test_regime_provider.py tests/test_signal_generator.py tests/test_backtest_engine.py -v
+```
+
+期待: 全件 PASSED
+
+- [ ] **Step 3: `TODO_CoreAddonImportBoundaryAudit.md` の Section 2.1 と Section 5 を更新**
+
+Section 2.1（AI — 判定）の「データ境界: `未分離`」を「データ境界: `✅ 分離済み（Issue #271）`」に変更する。
+
+Section 5（Issue 3 の次アクション）の item 1・2 に ✅ を追加:
+```markdown
+1. ~~`signal_generator.py` の `ai_scores` / `market_regime` 参照を抽象化する~~ ✅ 完了（Issue #271 / PR #???）
+2. ~~`backtest` の `Core-only` 入力要件を定義する~~ ✅ 完了（Issue #271 / PR #???）
+```
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add documents/00_Architecture/TODO_CoreAddonImportBoundaryAudit.md
+git commit -m "docs: Core-only モード定義の完了を設計書に反映 (Issue #271)"
+```

--- a/documents/00_Architecture/TODO_CoreAddonImportBoundaryAudit.md
+++ b/documents/00_Architecture/TODO_CoreAddonImportBoundaryAudit.md
@@ -1,0 +1,197 @@
+# Core Import Boundary Audit
+
+`Issue 3` として、`Core` から `Addon` 候補への結合を監査した記録。
+
+この監査では次の 2 種類を分けて見ている。
+
+- `import` 結合
+- `Addon` が作るテーブルやページを `Core` が前提にするデータ結合
+
+## 1. 結論
+
+現状の `KabuSys` は、`AI / Yahoo News / Disclosure` については `Core` からの直接 `import` は比較的少ない。  
+一方で、`AI` と `Strategy Lab` は `Core` 側にデータ結合が残っている。
+
+優先度順の論点は次のとおり。
+
+1. `signal_generator.py` が `ai_scores` / `market_regime` を直接前提にしている
+2. `backtest` が `ai_scores` / `market_regime` を入力前提にしている
+3. `dashboard_data.py` に `Strategy Lab` 用ローダーが同居している
+4. `scripts/` に Addon 実行入口が本体同居している
+
+## 2. 対象別の監査結果
+
+### 2.1 AI
+
+#### 直接 import
+
+`Core` 本体から `kabusys.ai` への直接 `import` は広くは発生していない。確認できた主な参照は次。
+
+- [scripts/run_ai_analysis.py](/C:/Users/tetsu/Projects/KabuSys/scripts/run_ai_analysis.py:19)
+- [src/kabusys/ai/regime_detector.py](/C:/Users/tetsu/Projects/KabuSys/src/kabusys/ai/regime_detector.py:41)
+- [src/kabusys/ai/__init__.py](/C:/Users/tetsu/Projects/KabuSys/src/kabusys/ai/__init__.py:1)
+
+このうち `scripts/run_ai_analysis.py` は Addon 側の入口として扱える。  
+`src/kabusys/ai/regime_detector.py` 内の `news_nlp` 参照は Addon 内部結合なので、`Core` / `Addon` 分離の主論点ではない。
+
+#### データ結合
+
+`Core` は AI モジュールを直接 import しなくても、AI が作るテーブルを使っている。
+
+- [src/kabusys/strategy/signal_generator.py](/C:/Users/tetsu/Projects/KabuSys/src/kabusys/strategy/signal_generator.py:872)
+  - `ai_scores` を直接参照
+- [src/kabusys/strategy/signal_generator.py](/C:/Users/tetsu/Projects/KabuSys/src/kabusys/strategy/signal_generator.py:216)
+  - `market_regime` を直接参照
+- [src/kabusys/backtest/engine.py](/C:/Users/tetsu/Projects/KabuSys/src/kabusys/backtest/engine.py:92)
+  - インメモリ DB に `ai_scores` / `market_regime` をコピー
+- [src/kabusys/backtest/run.py](/C:/Users/tetsu/Projects/KabuSys/src/kabusys/backtest/run.py:10)
+  - 事前投入テーブルとして `ai_scores` / `market_regime` を明記
+- [src/kabusys/portfolio/risk_adjustment.py](/C:/Users/tetsu/Projects/KabuSys/src/kabusys/portfolio/risk_adjustment.py:88)
+  - `market_regime.regime_label` 前提のロジック
+
+#### 判定
+
+- `import` 境界: `概ね良好`
+- データ境界: `未分離`
+
+#### 分離 TODO
+
+- `StrategyEnhancer` か `RegimeProvider` のような `Core` 側 IF を作る
+- `signal_generator.py` は `ai_scores` / `market_regime` を直接読む代わりに、`Addon` 未導入時フォールバックを明示する
+- `backtest` は `AI なしで動く Core モード` を別定義する
+
+### 2.2 Yahoo News
+
+#### 直接 import
+
+Yahoo News 収集は専用スクリプトに閉じている。
+
+- [scripts/run_yahoonews_collection.py](/C:/Users/tetsu/Projects/KabuSys/scripts/run_yahoonews_collection.py:18)
+- [src/kabusys/data/news_collector.py](/C:/Users/tetsu/Projects/KabuSys/src/kabusys/data/news_collector.py:1)
+
+`run_data_update.py` や日次 ETL 本体は `news_collector` を直接呼んでいない。
+
+- [scripts/run_data_update.py](/C:/Users/tetsu/Projects/KabuSys/scripts/run_data_update.py:18)
+
+#### データ結合
+
+Yahoo News 自体の収集は `Core` に未接続だが、AI 側は `raw_news` を前提にする。
+
+- [src/kabusys/ai/news_nlp.py](/C:/Users/tetsu/Projects/KabuSys/src/kabusys/ai/news_nlp.py:111)
+- [src/kabusys/ai/regime_detector.py](/C:/Users/tetsu/Projects/KabuSys/src/kabusys/ai/regime_detector.py:292)
+
+ただし、これは `AI Addon` 内の連携として閉じており、`Core` が `news_collector` を直接 import しているわけではない。
+
+#### 判定
+
+- `import` 境界: `良好`
+- データ境界: `AI Addon 内の依存として許容`
+
+#### 分離 TODO
+
+- `run_yahoonews_collection.py` は将来的に `addons` 側へ移設
+- `Core` ドキュメントでは Yahoo News を必須導線に書かない
+
+### 2.3 Disclosure
+
+#### 直接 import
+
+TDnet / EDINET / 開示分類は独立スクリプトからのみ呼ばれている。
+
+- [scripts/run_tdnet_collection.py](/C:/Users/tetsu/Projects/KabuSys/scripts/run_tdnet_collection.py:17)
+- [scripts/run_edinet_collection.py](/C:/Users/tetsu/Projects/KabuSys/scripts/run_edinet_collection.py:17)
+- [scripts/run_disclosure_classification.py](/C:/Users/tetsu/Projects/KabuSys/scripts/run_disclosure_classification.py:17)
+
+`Core` の通常実行系からこれらを直接 import している箇所は今回の監査では見当たらなかった。
+
+#### データ結合
+
+`EDINET` 側は `TDnet` の保存関数を再利用している。
+
+- [src/kabusys/data/edinet_collector.py](/C:/Users/tetsu/Projects/KabuSys/src/kabusys/data/edinet_collector.py:41)
+
+これは `Disclosure Addon` 内部の結合であり、`Core` 側の問題ではない。
+
+#### 判定
+
+- `import` 境界: `良好`
+- データ境界: `Addon 内部結合のみ`
+
+#### 分離 TODO
+
+- `DisclosureProvider` 単位で Addon repo にまとめる
+- `scripts/run_tdnet_collection.py` などの入口を Core 配布物から外せる形にする
+
+### 2.4 Strategy Lab
+
+#### 直接 import
+
+`Streamlit` 本体はページを直接 import していない。
+
+- [src/kabusys/monitoring/streamlit_dashboard.py](/C:/Users/tetsu/Projects/KabuSys/src/kabusys/monitoring/streamlit_dashboard.py:1)
+- ページ実体: [10_Strategy_Lab.py](/C:/Users/tetsu/Projects/KabuSys/src/kabusys/monitoring/pages/10_Strategy_Lab.py:1)
+
+この点は `Streamlit` の `pages/` 自動検出に乗っているため、`Home` 側の import 結合は薄い。
+
+#### データ結合
+
+**✅ 対応済み（Issue #272 / PR #275）**
+
+`Strategy Lab` 専用のデータ取得関数が `dashboard_data.py` に同居していた問題を解消した。
+
+- [src/kabusys/monitoring/strategy_lab_data.py](/C:/Users/tetsu/Projects/KabuSys/src/kabusys/monitoring/strategy_lab_data.py)
+  - `load_market_regime` / `load_ai_scores` / `load_signal_summary` を新ファイルに分離
+- `dashboard_data.py` は Core 運用ページ（Home / Signal Queue / Performance）用ローダーのみを保持
+
+`10_Strategy_Lab.py` は `strategy_lab_data` から import しており、`dashboard_data` への依存が解消された。
+
+#### 判定
+
+- `import` 境界: `良好`
+- モジュール配置境界: `✅ 分離済み`
+
+## 3. 設定フラグの監査
+
+`Core` 側には optional 機能のトグルが残っている。
+
+- [src/kabusys/config.py](/C:/Users/tetsu/Projects/KabuSys/src/kabusys/config.py:177) `ENABLE_AI_SENTIMENT`
+- [src/kabusys/config.py](/C:/Users/tetsu/Projects/KabuSys/src/kabusys/config.py:186) `ENABLE_TDNET`
+- [src/kabusys/config.py](/C:/Users/tetsu/Projects/KabuSys/src/kabusys/config.py:196) `ENABLE_EDINET`
+- [src/kabusys/config.py](/C:/Users/tetsu/Projects/KabuSys/src/kabusys/config.py:214) `ENABLE_YAHOONEWS`
+- [src/kabusys/config.py](/C:/Users/tetsu/Projects/KabuSys/src/kabusys/config.py:232) `LINE_NOTIFY_ENABLED`
+
+現状では `Core` が `Addon` を「設定で無効化できる同居機能」として扱っている。  
+別 repo 化を進めるなら、次のどちらかに寄せる必要がある。
+
+- `Core` に最小限のトグルだけ残し、未導入時は常に no-op
+- `Addon` 固有フラグを `core` 設定から外し、Addon 側設定へ移す
+
+## 4. 総合判定
+
+### 4.1 すでに境界が良いもの
+
+- Yahoo News 収集
+- TDnet / EDINET / 開示分類
+- `Strategy Lab` ページファイル自体
+
+理由は、専用スクリプトや専用ページとして孤立度が高く、`Core` 実行系が直接 import していないため。
+
+### 4.2 境界がまだ弱いもの
+
+- `AI` のスコアとレジームを `Core` 戦略が直接前提にしている点
+- `backtest` が `ai_scores` / `market_regime` を前提にしている点
+
+## 5. Issue 3 の次アクション
+
+優先順位は次のとおり。
+
+1. `signal_generator.py` の `ai_scores` / `market_regime` 参照を抽象化する
+2. `backtest` の `Core-only` 入力要件を定義する
+3. ~~`dashboard_data.py` から `Strategy Lab` ローダーを分離する~~ ✅ 完了（Issue #272 / PR #275）
+4. `scripts/run_ai_analysis.py` / `run_yahoonews_collection.py` / `run_tdnet_collection.py` を Addon 配置前提で再整理する
+
+## 6. 関連
+
+- [TODO_CoreAddonRepoSplit.md](/C:/Users/tetsu/Projects/KabuSys/documents/00_Architecture/TODO_CoreAddonRepoSplit.md)
+- [TODO_CoreAddonResponsibilityMatrix.md](/C:/Users/tetsu/Projects/KabuSys/documents/00_Architecture/TODO_CoreAddonResponsibilityMatrix.md)
+- [TODO_CoreAddonExtensionPoints.md](/C:/Users/tetsu/Projects/KabuSys/documents/00_Architecture/TODO_CoreAddonExtensionPoints.md)

--- a/documents/00_Architecture/TODO_CoreAddonImportBoundaryAudit.md
+++ b/documents/00_Architecture/TODO_CoreAddonImportBoundaryAudit.md
@@ -52,7 +52,7 @@
 #### 判定
 
 - `import` 境界: `概ね良好`
-- データ境界: `未分離`
+- データ境界: `✅ 分離済み（Issue #271）`
 
 #### 分離 TODO
 
@@ -185,8 +185,8 @@ TDnet / EDINET / 開示分類は独立スクリプトからのみ呼ばれてい
 
 優先順位は次のとおり。
 
-1. `signal_generator.py` の `ai_scores` / `market_regime` 参照を抽象化する
-2. `backtest` の `Core-only` 入力要件を定義する
+1. ~~`signal_generator.py` の `ai_scores` / `market_regime` 参照を抽象化する~~ ✅ 完了（Issue #271）
+2. ~~`backtest` の `Core-only` 入力要件を定義する~~ ✅ 完了（Issue #271）
 3. ~~`dashboard_data.py` から `Strategy Lab` ローダーを分離する~~ ✅ 完了（Issue #272 / PR #275）
 4. `scripts/run_ai_analysis.py` / `run_yahoonews_collection.py` / `run_tdnet_collection.py` を Addon 配置前提で再整理する
 

--- a/documents/08_Operations/Monitoring.md
+++ b/documents/08_Operations/Monitoring.md
@@ -403,7 +403,7 @@ MonitoringEngine(system_monitor, trade_monitor, risk_monitor, interval_sec=60)
 
 ### StreamlitDashboard（Phase 7 実装 Issue #35、Issue #231 で拡張）
 
-Streamlit マルチページ構成で実装。ページファイルは `pages/` 配下に配置され、自動的にサイドバーへ表示される。データロードロジックは `dashboard_data.py` に集約し Streamlit 非依存・単体テスト可能な設計とする。
+Streamlit マルチページ構成で実装。ページファイルは `pages/` 配下に配置され、自動的にサイドバーへ表示される。データロードロジックは各モジュールに分離し Streamlit 非依存・単体テスト可能な設計とする。
 
 **起動方法:**
 
@@ -416,8 +416,9 @@ streamlit run src/kabusys/monitoring/streamlit_dashboard.py -- --db data/monitor
 | ファイル | 役割 |
 |---|---|
 | `streamlit_dashboard.py` | Home ページ（エントリーポイント）。SQLite `monitoring.db` を読み取り |
-| `dashboard_data.py` | 全ページ共通のデータロード関数群（Streamlit 非依存） |
+| `dashboard_data.py` | Core 運用ページ向けデータロード関数群（Streamlit 非依存） |
 | `operations_data.py` | 運用フローページ向けデータロード関数群（Streamlit 非依存） |
+| `strategy_lab_data.py` | Strategy Lab ページ（AI Addon）専用データロード関数群（Streamlit 非依存） |
 | `pages/2_Initial_Setup.py` | 環境変数・設定・DB・Task Scheduler 確認（4タブ） |
 | `pages/3_Pre_Market.py` | 朝の READY/BLOCKED 判定・データ鮮度・停止フラグ確認 |
 | `pages/4_Execution_Startup.py` | 起動直後のリコンシリエーション差分・ポジション整合確認 |

--- a/src/kabusys/backtest/engine.py
+++ b/src/kabusys/backtest/engine.py
@@ -70,6 +70,8 @@ def _build_backtest_conn(
     source_conn: duckdb.DuckDBPyConnection,
     start_date: date,
     end_date: date,
+    *,
+    ai_enabled: bool,
 ) -> duckdb.DuckDBPyConnection:
     """本番 DB からインメモリ DuckDB にデータをコピーしてバックテスト用接続を返す。
 
@@ -90,11 +92,8 @@ def _build_backtest_conn(
     data_start = start_date - timedelta(days=300)
 
     # 日付範囲でフィルタするテーブル
-    from kabusys.config import Settings
-
-    _ai_enabled = Settings().enable_ai_sentiment
     _core_tables: tuple[str, ...] = ("prices_daily", "features", "market_regime")
-    _ai_tables: tuple[str, ...] = ("ai_scores",) if _ai_enabled else ()
+    _ai_tables: tuple[str, ...] = ("ai_scores",) if ai_enabled else ()
     date_filtered_tables = _core_tables + _ai_tables
     for table in date_filtered_tables:
         try:
@@ -467,11 +466,11 @@ def run_backtest(
 
     from kabusys.data.calendar_management import get_trading_days
     from kabusys.strategy.signal_generator import generate_signals
-
-    bt_conn = _build_backtest_conn(conn, start_date, end_date)
     from kabusys.config import Settings
 
-    _regime_provider = build_regime_provider(bt_conn, Settings().enable_ai_sentiment)
+    _ai_enabled = Settings().enable_ai_sentiment
+    bt_conn = _build_backtest_conn(conn, start_date, end_date, ai_enabled=_ai_enabled)
+    _regime_provider = build_regime_provider(bt_conn, _ai_enabled)
     simulator = PortfolioSimulator(initial_cash=initial_cash)
     # バックテストループ内でメモリ上に持ち回る翌日用発注リスト
     # （本番 live trading とは異なり、バックテストは単一関数呼び出し内で完結するためDB永続化不要）

--- a/src/kabusys/backtest/engine.py
+++ b/src/kabusys/backtest/engine.py
@@ -16,6 +16,7 @@ import duckdb
 
 from kabusys.backtest.metrics import BacktestMetrics, calc_metrics
 from kabusys.backtest.simulator import DailySnapshot, PortfolioSimulator, TradeRecord
+from kabusys.core.interfaces import build_regime_provider
 from kabusys.portfolio import (
     apply_sector_cap,
     calc_equal_weights,
@@ -89,7 +90,12 @@ def _build_backtest_conn(
     data_start = start_date - timedelta(days=300)
 
     # 日付範囲でフィルタするテーブル
-    date_filtered_tables = ("prices_daily", "features", "ai_scores", "market_regime")
+    from kabusys.config import Settings
+
+    _ai_enabled = Settings().enable_ai_sentiment
+    _core_tables: tuple[str, ...] = ("prices_daily", "features", "market_regime")
+    _ai_tables: tuple[str, ...] = ("ai_scores",) if _ai_enabled else ()
+    date_filtered_tables = _core_tables + _ai_tables
     for table in date_filtered_tables:
         try:
             rows = source_conn.execute(
@@ -337,24 +343,6 @@ def _read_day_signals(
     return buy_signals, sell_signals
 
 
-def _fetch_regime(conn: duckdb.DuckDBPyConnection, trading_day: date) -> str:
-    """market_regime テーブルから当日レジームを返す。データなしなら 'bull' でフォールバック。
-
-    schema.py の market_regime テーブルのレジーム列名は `regime_label`。
-    """
-    row = conn.execute(
-        "SELECT regime_label FROM market_regime WHERE date = ?", [trading_day]
-    ).fetchone()
-    if row is None:
-        # バックテスト序盤などでレジームデータが未整備の場合は通常の運用。INFO に留める。
-        logger.info(
-            "_fetch_regime: %s のレジームが取得できません。'bull' でフォールバック。",
-            trading_day,
-        )
-        return "bull"
-    return row[0]
-
-
 def _fetch_sector_map(conn: duckdb.DuckDBPyConnection) -> dict[str, str]:
     """stocks テーブルから {code: sector} を返す。テーブルが空なら {}。
 
@@ -481,6 +469,9 @@ def run_backtest(
     from kabusys.strategy.signal_generator import generate_signals
 
     bt_conn = _build_backtest_conn(conn, start_date, end_date)
+    from kabusys.config import Settings
+
+    _regime_provider = build_regime_provider(bt_conn, Settings().enable_ai_sentiment)
     simulator = PortfolioSimulator(initial_cash=initial_cash)
     # バックテストループ内でメモリ上に持ち回る翌日用発注リスト
     # （本番 live trading とは異なり、バックテストは単一関数呼び出し内で完結するためDB永続化不要）
@@ -564,7 +555,7 @@ def run_backtest(
 
             # Step 5: ポートフォリオ構築（Phase 5 モジュール使用）
             buy_signals, sell_signals = _read_day_signals(bt_conn, trading_day)
-            regime = _fetch_regime(bt_conn, trading_day)
+            regime = _regime_provider.get_regime(trading_day)
             multiplier = calc_regime_multiplier(regime)
             # 当日 mark_to_market 後の最新ポートフォリオ価値（翌日用発注サイジングに使用）
             current_pv = (

--- a/src/kabusys/core/interfaces/__init__.py
+++ b/src/kabusys/core/interfaces/__init__.py
@@ -19,10 +19,12 @@ __all__ = [
 
 
 def build_regime_provider(
-    conn: duckdb.DuckDBPyConnection,
+    conn: duckdb.DuckDBPyConnection | None,
     enabled: bool,
 ) -> RegimeProvider:
     """ENABLE_AI_SENTIMENT フラグに基づいて RegimeProvider を返す。"""
     if enabled:
+        if conn is None:
+            raise ValueError("enabled=True の場合は conn が必要です。")
         return DatabaseRegimeProvider(conn)
     return NullRegimeProvider()

--- a/src/kabusys/core/interfaces/__init__.py
+++ b/src/kabusys/core/interfaces/__init__.py
@@ -1,0 +1,28 @@
+"""core/interfaces — Core が Addon に公開する接続点の定義。"""
+
+from __future__ import annotations
+
+import duckdb
+
+from kabusys.core.interfaces.regime import (
+    DatabaseRegimeProvider,
+    NullRegimeProvider,
+    RegimeProvider,
+)
+
+__all__ = [
+    "RegimeProvider",
+    "NullRegimeProvider",
+    "DatabaseRegimeProvider",
+    "build_regime_provider",
+]
+
+
+def build_regime_provider(
+    conn: duckdb.DuckDBPyConnection,
+    enabled: bool,
+) -> RegimeProvider:
+    """ENABLE_AI_SENTIMENT フラグに基づいて RegimeProvider を返す。"""
+    if enabled:
+        return DatabaseRegimeProvider(conn)
+    return NullRegimeProvider()

--- a/src/kabusys/core/interfaces/regime.py
+++ b/src/kabusys/core/interfaces/regime.py
@@ -7,11 +7,12 @@ AI Addon 有効時は DatabaseRegimeProvider が market_regime テーブルを�
 from __future__ import annotations
 
 from datetime import date
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
 import duckdb
 
 
+@runtime_checkable
 class RegimeProvider(Protocol):
     """市場レジームラベルを返すインターフェース。"""
 

--- a/src/kabusys/core/interfaces/regime.py
+++ b/src/kabusys/core/interfaces/regime.py
@@ -1,0 +1,41 @@
+"""regime.py — RegimeProvider プロトコルと Core 実装。
+
+Core-only モード（AI Addon 未導入時）は NullRegimeProvider を使う。
+AI Addon 有効時は DatabaseRegimeProvider が market_regime テーブルを参照する。
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Protocol
+
+import duckdb
+
+
+class RegimeProvider(Protocol):
+    """市場レジームラベルを返すインターフェース。"""
+
+    def get_regime(self, target_date: date) -> str:
+        """レジームラベルを返す。データなし時は 'bull' を返す。"""
+        ...
+
+
+class NullRegimeProvider:
+    """AI Addon 未導入時のフォールバック。常に 'bull' を返す。"""
+
+    def get_regime(self, target_date: date) -> str:
+        return "bull"
+
+
+class DatabaseRegimeProvider:
+    """market_regime テーブルからレジームを取得する Core 実装。"""
+
+    def __init__(self, conn: duckdb.DuckDBPyConnection) -> None:
+        self._conn = conn
+
+    def get_regime(self, target_date: date) -> str:
+        row = self._conn.execute(
+            "SELECT regime_label FROM market_regime WHERE date = ?",
+            [target_date],
+        ).fetchone()
+        return row[0] if row else "bull"

--- a/src/kabusys/core/interfaces/regime.py
+++ b/src/kabusys/core/interfaces/regime.py
@@ -6,10 +6,13 @@ AI Addon 有効時は DatabaseRegimeProvider が market_regime テーブルを�
 
 from __future__ import annotations
 
+import logging
 from datetime import date
 from typing import Protocol, runtime_checkable
 
 import duckdb
+
+logger = logging.getLogger(__name__)
 
 
 @runtime_checkable
@@ -39,4 +42,9 @@ class DatabaseRegimeProvider:
             "SELECT regime_label FROM market_regime WHERE date = ?",
             [target_date],
         ).fetchone()
-        return row[0] if row else "bull"
+        if row is None:
+            logger.debug(
+                "market_regime not found for %s; fallback to 'bull'", target_date
+            )
+            return "bull"
+        return row[0]

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from kabusys.backtest.engine import BacktestScope
 
 from kabusys.data.calendar_management import get_trading_days, next_trading_day
+from kabusys.core.interfaces import RegimeProvider, build_regime_provider
 
 logger = logging.getLogger(__name__)
 
@@ -423,23 +424,6 @@ def _compute_volatility_score(feat: dict[str, Any]) -> float | None:
 def _compute_liquidity_score(feat: dict[str, Any]) -> float | None:
     """流動性スコア（出来高比率が高いほど高スコア）。"""
     return _sigmoid(feat.get("volume_ratio"))
-
-
-def _is_bear_regime(
-    conn: duckdb.DuckDBPyConnection,
-    target_date: date,
-) -> bool:
-    """market_regime テーブルの regime_label を参照し、Bear 相場か否かを判定する。
-
-    データが存在しない場合は False（安全側：BUY を許可）を返す。
-    """
-    row = conn.execute(
-        "SELECT regime_label FROM market_regime WHERE date = ?",
-        [target_date],
-    ).fetchone()
-    if row is None:
-        return False
-    return row[0] == "bear"
 
 
 def _is_breadth_stop(
@@ -1012,6 +996,8 @@ def generate_signals(
     min_holding_days: int | None = None,
     max_holding_days: int | None = None,
     trailing_stop_atr: float | None = None,
+    *,
+    regime_provider: RegimeProvider | None = None,
 ) -> int:
     """features テーブルを読み込み、売買シグナルを生成して signals テーブルへ書き込む。
 
@@ -1153,15 +1139,25 @@ def generate_signals(
             target_date,
         )
 
-    # 2. AI スコア読み込み（センチメントスコアのみ使用）
-    ai_rows = conn.execute(
-        "SELECT code, ai_score FROM ai_scores WHERE date = ?",
-        [target_date],
-    ).fetchall()
-    ai_map: dict[str, dict] = {code: {"ai_score": ai} for code, ai in ai_rows}
+    # 2. AI スコア読み込み（ENABLE_AI_SENTIMENT=false 時はスキップ）
+    from kabusys.config import Settings
 
-    # 3. Bear レジーム判定（market_regime テーブルから取得）
-    regime_is_bear = _is_bear_regime(conn, target_date)
+    ai_enabled = Settings().enable_ai_sentiment
+    ai_map: dict[str, dict]
+    if ai_enabled:
+        ai_rows = conn.execute(
+            "SELECT code, ai_score FROM ai_scores WHERE date = ?",
+            [target_date],
+        ).fetchall()
+        ai_map = {code: {"ai_score": ai} for code, ai in ai_rows}
+    else:
+        ai_map = {}
+
+    if regime_provider is None:
+        regime_provider = build_regime_provider(conn, ai_enabled)
+
+    # 3. Bear レジーム判定
+    regime_is_bear = regime_provider.get_regime(target_date) == "bear"
     if regime_is_bear:
         logger.info(
             "generate_signals: Bear レジーム検知 — BUY シグナル抑制 date=%s",
@@ -1188,10 +1184,7 @@ def generate_signals(
 
     # 4. 各銘柄の final_score 計算（Section 4.1）
     # バリュースコア設定・AI フラグをループ外で1回だけ評価する
-    from kabusys.config import Settings
-
     value_config = _load_value_config()
-    ai_enabled = Settings().enable_ai_sentiment
     scored: list[dict[str, Any]] = []
     for feat in features:
         code = feat["code"]

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -1018,6 +1018,9 @@ def generate_signals(
                            1 以上を指定すること。
         trailing_stop_atr: ATR 乗数。peak_close − N×ATR を下回ったら trailing_stop SELL。
                            正の値を指定すること（None の場合は config から読み込む）。
+        regime_provider:   レジームラベルを返すプロバイダー。明示的に渡した場合は
+                           ENABLE_AI_SENTIMENT の設定値より優先される。省略時は
+                           ENABLE_AI_SENTIMENT フラグに基づいて自動生成する。
 
     Returns:
         signals テーブルへ書き込んだシグナル数（BUY + SELL の合計）。

--- a/tests/test_backtest_framework.py
+++ b/tests/test_backtest_framework.py
@@ -274,7 +274,7 @@ def test_build_backtest_conn_copies_prices(conn):
     d = date(2024, 1, 5)
     _insert_price(conn, "1234", d, open_=1000.0, close=1010.0)
 
-    bt_conn = _build_backtest_conn(conn, date(2024, 1, 5), date(2024, 1, 5))
+    bt_conn = _build_backtest_conn(conn, date(2024, 1, 5), date(2024, 1, 5), ai_enabled=False)
     row = bt_conn.execute(
         "SELECT close FROM prices_daily WHERE code = ? AND date = ?", ["1234", d]
     ).fetchone()
@@ -533,7 +533,7 @@ def test_build_backtest_conn_copies_stocks(conn):
         "INSERT INTO stocks (code, name, market, sector) VALUES (?, ?, ?, ?)",
         ["1234", "テスト", "Prime", "電気機器"],
     )
-    bt_conn = _build_backtest_conn(conn, date(2024, 1, 5), date(2024, 1, 5))
+    bt_conn = _build_backtest_conn(conn, date(2024, 1, 5), date(2024, 1, 5), ai_enabled=False)
     row = bt_conn.execute("SELECT sector FROM stocks WHERE code = '1234'").fetchone()
     assert row is not None
     assert row[0] == "電気機器"
@@ -1029,7 +1029,7 @@ def test_build_backtest_conn_populates_breadth(conn):
     target = date(2024, 3, 1)
     _insert_prices_for_breadth(conn, target, n_days=30)
 
-    bt_conn = _build_backtest_conn(conn, target, target)
+    bt_conn = _build_backtest_conn(conn, target, target, ai_enabled=False)
     row = bt_conn.execute(
         "SELECT breadth_stop FROM market_breadth WHERE date = ?", [target]
     ).fetchone()

--- a/tests/test_backtest_framework.py
+++ b/tests/test_backtest_framework.py
@@ -274,7 +274,9 @@ def test_build_backtest_conn_copies_prices(conn):
     d = date(2024, 1, 5)
     _insert_price(conn, "1234", d, open_=1000.0, close=1010.0)
 
-    bt_conn = _build_backtest_conn(conn, date(2024, 1, 5), date(2024, 1, 5), ai_enabled=False)
+    bt_conn = _build_backtest_conn(
+        conn, date(2024, 1, 5), date(2024, 1, 5), ai_enabled=False
+    )
     row = bt_conn.execute(
         "SELECT close FROM prices_daily WHERE code = ? AND date = ?", ["1234", d]
     ).fetchone()
@@ -533,7 +535,9 @@ def test_build_backtest_conn_copies_stocks(conn):
         "INSERT INTO stocks (code, name, market, sector) VALUES (?, ?, ?, ?)",
         ["1234", "テスト", "Prime", "電気機器"],
     )
-    bt_conn = _build_backtest_conn(conn, date(2024, 1, 5), date(2024, 1, 5), ai_enabled=False)
+    bt_conn = _build_backtest_conn(
+        conn, date(2024, 1, 5), date(2024, 1, 5), ai_enabled=False
+    )
     row = bt_conn.execute("SELECT sector FROM stocks WHERE code = '1234'").fetchone()
     assert row is not None
     assert row[0] == "電気機器"

--- a/tests/test_backtest_framework.py
+++ b/tests/test_backtest_framework.py
@@ -476,17 +476,18 @@ def test_run_backtest_max_position_pct(conn):
 
 
 def test_fetch_regime_returns_bull_on_no_data(conn):
-    """_fetch_regime: market_regime にデータなし → 'bull' を返す。"""
-    from kabusys.backtest.engine import _fetch_regime
+    """DatabaseRegimeProvider: market_regime にデータなし → 'bull' を返す。"""
+    from kabusys.core.interfaces import DatabaseRegimeProvider
     from datetime import date
 
-    result = _fetch_regime(conn, date(2024, 1, 5))
+    provider = DatabaseRegimeProvider(conn)
+    result = provider.get_regime(date(2024, 1, 5))
     assert result == "bull"
 
 
 def test_fetch_regime_returns_correct_label(conn):
-    """_fetch_regime: market_regime にデータあり → regime_label を返す。"""
-    from kabusys.backtest.engine import _fetch_regime
+    """DatabaseRegimeProvider: market_regime にデータあり → regime_label を返す。"""
+    from kabusys.core.interfaces import DatabaseRegimeProvider
     from datetime import date
 
     d = date(2024, 1, 5)
@@ -494,7 +495,8 @@ def test_fetch_regime_returns_correct_label(conn):
         "INSERT INTO market_regime (date, regime_score, regime_label) VALUES (?, ?, ?)",
         [d, -0.5, "bear"],
     )
-    result = _fetch_regime(conn, d)
+    provider = DatabaseRegimeProvider(conn)
+    result = provider.get_regime(d)
     assert result == "bear"
 
 

--- a/tests/test_min_holding_days.py
+++ b/tests/test_min_holding_days.py
@@ -188,7 +188,9 @@ class TestMinHoldingDaysExceptions:
         _insert_position_entry(conn, code, entry_date=TARGET_DATE)
 
         regime_provider = DatabaseRegimeProvider(conn)
-        generate_signals(conn, TARGET_DATE, min_holding_days=5, regime_provider=regime_provider)
+        generate_signals(
+            conn, TARGET_DATE, min_holding_days=5, regime_provider=regime_provider
+        )
 
         rows = conn.execute(
             "SELECT code FROM signals WHERE date = ? AND side = 'sell'",

--- a/tests/test_min_holding_days.py
+++ b/tests/test_min_holding_days.py
@@ -176,6 +176,8 @@ class TestMinHoldingDaysExceptions:
 
     def test_bear_regime_bypasses_min_holding_days(self, conn):
         """Bear レジームのとき、min_holding_days=5 でも entry 当日に score_drop SELL が発生する。"""
+        from kabusys.core.interfaces import DatabaseRegimeProvider
+
         code = "4444"
         avg_price = 1000.0
         _insert_regime(conn, TARGET_DATE, label="bear")
@@ -185,7 +187,8 @@ class TestMinHoldingDaysExceptions:
         _insert_position(conn, code, TARGET_DATE, avg_price=avg_price)
         _insert_position_entry(conn, code, entry_date=TARGET_DATE)
 
-        generate_signals(conn, TARGET_DATE, min_holding_days=5)
+        regime_provider = DatabaseRegimeProvider(conn)
+        generate_signals(conn, TARGET_DATE, min_holding_days=5, regime_provider=regime_provider)
 
         rows = conn.execute(
             "SELECT code FROM signals WHERE date = ? AND side = 'sell'",

--- a/tests/test_regime_provider.py
+++ b/tests/test_regime_provider.py
@@ -60,6 +60,11 @@ def test_build_regime_provider_enabled_returns_db(duck_conn):
     assert isinstance(p, DatabaseRegimeProvider)
 
 
+def test_build_regime_provider_enabled_true_conn_none_raises_value_error():
+    with pytest.raises(ValueError):
+        build_regime_provider(None, enabled=True)
+
+
 def test_regime_provider_isinstance_check(duck_conn):
     from kabusys.core.interfaces.regime import RegimeProvider
 

--- a/tests/test_regime_provider.py
+++ b/tests/test_regime_provider.py
@@ -1,0 +1,60 @@
+"""tests/test_regime_provider.py — RegimeProvider 実装の単体テスト"""
+
+from datetime import date
+
+import pytest
+
+from kabusys.core.interfaces import build_regime_provider
+from kabusys.core.interfaces.regime import DatabaseRegimeProvider, NullRegimeProvider
+
+
+@pytest.fixture
+def duck_conn():
+    from kabusys.data.schema import init_schema
+
+    conn = init_schema(":memory:")
+    yield conn
+    conn.close()
+
+
+def test_null_regime_provider_always_bull():
+    p = NullRegimeProvider()
+    assert p.get_regime(date.today()) == "bull"
+
+
+def test_null_regime_provider_any_date():
+    p = NullRegimeProvider()
+    assert p.get_regime(date(2020, 1, 1)) == "bull"
+
+
+def test_db_regime_provider_empty_table_returns_bull(duck_conn):
+    p = DatabaseRegimeProvider(duck_conn)
+    assert p.get_regime(date.today()) == "bull"
+
+
+def test_db_regime_provider_returns_stored_label(duck_conn):
+    duck_conn.execute(
+        "INSERT INTO market_regime (date, regime_score, regime_label, ma200_ratio, macro_sentiment)"
+        " VALUES ('2024-09-01', 0.8, 'neutral', 1.05, 0.1)"
+    )
+    p = DatabaseRegimeProvider(duck_conn)
+    assert p.get_regime(date(2024, 9, 1)) == "neutral"
+
+
+def test_db_regime_provider_bear(duck_conn):
+    duck_conn.execute(
+        "INSERT INTO market_regime (date, regime_score, regime_label, ma200_ratio, macro_sentiment)"
+        " VALUES ('2024-09-02', -0.5, 'bear', 0.88, -0.4)"
+    )
+    p = DatabaseRegimeProvider(duck_conn)
+    assert p.get_regime(date(2024, 9, 2)) == "bear"
+
+
+def test_build_regime_provider_disabled_returns_null(duck_conn):
+    p = build_regime_provider(duck_conn, enabled=False)
+    assert isinstance(p, NullRegimeProvider)
+
+
+def test_build_regime_provider_enabled_returns_db(duck_conn):
+    p = build_regime_provider(duck_conn, enabled=True)
+    assert isinstance(p, DatabaseRegimeProvider)

--- a/tests/test_regime_provider.py
+++ b/tests/test_regime_provider.py
@@ -58,3 +58,12 @@ def test_build_regime_provider_disabled_returns_null(duck_conn):
 def test_build_regime_provider_enabled_returns_db(duck_conn):
     p = build_regime_provider(duck_conn, enabled=True)
     assert isinstance(p, DatabaseRegimeProvider)
+
+
+def test_regime_provider_isinstance_check(duck_conn):
+    from kabusys.core.interfaces.regime import RegimeProvider
+
+    p_null = NullRegimeProvider()
+    p_db = DatabaseRegimeProvider(duck_conn)
+    assert isinstance(p_null, RegimeProvider)
+    assert isinstance(p_db, RegimeProvider)

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -1,7 +1,7 @@
 """
 シグナル生成モジュール テスト
 
-_is_bear_regime バグ修正（market_regime.regime_label 参照）および
+RegimeProvider 移行後（market_regime.regime_label 参照）および
 breadth_stop による BUY 停止の動作検証。
 """
 
@@ -75,31 +75,34 @@ def _insert_regime(conn, d: date, regime_label: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# _is_bear_regime バグ修正テスト
+# DatabaseRegimeProvider テスト（market_regime テーブル参照）
 # ---------------------------------------------------------------------------
 
 
 def test_is_bear_regime_from_market_regime(conn):
-    """regime_label='bear' → True を返す（market_regime テーブルを正しく参照）。"""
-    from kabusys.strategy.signal_generator import _is_bear_regime
+    """regime_label='bear' → 'bear' を返す（market_regime テーブルを正しく参照）。"""
+    from kabusys.core.interfaces import DatabaseRegimeProvider
 
     _insert_regime(conn, TARGET_DATE, "bear")
-    assert _is_bear_regime(conn, TARGET_DATE) is True
+    provider = DatabaseRegimeProvider(conn)
+    assert provider.get_regime(TARGET_DATE) == "bear"
 
 
 def test_is_bear_regime_bull_returns_false(conn):
-    """regime_label='bull' → False を返す。"""
-    from kabusys.strategy.signal_generator import _is_bear_regime
+    """regime_label='bull' → 'bull' を返す。"""
+    from kabusys.core.interfaces import DatabaseRegimeProvider
 
     _insert_regime(conn, TARGET_DATE, "bull")
-    assert _is_bear_regime(conn, TARGET_DATE) is False
+    provider = DatabaseRegimeProvider(conn)
+    assert provider.get_regime(TARGET_DATE) == "bull"
 
 
 def test_is_bear_regime_no_data_returns_false(conn):
-    """market_regime にデータなし → False を返す（安全側）。"""
-    from kabusys.strategy.signal_generator import _is_bear_regime
+    """market_regime にデータなし → 'bull' を返す（安全側）。"""
+    from kabusys.core.interfaces import DatabaseRegimeProvider
 
-    assert _is_bear_regime(conn, TARGET_DATE) is False
+    provider = DatabaseRegimeProvider(conn)
+    assert provider.get_regime(TARGET_DATE) == "bull"
 
 
 # ---------------------------------------------------------------------------
@@ -492,6 +495,7 @@ class TestMinHoldingDaysBearException:
 
     def test_score_drop_sell_allowed_in_bear_regime_within_5_days(self, conn):
         from datetime import timedelta
+        from kabusys.core.interfaces import DatabaseRegimeProvider
         from kabusys.strategy.signal_generator import generate_signals
 
         base = date(2026, 4, 1)
@@ -513,7 +517,9 @@ class TestMinHoldingDaysBearException:
             [target_date],
         )
 
-        generate_signals(conn, target_date)
+        generate_signals(
+            conn, target_date, regime_provider=DatabaseRegimeProvider(conn)
+        )
 
         sell_rows = conn.execute(
             "SELECT code FROM signals WHERE date = ? AND side = 'sell'",

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -23,7 +23,6 @@ from kabusys.strategy.signal_generator import (
     _compute_value_score,
     _compute_volatility_score,
     _fetch_gap_ratios,
-    _is_bear_regime,
     _sigmoid,
     generate_signals,
 )
@@ -191,35 +190,50 @@ def test_compute_liquidity_score_none():
 
 def test_is_bear_regime_empty(conn):
     """market_regime にデータなし → False（安全側）"""
-    assert _is_bear_regime(conn, TARGET_DATE) is False
+    from kabusys.core.interfaces import DatabaseRegimeProvider
+
+    provider = DatabaseRegimeProvider(conn)
+    assert provider.get_regime(TARGET_DATE) == "bull"
 
 
 def test_is_bear_regime_bull(conn):
     """regime_label='bull' → False"""
+    from kabusys.core.interfaces import DatabaseRegimeProvider
+
     conn.execute(
         "INSERT INTO market_regime (date, regime_score, regime_label) VALUES (?, ?, ?)",
         [TARGET_DATE, 0.5, "bull"],
     )
-    assert _is_bear_regime(conn, TARGET_DATE) is False
+    provider = DatabaseRegimeProvider(conn)
+    assert provider.get_regime(TARGET_DATE) == "bull"
 
 
 def test_is_bear_regime_bear(conn):
     """regime_label='bear' → True"""
+    from kabusys.core.interfaces import DatabaseRegimeProvider
+
     conn.execute(
         "INSERT INTO market_regime (date, regime_score, regime_label) VALUES (?, ?, ?)",
         [TARGET_DATE, -0.5, "bear"],
     )
-    assert _is_bear_regime(conn, TARGET_DATE) is True
+    provider = DatabaseRegimeProvider(conn)
+    assert provider.get_regime(TARGET_DATE) == "bear"
 
 
 def test_is_bear_regime_insufficient_samples(conn):
     """market_regime にデータなし（旧：サンプル不足）→ False"""
-    assert _is_bear_regime(conn, TARGET_DATE) is False
+    from kabusys.core.interfaces import DatabaseRegimeProvider
+
+    provider = DatabaseRegimeProvider(conn)
+    assert provider.get_regime(TARGET_DATE) == "bull"
 
 
 def test_is_bear_regime_all_none(conn):
     """market_regime にデータなし → False"""
-    assert _is_bear_regime(conn, TARGET_DATE) is False
+    from kabusys.core.interfaces import DatabaseRegimeProvider
+
+    provider = DatabaseRegimeProvider(conn)
+    assert provider.get_regime(TARGET_DATE) == "bull"
 
 
 # ---------------------------------------------------------------------------
@@ -369,6 +383,8 @@ def test_generate_signals_below_threshold_no_buy(conn):
 
 def test_generate_signals_bear_regime_suppresses_buy(conn):
     """Bear レジーム時は BUY シグナルが抑制される"""
+    from kabusys.core.interfaces import DatabaseRegimeProvider
+
     _insert_price_history(
         conn, [("A", 1000.0, 6e8), ("B", 1000.0, 6e8), ("C", 1000.0, 6e8)]
     )
@@ -382,7 +398,8 @@ def test_generate_signals_bear_regime_suppresses_buy(conn):
         "INSERT INTO market_regime (date, regime_score, regime_label) VALUES (?, ?, ?)",
         [TARGET_DATE, -0.8, "bear"],
     )
-    generate_signals(conn, TARGET_DATE, threshold=0.1)
+    regime_provider = DatabaseRegimeProvider(conn)
+    generate_signals(conn, TARGET_DATE, threshold=0.1, regime_provider=regime_provider)
     rows = conn.execute(
         "SELECT side FROM signals WHERE date = ? AND side = 'buy'", [TARGET_DATE]
     ).fetchall()
@@ -769,11 +786,14 @@ def test_generate_signals_no_price_suppresses_sell(conn):
 
 def test_is_bear_regime_exactly_min_samples(conn):
     """regime_label='bear' → True（旧：_BEAR_MIN_SAMPLES ちょうどのサンプル数テスト）"""
+    from kabusys.core.interfaces import DatabaseRegimeProvider
+
     conn.execute(
         "INSERT INTO market_regime (date, regime_score, regime_label) VALUES (?, ?, ?)",
         [TARGET_DATE, -0.3, "bear"],
     )
-    assert _is_bear_regime(conn, TARGET_DATE) is True
+    provider = DatabaseRegimeProvider(conn)
+    assert provider.get_regime(TARGET_DATE) == "bear"
 
 
 # ---------------------------------------------------------------------------
@@ -1112,6 +1132,8 @@ def test_sector_unknown_not_affected(conn):
 
 def test_sector_filter_skipped_in_bear(conn):
     """Bear レジーム時はセクターフィルタが適用されない"""
+    from kabusys.core.interfaces import DatabaseRegimeProvider
+
     _insert_sector_test_data(
         conn,
         [
@@ -1131,7 +1153,8 @@ def test_sector_filter_skipped_in_bear(conn):
             "VALUES (?, ?, 3.0, 3.0, 0.0, 0.0, 20.0, 0.0)",
             [TARGET_DATE, code],
         )
-    generate_signals(conn, TARGET_DATE)
+    regime_provider = DatabaseRegimeProvider(conn)
+    generate_signals(conn, TARGET_DATE, regime_provider=regime_provider)
     buy_count = conn.execute(
         "SELECT COUNT(*) FROM signals WHERE date = ? AND side = 'buy'", [TARGET_DATE]
     ).fetchone()[0]


### PR DESCRIPTION
## Summary

- `src/kabusys/core/interfaces/regime.py` に `RegimeProvider` Protocol・`NullRegimeProvider`・`DatabaseRegimeProvider` を新設し、`build_regime_provider()` ファクトリで `ENABLE_AI_SENTIMENT` フラグに応じて切り替える
- `signal_generator.py` の `_is_bear_regime()` を廃止し `regime_provider.get_regime()` に置き換え。`ai_scores` クエリを `if ai_enabled:` でガード化
- `backtest/engine.py` の `_fetch_regime()` を廃止し `_regime_provider` を `run_backtest()` 内で一元構築。`ai_scores` のインメモリコピーも `ai_enabled` フラグで条件化

## Motivation

`ENABLE_AI_SENTIMENT=false` かつ `ai_scores` / `market_regime` テーブルが空の状態で Core の売買フローとバックテストが明示的・意図的に正常動作することを保証する（Issue #271）。従来は空テーブルへの暗黙的なフォールバックに依存していたが、今後の Core/Addon 分離に向けた足場として明示的な抽象化を導入した。

## Test Plan

- [ ] `pytest tests/test_regime_provider.py` — 8 件（NullRegimeProvider・DatabaseRegimeProvider・factory・isinstance）
- [ ] `pytest tests/test_signal_generator.py` — 24 件（リグレッションなし）
- [ ] `pytest tests/test_backtest_framework.py tests/test_backtest_scope.py` — 68 件（リグレッションなし）
- [ ] `pytest --tb=short -q` — 全 1,696 件 PASSED
- [ ] `ruff check` / `ruff format --check` — 全ファイル通過

Closes #271