### PR TITLE
docs: WebManual に Core / Addon 区分表示を実装 (Issue #273)

### DIFF
--- a/documents/08_Operations/Monitoring.md
+++ b/documents/08_Operations/Monitoring.md
@@ -168,10 +168,10 @@ AIスコア分布 | 偏り検知 |
 
 通知方法
 
-| 方法 | 内容 |
-|----|----|
-LINE通知 | 推奨（`LINE_NOTIFY_ENABLED=true` かつ認証情報設定時のみ有効） |
-ログ | 必須（常に有効） |
+| 方法 | 区分 | 内容 |
+|----|----|----|
+| LINE通知 | Notification Addon（任意） | `LINE_NOTIFY_ENABLED=true` かつ認証情報設定時のみ有効。未設定でも Core は動作する |
+| ログ | Core 標準 | 必須（常に有効） |
 
 ### LINE 通知アーキテクチャ（Null Object パターン）
 
@@ -194,6 +194,8 @@ Core コードは返り値の型を意識せず `.send(message)` を呼ぶだけ
 
 **Phase 1 実装（Issue #231 / Issue #260）:** Streamlit マルチページ構成（10ページ）
 
+**Core 標準ページ（9ページ）:**
+
 | ページ | ファイル | 表示内容 |
 |---|---|---|
 | Home | `streamlit_dashboard.py` | Kill Switch / Execution / Monitoring 状態、ドローダウン、エラーログ |
@@ -205,7 +207,12 @@ Core コードは返り値の型を意識せず `.send(message)` を呼ぶだけ
 | Performance | `pages/7_Performance.py` | エクイティカーブ・ポジション・取引履歴・Paper Verification |
 | Failure Recovery | `pages/8_Failure_Recovery.py` | 障害イベント集約・復旧ガイド |
 | WebManual | `pages/9_WebManual.py` | 運用マニュアル閲覧ビュー |
-| Strategy Lab | `pages/10_Strategy_Lab.py` | 市場レジーム・AI スコア・シグナル推移 |
+
+**Addon ページ:**（未設定でも Core は動作します）
+
+| ページ | ファイル | 区分 | 表示内容 |
+|---|---|---|---|
+| Strategy Lab | `pages/10_Strategy_Lab.py` | Operations UI Addon | 市場レジーム・AI スコア・シグナル推移（AI Addon 有効時に意味をもつ） |
 
 推奨
 
@@ -273,8 +280,8 @@ Windows 1台での稼働を前提とし、オーバーヘッドの少ない構�
 | 種類 | ツール / 技術 | 用途・保存先 |
 |----|----|----|
 | データベース | SQLite | `monitoring.db` (テーブル: `system_status`, `trade_logs`, `positions`, `risk_logs`, `dashboard`) |
-| ダッシュボード | Streamlit | 10ページ構成（Home / Initial Setup / Pre-Market / Execution Startup / Intraday Monitor / Signal Queue / Performance / Failure Recovery / WebManual / Strategy Lab）|
-| アラート | LINE | LINE Messaging API 経由での異常通知 |
+| ダッシュボード | Streamlit | Core 標準 9ページ（Home / Initial Setup / Pre-Market / Execution Startup / Intraday Monitor / Signal Queue / Performance / Failure Recovery / WebManual）+ Addon ページ（Strategy Lab）|
+| アラート | LINE | LINE Messaging API 経由での異常通知（Notification Addon — 任意） |
 
 ### SQLite テーブル設計（Phase 7 実装）
 

--- a/documents/08_Operations/Monitoring.md
+++ b/documents/08_Operations/Monitoring.md
@@ -192,7 +192,7 @@ Core コードは返り値の型を意識せず `.send(message)` を呼ぶだけ
 
 監視ダッシュボードを用意する。
 
-**Phase 1 実装（Issue #231 / Issue #260）:** Streamlit マルチページ構成（10ページ）
+**Phase 1 実装（Issue #231 / Issue #260）:** Streamlit マルチページ構成（Core 9 + Addon 1 = 10ページ）
 
 **Core 標準ページ（9ページ）:**
 

--- a/documents/08_Operations/Monitoring.md
+++ b/documents/08_Operations/Monitoring.md
@@ -170,7 +170,7 @@ AIスコア分布 | 偏り検知 |
 
 | 方法 | 区分 | 内容 |
 |----|----|----|
-| LINE通知 | Notification Addon（任意） | `LINE_NOTIFY_ENABLED=true` かつ認証情報設定時のみ有効。未設定でも Core は動作する |
+| LINE通知 | Notification Addon — 任意 | `LINE_NOTIFY_ENABLED=true` かつ認証情報設定時のみ有効。未設定でも Core は動作します |
 | ログ | Core 標準 | 必須（常に有効） |
 
 ### LINE 通知アーキテクチャ（Null Object パターン）

--- a/documents/WebManual/A_Overview.md
+++ b/documents/WebManual/A_Overview.md
@@ -32,11 +32,11 @@ Core 機能:
 
 Addon 機能:（任意・後から追加可能。未設定でも Core は動作します）
 
-- AI によるニュース / regime 補助判定（AI Addon）
+- AI によるニュース / regime 補助判定（AI Addon — News/Disclosure Addon との併用を推奨）
 - TDnet / EDINET 適時開示収集（Disclosure Addon）
 - Yahoo News RSS 収集（News Addon）
 - LINE 通知（Notification Addon）
-- Strategy Lab 分析ページ（Operations UI Addon）
+- Strategy Lab 分析ページ（Operations UI Addon — AI Addon なしでも表示されますが分析指標は限定的になります）
 
 運用インターフェース:
 

--- a/documents/WebManual/A_Overview.md
+++ b/documents/WebManual/A_Overview.md
@@ -82,10 +82,10 @@ Addon 機能:（任意・後から追加可能。未設定でも Core は動作�
 20:00  strategy_signal
 21:00  portfolio_construction
 21:15  night_batch_report（自動）
-08:00  pre_market_report
+08:00  pre_market_report（手動）
 08:30  execution start
 09:00  monitoring start
-15:00  market_close_report
+15:00  market_close_report（手動）
 
 # AI Addon（ENABLE_AI_SENTIMENT=true のときのみ）
 18:00  ai_analysis

--- a/documents/WebManual/A_Overview.md
+++ b/documents/WebManual/A_Overview.md
@@ -24,12 +24,19 @@ Core 機能:
 
 - 日次データ更新
 - 特徴量生成
-- AI によるニュース / regime 補助判定
 - 売買シグナル生成
 - ポートフォリオ構築
 - 自動執行
 - リスク管理と Kill Switch
 - 日次 / 週次 / 月次レポート
+
+Addon 機能:（任意・後から追加可能。未設定でも Core は動作します）
+
+- AI によるニュース / regime 補助判定（AI Addon）
+- TDnet / EDINET 適時開示収集（Disclosure Addon）
+- Yahoo News RSS 収集（News Addon）
+- LINE 通知（Notification Addon）
+- Strategy Lab 分析ページ（Operations UI Addon）
 
 運用インターフェース:
 
@@ -37,7 +44,7 @@ Core 機能:
 - Streamlit ダッシュボード
 - Streamlit 内 WebManual ビュー
 
-Streamlit で確認できる主なページ:
+**Core 標準ページ:**
 
 - `Home`
 - `Initial Setup`（初期セットアップ確認）
@@ -48,7 +55,10 @@ Streamlit で確認できる主なページ:
 - `Performance`（Paper Verification 含む）
 - `Failure Recovery`（障害イベント集約）
 - `WebManual`
-- `Strategy Lab`
+
+**Addon ページ:**（未設定でも Core は動作します）
+
+- `Strategy Lab`（市場レジーム・AI スコア分析 — AI Addon 有効時に意味をもつ）
 
 ---
 
@@ -66,16 +76,19 @@ Streamlit で確認できる主なページ:
 ## A-4. 1日の流れ
 
 ```text
+# Core 標準フロー
 15:30  data_update
 16:00  feature_gen
-18:00  ai_analysis
 20:00  strategy_signal
 21:00  portfolio_construction
-21:30  Night Batch 状態確認
+21:15  night_batch_report（自動）
 08:00  pre_market_report
 08:30  execution start
 09:00  monitoring start
 15:00  market_close_report
+
+# AI Addon（ENABLE_AI_SENTIMENT=true のときのみ）
+18:00  ai_analysis
 ```
 
 運用判断は、個別ログだけでなく次のレポートで行う。

--- a/documents/WebManual/B_CoreSetup.md
+++ b/documents/WebManual/B_CoreSetup.md
@@ -68,6 +68,14 @@ python -m kabusys.config_setup
 
 ウィザードの質問に回答すると、プロジェクトルートに `.env` が生成されます。
 
+**設定区分の凡例:**
+
+| ラベル | 意味 |
+|---|---|
+| Core 必須 | Core を動かすために必要な設定 |
+| Core 任意 | Core が使う設定だが、未設定でもデフォルト値で Core は動作する |
+| Addon 任意 | Addon 導入時のみ意味をもつ設定。未設定でも Core の自動売買フローには影響しない |
+
 **Core 必須設定:**
 
 | 環境変数 | 説明 | 例 |
@@ -190,6 +198,8 @@ powershell -File scripts\setup_task_scheduler.ps1
 
 > 詳細は `documents/10_Runtime/RuntimeJobSchedule.md` を参照してください。
 
+> **補足:** `pre_market_report`（08:00）および `market_close_report`（15:00）は Task Scheduler の自動ジョブではなく、オペレーターが手動で実行するコマンドです（`python -m kabusys.run_pre_market_report`、`python -m kabusys.run_market_close_report`）。詳細は [D_LiveOperation.md](./D_LiveOperation.md) を参照してください。
+
 ---
 
 ## B-2. Addon 機能の有効化
@@ -227,6 +237,10 @@ Yahoo ニュースの記事を OpenAI が自動的に読み取り、各銘柄の
 - レジーム判定は `NullRegimeProvider` が使用され、常に `'bull'`（非 Bear）として扱います
 - Bear レジームフィルタは発動せず、全銘柄が BUY 候補になります
 - Core の自動売買フロー・バックテストは AI データなしで完全に動作します
+
+**他の Addon との依存関係:**
+
+> AI Addon は、ニュース原文（`raw_news`）の入力として **News Addon**（`ENABLE_YAHOONEWS=true`）または **Disclosure Addon**（`ENABLE_TDNET=true`）との併用を推奨します。いずれのニュースソースも有効でない場合、AI 分析バッチは入力データなしで実行され、`ai_scores` は空（0件）になります。その場合でも Core の自動売買フローはスキップなしで正常に動作します（ニューススコアはデフォルト値で補完されます）。
 
 **必要なもの:**
 - OpenAI API キー（有料・従量課金）

--- a/documents/WebManual/B_CoreSetup.md
+++ b/documents/WebManual/B_CoreSetup.md
@@ -68,7 +68,7 @@ python -m kabusys.config_setup
 
 ウィザードの質問に回答すると、プロジェクトルートに `.env` が生成されます。
 
-**最低限設定が必要な項目:**
+**Core 必須設定:**
 
 | 環境変数 | 説明 | 例 |
 |---|---|---|
@@ -76,7 +76,7 @@ python -m kabusys.config_setup
 | `JQUANTS_REFRESH_TOKEN` | J-Quants の Refresh Token | `eyJ...` |
 | `KABU_API_PASSWORD` | kabuステーション API パスワード（本番用） | `your_api_password` |
 
-**よく使うオプション設定:**
+**Core 任意設定:**（未設定でもデフォルト値で Core は動作します）
 
 | 環境変数 | 説明 | デフォルト |
 |---|---|---|
@@ -84,13 +84,19 @@ python -m kabusys.config_setup
 | `PAPER_TRADING_INITIAL_CASH` | MockBrokerClient の初期仮想資金（円） | `10000000` |
 | `KABU_USE_SANDBOX` | `true` でポート 18081 のkabu検証環境を使用（`paper_trading` 時のみ有効） | `false` |
 | `KABU_SANDBOX_API_PASSWORD` | kabu検証環境用 API パスワード（`KABU_USE_SANDBOX=true` 時） | （空） |
-| `LINE_NOTIFY_ENABLED` | LINE 通知の有効化 | `false` |
-| `ENABLE_AI_SENTIMENT` | AI センチメントの有効化 | `false` |
-| `ENABLE_TDNET` | TDnet 適時開示収集の有効化 | `false` |
-| `ENABLE_EDINET` | EDINET 法定開示収集の有効化 | `false` |
-| `EDINET_API_KEY` | EDINET API サブスクリプションキー | （空） |
-| `ENABLE_YAHOONEWS` | Yahoo News RSS 収集の有効化 | `false` |
 | `LOG_LEVEL` | ログの詳細レベル | `INFO` |
+
+**Addon 任意設定:**（未設定でも Core の自動売買フローには影響しません）
+
+| 環境変数 | 区分 | 説明 | デフォルト |
+|---|---|---|---|
+| `LINE_NOTIFY_ENABLED` | Notification Addon | LINE 通知の有効化 | `false` |
+| `ENABLE_AI_SENTIMENT` | AI Addon | AI センチメントの有効化 | `false` |
+| `OPENAI_API_KEY` | AI Addon | OpenAI API キー（`ENABLE_AI_SENTIMENT=true` 時に必須） | （空） |
+| `ENABLE_TDNET` | Disclosure Addon | TDnet 適時開示収集の有効化 | `false` |
+| `ENABLE_EDINET` | Disclosure Addon | EDINET 法定開示収集の有効化 | `false` |
+| `EDINET_API_KEY` | Disclosure Addon | EDINET API サブスクリプションキー（`ENABLE_EDINET=true` 時に必須） | （空） |
+| `ENABLE_YAHOONEWS` | News Addon | Yahoo News RSS 収集の有効化 | `false` |
 
 ### B-1-4. 設定の検証
 
@@ -138,13 +144,16 @@ python -m kabusys.data.bootstrap --endpoint /equities/bars/daily
 
 **取得対象エンドポイント:** `prices_daily`, `master`, `financials`, `market_calendar`, `dividend`, `topix`
 
-Bootstrap 後、特徴量生成・レジーム判定などを一度手動実行してデータが正しく処理されるか確認します。
+Bootstrap 後、Core の処理フローを一度手動実行してデータが正しく処理されるか確認します。
 
 ```powershell
+# Core 標準フロー（必須確認）
 python scripts/run_feature_gen.py
-python scripts/run_ai_analysis.py
 python scripts/run_strategy_signal.py
 python scripts/run_portfolio_construction.py
+
+# AI Addon（ENABLE_AI_SENTIMENT=true のときのみ）
+# python scripts/run_ai_analysis.py
 ```
 
 ### B-1-7. Task Scheduler の設定（夜間バッチの自動化）
@@ -157,38 +166,38 @@ Windows タスクスケジューラに登録することで、毎日自動で動
 powershell -File scripts\setup_task_scheduler.ps1
 ```
 
-**登録されるタスクのスケジュール:**
+**Core 標準ジョブ一覧:**
 
 | 時刻 | 処理 | スクリプト |
 |---|---|---|
 | 15:30 | 市場データ更新 | `scripts/run_data_update.py` |
-| 15:33 | Yahoo News RSS 収集（オプション） | `scripts/run_yahoonews_collection.py` |
-| 15:35 | TDnet 適時開示収集（オプション） | `scripts/run_tdnet_collection.py` |
-| 15:40 | EDINET 法定開示収集（オプション） | `scripts/run_edinet_collection.py` |
 | 16:00 | 特徴量計算 | `scripts/run_feature_gen.py` |
-| 17:00 | 開示イベント分類（オプション） | `scripts/run_disclosure_classification.py` |
-| 18:00 | AI 分析（オプション） | `scripts/run_ai_analysis.py` |
 | 20:00 | 売買シグナル生成 | `scripts/run_strategy_signal.py` |
 | 21:00 | ポートフォリオ構築 | `scripts/run_portfolio_construction.py` |
+| 21:15 | 夜間バッチ結果レポート | `scripts/run_night_batch_report.py` |
 | 08:30 | Execution Engine 起動 | `python -m kabusys.run_execution` |
 | 09:00 | Monitoring 起動 | `python -m kabusys.run_monitoring` |
 
-> TDnet 収集・開示イベント分類は `ENABLE_TDNET=false`（デフォルト）のときスキップされます。有効化手順は [B-2-3](#b-2-3-tdnet-適時開示収集の設定) を参照してください。
+**Addon 有効時のみ動くジョブ一覧:**（未設定でも Core の売買フローには影響しません）
 
-> EDINET 法定開示収集は `ENABLE_EDINET=false`（デフォルト）のときスキップされます。有効化手順は [B-2-4](#b-2-4-edinet-法定開示収集の設定) を参照してください。
-
-> Yahoo News RSS 収集は `ENABLE_YAHOONEWS=false`（デフォルト）のときスキップされます。有効化手順は [B-2-5](#b-2-5-yahoo-news-rss-収集の設定) を参照してください。
+| 時刻 | 処理 | Addon | スクリプト |
+|---|---|---|---|
+| 15:33 | Yahoo News RSS 収集 | News Addon（`ENABLE_YAHOONEWS=true`） | `scripts/run_yahoonews_collection.py` |
+| 15:35 | TDnet 適時開示収集 | Disclosure Addon（`ENABLE_TDNET=true`） | `scripts/run_tdnet_collection.py` |
+| 15:40 | EDINET 法定開示収集 | Disclosure Addon（`ENABLE_EDINET=true`） | `scripts/run_edinet_collection.py` |
+| 17:00 | 開示イベント分類 | Disclosure Addon（`ENABLE_TDNET=true`） | `scripts/run_disclosure_classification.py` |
+| 18:00 | AI 分析 | AI Addon（`ENABLE_AI_SENTIMENT=true`） | `scripts/run_ai_analysis.py` |
 
 > 詳細は `documents/10_Runtime/RuntimeJobSchedule.md` を参照してください。
 
 ---
 
-## B-2. オプション機能の導入
+## B-2. Addon 機能の有効化
 
-オプション機能は `.env` の設定を変更するだけで有効化できます。
-Core 機能（自動売買）に影響なくいつでも追加・削除できます。
+Addon 機能は `.env` の設定を変更するだけで有効化できます。
+Core の自動売買フローに影響なくいつでも追加・削除できます。
 
-### B-2-1. LINE 通知の設定
+### B-2-1. LINE 通知の設定（Notification Addon — 任意）
 
 LINE 通知を使うと、発注・約定・エラーなどの重要なイベントをスマホの LINE で受け取れます。
 
@@ -207,7 +216,7 @@ LINE_USER_ID=your_line_user_id
 
 設定後、`python -m kabusys.validate_config` で検証します。
 
-### B-2-2. AI センチメント分析の設定
+### B-2-2. AI センチメント分析の設定（AI Addon — 任意）
 
 Yahoo ニュースの記事を OpenAI が自動的に読み取り、各銘柄の市場センチメント（強気・弱気）をスコア化して売買判断に加味します（最大 10% の影響）。
 
@@ -231,7 +240,7 @@ ENABLE_AI_SENTIMENT=true
 OPENAI_API_KEY=sk-...
 ```
 
-### B-2-3. TDnet 適時開示収集の設定
+### B-2-3. TDnet 適時開示収集の設定（Disclosure Addon — 任意）
 
 TDnet（適時開示情報閲覧サービス）から当日の開示一覧を自動収集し、決算短信・業績修正・自己株取得などのイベントを分類・スコア化します。
 
@@ -253,7 +262,7 @@ ENABLE_TDNET=true
 
 > ℹ️ `ENABLE_TDNET=false`（デフォルト）の場合、両ジョブは即座にスキップされ Core 機能（自動売買）に影響しません。
 
-### B-2-4. EDINET 法定開示収集の設定
+### B-2-4. EDINET 法定開示収集の設定（Disclosure Addon — 任意）
 
 EDINET（Electronic Disclosure for Investors' NETwork）API から有価証券報告書・四半期報告書・大量保有報告書などの法定開示を自動収集します。TDnet では取得できない開示書類の補完層として機能します。
 
@@ -285,7 +294,7 @@ EDINET_API_KEY=your_subscription_key
 
 ---
 
-### B-2-5. Yahoo News RSS 収集の設定
+### B-2-5. Yahoo News RSS 収集の設定（News Addon — 任意）
 
 Yahoo News（ビジネスカテゴリ）の RSS フィードから当日のニュースを収集し、`raw_news` テーブルへ保存します。AI センチメント分析（`ENABLE_AI_SENTIMENT=true`）の前段データソースとして機能します。
 
@@ -314,29 +323,28 @@ ENABLE_YAHOONEWS=true
 
 ## B-3. 導入完了チェックリスト
 
-すべての項目にチェックが入れば、初期導入は完了です。
+### Core セットアップ完了チェック
 
-### Core 機能
+ここまで通れば Core は使い始められます。
 
 - [ ] `python -m kabusys.validate_config` がエラーなく完了する
 - [ ] `python scripts/setup_db.py` で `data/kabusys.duckdb` と `data/monitoring.db` が作成されている
 - [ ] `python scripts/setup_db.py --paper` で `data/paper_trading.db` が作成されている
 - [ ] DuckDB に市場データ（`prices_daily`, `stocks` など）が存在する
-- [ ] Task Scheduler にバッチジョブが登録されている
-
-### ペーパートレードの起動確認
-
+- [ ] Task Scheduler に Core 標準ジョブが登録されている
 - [ ] `.env` に `KABUSYS_ENV=paper_trading` が設定されている
 - [ ] `python -m kabusys.run_pre_market_report` が正常に動作する
 - [ ] `python -m kabusys.run_execution`（別ターミナルで起動）が起動エラーなく動く
 
-### オプション機能（有効化した場合のみ）
+### Addon 有効化時の追加チェック
 
-- [ ] LINE 通知: テストメッセージが LINE に届く
-- [ ] AI センチメント: `ENABLE_AI_SENTIMENT=true` で AI 分析バッチが正常完了する
-- [ ] TDnet 収集: `ENABLE_TDNET=true` で `run_tdnet_collection.py` が正常完了する
-- [ ] EDINET 収集: `ENABLE_EDINET=true` で `run_edinet_collection.py` が正常完了する
-- [ ] Yahoo News 収集: `ENABLE_YAHOONEWS=true` で `run_yahoonews_collection.py` が正常完了する
+（各 Addon を有効化した場合のみ確認します。未設定でも Core は動作します）
+
+- [ ] LINE 通知（Notification Addon）: テストメッセージが LINE に届く
+- [ ] AI センチメント（AI Addon）: `ENABLE_AI_SENTIMENT=true` で AI 分析バッチが正常完了する
+- [ ] TDnet 収集（Disclosure Addon）: `ENABLE_TDNET=true` で `run_tdnet_collection.py` が正常完了する
+- [ ] EDINET 収集（Disclosure Addon）: `ENABLE_EDINET=true` で `run_edinet_collection.py` が正常完了する
+- [ ] Yahoo News 収集（News Addon）: `ENABLE_YAHOONEWS=true` で `run_yahoonews_collection.py` が正常完了する
 
 ---
 

--- a/documents/WebManual/D_LiveOperation.md
+++ b/documents/WebManual/D_LiveOperation.md
@@ -91,7 +91,7 @@ Streamlit:
 streamlit run src/kabusys/monitoring/streamlit_dashboard.py -- --db data/monitoring.db
 ```
 
-使うページ:
+**Core 標準導線 — 使うページ:**
 
 - `Home`（Kill Switch・プロセス状態・ドローダウン・エラーイベント）
 - `Pre-Market`（READY/BLOCKED 判定・データ鮮度確認）
@@ -101,7 +101,10 @@ streamlit run src/kabusys/monitoring/streamlit_dashboard.py -- --db data/monitor
 - `Performance`（エクイティカーブ・ポジション・取引履歴・Paper Verification）
 - `Failure Recovery`（障害イベント集約・復旧ガイド）
 - `WebManual`
-- `Strategy Lab`（市場レジーム・AI スコア）
+
+**Addon 導線 — 追加ページ:**（未設定でも Core は動作します）
+
+- `Strategy Lab`（市場レジーム・AI スコア — AI Addon 有効時に意味をもつ）
 
 ---
 


### PR DESCRIPTION
## Summary

- `B_CoreSetup.md` の設定一覧・Task Scheduler・完了チェックを `Core 必須 / Core 任意 / Addon 任意` の3区分に整理
- `A_Overview.md` の機能リストおよびページ一覧を `Core 標準ページ / Addon ページ` に分割
- `D_LiveOperation.md` のザラ場監視ページ一覧を `Core 標準導線 / Addon 導線` に分割
- `Monitoring.md` のページ表・アラート表に区分列を追加

## 設計方針

- Addon 情報は削除せず、ラベルで区分するアプローチ（`TODO_CoreAddonDocumentationBaselinePlan.md` の方針に従う）
- ラベル体系は `TODO_CoreAddonDocumentationLabelGuide.md` に準拠
- Core だけ読んでもセットアップ完了 → paper → live まで完結する導線になっていることを確認済み

## Test Plan

- [ ] `B_CoreSetup.md` を頭から読んで、Addon 設定なしで Core セットアップが完結するか確認
- [ ] `A_Overview.md` の Core 標準ページ / Addon ページ区分が正しいか確認
- [ ] `D_LiveOperation.md` の Addon 導線が明示されているか確認
- [ ] `Monitoring.md` の区分表示が整合しているか確認

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)