### PR TITLE
feat: strategy_config.yaml の sector/regime セクションから残り4定数を runtime 読み込みに変更 (Issue #275)

### DIFF
--- a/config/strategy_config.yaml
+++ b/config/strategy_config.yaml
@@ -45,7 +45,7 @@ sector:
   quartile: 0.25
 
 regime:
-  # TOPIX 200MA 乖離率がこの値以下で地合い悪化と判定（負値）
+  # TOPIX 200MA 乖離率がこの値未満で地合い悪化と判定（負値）
   topix_drawdown_threshold: -0.15
   # 地合い悪化時の size_multiplier（0 < x ≤ 1）
   topix_size_multiplier_bear: 0.5

--- a/config/strategy_config.yaml
+++ b/config/strategy_config.yaml
@@ -37,3 +37,15 @@ value_score:
     per_mid: 20.0
     pbr_mid: 1.5
     div_yield_max: 3.0
+
+sector:
+  # 上位セクター銘柄への final_score 加算量（≥ 0）
+  boost: 0.03
+  # 上位・下位セクターの区切り割合（0 < x < 1）
+  quartile: 0.25
+
+regime:
+  # TOPIX 200MA 乖離率がこの値以下で地合い悪化と判定（負値）
+  topix_drawdown_threshold: -0.15
+  # 地合い悪化時の size_multiplier（0 < x ≤ 1）
+  topix_size_multiplier_bear: 0.5

--- a/docs/superpowers/plans/2026-05-09-strategy-param-externalization.md
+++ b/docs/superpowers/plans/2026-05-09-strategy-param-externalization.md
@@ -1,0 +1,532 @@
+# Strategy Parameter Externalization (Remaining 4 Constants) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `signal_generator.py` に残るハードコード定数 4 件（`_SECTOR_BOOST`, `_SECTOR_QUARTILE`, `_TOPIX_DRAWDOWN_THRESHOLD`, `_TOPIX_SIZE_MULTIPLIER_BEAR`）を `config/strategy_config.yaml` の `sector:` / `regime:` セクションから runtime 読み込みに変更し、再起動不要でパラメータを変更できるようにする。
+
+**Architecture:** 既存の `_load_strategy_config()` / `_STRATEGY_CONFIG_DEFAULTS` パターンを踏襲し、YAML の `sector:` / `regime:` セクションを解析して返却 dict に 4 キーを追加する。`_calc_sector_strengths()` と `_get_topix_size_multiplier()` はデフォルト付き明示パラメータを受け取り、`generate_signals()` が `_cfg` から渡す。
+
+**Tech Stack:** Python 3.10+, PyYAML（既存依存）, pytest
+
+---
+
+## File Map
+
+- Modify: `src/kabusys/strategy/signal_generator.py` — `_STRATEGY_CONFIG_DEFAULTS`, `_load_strategy_config()`, `_calc_sector_strengths()`, `_get_topix_size_multiplier()`, `generate_signals()` の 5 箇所
+- Modify: `config/strategy_config.yaml` — `sector:` / `regime:` セクション追加
+- Modify: `tests/test_signal_generator.py` — 新テスト追加
+
+---
+
+## Background（コードベース把握）
+
+`signal_generator.py` の現状:
+- `_STRATEGY_CONFIG_PATH` (line 103): `config/strategy_config.yaml` へのパス
+- `_strategy_config_cache` / `_strategy_config_mtime` (lines 107-108): グローバルキャッシュ
+- `_load_strategy_config()` (line 111): YAML を読んで flat dict を返す。`strategy:` セクションのみ解析済み
+- `_STRATEGY_CONFIG_DEFAULTS` (line 91): デフォルト dict。現状 9 キー
+- `_calc_sector_strengths(conn, target_date)` (line 533): `_SECTOR_QUARTILE` をモジュール定数として使用
+- `_get_topix_size_multiplier(conn, target_date)` (line 447): `_TOPIX_DRAWDOWN_THRESHOLD` / `_TOPIX_SIZE_MULTIPLIER_BEAR` をモジュール定数として使用
+- `generate_signals()` (line 989): `_cfg = _load_strategy_config()` を呼び出し済み（line 1028）
+
+テスト:
+- `TestGetTopixSizeMultiplier` クラス (line 624): `_get_topix_size_multiplier` を引数 2 つで呼ぶ既存テストがある。パラメータ追加後もデフォルト値で動作する。
+
+---
+
+## Task 1: `_load_strategy_config()` に sector/regime セクション解析を追加
+
+**Files:**
+- Modify: `src/kabusys/strategy/signal_generator.py:91-234`
+- Modify: `tests/test_signal_generator.py`（末尾に追加）
+
+### Step 1: 失敗するテストを書く
+
+`tests/test_signal_generator.py` の末尾に追加する:
+
+```python
+# ---------------------------------------------------------------------------
+# Task 1: _load_strategy_config() sector/regime セクション
+# ---------------------------------------------------------------------------
+
+import kabusys.strategy.signal_generator as _sg
+
+
+def _load_cfg_with_yaml(yaml_text: str, tmp_path, monkeypatch) -> dict:
+    """tmp_path に YAML ファイルを書き、モジュールのパスとキャッシュをパッチして _load_strategy_config() を呼ぶ。"""
+    cfg_file = tmp_path / "strategy_config.yaml"
+    cfg_file.write_text(yaml_text, encoding="utf-8")
+    monkeypatch.setattr(_sg, "_STRATEGY_CONFIG_PATH", cfg_file)
+    monkeypatch.setattr(_sg, "_strategy_config_cache", None)
+    monkeypatch.setattr(_sg, "_strategy_config_mtime", -1.0)
+    return _sg._load_strategy_config()
+
+
+class TestLoadStrategyConfigSectorRegime:
+    """_load_strategy_config() の sector/regime セクション解析テスト。"""
+
+    def test_valid_sector_and_regime(self, tmp_path, monkeypatch):
+        yaml_text = """
+strategy:
+  threshold: 0.60
+sector:
+  boost: 0.05
+  quartile: 0.30
+regime:
+  topix_drawdown_threshold: -0.20
+  topix_size_multiplier_bear: 0.4
+"""
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["sector_boost"] == 0.05
+        assert cfg["sector_quartile"] == 0.30
+        assert cfg["topix_drawdown_threshold"] == -0.20
+        assert cfg["topix_size_multiplier_bear"] == 0.4
+
+    def test_missing_sector_section_uses_defaults(self, tmp_path, monkeypatch):
+        yaml_text = "strategy:\n  threshold: 0.60\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["sector_boost"] == 0.03
+        assert cfg["sector_quartile"] == 0.25
+
+    def test_missing_regime_section_uses_defaults(self, tmp_path, monkeypatch):
+        yaml_text = "strategy:\n  threshold: 0.60\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["topix_drawdown_threshold"] == -0.15
+        assert cfg["topix_size_multiplier_bear"] == 0.5
+
+    def test_sector_boost_negative_falls_back(self, tmp_path, monkeypatch):
+        yaml_text = "sector:\n  boost: -0.01\n  quartile: 0.25\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["sector_boost"] == 0.03  # default
+
+    def test_sector_quartile_zero_falls_back(self, tmp_path, monkeypatch):
+        yaml_text = "sector:\n  boost: 0.03\n  quartile: 0.0\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["sector_quartile"] == 0.25  # default
+
+    def test_sector_quartile_one_falls_back(self, tmp_path, monkeypatch):
+        yaml_text = "sector:\n  boost: 0.03\n  quartile: 1.0\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["sector_quartile"] == 0.25  # default
+
+    def test_topix_drawdown_threshold_positive_falls_back(self, tmp_path, monkeypatch):
+        yaml_text = "regime:\n  topix_drawdown_threshold: 0.10\n  topix_size_multiplier_bear: 0.5\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["topix_drawdown_threshold"] == -0.15  # default
+
+    def test_topix_size_multiplier_bear_over_one_falls_back(self, tmp_path, monkeypatch):
+        yaml_text = "regime:\n  topix_drawdown_threshold: -0.15\n  topix_size_multiplier_bear: 1.5\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["topix_size_multiplier_bear"] == 0.5  # default
+```
+
+- [ ] **Step 2: テストが失敗することを確認する**
+
+```
+pytest tests/test_signal_generator.py::TestLoadStrategyConfigSectorRegime -v
+```
+
+期待: `KeyError: 'sector_boost'` などで FAIL（キーがまだ存在しない）
+
+- [ ] **Step 3: `_STRATEGY_CONFIG_DEFAULTS` に 4 キーを追加する**
+
+`src/kabusys/strategy/signal_generator.py` の `_STRATEGY_CONFIG_DEFAULTS` (line 91) を以下に変更する:
+
+```python
+_STRATEGY_CONFIG_DEFAULTS: dict = {
+    "weights": {k: v for k, v in _DEFAULT_WEIGHTS.items()},
+    "threshold": _DEFAULT_THRESHOLD,
+    "stop_loss_rate": _STOP_LOSS_RATE,
+    "gap_up_threshold": _GAP_UP_THRESHOLD,
+    "gap_down_threshold": _GAP_DOWN_THRESHOLD,
+    "min_holding_days": _MIN_HOLDING_DAYS,
+    "max_holding_days": _MAX_HOLDING_DAYS,
+    "trailing_stop_atr_mult": _TRAILING_STOP_ATR_MULT,
+    "reentry_cooldown_days": _REENTRY_COOLDOWN_DAYS,
+    "sector_boost": _SECTOR_BOOST,
+    "sector_quartile": _SECTOR_QUARTILE,
+    "topix_drawdown_threshold": _TOPIX_DRAWDOWN_THRESHOLD,
+    "topix_size_multiplier_bear": _TOPIX_SIZE_MULTIPLIER_BEAR,
+}
+```
+
+- [ ] **Step 4: `_load_strategy_config()` の docstring を更新する**
+
+`_load_strategy_config()` の Returns docstring (lines 119-129) を以下に変更する:
+
+```python
+    Returns:
+        {
+            "weights": dict[str, float],
+            "threshold": float,
+            "stop_loss_rate": float,
+            "gap_up_threshold": float,
+            "gap_down_threshold": float,
+            "min_holding_days": int,
+            "max_holding_days": int,
+            "trailing_stop_atr_mult": float,
+            "reentry_cooldown_days": int,
+            "sector_boost": float,
+            "sector_quartile": float,
+            "topix_drawdown_threshold": float,
+            "topix_size_multiplier_bear": float,
+        }
+```
+
+- [ ] **Step 5: `_load_strategy_config()` に sector/regime 解析を追加する**
+
+`_load_strategy_config()` 内の `# int スカラーパラメータ` ブロックの直後（line 229 の `_strategy_config_cache = result` の前）に以下を挿入する:
+
+```python
+    # sector セクション
+    sec = data.get("sector")
+    if isinstance(sec, dict):
+        v = sec.get("boost")
+        if (
+            v is not None
+            and isinstance(v, (int, float))
+            and not isinstance(v, bool)
+            and math.isfinite(float(v))
+            and float(v) >= 0
+        ):
+            result["sector_boost"] = float(v)
+
+        v = sec.get("quartile")
+        if (
+            v is not None
+            and isinstance(v, (int, float))
+            and not isinstance(v, bool)
+            and math.isfinite(float(v))
+            and 0.0 < float(v) < 1.0
+        ):
+            result["sector_quartile"] = float(v)
+
+    # regime セクション
+    reg = data.get("regime")
+    if isinstance(reg, dict):
+        v = reg.get("topix_drawdown_threshold")
+        if (
+            v is not None
+            and isinstance(v, (int, float))
+            and not isinstance(v, bool)
+            and math.isfinite(float(v))
+            and float(v) < 0
+        ):
+            result["topix_drawdown_threshold"] = float(v)
+
+        v = reg.get("topix_size_multiplier_bear")
+        if (
+            v is not None
+            and isinstance(v, (int, float))
+            and not isinstance(v, bool)
+            and math.isfinite(float(v))
+            and 0.0 < float(v) <= 1.0
+        ):
+            result["topix_size_multiplier_bear"] = float(v)
+```
+
+- [ ] **Step 6: テストが通ることを確認する**
+
+```
+pytest tests/test_signal_generator.py::TestLoadStrategyConfigSectorRegime -v
+```
+
+期待: 8 件 PASS
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add src/kabusys/strategy/signal_generator.py tests/test_signal_generator.py
+git commit -m "feat: _load_strategy_config に sector/regime セクション解析を追加"
+```
+
+---
+
+## Task 2: `_calc_sector_strengths()` を `sector_quartile` パラメータ化する
+
+**Files:**
+- Modify: `src/kabusys/strategy/signal_generator.py:533-598`（`_calc_sector_strengths` 定義）
+- Modify: `src/kabusys/strategy/signal_generator.py:1184-1186`（`generate_signals` 内の呼び出し箇所）
+- Modify: `tests/test_signal_generator.py`（末尾に追加）
+
+### Step 1: 失敗するテストを書く
+
+`tests/test_signal_generator.py` の末尾に追加する:
+
+```python
+# ---------------------------------------------------------------------------
+# Task 2: _calc_sector_strengths sector_quartile パラメータ
+# ---------------------------------------------------------------------------
+
+from kabusys.strategy.signal_generator import _calc_sector_strengths  # noqa: E402
+
+
+class TestCalcSectorStrengthsQuartile:
+    """_calc_sector_strengths の sector_quartile パラメータテスト。"""
+
+    def _setup_4sectors(self, conn) -> None:
+        """4セクター・4銘柄・21日分の価格データを挿入する。"""
+        sectors = [
+            ("1001", "製造業", 1.10),
+            ("1002", "金融業", 1.05),
+            ("1003", "情報通信", 1.02),
+            ("1004", "小売業", 0.98),
+        ]
+        for code, sector, _ in sectors:
+            conn.execute(
+                "INSERT INTO stocks (code, sector) VALUES (?, ?)", [code, sector]
+            )
+        base = date(2026, 1, 1)
+        for j in range(21):
+            d = base + timedelta(days=j)
+            for code, _, ret in sectors:
+                c = 1000.0 * ret if j == 20 else 1000.0
+                conn.execute(
+                    "INSERT INTO prices_daily (date, code, open, high, low, close, volume)"
+                    " VALUES (?, ?, 1000, 1000, 1000, ?, 1000)",
+                    [d, code, c],
+                )
+
+    def test_default_quartile_gives_1_top_sector(self, conn):
+        self._setup_4sectors(conn)
+        top, _, _ = _calc_sector_strengths(conn, date(2026, 1, 21))
+        assert len(top) == 1  # ceil(4 * 0.25) = 1
+
+    def test_custom_quartile_50_gives_2_top_sectors(self, conn):
+        self._setup_4sectors(conn)
+        top, _, _ = _calc_sector_strengths(conn, date(2026, 1, 21), sector_quartile=0.50)
+        assert len(top) == 2  # ceil(4 * 0.50) = 2
+```
+
+- [ ] **Step 2: テストが失敗することを確認する**
+
+```
+pytest tests/test_signal_generator.py::TestCalcSectorStrengthsQuartile -v
+```
+
+期待: `TypeError: _calc_sector_strengths() got an unexpected keyword argument 'sector_quartile'` で FAIL
+
+- [ ] **Step 3: `_calc_sector_strengths()` のシグネチャと本体を更新する**
+
+`src/kabusys/strategy/signal_generator.py` の `_calc_sector_strengths` 定義（line 533-534）を以下に変更する:
+
+```python
+def _calc_sector_strengths(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date,
+    sector_quartile: float = _SECTOR_QUARTILE,
+) -> tuple[frozenset[str], frozenset[str], dict[str, str]]:
+```
+
+同関数内の `_SECTOR_QUARTILE` の使用箇所（lines 594-595）を以下に変更する:
+
+```python
+    top_n = max(1, math.ceil(n * sector_quartile))
+    bottom_n = max(1, math.ceil(n * sector_quartile))
+```
+
+- [ ] **Step 4: `generate_signals()` の呼び出し箇所を更新する**
+
+`generate_signals()` 内の `_calc_sector_strengths` 呼び出し（lines 1184-1186）を以下に変更する:
+
+```python
+        top_sectors, bottom_sectors, sector_map = _calc_sector_strengths(
+            conn, target_date, sector_quartile=_cfg["sector_quartile"]
+        )
+```
+
+- [ ] **Step 5: テストが通ることを確認する**
+
+```
+pytest tests/test_signal_generator.py::TestCalcSectorStrengthsQuartile -v
+```
+
+期待: 2 件 PASS
+
+- [ ] **Step 6: 既存テストが壊れていないことを確認する**
+
+```
+pytest tests/test_signal_generator.py -v --tb=short
+```
+
+期待: 全件 PASS
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add src/kabusys/strategy/signal_generator.py tests/test_signal_generator.py
+git commit -m "feat: _calc_sector_strengths に sector_quartile パラメータを追加"
+```
+
+---
+
+## Task 3: `_get_topix_size_multiplier()` をパラメータ化する
+
+**Files:**
+- Modify: `src/kabusys/strategy/signal_generator.py:447-492`（`_get_topix_size_multiplier` 定義）
+- Modify: `src/kabusys/strategy/signal_generator.py:1093`（`generate_signals` 内の呼び出し箇所）
+- Modify: `tests/test_signal_generator.py`（`TestGetTopixSizeMultiplier` クラスに追加）
+
+### Step 1: 失敗するテストを書く
+
+`tests/test_signal_generator.py` の `TestGetTopixSizeMultiplier` クラス（line 624）の末尾に追加する:
+
+```python
+    def test_custom_drawdown_threshold_and_multiplier(self, conn):
+        """カスタム drawdown_threshold と size_multiplier_bear が適用されることを確認する。"""
+        # 240日は 2000.0、直近11日は 1600.0（乖離率≈-20%）
+        self._make_topix_series(
+            conn, TARGET_DATE - timedelta(days=250), 240, 2000.0, 2000.0
+        )
+        recent_start = TARGET_DATE - timedelta(days=10)
+        self._make_topix_series(conn, recent_start, 11, 1600.0, 1600.0)
+
+        # drawdown_threshold=-0.10 → 乖離率-20% < -10% → Bear 判定 → 0.3 を返す
+        result = _get_topix_size_multiplier(
+            conn, TARGET_DATE, drawdown_threshold=-0.10, size_multiplier_bear=0.3
+        )
+        assert result == 0.3
+
+    def test_custom_threshold_not_triggered(self, conn):
+        """乖離率が drawdown_threshold を超えない場合は 1.0 を返すことを確認する。"""
+        # 250日すべて 2000.0（乖離率≈0%）
+        self._make_topix_series(
+            conn, TARGET_DATE - timedelta(days=250), 250, 2000.0, 2000.0
+        )
+        # drawdown_threshold=-0.10 → 乖離率≈0% > -10% → Bear 未判定 → 1.0
+        result = _get_topix_size_multiplier(
+            conn, TARGET_DATE, drawdown_threshold=-0.10, size_multiplier_bear=0.3
+        )
+        assert result == 1.0
+```
+
+- [ ] **Step 2: テストが失敗することを確認する**
+
+```
+pytest tests/test_signal_generator.py::TestGetTopixSizeMultiplier::test_custom_drawdown_threshold_and_multiplier tests/test_signal_generator.py::TestGetTopixSizeMultiplier::test_custom_threshold_not_triggered -v
+```
+
+期待: `TypeError: _get_topix_size_multiplier() got an unexpected keyword argument 'drawdown_threshold'` で FAIL
+
+- [ ] **Step 3: `_get_topix_size_multiplier()` のシグネチャと本体を更新する**
+
+`src/kabusys/strategy/signal_generator.py` の `_get_topix_size_multiplier` 定義（lines 447-492）のシグネチャを以下に変更する:
+
+```python
+def _get_topix_size_multiplier(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date,
+    drawdown_threshold: float = _TOPIX_DRAWDOWN_THRESHOLD,
+    size_multiplier_bear: float = _TOPIX_SIZE_MULTIPLIER_BEAR,
+) -> float:
+```
+
+同関数内の判定ロジック（line 490-491）を以下に変更する:
+
+```python
+    if ma200 > 0 and (close / ma200 - 1.0) < drawdown_threshold:
+        return size_multiplier_bear
+```
+
+- [ ] **Step 4: `generate_signals()` の呼び出し箇所を更新する**
+
+`generate_signals()` 内の `_get_topix_size_multiplier` 呼び出し（line 1093）を以下に変更する:
+
+```python
+    topix_multiplier = _get_topix_size_multiplier(
+        conn,
+        target_date,
+        drawdown_threshold=_cfg["topix_drawdown_threshold"],
+        size_multiplier_bear=_cfg["topix_size_multiplier_bear"],
+    )
+```
+
+- [ ] **Step 5: テストが通ることを確認する**
+
+```
+pytest tests/test_signal_generator.py::TestGetTopixSizeMultiplier -v
+```
+
+期待: 6 件（既存 4 + 新規 2）すべて PASS
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/kabusys/strategy/signal_generator.py tests/test_signal_generator.py
+git commit -m "feat: _get_topix_size_multiplier に drawdown_threshold / size_multiplier_bear パラメータを追加"
+```
+
+---
+
+## Task 4: `generate_signals()` で `sector_boost` を `_cfg` から読む + YAML 更新
+
+**Files:**
+- Modify: `src/kabusys/strategy/signal_generator.py:1221`（`generate_signals` 内 sector_boost 使用箇所）
+- Modify: `config/strategy_config.yaml`（sector/regime セクション追加）
+
+### Step 1: `generate_signals()` 内の `_SECTOR_BOOST` を `_cfg["sector_boost"]` に変える
+
+`generate_signals()` 冒頭の `_cfg` 抽出ブロック（line 1028 周辺）に以下を追加する:
+
+```python
+    _cfg = _load_strategy_config()
+    if threshold is None:
+        threshold = _cfg["threshold"]
+    if weights is None:
+        weights = _cfg["weights"]
+    if min_holding_days is None:
+        min_holding_days = _cfg["min_holding_days"]
+    if max_holding_days is None:
+        max_holding_days = _cfg["max_holding_days"]
+    if trailing_stop_atr is None:
+        trailing_stop_atr = _cfg["trailing_stop_atr_mult"]
+    sector_boost = _cfg["sector_boost"]  # ← 追加
+```
+
+`generate_signals()` 内の `_SECTOR_BOOST` の使用箇所（line 1221）を以下に変更する:
+
+```python
+            final_score += sector_boost
+```
+
+- [ ] **Step 2: `config/strategy_config.yaml` に sector/regime セクションを追加する**
+
+ファイル末尾（`value_score:` セクションの後）に追加する:
+
+```yaml
+sector:
+  # 上位セクター銘柄への final_score 加算量（≥ 0）
+  boost: 0.03
+  # 上位・下位セクターの区切り割合（0 < x < 1）
+  quartile: 0.25
+
+regime:
+  # TOPIX 200MA 乖離率がこの値以下で地合い悪化と判定（負値）
+  topix_drawdown_threshold: -0.15
+  # 地合い悪化時の size_multiplier（0 < x ≤ 1）
+  topix_size_multiplier_bear: 0.5
+```
+
+- [ ] **Step 3: 全テストを実行して PASS を確認する**
+
+```
+pytest tests/ -v --tb=short
+```
+
+期待: 全件 PASS（既存テストへの影響なし）
+
+- [ ] **Step 4: ruff チェック**
+
+```
+ruff check src/kabusys/strategy/signal_generator.py
+ruff format --check src/kabusys/strategy/signal_generator.py
+```
+
+期待: エラーなし（フォーマット差分があれば `ruff format` を実行して修正）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/kabusys/strategy/signal_generator.py config/strategy_config.yaml
+git commit -m "feat: generate_signals で sector_boost を cfg から読み取り、strategy_config.yaml に sector/regime セクションを追加"
+```

--- a/docs/superpowers/specs/2026-05-08-strategy-param-externalization-design.md
+++ b/docs/superpowers/specs/2026-05-08-strategy-param-externalization-design.md
@@ -1,0 +1,179 @@
+# Strategy Parameter Externalization (Remaining 4 Constants) Design
+
+## Goal
+
+`signal_generator.py` に残るハードコード定数 4 件を `config/strategy_config.yaml` の `sector:` / `regime:` セクションから runtime 読み込みに変更し、再起動不要でパラメータを変更できるようにする。
+
+## Background
+
+`_load_strategy_config()` と `strategy_config.yaml` はすでに実装済みで、`weights` / `threshold` / `stop_loss_rate` など主要パラメータはすでに外出し済み。残るハードコードは 4 定数のみ。
+
+| 定数 | 値 | 用途 |
+|------|----|------|
+| `_SECTOR_BOOST` | 0.03 | 上位セクター銘柄への final_score 加算量 |
+| `_SECTOR_QUARTILE` | 0.25 | セクター上位・下位の区切り割合 |
+| `_TOPIX_DRAWDOWN_THRESHOLD` | -0.15 | TOPIX 200MA 乖離率の地合い悪化判定閾値 |
+| `_TOPIX_SIZE_MULTIPLIER_BEAR` | 0.5 | 地合い悪化時の size_multiplier |
+
+## Architecture
+
+既存の `_load_strategy_config()` パターンを踏襲する。YAML に `sector:` / `regime:` セクションを追加し、返却 dict は既存の flat 構造に 4 キーを追加する。ヘルパー関数には明示的パラメータとして渡す。
+
+## Changes
+
+### 1. `config/strategy_config.yaml`
+
+```yaml
+sector:
+  boost: 0.03       # 上位セクター銘柄への final_score 加算量（≥ 0）
+  quartile: 0.25    # 上位・下位の区切り割合（0 < x < 1）
+
+regime:
+  topix_drawdown_threshold: -0.15   # TOPIX 200MA 乖離率の地合い悪化判定閾値（< 0）
+  topix_size_multiplier_bear: 0.5   # 地合い悪化時の size_multiplier（0 < x ≤ 1）
+```
+
+### 2. `src/kabusys/strategy/signal_generator.py`
+
+**`_STRATEGY_CONFIG_DEFAULTS` に 4 キー追加：**
+
+```python
+_STRATEGY_CONFIG_DEFAULTS: dict = {
+    # 既存キー（変更なし）
+    "weights": {k: v for k, v in _DEFAULT_WEIGHTS.items()},
+    "threshold": _DEFAULT_THRESHOLD,
+    "stop_loss_rate": _STOP_LOSS_RATE,
+    "gap_up_threshold": _GAP_UP_THRESHOLD,
+    "gap_down_threshold": _GAP_DOWN_THRESHOLD,
+    "min_holding_days": _MIN_HOLDING_DAYS,
+    "max_holding_days": _MAX_HOLDING_DAYS,
+    "trailing_stop_atr_mult": _TRAILING_STOP_ATR_MULT,
+    "reentry_cooldown_days": _REENTRY_COOLDOWN_DAYS,
+    # 追加
+    "sector_boost": _SECTOR_BOOST,
+    "sector_quartile": _SECTOR_QUARTILE,
+    "topix_drawdown_threshold": _TOPIX_DRAWDOWN_THRESHOLD,
+    "topix_size_multiplier_bear": _TOPIX_SIZE_MULTIPLIER_BEAR,
+}
+```
+
+**`_load_strategy_config()` に `sector:` / `regime:` セクション解析を追加：**
+
+```python
+# sector セクション
+sec = data.get("sector")
+if isinstance(sec, dict):
+    v = sec.get("boost")
+    if v is not None and isinstance(v, (int, float)) and not isinstance(v, bool) \
+            and math.isfinite(float(v)) and float(v) >= 0:
+        result["sector_boost"] = float(v)
+
+    v = sec.get("quartile")
+    if v is not None and isinstance(v, (int, float)) and not isinstance(v, bool) \
+            and math.isfinite(float(v)) and 0.0 < float(v) < 1.0:
+        result["sector_quartile"] = float(v)
+
+# regime セクション
+reg = data.get("regime")
+if isinstance(reg, dict):
+    v = reg.get("topix_drawdown_threshold")
+    if v is not None and isinstance(v, (int, float)) and not isinstance(v, bool) \
+            and math.isfinite(float(v)) and float(v) < 0:
+        result["topix_drawdown_threshold"] = float(v)
+
+    v = reg.get("topix_size_multiplier_bear")
+    if v is not None and isinstance(v, (int, float)) and not isinstance(v, bool) \
+            and math.isfinite(float(v)) and 0.0 < float(v) <= 1.0:
+        result["topix_size_multiplier_bear"] = float(v)
+```
+
+**`_calc_sector_strengths()` シグネチャ変更：**
+
+```python
+def _calc_sector_strengths(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date,
+    sector_quartile: float = _SECTOR_QUARTILE,
+) -> tuple[frozenset[str], frozenset[str], dict[str, str]]:
+    ...
+    top_n = max(1, math.ceil(n * sector_quartile))
+    bottom_n = max(1, math.ceil(n * sector_quartile))
+```
+
+**`_get_topix_size_multiplier()` シグネチャ変更：**
+
+```python
+def _get_topix_size_multiplier(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date,
+    drawdown_threshold: float = _TOPIX_DRAWDOWN_THRESHOLD,
+    size_multiplier_bear: float = _TOPIX_SIZE_MULTIPLIER_BEAR,
+) -> float:
+    ...
+    if ma200 > 0 and (close / ma200 - 1.0) < drawdown_threshold:
+        return size_multiplier_bear
+```
+
+**`generate_signals()` 内での渡し方：**
+
+```python
+_cfg = _load_strategy_config()
+# 既存（変更なし）
+threshold = _cfg["threshold"]
+weights = _cfg["weights"]
+...
+# 追加
+sector_boost = _cfg["sector_boost"]
+
+top_sectors, bottom_sectors, sector_map = _calc_sector_strengths(
+    conn, target_date, sector_quartile=_cfg["sector_quartile"]
+)
+
+topix_multiplier = _get_topix_size_multiplier(
+    conn, target_date,
+    drawdown_threshold=_cfg["topix_drawdown_threshold"],
+    size_multiplier_bear=_cfg["topix_size_multiplier_bear"],
+)
+
+# final_score 補正箇所
+final_score += sector_boost  # _SECTOR_BOOST → sector_boost
+```
+
+### 3. テスト — `tests/test_signal_generator.py`
+
+既存の `_load_strategy_config` テストパターンを踏襲し、以下を追加する。
+
+**設定読み込みテスト：**
+- `sector:` / `regime:` セクション正常値 → 各キーが設定値で返る
+- `sector.boost = -0.01`（負値）→ デフォルト `0.03` にフォールバック
+- `sector.quartile = 0.0`（境界値 = 0）→ デフォルト `0.25` にフォールバック
+- `sector.quartile = 1.0`（境界値 = 1）→ デフォルト `0.25` にフォールバック
+- `regime.topix_drawdown_threshold = 0.10`（正値）→ デフォルト `-0.15` にフォールバック
+- `regime.topix_size_multiplier_bear = 1.5`（> 1）→ デフォルト `0.5` にフォールバック
+- `sector:` セクション欠落 → デフォルト値が使われる
+- `regime:` セクション欠落 → デフォルト値が使われる
+
+**ヘルパー関数テスト：**
+- `_calc_sector_strengths(conn, date, sector_quartile=0.5)` → top/bottom セクター数が増える
+- `_get_topix_size_multiplier(conn, date, drawdown_threshold=-0.01, size_multiplier_bear=0.3)` → TOPIX データがあれば `0.3` を返す
+
+## Validation Rules
+
+| キー | 有効範囲 | 不正時の挙動 |
+|------|---------|------------|
+| `sector_boost` | float ≥ 0、finite | デフォルト `0.03` |
+| `sector_quartile` | float、0 < x < 1、finite | デフォルト `0.25` |
+| `topix_drawdown_threshold` | float < 0、finite | デフォルト `-0.15` |
+| `topix_size_multiplier_bear` | float、0 < x ≤ 1、finite | デフォルト `0.5` |
+
+## Files
+
+- Modify: `config/strategy_config.yaml`
+- Modify: `src/kabusys/strategy/signal_generator.py`
+- Modify: `tests/test_signal_generator.py`
+
+## Out of Scope
+
+- breadth_stop の 35% 閾値（DB の `market_breadth.breadth_stop` フラグとして管理されており、本 Issue では変更しない）
+- `value_score:` セクションの変更（既存の `_load_value_config()` で対応済み）
+- UI / Streamlit からのパラメータ変更機能（Issue #233 の範囲）

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -501,19 +501,23 @@ def _is_breadth_stop(
 def _get_topix_size_multiplier(
     conn: duckdb.DuckDBPyConnection,
     target_date: date,
+    drawdown_threshold: float = _TOPIX_DRAWDOWN_THRESHOLD,
+    size_multiplier_bear: float = _TOPIX_SIZE_MULTIPLIER_BEAR,
 ) -> float:
     """TOPIX の 200 日移動平均乖離率に基づく size_multiplier を返す。
 
-    TOPIX が 200 日 MA から _TOPIX_DRAWDOWN_THRESHOLD (−15%) 以上下落している場合は
-    _TOPIX_SIZE_MULTIPLIER_BEAR (0.5) を返す。
+    TOPIX が 200 日 MA から drawdown_threshold 以上下落している場合は
+    size_multiplier_bear を返す。
     データ不足または topix_daily が空の場合は 1.0 を返す（制限なし）。
 
     Args:
-        conn:        DuckDB 接続。topix_daily テーブルを参照する。
-        target_date: 基準日（この日以前の最新 TOPIX を使用）。
+        conn:                DuckDB 接続。topix_daily テーブルを参照する。
+        target_date:         基準日（この日以前の最新 TOPIX を使用）。
+        drawdown_threshold:  Bear 判定の乖離率閾値（デフォルト: _TOPIX_DRAWDOWN_THRESHOLD）。
+        size_multiplier_bear: Bear 時の size_multiplier（デフォルト: _TOPIX_SIZE_MULTIPLIER_BEAR）。
 
     Returns:
-        size_multiplier（0.5 または 1.0）。
+        size_multiplier（size_multiplier_bear または 1.0）。
     """
     try:
         row = conn.execute(
@@ -541,8 +545,8 @@ def _get_topix_size_multiplier(
     if row is None or row[1] is None or row[2] < _TOPIX_MIN_DATA_COUNT:
         return 1.0
     close, ma200, _ = float(row[0]), float(row[1]), row[2]
-    if ma200 > 0 and (close / ma200 - 1.0) < _TOPIX_DRAWDOWN_THRESHOLD:
-        return _TOPIX_SIZE_MULTIPLIER_BEAR
+    if ma200 > 0 and (close / ma200 - 1.0) < drawdown_threshold:
+        return size_multiplier_bear
     return 1.0
 
 
@@ -1145,7 +1149,12 @@ def generate_signals(
 
     event_dates = event_dates or {}
     size_multiplier = _get_event_size_multiplier(event_dates, target_date, conn)
-    topix_multiplier = _get_topix_size_multiplier(conn, target_date)
+    topix_multiplier = _get_topix_size_multiplier(
+        conn,
+        target_date,
+        drawdown_threshold=_cfg["topix_drawdown_threshold"],
+        size_multiplier_bear=_cfg["topix_size_multiplier_bear"],
+    )
     size_multiplier = min(size_multiplier, topix_multiplier)
 
     # 1. features 読み込み（scope.mode="manual_codes" の場合は対象銘柄に限定）

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -587,6 +587,7 @@ def _fetch_gap_ratios(
 def _calc_sector_strengths(
     conn: duckdb.DuckDBPyConnection,
     target_date: date,
+    sector_quartile: float = _SECTOR_QUARTILE,
 ) -> tuple[frozenset[str], frozenset[str], dict[str, str]]:
     """セクター20営業日リターンを算出し、上位・下位セクターと銘柄→セクターマップを返す。
 
@@ -645,8 +646,8 @@ def _calc_sector_strengths(
         return frozenset(), frozenset(), sector_map
 
     n = len(rows)
-    top_n = max(1, math.ceil(n * _SECTOR_QUARTILE))
-    bottom_n = max(1, math.ceil(n * _SECTOR_QUARTILE))
+    top_n = max(1, math.ceil(n * sector_quartile))
+    bottom_n = max(1, math.ceil(n * sector_quartile))
 
     top_sectors = frozenset(s for s, _ in rows[:top_n])
     bottom_sectors = frozenset(s for s, _ in rows[-bottom_n:])
@@ -1236,7 +1237,7 @@ def generate_signals(
     boosted_count = 0
     if not regime_is_bear and not breadth_stop:
         top_sectors, bottom_sectors, sector_map = _calc_sector_strengths(
-            conn, target_date
+            conn, target_date, sector_quartile=_cfg["sector_quartile"]
         )
 
     # 4. 各銘柄の final_score 計算（Section 4.1）

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -98,6 +98,10 @@ _STRATEGY_CONFIG_DEFAULTS: dict = {
     "max_holding_days": _MAX_HOLDING_DAYS,
     "trailing_stop_atr_mult": _TRAILING_STOP_ATR_MULT,
     "reentry_cooldown_days": _REENTRY_COOLDOWN_DAYS,
+    "sector_boost": _SECTOR_BOOST,
+    "sector_quartile": _SECTOR_QUARTILE,
+    "topix_drawdown_threshold": _TOPIX_DRAWDOWN_THRESHOLD,
+    "topix_size_multiplier_bear": _TOPIX_SIZE_MULTIPLIER_BEAR,
 }
 
 _STRATEGY_CONFIG_PATH = (
@@ -126,6 +130,10 @@ def _load_strategy_config() -> dict:
             "max_holding_days": int,
             "trailing_stop_atr_mult": float,
             "reentry_cooldown_days": int,
+            "sector_boost": float,
+            "sector_quartile": float,
+            "topix_drawdown_threshold": float,
+            "topix_size_multiplier_bear": float,
         }
     """
     global _strategy_config_cache, _strategy_config_mtime
@@ -226,6 +234,52 @@ def _load_strategy_config() -> dict:
             iv = int(v)
             if iv >= 0:
                 result[key] = iv
+
+    # sector セクション
+    sec = data.get("sector")
+    if isinstance(sec, dict):
+        v = sec.get("boost")
+        if (
+            v is not None
+            and isinstance(v, (int, float))
+            and not isinstance(v, bool)
+            and math.isfinite(float(v))
+            and float(v) >= 0
+        ):
+            result["sector_boost"] = float(v)
+
+        v = sec.get("quartile")
+        if (
+            v is not None
+            and isinstance(v, (int, float))
+            and not isinstance(v, bool)
+            and math.isfinite(float(v))
+            and 0.0 < float(v) < 1.0
+        ):
+            result["sector_quartile"] = float(v)
+
+    # regime セクション
+    reg = data.get("regime")
+    if isinstance(reg, dict):
+        v = reg.get("topix_drawdown_threshold")
+        if (
+            v is not None
+            and isinstance(v, (int, float))
+            and not isinstance(v, bool)
+            and math.isfinite(float(v))
+            and float(v) < 0
+        ):
+            result["topix_drawdown_threshold"] = float(v)
+
+        v = reg.get("topix_size_multiplier_bear")
+        if (
+            v is not None
+            and isinstance(v, (int, float))
+            and not isinstance(v, bool)
+            and math.isfinite(float(v))
+            and 0.0 < float(v) <= 1.0
+        ):
+            result["topix_size_multiplier_bear"] = float(v)
 
     _strategy_config_cache = result
     _strategy_config_mtime = current_mtime

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -79,7 +79,7 @@ _REENTRY_COOLDOWN_DAYS: int = (
     5  # SELL 後この営業日数を経過するまで同一銘柄の BUY を禁止
 )
 
-_TOPIX_DRAWDOWN_THRESHOLD: float = -0.15  # 200MA 乖離率がこの値以下で縮小
+_TOPIX_DRAWDOWN_THRESHOLD: float = -0.15  # 200MA 乖離率がこの値未満で縮小
 _TOPIX_SIZE_MULTIPLIER_BEAR: float = 0.5  # 地合い悪化時の size_multiplier
 _TOPIX_MIN_DATA_COUNT: int = 100  # 200MA を信頼できる最低データ数（初期運用でのデータ蓄積期間を考慮し 200 でなく 100 に設定）
 
@@ -506,7 +506,7 @@ def _get_topix_size_multiplier(
 ) -> float:
     """TOPIX の 200 日移動平均乖離率に基づく size_multiplier を返す。
 
-    TOPIX が 200 日 MA から drawdown_threshold 以上下落している場合は
+    TOPIX の 200 日 MA に対する乖離率が drawdown_threshold 未満（より低い側）の場合は
     size_multiplier_bear を返す。
     データ不足または topix_daily が空の場合は 1.0 を返す（制限なし）。
 

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -596,14 +596,14 @@ def _calc_sector_strengths(
     """セクター20営業日リターンを算出し、上位・下位セクターと銘柄→セクターマップを返す。
 
     stocks テーブルの全銘柄 × prices_daily で等加重セクターリターンを計算し、
-    上位 _SECTOR_QUARTILE / 下位 _SECTOR_QUARTILE のセクターを分類する。
+    上位 sector_quartile / 下位 sector_quartile のセクターを分類する。
 
     データ欠損・セクター未登録銘柄は安全側（BUY 許可・スコアブーストなし）に倒す。
 
     Returns:
         (top_sectors, bottom_sectors, sector_map)
-        - top_sectors:    上位 _SECTOR_QUARTILE セクター名の frozenset
-        - bottom_sectors: 下位 _SECTOR_QUARTILE セクター名の frozenset
+        - top_sectors:    上位 sector_quartile セクター名の frozenset
+        - bottom_sectors: 下位 sector_quartile セクター名の frozenset
         - sector_map:     {code: sector}（NULL/空文字のセクターは除外）
 
     Note: 有効セクターが1つの場合は top と bottom が同一になるためフィルタ無効。
@@ -1095,6 +1095,7 @@ def generate_signals(
         max_holding_days = _cfg["max_holding_days"]
     if trailing_stop_atr is None:
         trailing_stop_atr = _cfg["trailing_stop_atr_mult"]
+    sector_boost = _cfg["sector_boost"]
 
     if min_holding_days < 0:
         raise ValueError(
@@ -1278,11 +1279,11 @@ def generate_signals(
             + weights["liquidity"] * (s_liq if s_liq is not None else 0.5)
             + weights["news"] * (s_news if s_news is not None else 0.5)
         )
-        # セクター強弱スコア補正（上位セクターは +_SECTOR_BOOST）
+        # セクター強弱スコア補正（上位セクターは +sector_boost）
         sector = sector_map.get(code, "")
         if sector and sector in top_sectors:
             old_score = final_score
-            final_score += _SECTOR_BOOST
+            final_score += sector_boost
             logger.debug(
                 "sector boost: %s sector=%s score %.4f→%.4f date=%s",
                 code,

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -672,6 +672,33 @@ class TestGetTopixSizeMultiplier:
         )
         assert _get_topix_size_multiplier(conn, TARGET_DATE) == 1.0
 
+    def test_custom_drawdown_threshold_and_multiplier(self, conn):
+        """カスタム drawdown_threshold と size_multiplier_bear が適用されることを確認する。"""
+        # 240日は 2000.0、直近11日は 1600.0（乖離率≈-20%）
+        self._make_topix_series(
+            conn, TARGET_DATE - timedelta(days=250), 240, 2000.0, 2000.0
+        )
+        recent_start = TARGET_DATE - timedelta(days=10)
+        self._make_topix_series(conn, recent_start, 11, 1600.0, 1600.0)
+
+        # drawdown_threshold=-0.10 → 乖離率-20% < -10% → Bear 判定 → 0.3 を返す
+        result = _get_topix_size_multiplier(
+            conn, TARGET_DATE, drawdown_threshold=-0.10, size_multiplier_bear=0.3
+        )
+        assert result == 0.3
+
+    def test_custom_threshold_not_triggered(self, conn):
+        """乖離率が drawdown_threshold を超えない場合は 1.0 を返すことを確認する。"""
+        # 250日すべて 2000.0（乖離率≈0%）
+        self._make_topix_series(
+            conn, TARGET_DATE - timedelta(days=250), 250, 2000.0, 2000.0
+        )
+        # drawdown_threshold=-0.10 → 乖離率≈0% > -10% → Bear 未判定 → 1.0
+        result = _get_topix_size_multiplier(
+            conn, TARGET_DATE, drawdown_threshold=-0.10, size_multiplier_bear=0.3
+        )
+        assert result == 1.0
+
 
 # ---------------------------------------------------------------------------
 # Task 1: _load_strategy_config() sector/regime セクション

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -704,7 +704,7 @@ class TestGetTopixSizeMultiplier:
 # Task 1: _load_strategy_config() sector/regime セクション
 # ---------------------------------------------------------------------------
 
-import kabusys.strategy.signal_generator as _sg
+import kabusys.strategy.signal_generator as _sg  # noqa: E402
 
 
 def _load_cfg_with_yaml(yaml_text: str, tmp_path, monkeypatch) -> dict:

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -750,17 +750,23 @@ regime:
         assert cfg["topix_size_multiplier_bear"] == 0.5
 
     def test_sector_boost_negative_falls_back(self, tmp_path, monkeypatch):
-        yaml_text = "strategy:\n  threshold: 0.60\nsector:\n  boost: -0.01\n  quartile: 0.25\n"
+        yaml_text = (
+            "strategy:\n  threshold: 0.60\nsector:\n  boost: -0.01\n  quartile: 0.25\n"
+        )
         cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
         assert cfg["sector_boost"] == 0.03  # default
 
     def test_sector_quartile_zero_falls_back(self, tmp_path, monkeypatch):
-        yaml_text = "strategy:\n  threshold: 0.60\nsector:\n  boost: 0.03\n  quartile: 0.0\n"
+        yaml_text = (
+            "strategy:\n  threshold: 0.60\nsector:\n  boost: 0.03\n  quartile: 0.0\n"
+        )
         cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
         assert cfg["sector_quartile"] == 0.25  # default
 
     def test_sector_quartile_one_falls_back(self, tmp_path, monkeypatch):
-        yaml_text = "strategy:\n  threshold: 0.60\nsector:\n  boost: 0.03\n  quartile: 1.0\n"
+        yaml_text = (
+            "strategy:\n  threshold: 0.60\nsector:\n  boost: 0.03\n  quartile: 1.0\n"
+        )
         cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
         assert cfg["sector_quartile"] == 0.25  # default
 
@@ -769,12 +775,16 @@ regime:
         cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
         assert cfg["topix_drawdown_threshold"] == -0.15  # default
 
-    def test_topix_size_multiplier_bear_over_one_falls_back(self, tmp_path, monkeypatch):
+    def test_topix_size_multiplier_bear_over_one_falls_back(
+        self, tmp_path, monkeypatch
+    ):
         yaml_text = "strategy:\n  threshold: 0.60\nregime:\n  topix_drawdown_threshold: -0.15\n  topix_size_multiplier_bear: 1.5\n"
         cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
         assert cfg["topix_size_multiplier_bear"] == 0.5  # default
 
-    def test_topix_size_multiplier_bear_exactly_one_accepted(self, tmp_path, monkeypatch):
+    def test_topix_size_multiplier_bear_exactly_one_accepted(
+        self, tmp_path, monkeypatch
+    ):
         yaml_text = "strategy:\n  threshold: 0.60\nregime:\n  topix_drawdown_threshold: -0.15\n  topix_size_multiplier_bear: 1.0\n"
         cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
         assert cfg["topix_size_multiplier_bear"] == 1.0
@@ -820,5 +830,7 @@ class TestCalcSectorStrengthsQuartile:
 
     def test_custom_quartile_50_gives_2_top_sectors(self, conn):
         self._setup_4sectors(conn)
-        top, _, _ = _calc_sector_strengths(conn, date(2026, 1, 21), sector_quartile=0.50)
+        top, _, _ = _calc_sector_strengths(
+            conn, date(2026, 1, 21), sector_quartile=0.50
+        )
         assert len(top) == 2  # ceil(4 * 0.50) = 2

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -723,26 +723,31 @@ regime:
         assert cfg["topix_size_multiplier_bear"] == 0.5
 
     def test_sector_boost_negative_falls_back(self, tmp_path, monkeypatch):
-        yaml_text = "sector:\n  boost: -0.01\n  quartile: 0.25\n"
+        yaml_text = "strategy:\n  threshold: 0.60\nsector:\n  boost: -0.01\n  quartile: 0.25\n"
         cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
         assert cfg["sector_boost"] == 0.03  # default
 
     def test_sector_quartile_zero_falls_back(self, tmp_path, monkeypatch):
-        yaml_text = "sector:\n  boost: 0.03\n  quartile: 0.0\n"
+        yaml_text = "strategy:\n  threshold: 0.60\nsector:\n  boost: 0.03\n  quartile: 0.0\n"
         cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
         assert cfg["sector_quartile"] == 0.25  # default
 
     def test_sector_quartile_one_falls_back(self, tmp_path, monkeypatch):
-        yaml_text = "sector:\n  boost: 0.03\n  quartile: 1.0\n"
+        yaml_text = "strategy:\n  threshold: 0.60\nsector:\n  boost: 0.03\n  quartile: 1.0\n"
         cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
         assert cfg["sector_quartile"] == 0.25  # default
 
     def test_topix_drawdown_threshold_positive_falls_back(self, tmp_path, monkeypatch):
-        yaml_text = "regime:\n  topix_drawdown_threshold: 0.10\n  topix_size_multiplier_bear: 0.5\n"
+        yaml_text = "strategy:\n  threshold: 0.60\nregime:\n  topix_drawdown_threshold: 0.10\n  topix_size_multiplier_bear: 0.5\n"
         cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
         assert cfg["topix_drawdown_threshold"] == -0.15  # default
 
     def test_topix_size_multiplier_bear_over_one_falls_back(self, tmp_path, monkeypatch):
-        yaml_text = "regime:\n  topix_drawdown_threshold: -0.15\n  topix_size_multiplier_bear: 1.5\n"
+        yaml_text = "strategy:\n  threshold: 0.60\nregime:\n  topix_drawdown_threshold: -0.15\n  topix_size_multiplier_bear: 1.5\n"
         cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
         assert cfg["topix_size_multiplier_bear"] == 0.5  # default
+
+    def test_topix_size_multiplier_bear_exactly_one_accepted(self, tmp_path, monkeypatch):
+        yaml_text = "strategy:\n  threshold: 0.60\nregime:\n  topix_drawdown_threshold: -0.15\n  topix_size_multiplier_bear: 1.0\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["topix_size_multiplier_bear"] == 1.0

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -751,3 +751,47 @@ regime:
         yaml_text = "strategy:\n  threshold: 0.60\nregime:\n  topix_drawdown_threshold: -0.15\n  topix_size_multiplier_bear: 1.0\n"
         cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
         assert cfg["topix_size_multiplier_bear"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Task 2: _calc_sector_strengths sector_quartile パラメータ
+# ---------------------------------------------------------------------------
+
+from kabusys.strategy.signal_generator import _calc_sector_strengths  # noqa: E402
+
+
+class TestCalcSectorStrengthsQuartile:
+    """_calc_sector_strengths の sector_quartile パラメータテスト。"""
+
+    def _setup_4sectors(self, conn) -> None:
+        """4セクター・4銘柄・21日分の価格データを挿入する。"""
+        sectors = [
+            ("1001", "製造業", 1.10),
+            ("1002", "金融業", 1.05),
+            ("1003", "情報通信", 1.02),
+            ("1004", "小売業", 0.98),
+        ]
+        for code, sector, _ in sectors:
+            conn.execute(
+                "INSERT INTO stocks (code, sector) VALUES (?, ?)", [code, sector]
+            )
+        base = date(2026, 1, 1)
+        for j in range(21):
+            d = base + timedelta(days=j)
+            for code, _, ret in sectors:
+                c = 1000.0 * ret if j == 20 else 1000.0
+                conn.execute(
+                    "INSERT INTO prices_daily (date, code, open, high, low, close, volume)"
+                    " VALUES (?, ?, 1000, 1000, 1000, ?, 1000)",
+                    [d, code, c],
+                )
+
+    def test_default_quartile_gives_1_top_sector(self, conn):
+        self._setup_4sectors(conn)
+        top, _, _ = _calc_sector_strengths(conn, date(2026, 1, 21))
+        assert len(top) == 1  # ceil(4 * 0.25) = 1
+
+    def test_custom_quartile_50_gives_2_top_sectors(self, conn):
+        self._setup_4sectors(conn)
+        top, _, _ = _calc_sector_strengths(conn, date(2026, 1, 21), sector_quartile=0.50)
+        assert len(top) == 2  # ceil(4 * 0.50) = 2

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -671,3 +671,78 @@ class TestGetTopixSizeMultiplier:
             conn, TARGET_DATE - timedelta(days=50), 50, 2000.0, 2000.0
         )
         assert _get_topix_size_multiplier(conn, TARGET_DATE) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Task 1: _load_strategy_config() sector/regime セクション
+# ---------------------------------------------------------------------------
+
+import kabusys.strategy.signal_generator as _sg
+
+
+def _load_cfg_with_yaml(yaml_text: str, tmp_path, monkeypatch) -> dict:
+    """tmp_path に YAML ファイルを書き、モジュールのパスとキャッシュをパッチして _load_strategy_config() を呼ぶ。"""
+    cfg_file = tmp_path / "strategy_config.yaml"
+    cfg_file.write_text(yaml_text, encoding="utf-8")
+    monkeypatch.setattr(_sg, "_STRATEGY_CONFIG_PATH", cfg_file)
+    monkeypatch.setattr(_sg, "_strategy_config_cache", None)
+    monkeypatch.setattr(_sg, "_strategy_config_mtime", -1.0)
+    return _sg._load_strategy_config()
+
+
+class TestLoadStrategyConfigSectorRegime:
+    """_load_strategy_config() の sector/regime セクション解析テスト。"""
+
+    def test_valid_sector_and_regime(self, tmp_path, monkeypatch):
+        yaml_text = """
+strategy:
+  threshold: 0.60
+sector:
+  boost: 0.05
+  quartile: 0.30
+regime:
+  topix_drawdown_threshold: -0.20
+  topix_size_multiplier_bear: 0.4
+"""
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["sector_boost"] == 0.05
+        assert cfg["sector_quartile"] == 0.30
+        assert cfg["topix_drawdown_threshold"] == -0.20
+        assert cfg["topix_size_multiplier_bear"] == 0.4
+
+    def test_missing_sector_section_uses_defaults(self, tmp_path, monkeypatch):
+        yaml_text = "strategy:\n  threshold: 0.60\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["sector_boost"] == 0.03
+        assert cfg["sector_quartile"] == 0.25
+
+    def test_missing_regime_section_uses_defaults(self, tmp_path, monkeypatch):
+        yaml_text = "strategy:\n  threshold: 0.60\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["topix_drawdown_threshold"] == -0.15
+        assert cfg["topix_size_multiplier_bear"] == 0.5
+
+    def test_sector_boost_negative_falls_back(self, tmp_path, monkeypatch):
+        yaml_text = "sector:\n  boost: -0.01\n  quartile: 0.25\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["sector_boost"] == 0.03  # default
+
+    def test_sector_quartile_zero_falls_back(self, tmp_path, monkeypatch):
+        yaml_text = "sector:\n  boost: 0.03\n  quartile: 0.0\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["sector_quartile"] == 0.25  # default
+
+    def test_sector_quartile_one_falls_back(self, tmp_path, monkeypatch):
+        yaml_text = "sector:\n  boost: 0.03\n  quartile: 1.0\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["sector_quartile"] == 0.25  # default
+
+    def test_topix_drawdown_threshold_positive_falls_back(self, tmp_path, monkeypatch):
+        yaml_text = "regime:\n  topix_drawdown_threshold: 0.10\n  topix_size_multiplier_bear: 0.5\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["topix_drawdown_threshold"] == -0.15  # default
+
+    def test_topix_size_multiplier_bear_over_one_falls_back(self, tmp_path, monkeypatch):
+        yaml_text = "regime:\n  topix_drawdown_threshold: -0.15\n  topix_size_multiplier_bear: 1.5\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["topix_size_multiplier_bear"] == 0.5  # default


### PR DESCRIPTION
## Summary

- `_load_strategy_config()` に `sector:` / `regime:` セクション解析を追加し、`_SECTOR_BOOST`, `_SECTOR_QUARTILE`, `_TOPIX_DRAWDOWN_THRESHOLD`, `_TOPIX_SIZE_MULTIPLIER_BEAR` の 4 定数を `config/strategy_config.yaml` から runtime 読み込みに変更
- `_calc_sector_strengths()` に `sector_quartile` パラメータを追加、`_get_topix_size_multiplier()` に `drawdown_threshold` / `size_multiplier_bear` パラメータを追加し、`generate_signals()` が `_cfg` 経由で渡すよう更新
- `config/strategy_config.yaml` に `sector:` / `regime:` セクションを追加（デフォルト値は変更前の定数値と同一）

## Test Plan

- [ ] `python -m pytest tests/test_signal_generator.py::TestLoadStrategyConfigSectorRegime -v` — 9 件 PASS
- [ ] `python -m pytest tests/test_signal_generator.py::TestCalcSectorStrengthsQuartile -v` — 2 件 PASS
- [ ] `python -m pytest tests/test_signal_generator.py::TestGetTopixSizeMultiplier -v` — 6 件 PASS
- [ ] `python -m pytest tests/ -q` — 1710 件すべて PASS
- [ ] `config/strategy_config.yaml` の `sector.boost` を変更して `run_strategy_signal.py` を実行し、再起動なしで反映されることを確認

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)