### PR TITLE
feat: AI Co-Pilot ウィザード Phase 1-3 — チャット UI + OpenAI ストリーミング (Issue #233)

### DIFF
--- a/docs/superpowers/plans/2026-05-09-ai-wizard-chat.md
+++ b/docs/superpowers/plans/2026-05-09-ai-wizard-chat.md
@@ -1,0 +1,979 @@
+# AI Co-Pilot ウィザード（Phase 1-3）実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Strategy Lab ページに「🤖 AI Co-Pilot」タブを追加し、最新バックテスト結果を OpenAI の system prompt に自動注入しながら戦略チューニングをチャット形式で支援する。
+
+**Architecture:** `backtest_summarizer.py` が DuckDB から最新バックテスト結果を Markdown 化して system prompt に注入し、`components/ai_wizard.py` が Streamlit チャット UI とストリーミング呼び出し・SQLite 履歴管理を担う。`10_Strategy_Lab.py` は 4 番目のタブでコンポーネントを呼び出すだけの薄い層。
+
+**Tech Stack:** Python 3.10+, DuckDB, SQLite, Streamlit, openai Python SDK (`openai.OpenAI`)
+
+---
+
+## ファイル構成
+
+| 操作 | ファイル | 責務 |
+|------|---------|------|
+| 変更 | `src/kabusys/monitoring/monitoring_db.py` | `ai_wizard_messages` テーブル + 履歴 CRUD メソッド追加 |
+| 新規 | `src/kabusys/ai/backtest_summarizer.py` | DuckDB → system prompt 用 Markdown 生成 |
+| 新規 | `src/kabusys/monitoring/components/__init__.py` | パッケージ宣言 |
+| 新規 | `src/kabusys/monitoring/components/ai_wizard.py` | 再利用可能 Streamlit チャットコンポーネント |
+| 変更 | `src/kabusys/monitoring/pages/10_Strategy_Lab.py` | 4 番目のタブ追加 |
+| 変更 | `tests/test_monitoring_db.py` | wizard 履歴 CRUD テスト追記 |
+| 新規 | `tests/test_backtest_summarizer.py` | 要約生成テスト |
+| 新規 | `tests/test_ai_wizard.py` | コンポーネントテスト |
+
+---
+
+### Task 1: ai_wizard_messages テーブル + MonitoringDB 拡張
+
+**Files:**
+- Modify: `src/kabusys/monitoring/monitoring_db.py`
+- Modify: `tests/test_monitoring_db.py`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`tests/test_monitoring_db.py` のファイル末尾に以下を追記する。
+
+```python
+class TestWizardMessages:
+    def test_save_and_load_messages(self, monitoring_conn):
+        """save → load でメッセージが時系列順に返る。"""
+        db = MonitoringDB(monitoring_conn)
+        db.save_wizard_message("sess1", "user", "テスト質問")
+        db.save_wizard_message("sess1", "assistant", "テスト回答")
+        msgs = db.load_wizard_messages("sess1")
+        assert len(msgs) == 2
+        assert msgs[0] == {"role": "user", "content": "テスト質問"}
+        assert msgs[1] == {"role": "assistant", "content": "テスト回答"}
+
+    def test_load_empty_session(self, monitoring_conn):
+        """存在しない session_id は空リストを返す。"""
+        db = MonitoringDB(monitoring_conn)
+        assert db.load_wizard_messages("nonexistent") == []
+
+    def test_clear_removes_only_target_session(self, monitoring_conn):
+        """clear は対象 session_id のみ削除し、別セッションは残る。"""
+        db = MonitoringDB(monitoring_conn)
+        db.save_wizard_message("sess1", "user", "question")
+        db.save_wizard_message("sess2", "user", "other")
+        db.clear_wizard_messages("sess1")
+        assert db.load_wizard_messages("sess1") == []
+        assert len(db.load_wizard_messages("sess2")) == 1
+
+    def test_ai_wizard_messages_table_exists(self, monitoring_conn):
+        """init_monitoring_db 後に ai_wizard_messages テーブルが存在する。"""
+        tables = {
+            row[0]
+            for row in monitoring_conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        assert "ai_wizard_messages" in tables
+```
+
+- [ ] **Step 2: テストが FAIL することを確認**
+
+```bash
+pytest tests/test_monitoring_db.py::TestWizardMessages -v
+```
+
+期待: `AttributeError: 'MonitoringDB' object has no attribute 'save_wizard_message'`
+
+- [ ] **Step 3: `init_monitoring_db` に `ai_wizard_messages` テーブルを追加**
+
+`src/kabusys/monitoring/monitoring_db.py` の `init_monitoring_db` 関数内の
+`conn.executescript("""` ブロックの末尾（`dashboard` テーブルの `);` の直後、
+閉じる `"""` の直前）に以下を追加する：
+
+```python
+        CREATE TABLE IF NOT EXISTS ai_wizard_messages (
+            id          INTEGER   PRIMARY KEY AUTOINCREMENT,
+            session_id  TEXT      NOT NULL,
+            role        TEXT      NOT NULL CHECK (role IN ('user', 'assistant', 'system')),
+            content     TEXT      NOT NULL,
+            created_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE INDEX IF NOT EXISTS idx_wizard_messages_session
+            ON ai_wizard_messages (session_id, created_at);
+```
+
+- [ ] **Step 4: `MonitoringDB` クラスに 3 メソッドを追加**
+
+`src/kabusys/monitoring/monitoring_db.py` の `MonitoringDB` クラスの末尾（`get_dashboard` メソッドの後）に以下を追加する：
+
+```python
+    def save_wizard_message(self, session_id: str, role: str, content: str) -> None:
+        """AI ウィザードの発言を ai_wizard_messages テーブルに保存する。"""
+        self._conn.execute(
+            "INSERT INTO ai_wizard_messages (session_id, role, content) VALUES (?, ?, ?)",
+            (session_id, role, content),
+        )
+        self._conn.commit()
+
+    def load_wizard_messages(self, session_id: str) -> list[dict]:
+        """session_id に紐づく発言履歴を時系列順で返す。
+
+        Returns:
+            [{"role": "user"|"assistant", "content": "..."}, ...]
+        """
+        rows = self._conn.execute(
+            "SELECT role, content FROM ai_wizard_messages "
+            "WHERE session_id = ? ORDER BY created_at ASC",
+            (session_id,),
+        ).fetchall()
+        return [{"role": row["role"], "content": row["content"]} for row in rows]
+
+    def clear_wizard_messages(self, session_id: str) -> None:
+        """session_id に紐づく全発言を削除する。"""
+        self._conn.execute(
+            "DELETE FROM ai_wizard_messages WHERE session_id = ?",
+            (session_id,),
+        )
+        self._conn.commit()
+```
+
+- [ ] **Step 5: テストが PASS することを確認**
+
+```bash
+pytest tests/test_monitoring_db.py::TestWizardMessages -v
+```
+
+期待: 4 テスト全 PASS
+
+- [ ] **Step 6: 全テストで回帰がないことを確認**
+
+```bash
+pytest tests/test_monitoring_db.py -v
+```
+
+期待: 全 PASS
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add src/kabusys/monitoring/monitoring_db.py tests/test_monitoring_db.py
+git commit -m "feat: ai_wizard_messages テーブル + MonitoringDB 履歴 CRUD (Issue #233)"
+```
+
+---
+
+### Task 2: backtest_summarizer.py
+
+**Files:**
+- Create: `src/kabusys/ai/backtest_summarizer.py`
+- Create: `tests/test_backtest_summarizer.py`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`tests/test_backtest_summarizer.py` を新規作成する：
+
+```python
+"""backtest_summarizer 単体テスト（Issue #233）"""
+
+from __future__ import annotations
+
+import json
+
+import duckdb
+import pytest
+
+from kabusys.ai.backtest_summarizer import load_latest_summary
+
+_BACKTEST_RUNS_DDL = """
+    CREATE TABLE backtest_runs (
+        run_id                  VARCHAR       PRIMARY KEY,
+        created_at              TIMESTAMP     NOT NULL DEFAULT current_timestamp,
+        start_date              DATE          NOT NULL,
+        end_date                DATE          NOT NULL,
+        initial_cash            DECIMAL(18,2) NOT NULL,
+        scope_mode              VARCHAR       NOT NULL,
+        scope_codes_json        VARCHAR,
+        params_json             VARCHAR       NOT NULL,
+        cagr                    DOUBLE,
+        sharpe                  DOUBLE,
+        max_drawdown            DOUBLE,
+        win_rate                DOUBLE,
+        payoff_ratio            DOUBLE,
+        profit_factor           DOUBLE,
+        annual_volatility       DOUBLE,
+        calmar_ratio            DOUBLE,
+        avg_holding_days        DOUBLE,
+        total_trades            INTEGER,
+        effective_universe_size INTEGER
+    )
+"""
+
+_SAMPLE_PARAMS = {
+    "weights": {"momentum": 0.4, "value": 0.3, "quality": 0.2, "ai": 0.1},
+    "threshold": 0.60,
+    "sector_boost": 0.03,
+    "sector_quartile": 0.25,
+    "stop_loss_rate": -0.08,
+    "trailing_stop_atr_mult": 2.0,
+    "gap_up_threshold": 0.04,
+    "gap_down_threshold": -0.04,
+    "min_holding_days": 5,
+    "max_holding_days": 60,
+    "topix_drawdown_threshold": -0.15,
+    "topix_size_multiplier_bear": 0.5,
+}
+
+
+@pytest.fixture
+def bt_conn():
+    conn = duckdb.connect(":memory:")
+    conn.execute(_BACKTEST_RUNS_DDL)
+    yield conn
+    conn.close()
+
+
+def _insert_run(conn, run_id="r1", params=None):
+    p = params if params is not None else _SAMPLE_PARAMS
+    conn.execute(
+        """
+        INSERT INTO backtest_runs (
+            run_id, start_date, end_date, initial_cash, scope_mode, params_json,
+            cagr, sharpe, max_drawdown, win_rate, payoff_ratio, profit_factor, total_trades
+        ) VALUES (?, '2026-01-01', '2026-04-30', 1000000, 'default_universe', ?,
+                  0.123, 1.45, -0.082, 0.583, 1.82, 2.10, 142)
+        """,
+        [run_id, json.dumps(p)],
+    )
+
+
+class TestLoadLatestSummary:
+    def test_returns_none_when_empty(self, bt_conn):
+        assert load_latest_summary(bt_conn) is None
+
+    def test_contains_cagr(self, bt_conn):
+        _insert_run(bt_conn)
+        result = load_latest_summary(bt_conn)
+        assert result is not None
+        assert "+12.30%" in result
+
+    def test_contains_sharpe_and_drawdown(self, bt_conn):
+        _insert_run(bt_conn)
+        result = load_latest_summary(bt_conn)
+        assert "1.450" in result
+        assert "-8.20%" in result
+
+    def test_contains_win_rate_and_trades(self, bt_conn):
+        _insert_run(bt_conn)
+        result = load_latest_summary(bt_conn)
+        assert "58.30%" in result
+        assert "142" in result
+
+    def test_contains_buy_logic_params(self, bt_conn):
+        _insert_run(bt_conn)
+        result = load_latest_summary(bt_conn)
+        assert result is not None
+        assert "threshold=0.6" in result
+        assert "sector_boost=0.03" in result
+
+    def test_contains_risk_filter_params(self, bt_conn):
+        _insert_run(bt_conn)
+        result = load_latest_summary(bt_conn)
+        assert result is not None
+        assert "stop_loss_rate=-0.08" in result
+        assert "trailing_stop_atr_mult=2.0" in result
+        assert "topix_drawdown_threshold=-0.15" in result
+
+    def test_invalid_params_json_no_crash(self, bt_conn):
+        bt_conn.execute(
+            """
+            INSERT INTO backtest_runs (
+                run_id, start_date, end_date, initial_cash, scope_mode, params_json,
+                cagr, sharpe, max_drawdown, win_rate, payoff_ratio, profit_factor, total_trades
+            ) VALUES ('r_bad', '2026-01-01', '2026-04-30', 1000000, 'default_universe',
+                      'INVALID_JSON', 0.10, 1.0, -0.05, 0.5, 1.5, 1.8, 100)
+            """
+        )
+        result = load_latest_summary(bt_conn)
+        assert result is not None
+        assert "CAGR" in result
+
+    def test_returns_latest_when_multiple_runs(self, bt_conn):
+        _insert_run(bt_conn, run_id="r_old")
+        newer_params = dict(_SAMPLE_PARAMS, threshold=0.70)
+        bt_conn.execute(
+            """
+            INSERT INTO backtest_runs (
+                run_id, start_date, end_date, initial_cash, scope_mode, params_json,
+                cagr, sharpe, max_drawdown, win_rate, payoff_ratio, profit_factor,
+                total_trades, created_at
+            ) VALUES ('r_new', '2026-01-01', '2026-04-30', 1000000, 'default_universe',
+                      ?, 0.20, 1.8, -0.06, 0.60, 2.0, 2.5, 180,
+                      current_timestamp + INTERVAL 1 SECOND)
+            """,
+            [json.dumps(newer_params)],
+        )
+        result = load_latest_summary(bt_conn)
+        assert result is not None
+        assert "r_new" in result
+        assert "threshold=0.7" in result
+```
+
+- [ ] **Step 2: テストが FAIL することを確認**
+
+```bash
+pytest tests/test_backtest_summarizer.py -v
+```
+
+期待: `ModuleNotFoundError: No module named 'kabusys.ai.backtest_summarizer'`
+
+- [ ] **Step 3: `backtest_summarizer.py` を実装する**
+
+`src/kabusys/ai/backtest_summarizer.py` を新規作成する：
+
+```python
+"""backtest_summarizer.py — バックテスト結果から AI system prompt 用 Markdown を生成する。"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import duckdb
+
+logger = logging.getLogger(__name__)
+
+
+def load_latest_summary(conn: duckdb.DuckDBPyConnection) -> str | None:
+    """backtest_runs の最新1件から system prompt 用 Markdown を生成する。
+
+    バックテスト結果がない場合は None を返す。
+    params_json が不正な場合はパラメータ行をスキップし、クラッシュしない。
+
+    Args:
+        conn: DuckDB 接続。backtest_runs テーブルを参照する。
+
+    Returns:
+        Markdown 形式の文字列、またはデータなしの場合は None。
+    """
+    try:
+        row = conn.execute("""
+            SELECT run_id, start_date, end_date,
+                   cagr, sharpe, max_drawdown, win_rate,
+                   payoff_ratio, profit_factor, total_trades,
+                   params_json
+            FROM backtest_runs
+            ORDER BY created_at DESC
+            LIMIT 1
+        """).fetchone()
+    except Exception as e:
+        logger.warning("load_latest_summary: backtest_runs 読み込みエラー: %s", e)
+        return None
+
+    if row is None:
+        return None
+
+    run_id = str(row[0])
+    start_date = str(row[1])
+    end_date = str(row[2])
+    cagr: float | None = row[3]
+    sharpe: float | None = row[4]
+    max_dd: float | None = row[5]
+    win_rate: float | None = row[6]
+    payoff: float | None = row[7]
+    profit_factor: float | None = row[8]
+    total_trades: int | None = row[9]
+    params_json_str: str | None = row[10]
+
+    def _pct(v: float | None) -> str:
+        return f"{v:+.2%}" if v is not None else "N/A"
+
+    def _f(v: float | None, prec: int = 3) -> str:
+        return f"{v:.{prec}f}" if v is not None else "N/A"
+
+    lines = [
+        f"## 最新バックテスト結果（run_id: {run_id}, {start_date}〜{end_date}）",
+        "",
+        "| 指標 | 値 |",
+        "|------|-----|",
+        f"| CAGR | {_pct(cagr)} |",
+        f"| Sharpe Ratio | {_f(sharpe)} |",
+        f"| Max Drawdown | {_pct(max_dd)} |",
+        f"| Win Rate | {_pct(win_rate)} |",
+        f"| Payoff Ratio | {_f(payoff)} |",
+        f"| Profit Factor | {_f(profit_factor)} |",
+        f"| Total Trades | {total_trades if total_trades is not None else 'N/A'} |",
+    ]
+
+    params: dict = {}
+    if params_json_str:
+        try:
+            parsed = json.loads(params_json_str)
+            if isinstance(parsed, dict):
+                params = parsed
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("load_latest_summary: params_json のパースに失敗しました")
+
+    if params:
+        weights = params.get("weights", {})
+        buy_parts = [
+            f"weights={weights}",
+            f"threshold={params.get('threshold', 'N/A')}",
+            f"sector_boost={params.get('sector_boost', 'N/A')}",
+            f"sector_quartile={params.get('sector_quartile', 'N/A')}",
+        ]
+        risk_parts = [
+            f"stop_loss_rate={params.get('stop_loss_rate', 'N/A')}",
+            f"trailing_stop_atr_mult={params.get('trailing_stop_atr_mult', 'N/A')}",
+            f"gap_up_threshold={params.get('gap_up_threshold', 'N/A')}",
+            f"gap_down_threshold={params.get('gap_down_threshold', 'N/A')}",
+            f"min_holding_days={params.get('min_holding_days', 'N/A')}",
+            f"max_holding_days={params.get('max_holding_days', 'N/A')}",
+            f"topix_drawdown_threshold={params.get('topix_drawdown_threshold', 'N/A')}",
+            f"topix_size_multiplier_bear={params.get('topix_size_multiplier_bear', 'N/A')}",
+        ]
+        lines += [
+            "",
+            "### 戦略パラメータ",
+            f"**購入ロジック**: {', '.join(buy_parts)}",
+            "",
+            f"**リスク・フィルター**: {', '.join(risk_parts)}",
+        ]
+
+    return "\n".join(lines)
+```
+
+- [ ] **Step 4: テストが PASS することを確認**
+
+```bash
+pytest tests/test_backtest_summarizer.py -v
+```
+
+期待: 8 テスト全 PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/kabusys/ai/backtest_summarizer.py tests/test_backtest_summarizer.py
+git commit -m "feat: backtest_summarizer — バックテスト結果→system prompt Markdown生成 (Issue #233)"
+```
+
+---
+
+### Task 3: components/ai_wizard.py
+
+**Files:**
+- Create: `src/kabusys/monitoring/components/__init__.py`
+- Create: `src/kabusys/monitoring/components/ai_wizard.py`
+- Create: `tests/test_ai_wizard.py`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`tests/test_ai_wizard.py` を新規作成する：
+
+```python
+"""ai_wizard コンポーネント単体テスト（Issue #233）"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import uuid
+from unittest.mock import MagicMock, patch
+
+import duckdb
+import pytest
+
+from kabusys.monitoring.monitoring_db import MonitoringDB, init_monitoring_db
+
+
+@pytest.fixture
+def wizard_sqlite():
+    conn = sqlite3.connect(":memory:")
+    init_monitoring_db(conn)
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def wizard_duckdb():
+    conn = duckdb.connect(":memory:")
+    conn.execute("""
+        CREATE TABLE backtest_runs (
+            run_id VARCHAR PRIMARY KEY,
+            created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+            start_date DATE NOT NULL, end_date DATE NOT NULL,
+            initial_cash DECIMAL(18,2) NOT NULL, scope_mode VARCHAR NOT NULL,
+            scope_codes_json VARCHAR, params_json VARCHAR NOT NULL,
+            cagr DOUBLE, sharpe DOUBLE, max_drawdown DOUBLE,
+            win_rate DOUBLE, payoff_ratio DOUBLE, profit_factor DOUBLE,
+            annual_volatility DOUBLE, calmar_ratio DOUBLE,
+            avg_holding_days DOUBLE, total_trades INTEGER,
+            effective_universe_size INTEGER
+        )
+    """)
+    yield conn
+    conn.close()
+
+
+def _make_st_mock(session_state=None):
+    """st モジュールのモックを生成する。"""
+    mock_st = MagicMock()
+    mock_st.session_state = session_state if session_state is not None else {}
+    mock_st.sidebar.__enter__ = MagicMock(return_value=None)
+    mock_st.sidebar.__exit__ = MagicMock(return_value=False)
+    mock_st.chat_message.return_value.__enter__ = MagicMock(return_value=None)
+    mock_st.chat_message.return_value.__exit__ = MagicMock(return_value=False)
+    mock_st.chat_input.return_value = None
+    return mock_st
+
+
+class TestRenderApiKeyMissing:
+    def test_shows_error_when_no_api_key(self, wizard_duckdb, wizard_sqlite):
+        import kabusys.monitoring.components.ai_wizard as mod
+
+        mock_st = _make_st_mock()
+        env = {k: v for k, v in os.environ.items() if k != "OPENAI_API_KEY"}
+        with patch.dict(os.environ, env, clear=True):
+            with patch.object(mod, "st", mock_st):
+                mod.render(wizard_duckdb, wizard_sqlite)
+
+        mock_st.error.assert_called_once()
+        assert "OPENAI_API_KEY" in mock_st.error.call_args[0][0]
+
+    def test_returns_early_without_chat_input(self, wizard_duckdb, wizard_sqlite):
+        """API キー未設定時はチャット入力が表示されない（return early）。"""
+        import kabusys.monitoring.components.ai_wizard as mod
+
+        mock_st = _make_st_mock()
+        env = {k: v for k, v in os.environ.items() if k != "OPENAI_API_KEY"}
+        with patch.dict(os.environ, env, clear=True):
+            with patch.object(mod, "st", mock_st):
+                mod.render(wizard_duckdb, wizard_sqlite)
+
+        mock_st.chat_input.assert_not_called()
+
+
+class TestSessionIdInitialization:
+    def test_session_id_set_as_uuid(self, wizard_duckdb, wizard_sqlite):
+        """初回呼び出しで wizard_session_id が UUID として session_state に設定される。"""
+        import kabusys.monitoring.components.ai_wizard as mod
+
+        state: dict = {}
+        mock_st = _make_st_mock(session_state=state)
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            with patch.object(mod, "st", mock_st):
+                mod.render(wizard_duckdb, wizard_sqlite)
+
+        assert "wizard_session_id" in state
+        uuid.UUID(state["wizard_session_id"])  # 不正なら ValueError
+
+
+class TestStreamOpenaiResponse:
+    def test_yields_content_strings_and_skips_none(self):
+        """_stream_openai_response がコンテンツを yield し、None チャンクをスキップする。"""
+        from kabusys.monitoring.components.ai_wizard import _stream_openai_response
+
+        chunk1 = MagicMock()
+        chunk1.choices[0].delta.content = "テスト"
+        chunk2 = MagicMock()
+        chunk2.choices[0].delta.content = None
+        chunk3 = MagicMock()
+        chunk3.choices[0].delta.content = "回答"
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = [chunk1, chunk2, chunk3]
+
+        result = list(
+            _stream_openai_response(mock_client, [{"role": "user", "content": "test"}])
+        )
+        assert result == ["テスト", "回答"]
+
+    def test_calls_openai_with_stream_true(self):
+        """_stream_openai_response が stream=True で API を呼び出す。"""
+        from kabusys.monitoring.components.ai_wizard import _stream_openai_response
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = []
+
+        list(_stream_openai_response(mock_client, []))
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs.get("stream") is True
+
+
+class TestRenderWithApiKey:
+    def test_saves_user_and_assistant_to_sqlite(self, wizard_duckdb, wizard_sqlite):
+        """render でユーザー入力 → AI 応答が SQLite に保存される。"""
+        import kabusys.monitoring.components.ai_wizard as mod
+
+        state: dict = {}
+        mock_st = _make_st_mock(session_state=state)
+        mock_st.chat_input.return_value = "ドローダウンを改善したい"
+        mock_st.write_stream.return_value = "ATR乗数を2.0から2.5にすることを提案します。"
+
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            with patch.object(mod, "st", mock_st):
+                with patch(
+                    "kabusys.monitoring.components.ai_wizard._stream_openai_response",
+                    return_value=iter(["ATR乗数を2.0から2.5にすることを提案します。"]),
+                ):
+                    with patch("kabusys.monitoring.components.ai_wizard.OpenAI"):
+                        mod.render(wizard_duckdb, wizard_sqlite)
+
+        session_id = state["wizard_session_id"]
+        db = MonitoringDB(wizard_sqlite)
+        msgs = db.load_wizard_messages(session_id)
+        assert len(msgs) == 2
+        assert msgs[0]["role"] == "user"
+        assert msgs[0]["content"] == "ドローダウンを改善したい"
+        assert msgs[1]["role"] == "assistant"
+```
+
+- [ ] **Step 2: テストが FAIL することを確認**
+
+```bash
+pytest tests/test_ai_wizard.py -v
+```
+
+期待: `ModuleNotFoundError: No module named 'kabusys.monitoring.components'`
+
+- [ ] **Step 3: `components/__init__.py` を作成する**
+
+`src/kabusys/monitoring/components/__init__.py` を空ファイルとして作成する：
+
+```python
+```
+
+（空ファイル）
+
+- [ ] **Step 4: `ai_wizard.py` を実装する**
+
+`src/kabusys/monitoring/components/ai_wizard.py` を新規作成する：
+
+```python
+"""ai_wizard.py — AI Co-Pilot チャットコンポーネント（再利用可能）。"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import uuid
+from typing import Generator
+
+import duckdb
+import streamlit as st
+from openai import OpenAI
+
+from kabusys.ai.backtest_summarizer import load_latest_summary
+from kabusys.monitoring.monitoring_db import MonitoringDB
+
+_MODEL = "gpt-4o"
+
+_SYSTEM_PROMPT_TEMPLATE = """\
+あなたは KabuSys の戦略チューニング・アシスタントです。
+以下のバックテスト結果を踏まえ、購入ロジック（weights / threshold / sector パラメータ）および
+リスク・フィルターロジック（stop_loss / trailing_stop / gap / holding_days / topix パラメータ）の
+改善案を提案してください。回答は簡潔な日本語で行い、具体的な数値変更案を含めてください。
+
+{context}"""
+
+_NO_DATA_CONTEXT = (
+    "バックテスト結果がまだありません。一般的な戦略チューニングについて質問できます。"
+)
+
+
+def _stream_openai_response(
+    client: OpenAI,
+    messages: list[dict],
+) -> Generator[str, None, None]:
+    """OpenAI Chat Completions API をストリーミングで呼び出す。
+
+    テスト時は
+    unittest.mock.patch("kabusys.monitoring.components.ai_wizard._stream_openai_response")
+    で差し替える。
+
+    Yields:
+        各チャンクのテキスト断片（content が None のチャンクはスキップ）。
+    """
+    stream = client.chat.completions.create(
+        model=_MODEL,
+        messages=messages,
+        stream=True,
+    )
+    for chunk in stream:
+        content = chunk.choices[0].delta.content
+        if content:
+            yield content
+
+
+def render(
+    duckdb_conn: duckdb.DuckDBPyConnection,
+    sqlite_conn: sqlite3.Connection,
+) -> None:
+    """AI Co-Pilot チャット UI を Streamlit に描画する。
+
+    Args:
+        duckdb_conn: DuckDB 接続（read_only=True 推奨）。backtest_runs を参照する。
+        sqlite_conn: SQLite 接続（monitoring.db）。ai_wizard_messages を読み書きする。
+    """
+    if "wizard_session_id" not in st.session_state:
+        st.session_state.wizard_session_id = str(uuid.uuid4())
+    session_id: str = st.session_state.wizard_session_id
+
+    db = MonitoringDB(sqlite_conn)
+
+    with st.sidebar:
+        if st.button("🗑 履歴クリア", key="wizard_clear"):
+            db.clear_wizard_messages(session_id)
+            st.session_state.wizard_session_id = str(uuid.uuid4())
+            st.rerun()
+
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        st.error("OPENAI_API_KEY が設定されていません。環境変数を設定してください。")
+        return
+
+    summary = load_latest_summary(duckdb_conn)
+    context = summary if summary is not None else _NO_DATA_CONTEXT
+    system_prompt = _SYSTEM_PROMPT_TEMPLATE.format(context=context)
+
+    history = db.load_wizard_messages(session_id)
+    for msg in history:
+        with st.chat_message(msg["role"]):
+            st.write(msg["content"])
+
+    user_input = st.chat_input("KabuSysの戦略について質問してください")
+    if not user_input:
+        return
+
+    with st.chat_message("user"):
+        st.write(user_input)
+    db.save_wizard_message(session_id, "user", user_input)
+
+    client = OpenAI(api_key=api_key)
+    messages: list[dict] = [{"role": "system", "content": system_prompt}]
+    messages += [{"role": m["role"], "content": m["content"]} for m in history]
+    messages.append({"role": "user", "content": user_input})
+
+    try:
+        with st.chat_message("assistant"):
+            response_text = st.write_stream(_stream_openai_response(client, messages))
+        db.save_wizard_message(session_id, "assistant", str(response_text))
+    except Exception as e:
+        st.error(f"OpenAI API エラー: {e}")
+```
+
+- [ ] **Step 5: テストが PASS することを確認**
+
+```bash
+pytest tests/test_ai_wizard.py -v
+```
+
+期待: 7 テスト全 PASS
+
+- [ ] **Step 6: 全テストで回帰がないことを確認**
+
+```bash
+pytest tests/ -v --tb=short 2>&1 | tail -20
+```
+
+期待: 全 PASS
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add src/kabusys/monitoring/components/ tests/test_ai_wizard.py
+git commit -m "feat: ai_wizard コンポーネント — Streamlit チャット UI + OpenAI ストリーミング (Issue #233)"
+```
+
+---
+
+### Task 4: 10_Strategy_Lab.py — AI Co-Pilot タブ統合
+
+**Files:**
+- Modify: `src/kabusys/monitoring/pages/10_Strategy_Lab.py`
+
+- [ ] **Step 1: ファイルを読んで現状を確認する**
+
+`src/kabusys/monitoring/pages/10_Strategy_Lab.py` を開く。現在の先頭部分：
+
+```python
+"""pages/4_Strategy_Lab.py — 市場レジーム・AI スコア・戦略状態ビュー。"""
+
+from __future__ import annotations
+
+import duckdb
+import streamlit as st
+
+from kabusys.config import Settings
+from kabusys.monitoring.strategy_lab_data import (
+    load_ai_scores,
+    load_market_regime,
+    load_signal_summary,
+)
+```
+
+- [ ] **Step 2: インポートに `sqlite3` と `render_wizard` を追加する**
+
+`src/kabusys/monitoring/pages/10_Strategy_Lab.py` のインポートブロックを以下に変更する（`import duckdb` の前に `import sqlite3` を追加し、`render_wizard` のインポートを末尾に追加）：
+
+```python
+"""pages/4_Strategy_Lab.py — 市場レジーム・AI スコア・戦略状態ビュー。"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import duckdb
+import streamlit as st
+
+from kabusys.config import Settings
+from kabusys.monitoring.components.ai_wizard import render as render_wizard
+from kabusys.monitoring.strategy_lab_data import (
+    load_ai_scores,
+    load_market_regime,
+    load_signal_summary,
+)
+```
+
+- [ ] **Step 3: タブ定義に `tab_copilot` を追加する**
+
+現在のタブ定義：
+
+```python
+    tab_regime, tab_ai, tab_signals = st.tabs(
+        ["市場レジーム", "AI スコア", "シグナル推移"]
+    )
+```
+
+これを以下に変更する：
+
+```python
+    tab_regime, tab_ai, tab_signals, tab_copilot = st.tabs(
+        ["市場レジーム", "AI スコア", "シグナル推移", "🤖 AI Co-Pilot"]
+    )
+```
+
+- [ ] **Step 4: `tab_copilot` の実装を追加する**
+
+既存の `with tab_signals:` ブロックの直後（`finally:` の前）に以下を追加する：
+
+```python
+    with tab_copilot:
+        sqlite_conn = sqlite3.connect(str(settings.sqlite_path))
+        try:
+            render_wizard(conn, sqlite_conn)
+        finally:
+            sqlite_conn.close()
+```
+
+変更後のファイル全体：
+
+```python
+"""pages/4_Strategy_Lab.py — 市場レジーム・AI スコア・戦略状態ビュー。"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import duckdb
+import streamlit as st
+
+from kabusys.config import Settings
+from kabusys.monitoring.components.ai_wizard import render as render_wizard
+from kabusys.monitoring.strategy_lab_data import (
+    load_ai_scores,
+    load_market_regime,
+    load_signal_summary,
+)
+
+st.set_page_config(page_title="Strategy Lab", layout="wide", page_icon="📊")
+st.title("📊 Strategy Lab — 市場レジーム・AI スコア")
+
+settings = Settings()
+with st.sidebar:
+    st.caption(f"環境: **{settings.env}**")
+    days = st.selectbox("表示期間", [14, 30, 60], index=1)
+    if st.button("🔄 Refresh"):
+        st.rerun()
+
+try:
+    conn = duckdb.connect(str(settings.duckdb_path), read_only=True)
+except Exception as e:
+    st.error(f"DuckDB 接続失敗: {e}")
+    st.stop()
+
+try:
+    tab_regime, tab_ai, tab_signals, tab_copilot = st.tabs(
+        ["市場レジーム", "AI スコア", "シグナル推移", "🤖 AI Co-Pilot"]
+    )
+
+    with tab_regime:
+        df = load_market_regime(conn, days=days)
+        if df.empty:
+            st.info("レジームデータがありません。")
+        else:
+            latest = df.iloc[-1]
+            col1, col2 = st.columns(2)
+            col1.metric("最新レジームスコア", f"{float(latest['regime_score']):.3f}")
+            col2.metric("レジームラベル", latest["regime_label"])
+            st.subheader("レジームスコア推移")
+            st.line_chart(df.set_index("date")["regime_score"])
+            st.dataframe(df, use_container_width=True)
+
+    with tab_ai:
+        df = load_ai_scores(conn)
+        if df.empty:
+            st.info(
+                "AI スコアデータがありません（ENABLE_AI_SENTIMENT=false の場合は空）。"
+            )
+        else:
+            st.caption(f"基準日: {df['date'].iloc[0]}")
+            col1, col2 = st.columns(2)
+            col1.metric("スコア最高銘柄", df.iloc[0]["code"])
+            col2.metric("最高 AI スコア", f"{float(df.iloc[0]['ai_score']):.3f}")
+            st.dataframe(df, use_container_width=True)
+
+    with tab_signals:
+        df = load_signal_summary(conn, days=days)
+        if df.empty:
+            st.info("シグナルデータがありません。")
+        else:
+            total_buy = int(df["buy_count"].sum())
+            total_sell = int(df["sell_count"].sum())
+            col1, col2 = st.columns(2)
+            col1.metric(f"買いシグナル合計（{days}日）", total_buy)
+            col2.metric(f"売りシグナル合計（{days}日）", total_sell)
+            st.subheader("日別シグナル件数")
+            st.bar_chart(df.set_index("date")[["buy_count", "sell_count"]])
+
+    with tab_copilot:
+        sqlite_conn = sqlite3.connect(str(settings.sqlite_path))
+        try:
+            render_wizard(conn, sqlite_conn)
+        finally:
+            sqlite_conn.close()
+
+finally:
+    conn.close()
+```
+
+- [ ] **Step 5: ruff チェック**
+
+```bash
+python -m ruff check src/kabusys/monitoring/pages/10_Strategy_Lab.py
+python -m ruff format --check src/kabusys/monitoring/pages/10_Strategy_Lab.py
+```
+
+期待: `All checks passed!`
+
+- [ ] **Step 6: 全テストが PASS することを確認**
+
+```bash
+pytest tests/ --tb=short 2>&1 | tail -10
+```
+
+期待: 全 PASS
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add src/kabusys/monitoring/pages/10_Strategy_Lab.py
+git commit -m "feat: Strategy Lab に AI Co-Pilot タブを追加 (Issue #233)"
+```

--- a/docs/superpowers/plans/2026-05-09-strategy-param-externalization.md
+++ b/docs/superpowers/plans/2026-05-09-strategy-param-externalization.md
@@ -1,0 +1,532 @@
+# Strategy Parameter Externalization (Remaining 4 Constants) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `signal_generator.py` に残るハードコード定数 4 件（`_SECTOR_BOOST`, `_SECTOR_QUARTILE`, `_TOPIX_DRAWDOWN_THRESHOLD`, `_TOPIX_SIZE_MULTIPLIER_BEAR`）を `config/strategy_config.yaml` の `sector:` / `regime:` セクションから runtime 読み込みに変更し、再起動不要でパラメータを変更できるようにする。
+
+**Architecture:** 既存の `_load_strategy_config()` / `_STRATEGY_CONFIG_DEFAULTS` パターンを踏襲し、YAML の `sector:` / `regime:` セクションを解析して返却 dict に 4 キーを追加する。`_calc_sector_strengths()` と `_get_topix_size_multiplier()` はデフォルト付き明示パラメータを受け取り、`generate_signals()` が `_cfg` から渡す。
+
+**Tech Stack:** Python 3.10+, PyYAML（既存依存）, pytest
+
+---
+
+## File Map
+
+- Modify: `src/kabusys/strategy/signal_generator.py` — `_STRATEGY_CONFIG_DEFAULTS`, `_load_strategy_config()`, `_calc_sector_strengths()`, `_get_topix_size_multiplier()`, `generate_signals()` の 5 箇所
+- Modify: `config/strategy_config.yaml` — `sector:` / `regime:` セクション追加
+- Modify: `tests/test_signal_generator.py` — 新テスト追加
+
+---
+
+## Background（コードベース把握）
+
+`signal_generator.py` の現状:
+- `_STRATEGY_CONFIG_PATH` (line 103): `config/strategy_config.yaml` へのパス
+- `_strategy_config_cache` / `_strategy_config_mtime` (lines 107-108): グローバルキャッシュ
+- `_load_strategy_config()` (line 111): YAML を読んで flat dict を返す。`strategy:` セクションのみ解析済み
+- `_STRATEGY_CONFIG_DEFAULTS` (line 91): デフォルト dict。現状 9 キー
+- `_calc_sector_strengths(conn, target_date)` (line 533): `_SECTOR_QUARTILE` をモジュール定数として使用
+- `_get_topix_size_multiplier(conn, target_date)` (line 447): `_TOPIX_DRAWDOWN_THRESHOLD` / `_TOPIX_SIZE_MULTIPLIER_BEAR` をモジュール定数として使用
+- `generate_signals()` (line 989): `_cfg = _load_strategy_config()` を呼び出し済み（line 1028）
+
+テスト:
+- `TestGetTopixSizeMultiplier` クラス (line 624): `_get_topix_size_multiplier` を引数 2 つで呼ぶ既存テストがある。パラメータ追加後もデフォルト値で動作する。
+
+---
+
+## Task 1: `_load_strategy_config()` に sector/regime セクション解析を追加
+
+**Files:**
+- Modify: `src/kabusys/strategy/signal_generator.py:91-234`
+- Modify: `tests/test_signal_generator.py`（末尾に追加）
+
+### Step 1: 失敗するテストを書く
+
+`tests/test_signal_generator.py` の末尾に追加する:
+
+```python
+# ---------------------------------------------------------------------------
+# Task 1: _load_strategy_config() sector/regime セクション
+# ---------------------------------------------------------------------------
+
+import kabusys.strategy.signal_generator as _sg
+
+
+def _load_cfg_with_yaml(yaml_text: str, tmp_path, monkeypatch) -> dict:
+    """tmp_path に YAML ファイルを書き、モジュールのパスとキャッシュをパッチして _load_strategy_config() を呼ぶ。"""
+    cfg_file = tmp_path / "strategy_config.yaml"
+    cfg_file.write_text(yaml_text, encoding="utf-8")
+    monkeypatch.setattr(_sg, "_STRATEGY_CONFIG_PATH", cfg_file)
+    monkeypatch.setattr(_sg, "_strategy_config_cache", None)
+    monkeypatch.setattr(_sg, "_strategy_config_mtime", -1.0)
+    return _sg._load_strategy_config()
+
+
+class TestLoadStrategyConfigSectorRegime:
+    """_load_strategy_config() の sector/regime セクション解析テスト。"""
+
+    def test_valid_sector_and_regime(self, tmp_path, monkeypatch):
+        yaml_text = """
+strategy:
+  threshold: 0.60
+sector:
+  boost: 0.05
+  quartile: 0.30
+regime:
+  topix_drawdown_threshold: -0.20
+  topix_size_multiplier_bear: 0.4
+"""
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["sector_boost"] == 0.05
+        assert cfg["sector_quartile"] == 0.30
+        assert cfg["topix_drawdown_threshold"] == -0.20
+        assert cfg["topix_size_multiplier_bear"] == 0.4
+
+    def test_missing_sector_section_uses_defaults(self, tmp_path, monkeypatch):
+        yaml_text = "strategy:\n  threshold: 0.60\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["sector_boost"] == 0.03
+        assert cfg["sector_quartile"] == 0.25
+
+    def test_missing_regime_section_uses_defaults(self, tmp_path, monkeypatch):
+        yaml_text = "strategy:\n  threshold: 0.60\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["topix_drawdown_threshold"] == -0.15
+        assert cfg["topix_size_multiplier_bear"] == 0.5
+
+    def test_sector_boost_negative_falls_back(self, tmp_path, monkeypatch):
+        yaml_text = "sector:\n  boost: -0.01\n  quartile: 0.25\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["sector_boost"] == 0.03  # default
+
+    def test_sector_quartile_zero_falls_back(self, tmp_path, monkeypatch):
+        yaml_text = "sector:\n  boost: 0.03\n  quartile: 0.0\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["sector_quartile"] == 0.25  # default
+
+    def test_sector_quartile_one_falls_back(self, tmp_path, monkeypatch):
+        yaml_text = "sector:\n  boost: 0.03\n  quartile: 1.0\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["sector_quartile"] == 0.25  # default
+
+    def test_topix_drawdown_threshold_positive_falls_back(self, tmp_path, monkeypatch):
+        yaml_text = "regime:\n  topix_drawdown_threshold: 0.10\n  topix_size_multiplier_bear: 0.5\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["topix_drawdown_threshold"] == -0.15  # default
+
+    def test_topix_size_multiplier_bear_over_one_falls_back(self, tmp_path, monkeypatch):
+        yaml_text = "regime:\n  topix_drawdown_threshold: -0.15\n  topix_size_multiplier_bear: 1.5\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["topix_size_multiplier_bear"] == 0.5  # default
+```
+
+- [ ] **Step 2: テストが失敗することを確認する**
+
+```
+pytest tests/test_signal_generator.py::TestLoadStrategyConfigSectorRegime -v
+```
+
+期待: `KeyError: 'sector_boost'` などで FAIL（キーがまだ存在しない）
+
+- [ ] **Step 3: `_STRATEGY_CONFIG_DEFAULTS` に 4 キーを追加する**
+
+`src/kabusys/strategy/signal_generator.py` の `_STRATEGY_CONFIG_DEFAULTS` (line 91) を以下に変更する:
+
+```python
+_STRATEGY_CONFIG_DEFAULTS: dict = {
+    "weights": {k: v for k, v in _DEFAULT_WEIGHTS.items()},
+    "threshold": _DEFAULT_THRESHOLD,
+    "stop_loss_rate": _STOP_LOSS_RATE,
+    "gap_up_threshold": _GAP_UP_THRESHOLD,
+    "gap_down_threshold": _GAP_DOWN_THRESHOLD,
+    "min_holding_days": _MIN_HOLDING_DAYS,
+    "max_holding_days": _MAX_HOLDING_DAYS,
+    "trailing_stop_atr_mult": _TRAILING_STOP_ATR_MULT,
+    "reentry_cooldown_days": _REENTRY_COOLDOWN_DAYS,
+    "sector_boost": _SECTOR_BOOST,
+    "sector_quartile": _SECTOR_QUARTILE,
+    "topix_drawdown_threshold": _TOPIX_DRAWDOWN_THRESHOLD,
+    "topix_size_multiplier_bear": _TOPIX_SIZE_MULTIPLIER_BEAR,
+}
+```
+
+- [ ] **Step 4: `_load_strategy_config()` の docstring を更新する**
+
+`_load_strategy_config()` の Returns docstring (lines 119-129) を以下に変更する:
+
+```python
+    Returns:
+        {
+            "weights": dict[str, float],
+            "threshold": float,
+            "stop_loss_rate": float,
+            "gap_up_threshold": float,
+            "gap_down_threshold": float,
+            "min_holding_days": int,
+            "max_holding_days": int,
+            "trailing_stop_atr_mult": float,
+            "reentry_cooldown_days": int,
+            "sector_boost": float,
+            "sector_quartile": float,
+            "topix_drawdown_threshold": float,
+            "topix_size_multiplier_bear": float,
+        }
+```
+
+- [ ] **Step 5: `_load_strategy_config()` に sector/regime 解析を追加する**
+
+`_load_strategy_config()` 内の `# int スカラーパラメータ` ブロックの直後（line 229 の `_strategy_config_cache = result` の前）に以下を挿入する:
+
+```python
+    # sector セクション
+    sec = data.get("sector")
+    if isinstance(sec, dict):
+        v = sec.get("boost")
+        if (
+            v is not None
+            and isinstance(v, (int, float))
+            and not isinstance(v, bool)
+            and math.isfinite(float(v))
+            and float(v) >= 0
+        ):
+            result["sector_boost"] = float(v)
+
+        v = sec.get("quartile")
+        if (
+            v is not None
+            and isinstance(v, (int, float))
+            and not isinstance(v, bool)
+            and math.isfinite(float(v))
+            and 0.0 < float(v) < 1.0
+        ):
+            result["sector_quartile"] = float(v)
+
+    # regime セクション
+    reg = data.get("regime")
+    if isinstance(reg, dict):
+        v = reg.get("topix_drawdown_threshold")
+        if (
+            v is not None
+            and isinstance(v, (int, float))
+            and not isinstance(v, bool)
+            and math.isfinite(float(v))
+            and float(v) < 0
+        ):
+            result["topix_drawdown_threshold"] = float(v)
+
+        v = reg.get("topix_size_multiplier_bear")
+        if (
+            v is not None
+            and isinstance(v, (int, float))
+            and not isinstance(v, bool)
+            and math.isfinite(float(v))
+            and 0.0 < float(v) <= 1.0
+        ):
+            result["topix_size_multiplier_bear"] = float(v)
+```
+
+- [ ] **Step 6: テストが通ることを確認する**
+
+```
+pytest tests/test_signal_generator.py::TestLoadStrategyConfigSectorRegime -v
+```
+
+期待: 8 件 PASS
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add src/kabusys/strategy/signal_generator.py tests/test_signal_generator.py
+git commit -m "feat: _load_strategy_config に sector/regime セクション解析を追加"
+```
+
+---
+
+## Task 2: `_calc_sector_strengths()` を `sector_quartile` パラメータ化する
+
+**Files:**
+- Modify: `src/kabusys/strategy/signal_generator.py:533-598`（`_calc_sector_strengths` 定義）
+- Modify: `src/kabusys/strategy/signal_generator.py:1184-1186`（`generate_signals` 内の呼び出し箇所）
+- Modify: `tests/test_signal_generator.py`（末尾に追加）
+
+### Step 1: 失敗するテストを書く
+
+`tests/test_signal_generator.py` の末尾に追加する:
+
+```python
+# ---------------------------------------------------------------------------
+# Task 2: _calc_sector_strengths sector_quartile パラメータ
+# ---------------------------------------------------------------------------
+
+from kabusys.strategy.signal_generator import _calc_sector_strengths  # noqa: E402
+
+
+class TestCalcSectorStrengthsQuartile:
+    """_calc_sector_strengths の sector_quartile パラメータテスト。"""
+
+    def _setup_4sectors(self, conn) -> None:
+        """4セクター・4銘柄・21日分の価格データを挿入する。"""
+        sectors = [
+            ("1001", "製造業", 1.10),
+            ("1002", "金融業", 1.05),
+            ("1003", "情報通信", 1.02),
+            ("1004", "小売業", 0.98),
+        ]
+        for code, sector, _ in sectors:
+            conn.execute(
+                "INSERT INTO stocks (code, sector) VALUES (?, ?)", [code, sector]
+            )
+        base = date(2026, 1, 1)
+        for j in range(21):
+            d = base + timedelta(days=j)
+            for code, _, ret in sectors:
+                c = 1000.0 * ret if j == 20 else 1000.0
+                conn.execute(
+                    "INSERT INTO prices_daily (date, code, open, high, low, close, volume)"
+                    " VALUES (?, ?, 1000, 1000, 1000, ?, 1000)",
+                    [d, code, c],
+                )
+
+    def test_default_quartile_gives_1_top_sector(self, conn):
+        self._setup_4sectors(conn)
+        top, _, _ = _calc_sector_strengths(conn, date(2026, 1, 21))
+        assert len(top) == 1  # ceil(4 * 0.25) = 1
+
+    def test_custom_quartile_50_gives_2_top_sectors(self, conn):
+        self._setup_4sectors(conn)
+        top, _, _ = _calc_sector_strengths(conn, date(2026, 1, 21), sector_quartile=0.50)
+        assert len(top) == 2  # ceil(4 * 0.50) = 2
+```
+
+- [ ] **Step 2: テストが失敗することを確認する**
+
+```
+pytest tests/test_signal_generator.py::TestCalcSectorStrengthsQuartile -v
+```
+
+期待: `TypeError: _calc_sector_strengths() got an unexpected keyword argument 'sector_quartile'` で FAIL
+
+- [ ] **Step 3: `_calc_sector_strengths()` のシグネチャと本体を更新する**
+
+`src/kabusys/strategy/signal_generator.py` の `_calc_sector_strengths` 定義（line 533-534）を以下に変更する:
+
+```python
+def _calc_sector_strengths(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date,
+    sector_quartile: float = _SECTOR_QUARTILE,
+) -> tuple[frozenset[str], frozenset[str], dict[str, str]]:
+```
+
+同関数内の `_SECTOR_QUARTILE` の使用箇所（lines 594-595）を以下に変更する:
+
+```python
+    top_n = max(1, math.ceil(n * sector_quartile))
+    bottom_n = max(1, math.ceil(n * sector_quartile))
+```
+
+- [ ] **Step 4: `generate_signals()` の呼び出し箇所を更新する**
+
+`generate_signals()` 内の `_calc_sector_strengths` 呼び出し（lines 1184-1186）を以下に変更する:
+
+```python
+        top_sectors, bottom_sectors, sector_map = _calc_sector_strengths(
+            conn, target_date, sector_quartile=_cfg["sector_quartile"]
+        )
+```
+
+- [ ] **Step 5: テストが通ることを確認する**
+
+```
+pytest tests/test_signal_generator.py::TestCalcSectorStrengthsQuartile -v
+```
+
+期待: 2 件 PASS
+
+- [ ] **Step 6: 既存テストが壊れていないことを確認する**
+
+```
+pytest tests/test_signal_generator.py -v --tb=short
+```
+
+期待: 全件 PASS
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add src/kabusys/strategy/signal_generator.py tests/test_signal_generator.py
+git commit -m "feat: _calc_sector_strengths に sector_quartile パラメータを追加"
+```
+
+---
+
+## Task 3: `_get_topix_size_multiplier()` をパラメータ化する
+
+**Files:**
+- Modify: `src/kabusys/strategy/signal_generator.py:447-492`（`_get_topix_size_multiplier` 定義）
+- Modify: `src/kabusys/strategy/signal_generator.py:1093`（`generate_signals` 内の呼び出し箇所）
+- Modify: `tests/test_signal_generator.py`（`TestGetTopixSizeMultiplier` クラスに追加）
+
+### Step 1: 失敗するテストを書く
+
+`tests/test_signal_generator.py` の `TestGetTopixSizeMultiplier` クラス（line 624）の末尾に追加する:
+
+```python
+    def test_custom_drawdown_threshold_and_multiplier(self, conn):
+        """カスタム drawdown_threshold と size_multiplier_bear が適用されることを確認する。"""
+        # 240日は 2000.0、直近11日は 1600.0（乖離率≈-20%）
+        self._make_topix_series(
+            conn, TARGET_DATE - timedelta(days=250), 240, 2000.0, 2000.0
+        )
+        recent_start = TARGET_DATE - timedelta(days=10)
+        self._make_topix_series(conn, recent_start, 11, 1600.0, 1600.0)
+
+        # drawdown_threshold=-0.10 → 乖離率-20% < -10% → Bear 判定 → 0.3 を返す
+        result = _get_topix_size_multiplier(
+            conn, TARGET_DATE, drawdown_threshold=-0.10, size_multiplier_bear=0.3
+        )
+        assert result == 0.3
+
+    def test_custom_threshold_not_triggered(self, conn):
+        """乖離率が drawdown_threshold を超えない場合は 1.0 を返すことを確認する。"""
+        # 250日すべて 2000.0（乖離率≈0%）
+        self._make_topix_series(
+            conn, TARGET_DATE - timedelta(days=250), 250, 2000.0, 2000.0
+        )
+        # drawdown_threshold=-0.10 → 乖離率≈0% > -10% → Bear 未判定 → 1.0
+        result = _get_topix_size_multiplier(
+            conn, TARGET_DATE, drawdown_threshold=-0.10, size_multiplier_bear=0.3
+        )
+        assert result == 1.0
+```
+
+- [ ] **Step 2: テストが失敗することを確認する**
+
+```
+pytest tests/test_signal_generator.py::TestGetTopixSizeMultiplier::test_custom_drawdown_threshold_and_multiplier tests/test_signal_generator.py::TestGetTopixSizeMultiplier::test_custom_threshold_not_triggered -v
+```
+
+期待: `TypeError: _get_topix_size_multiplier() got an unexpected keyword argument 'drawdown_threshold'` で FAIL
+
+- [ ] **Step 3: `_get_topix_size_multiplier()` のシグネチャと本体を更新する**
+
+`src/kabusys/strategy/signal_generator.py` の `_get_topix_size_multiplier` 定義（lines 447-492）のシグネチャを以下に変更する:
+
+```python
+def _get_topix_size_multiplier(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date,
+    drawdown_threshold: float = _TOPIX_DRAWDOWN_THRESHOLD,
+    size_multiplier_bear: float = _TOPIX_SIZE_MULTIPLIER_BEAR,
+) -> float:
+```
+
+同関数内の判定ロジック（line 490-491）を以下に変更する:
+
+```python
+    if ma200 > 0 and (close / ma200 - 1.0) < drawdown_threshold:
+        return size_multiplier_bear
+```
+
+- [ ] **Step 4: `generate_signals()` の呼び出し箇所を更新する**
+
+`generate_signals()` 内の `_get_topix_size_multiplier` 呼び出し（line 1093）を以下に変更する:
+
+```python
+    topix_multiplier = _get_topix_size_multiplier(
+        conn,
+        target_date,
+        drawdown_threshold=_cfg["topix_drawdown_threshold"],
+        size_multiplier_bear=_cfg["topix_size_multiplier_bear"],
+    )
+```
+
+- [ ] **Step 5: テストが通ることを確認する**
+
+```
+pytest tests/test_signal_generator.py::TestGetTopixSizeMultiplier -v
+```
+
+期待: 6 件（既存 4 + 新規 2）すべて PASS
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/kabusys/strategy/signal_generator.py tests/test_signal_generator.py
+git commit -m "feat: _get_topix_size_multiplier に drawdown_threshold / size_multiplier_bear パラメータを追加"
+```
+
+---
+
+## Task 4: `generate_signals()` で `sector_boost` を `_cfg` から読む + YAML 更新
+
+**Files:**
+- Modify: `src/kabusys/strategy/signal_generator.py:1221`（`generate_signals` 内 sector_boost 使用箇所）
+- Modify: `config/strategy_config.yaml`（sector/regime セクション追加）
+
+### Step 1: `generate_signals()` 内の `_SECTOR_BOOST` を `_cfg["sector_boost"]` に変える
+
+`generate_signals()` 冒頭の `_cfg` 抽出ブロック（line 1028 周辺）に以下を追加する:
+
+```python
+    _cfg = _load_strategy_config()
+    if threshold is None:
+        threshold = _cfg["threshold"]
+    if weights is None:
+        weights = _cfg["weights"]
+    if min_holding_days is None:
+        min_holding_days = _cfg["min_holding_days"]
+    if max_holding_days is None:
+        max_holding_days = _cfg["max_holding_days"]
+    if trailing_stop_atr is None:
+        trailing_stop_atr = _cfg["trailing_stop_atr_mult"]
+    sector_boost = _cfg["sector_boost"]  # ← 追加
+```
+
+`generate_signals()` 内の `_SECTOR_BOOST` の使用箇所（line 1221）を以下に変更する:
+
+```python
+            final_score += sector_boost
+```
+
+- [ ] **Step 2: `config/strategy_config.yaml` に sector/regime セクションを追加する**
+
+ファイル末尾（`value_score:` セクションの後）に追加する:
+
+```yaml
+sector:
+  # 上位セクター銘柄への final_score 加算量（≥ 0）
+  boost: 0.03
+  # 上位・下位セクターの区切り割合（0 < x < 1）
+  quartile: 0.25
+
+regime:
+  # TOPIX 200MA 乖離率がこの値以下で地合い悪化と判定（負値）
+  topix_drawdown_threshold: -0.15
+  # 地合い悪化時の size_multiplier（0 < x ≤ 1）
+  topix_size_multiplier_bear: 0.5
+```
+
+- [ ] **Step 3: 全テストを実行して PASS を確認する**
+
+```
+pytest tests/ -v --tb=short
+```
+
+期待: 全件 PASS（既存テストへの影響なし）
+
+- [ ] **Step 4: ruff チェック**
+
+```
+ruff check src/kabusys/strategy/signal_generator.py
+ruff format --check src/kabusys/strategy/signal_generator.py
+```
+
+期待: エラーなし（フォーマット差分があれば `ruff format` を実行して修正）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/kabusys/strategy/signal_generator.py config/strategy_config.yaml
+git commit -m "feat: generate_signals で sector_boost を cfg から読み取り、strategy_config.yaml に sector/regime セクションを追加"
+```

--- a/docs/superpowers/specs/2026-05-08-strategy-param-externalization-design.md
+++ b/docs/superpowers/specs/2026-05-08-strategy-param-externalization-design.md
@@ -1,0 +1,179 @@
+# Strategy Parameter Externalization (Remaining 4 Constants) Design
+
+## Goal
+
+`signal_generator.py` に残るハードコード定数 4 件を `config/strategy_config.yaml` の `sector:` / `regime:` セクションから runtime 読み込みに変更し、再起動不要でパラメータを変更できるようにする。
+
+## Background
+
+`_load_strategy_config()` と `strategy_config.yaml` はすでに実装済みで、`weights` / `threshold` / `stop_loss_rate` など主要パラメータはすでに外出し済み。残るハードコードは 4 定数のみ。
+
+| 定数 | 値 | 用途 |
+|------|----|------|
+| `_SECTOR_BOOST` | 0.03 | 上位セクター銘柄への final_score 加算量 |
+| `_SECTOR_QUARTILE` | 0.25 | セクター上位・下位の区切り割合 |
+| `_TOPIX_DRAWDOWN_THRESHOLD` | -0.15 | TOPIX 200MA 乖離率の地合い悪化判定閾値 |
+| `_TOPIX_SIZE_MULTIPLIER_BEAR` | 0.5 | 地合い悪化時の size_multiplier |
+
+## Architecture
+
+既存の `_load_strategy_config()` パターンを踏襲する。YAML に `sector:` / `regime:` セクションを追加し、返却 dict は既存の flat 構造に 4 キーを追加する。ヘルパー関数には明示的パラメータとして渡す。
+
+## Changes
+
+### 1. `config/strategy_config.yaml`
+
+```yaml
+sector:
+  boost: 0.03       # 上位セクター銘柄への final_score 加算量（≥ 0）
+  quartile: 0.25    # 上位・下位の区切り割合（0 < x < 1）
+
+regime:
+  topix_drawdown_threshold: -0.15   # TOPIX 200MA 乖離率の地合い悪化判定閾値（< 0）
+  topix_size_multiplier_bear: 0.5   # 地合い悪化時の size_multiplier（0 < x ≤ 1）
+```
+
+### 2. `src/kabusys/strategy/signal_generator.py`
+
+**`_STRATEGY_CONFIG_DEFAULTS` に 4 キー追加：**
+
+```python
+_STRATEGY_CONFIG_DEFAULTS: dict = {
+    # 既存キー（変更なし）
+    "weights": {k: v for k, v in _DEFAULT_WEIGHTS.items()},
+    "threshold": _DEFAULT_THRESHOLD,
+    "stop_loss_rate": _STOP_LOSS_RATE,
+    "gap_up_threshold": _GAP_UP_THRESHOLD,
+    "gap_down_threshold": _GAP_DOWN_THRESHOLD,
+    "min_holding_days": _MIN_HOLDING_DAYS,
+    "max_holding_days": _MAX_HOLDING_DAYS,
+    "trailing_stop_atr_mult": _TRAILING_STOP_ATR_MULT,
+    "reentry_cooldown_days": _REENTRY_COOLDOWN_DAYS,
+    # 追加
+    "sector_boost": _SECTOR_BOOST,
+    "sector_quartile": _SECTOR_QUARTILE,
+    "topix_drawdown_threshold": _TOPIX_DRAWDOWN_THRESHOLD,
+    "topix_size_multiplier_bear": _TOPIX_SIZE_MULTIPLIER_BEAR,
+}
+```
+
+**`_load_strategy_config()` に `sector:` / `regime:` セクション解析を追加：**
+
+```python
+# sector セクション
+sec = data.get("sector")
+if isinstance(sec, dict):
+    v = sec.get("boost")
+    if v is not None and isinstance(v, (int, float)) and not isinstance(v, bool) \
+            and math.isfinite(float(v)) and float(v) >= 0:
+        result["sector_boost"] = float(v)
+
+    v = sec.get("quartile")
+    if v is not None and isinstance(v, (int, float)) and not isinstance(v, bool) \
+            and math.isfinite(float(v)) and 0.0 < float(v) < 1.0:
+        result["sector_quartile"] = float(v)
+
+# regime セクション
+reg = data.get("regime")
+if isinstance(reg, dict):
+    v = reg.get("topix_drawdown_threshold")
+    if v is not None and isinstance(v, (int, float)) and not isinstance(v, bool) \
+            and math.isfinite(float(v)) and float(v) < 0:
+        result["topix_drawdown_threshold"] = float(v)
+
+    v = reg.get("topix_size_multiplier_bear")
+    if v is not None and isinstance(v, (int, float)) and not isinstance(v, bool) \
+            and math.isfinite(float(v)) and 0.0 < float(v) <= 1.0:
+        result["topix_size_multiplier_bear"] = float(v)
+```
+
+**`_calc_sector_strengths()` シグネチャ変更：**
+
+```python
+def _calc_sector_strengths(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date,
+    sector_quartile: float = _SECTOR_QUARTILE,
+) -> tuple[frozenset[str], frozenset[str], dict[str, str]]:
+    ...
+    top_n = max(1, math.ceil(n * sector_quartile))
+    bottom_n = max(1, math.ceil(n * sector_quartile))
+```
+
+**`_get_topix_size_multiplier()` シグネチャ変更：**
+
+```python
+def _get_topix_size_multiplier(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date,
+    drawdown_threshold: float = _TOPIX_DRAWDOWN_THRESHOLD,
+    size_multiplier_bear: float = _TOPIX_SIZE_MULTIPLIER_BEAR,
+) -> float:
+    ...
+    if ma200 > 0 and (close / ma200 - 1.0) < drawdown_threshold:
+        return size_multiplier_bear
+```
+
+**`generate_signals()` 内での渡し方：**
+
+```python
+_cfg = _load_strategy_config()
+# 既存（変更なし）
+threshold = _cfg["threshold"]
+weights = _cfg["weights"]
+...
+# 追加
+sector_boost = _cfg["sector_boost"]
+
+top_sectors, bottom_sectors, sector_map = _calc_sector_strengths(
+    conn, target_date, sector_quartile=_cfg["sector_quartile"]
+)
+
+topix_multiplier = _get_topix_size_multiplier(
+    conn, target_date,
+    drawdown_threshold=_cfg["topix_drawdown_threshold"],
+    size_multiplier_bear=_cfg["topix_size_multiplier_bear"],
+)
+
+# final_score 補正箇所
+final_score += sector_boost  # _SECTOR_BOOST → sector_boost
+```
+
+### 3. テスト — `tests/test_signal_generator.py`
+
+既存の `_load_strategy_config` テストパターンを踏襲し、以下を追加する。
+
+**設定読み込みテスト：**
+- `sector:` / `regime:` セクション正常値 → 各キーが設定値で返る
+- `sector.boost = -0.01`（負値）→ デフォルト `0.03` にフォールバック
+- `sector.quartile = 0.0`（境界値 = 0）→ デフォルト `0.25` にフォールバック
+- `sector.quartile = 1.0`（境界値 = 1）→ デフォルト `0.25` にフォールバック
+- `regime.topix_drawdown_threshold = 0.10`（正値）→ デフォルト `-0.15` にフォールバック
+- `regime.topix_size_multiplier_bear = 1.5`（> 1）→ デフォルト `0.5` にフォールバック
+- `sector:` セクション欠落 → デフォルト値が使われる
+- `regime:` セクション欠落 → デフォルト値が使われる
+
+**ヘルパー関数テスト：**
+- `_calc_sector_strengths(conn, date, sector_quartile=0.5)` → top/bottom セクター数が増える
+- `_get_topix_size_multiplier(conn, date, drawdown_threshold=-0.01, size_multiplier_bear=0.3)` → TOPIX データがあれば `0.3` を返す
+
+## Validation Rules
+
+| キー | 有効範囲 | 不正時の挙動 |
+|------|---------|------------|
+| `sector_boost` | float ≥ 0、finite | デフォルト `0.03` |
+| `sector_quartile` | float、0 < x < 1、finite | デフォルト `0.25` |
+| `topix_drawdown_threshold` | float < 0、finite | デフォルト `-0.15` |
+| `topix_size_multiplier_bear` | float、0 < x ≤ 1、finite | デフォルト `0.5` |
+
+## Files
+
+- Modify: `config/strategy_config.yaml`
+- Modify: `src/kabusys/strategy/signal_generator.py`
+- Modify: `tests/test_signal_generator.py`
+
+## Out of Scope
+
+- breadth_stop の 35% 閾値（DB の `market_breadth.breadth_stop` フラグとして管理されており、本 Issue では変更しない）
+- `value_score:` セクションの変更（既存の `_load_value_config()` で対応済み）
+- UI / Streamlit からのパラメータ変更機能（Issue #233 の範囲）

--- a/docs/superpowers/specs/2026-05-09-ai-wizard-chat-design.md
+++ b/docs/superpowers/specs/2026-05-09-ai-wizard-chat-design.md
@@ -1,0 +1,196 @@
+# AI Co-Pilot ウィザード（Phase 1-3）設計仕様
+
+## Goal
+
+`10_Strategy_Lab.py` に「AI Co-Pilot」タブを追加し、最新バックテスト結果をコンテキストとして OpenAI API に注入しながら、戦略パラメータのチューニング提案をチャット形式で行えるようにする。パラメータの自動反映・バックテスト再実行（Phase 4）は別 Issue とする。
+
+## スコープ
+
+### 含む（Phase 1-3）
+- `backtest_summarizer.py`: DuckDB `backtest_runs` から最新1件の要約 Markdown 生成
+- `components/ai_wizard.py`: 再利用可能な Streamlit チャットコンポーネント
+- `10_Strategy_Lab.py`: 「AI Co-Pilot」タブ追加
+- `monitoring.db`: `ai_wizard_messages` テーブルによる履歴永続化
+- `schema.py`: DDL 追加
+- OpenAI ストリーミング表示（`st.write_stream`）
+
+### 含まない（Phase 4 / 別 Issue）
+- AI 提案パラメータの `strategy_config.yaml` 自動反映
+- バックテスト再実行ループ
+- 変更前バックアップ・変更可能キー制限
+
+## アーキテクチャ
+
+```
+10_Strategy_Lab.py
+    └─ components/ai_wizard.render(duckdb_conn, sqlite_conn)
+            ├─ backtest_summarizer.load_latest_summary(duckdb_conn) → Markdown
+            ├─ monitoring_db: ai_wizard_messages 読み書き
+            └─ OpenAI API (gpt-4o) ストリーミング
+```
+
+## ファイル構成
+
+| 操作 | ファイル |
+|------|---------|
+| 新規 | `src/kabusys/ai/backtest_summarizer.py` |
+| 新規 | `src/kabusys/monitoring/components/__init__.py` |
+| 新規 | `src/kabusys/monitoring/components/ai_wizard.py` |
+| 変更 | `src/kabusys/data/schema.py` |
+| 変更 | `src/kabusys/monitoring/monitoring_db.py` |
+| 変更 | `src/kabusys/monitoring/pages/10_Strategy_Lab.py` |
+| 新規 | `tests/test_backtest_summarizer.py` |
+| 新規 | `tests/test_ai_wizard.py` |
+| 変更 | `tests/test_monitoring_db.py` |
+
+## データ層
+
+### `ai_wizard_messages` テーブル（monitoring.db / SQLite）
+
+```sql
+CREATE TABLE IF NOT EXISTS ai_wizard_messages (
+    id          INTEGER   PRIMARY KEY AUTOINCREMENT,
+    session_id  TEXT      NOT NULL,
+    role        TEXT      NOT NULL CHECK (role IN ('user', 'assistant', 'system')),
+    content     TEXT      NOT NULL,
+    created_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+- `session_id`: `st.session_state` に UUID を持たせ、同一ブラウザセッションを束ねる
+- ページリロード時は同じ `session_id` で履歴を復元する
+- 「🗑 履歴クリア」ボタンで当該 `session_id` の行を全削除する
+
+### `backtest_summarizer.py`
+
+```python
+def load_latest_summary(conn: duckdb.DuckDBPyConnection) -> str | None:
+    """backtest_runs の最新1件から system prompt 用 Markdown を生成する。
+
+    バックテスト結果がない場合は None を返す。
+    params_json が不正な場合はパラメータ行をスキップし、クラッシュしない。
+    """
+```
+
+注入するコンテキスト例：
+
+```markdown
+## 最新バックテスト結果（run_id: abc123, 2026-01-01〜2026-04-30）
+
+| 指標 | 値 |
+|------|-----|
+| CAGR | +12.3% |
+| Sharpe Ratio | 1.45 |
+| Max Drawdown | -8.2% |
+| Win Rate | 58.3% |
+| Payoff Ratio | 1.82 |
+| Profit Factor | 2.10 |
+| Total Trades | 142 |
+
+### 戦略パラメータ
+**購入ロジック**: weights={momentum: 0.40, value: 0.30, quality: 0.20, ai: 0.10},
+threshold=0.60, sector_boost=0.03, sector_quartile=0.25
+
+**リスク・フィルター**: stop_loss_rate=-0.08, trailing_stop_atr_mult=2.0,
+gap_up_threshold=0.04, gap_down_threshold=-0.04,
+min_holding_days=5, max_holding_days=60,
+topix_drawdown_threshold=-0.15, topix_size_multiplier_bear=0.5
+```
+
+## コンポーネント層
+
+### `components/ai_wizard.py`
+
+```python
+def render(
+    duckdb_conn: duckdb.DuckDBPyConnection,
+    sqlite_conn: sqlite3.Connection,
+) -> None:
+    """AI Co-Pilot チャット UI を Streamlit に描画する。"""
+```
+
+**処理フロー：**
+
+1. `session_id` を `st.session_state` に UUID で初期化（初回のみ）
+2. SQLite から当該 `session_id` の履歴を読み込み `st.chat_message` で表示
+3. `OPENAI_API_KEY` 未設定 → `st.error("OPENAI_API_KEY が設定されていません。環境変数を設定してください。")` で処理終了
+4. `load_latest_summary(duckdb_conn)` で system prompt 生成
+   - 結果なし → バックテスト未実行の旨を system prompt に記載（チャットは動作する）
+5. `st.chat_input("KabuSysの戦略について質問してください")` でユーザー入力受付
+6. ユーザーメッセージ → SQLite 保存 → OpenAI API 呼び出し
+7. `st.write_stream` でレスポンスをストリーミング表示
+8. アシスタントメッセージ → SQLite 保存
+
+**system prompt テンプレート：**
+
+```
+あなたは KabuSys の戦略チューニング・アシスタントです。
+以下のバックテスト結果を踏まえ、購入ロジック（weights / threshold / sector パラメータ）および
+リスク・フィルターロジック（stop_loss / trailing_stop / gap / holding_days / topix パラメータ）の
+改善案を提案してください。回答は簡潔な日本語で行い、具体的な数値変更案を含めてください。
+
+{backtest_summary_markdown}
+```
+
+**サイドバー：**
+- 「🗑 履歴クリア」ボタン → 当該 `session_id` の SQLite レコードを削除し `st.rerun()`
+
+### `10_Strategy_Lab.py` の変更
+
+既存の `tab_regime, tab_ai, tab_signals = st.tabs(...)` に `tab_copilot` を追加：
+
+```python
+# ファイル先頭のインポート追加
+import sqlite3
+from kabusys.monitoring.components.ai_wizard import render as render_wizard
+
+# タブ定義（既存3タブに追加）
+tab_regime, tab_ai, tab_signals, tab_copilot = st.tabs(
+    ["市場レジーム", "AI スコア", "シグナル推移", "🤖 AI Co-Pilot"]
+)
+
+with tab_copilot:
+    sqlite_conn = sqlite3.connect(str(settings.sqlite_path))
+    try:
+        render_wizard(conn, sqlite_conn)
+    finally:
+        sqlite_conn.close()
+```
+
+## テスト方針
+
+### `tests/test_backtest_summarizer.py`
+
+- `backtest_runs` にデータあり → Markdown に CAGR / Sharpe / Max Drawdown が含まれる
+- `backtest_runs` にデータあり → 購入ロジック・フィルターロジック両方のパラメータが含まれる
+- `backtest_runs` が空 → `None` を返す
+- `params_json` が不正な JSON → クラッシュせず、パラメータ行なしで返す
+
+### `tests/test_ai_wizard.py`
+
+- `OPENAI_API_KEY` 未設定時 → `st.error` が呼ばれ、チャット入力が表示されない
+- `session_id` が `st.session_state` に UUID として初期化される
+- SQLite 履歴の保存・読み込みラウンドトリップ
+- OpenAI API 呼び出しは `unittest.mock.patch` でモック（`news_nlp._call_openai_api` と同パターン）
+- 履歴クリア → SQLite の当該 `session_id` レコードが削除される
+
+### `tests/test_monitoring_db.py` への追加
+
+- `ai_wizard_messages` テーブルの作成・INSERT・SELECT・DELETE スモークテスト
+
+## バリデーション
+
+| 条件 | 挙動 |
+|------|------|
+| `OPENAI_API_KEY` 未設定 | `st.error` 表示、チャット入力非表示 |
+| `backtest_runs` が空 | system prompt に「バックテスト未実行」旨を記載、チャットは動作 |
+| `params_json` が不正 JSON | パラメータ行をスキップ、Markdown の他部分は正常出力 |
+| OpenAI API エラー | `st.error` でエラー内容を表示、履歴への保存はスキップ |
+
+## Out of Scope
+
+- パラメータ自動反映・バックテスト再実行（Phase 4 / 別 Issue）
+- 設定ファイル変更前バックアップ（Phase 4 / 別 Issue）
+- 変更可能キーの制限・破壊的変更防止（Phase 4 / 別 Issue）
+- 複数バックテスト実行の比較・選択 UI
+- LINE / メール通知との連携

--- a/docs/superpowers/specs/2026-05-09-ai-wizard-chat-design.md
+++ b/docs/superpowers/specs/2026-05-09-ai-wizard-chat-design.md
@@ -36,8 +36,7 @@
 | 新規 | `src/kabusys/ai/backtest_summarizer.py` |
 | 新規 | `src/kabusys/monitoring/components/__init__.py` |
 | 新規 | `src/kabusys/monitoring/components/ai_wizard.py` |
-| 変更 | `src/kabusys/data/schema.py` |
-| 変更 | `src/kabusys/monitoring/monitoring_db.py` |
+| 変更 | `src/kabusys/monitoring/monitoring_db.py`（`init_monitoring_db` に DDL 追加、`schema.py` 変更なし） |
 | 変更 | `src/kabusys/monitoring/pages/10_Strategy_Lab.py` |
 | 新規 | `tests/test_backtest_summarizer.py` |
 | 新規 | `tests/test_ai_wizard.py` |

--- a/src/kabusys/ai/backtest_summarizer.py
+++ b/src/kabusys/ai/backtest_summarizer.py
@@ -1,0 +1,109 @@
+"""backtest_summarizer.py — バックテスト結果から AI system prompt 用 Markdown を生成する。"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import duckdb
+
+logger = logging.getLogger(__name__)
+
+
+def load_latest_summary(conn: duckdb.DuckDBPyConnection) -> str | None:
+    """backtest_runs の最新1件から system prompt 用 Markdown を生成する。
+
+    バックテスト結果がない場合は None を返す。
+    params_json が不正な場合はパラメータ行をスキップし、クラッシュしない。
+
+    Args:
+        conn: DuckDB 接続。backtest_runs テーブルを参照する。
+
+    Returns:
+        Markdown 形式の文字列、またはデータなしの場合は None。
+    """
+    try:
+        row = conn.execute("""
+            SELECT run_id, start_date, end_date,
+                   cagr, sharpe, max_drawdown, win_rate,
+                   payoff_ratio, profit_factor, total_trades,
+                   params_json
+            FROM backtest_runs
+            ORDER BY created_at DESC
+            LIMIT 1
+        """).fetchone()
+    except Exception as e:
+        logger.warning("load_latest_summary: backtest_runs 読み込みエラー: %s", e)
+        return None
+
+    if row is None:
+        return None
+
+    run_id = str(row[0])
+    start_date = str(row[1])
+    end_date = str(row[2])
+    cagr: float | None = row[3]
+    sharpe: float | None = row[4]
+    max_dd: float | None = row[5]
+    win_rate: float | None = row[6]
+    payoff: float | None = row[7]
+    profit_factor: float | None = row[8]
+    total_trades: int | None = row[9]
+    params_json_str: str | None = row[10]
+
+    def _pct(v: float | None) -> str:
+        return f"{v:+.2%}" if v is not None else "N/A"
+
+    def _f(v: float | None, prec: int = 3) -> str:
+        return f"{v:.{prec}f}" if v is not None else "N/A"
+
+    lines = [
+        f"## 最新バックテスト結果（run_id: {run_id}, {start_date}〜{end_date}）",
+        "",
+        "| 指標 | 値 |",
+        "|------|-----|",
+        f"| CAGR | {_pct(cagr)} |",
+        f"| Sharpe Ratio | {_f(sharpe)} |",
+        f"| Max Drawdown | {_pct(max_dd)} |",
+        f"| Win Rate | {_pct(win_rate)} |",
+        f"| Payoff Ratio | {_f(payoff)} |",
+        f"| Profit Factor | {_f(profit_factor)} |",
+        f"| Total Trades | {total_trades if total_trades is not None else 'N/A'} |",
+    ]
+
+    params: dict = {}
+    if params_json_str:
+        try:
+            parsed = json.loads(params_json_str)
+            if isinstance(parsed, dict):
+                params = parsed
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("load_latest_summary: params_json のパースに失敗しました")
+
+    if params:
+        weights = params.get("weights", {})
+        buy_parts = [
+            f"weights={weights}",
+            f"threshold={params.get('threshold', 'N/A')}",
+            f"sector_boost={params.get('sector_boost', 'N/A')}",
+            f"sector_quartile={params.get('sector_quartile', 'N/A')}",
+        ]
+        risk_parts = [
+            f"stop_loss_rate={params.get('stop_loss_rate', 'N/A')}",
+            f"trailing_stop_atr_mult={params.get('trailing_stop_atr_mult', 'N/A')}",
+            f"gap_up_threshold={params.get('gap_up_threshold', 'N/A')}",
+            f"gap_down_threshold={params.get('gap_down_threshold', 'N/A')}",
+            f"min_holding_days={params.get('min_holding_days', 'N/A')}",
+            f"max_holding_days={params.get('max_holding_days', 'N/A')}",
+            f"topix_drawdown_threshold={params.get('topix_drawdown_threshold', 'N/A')}",
+            f"topix_size_multiplier_bear={params.get('topix_size_multiplier_bear', 'N/A')}",
+        ]
+        lines += [
+            "",
+            "### 戦略パラメータ",
+            f"**購入ロジック**: {', '.join(buy_parts)}",
+            "",
+            f"**リスク・フィルター**: {', '.join(risk_parts)}",
+        ]
+
+    return "\n".join(lines)

--- a/src/kabusys/monitoring/components/ai_wizard.py
+++ b/src/kabusys/monitoring/components/ai_wizard.py
@@ -1,0 +1,114 @@
+"""ai_wizard.py — AI Co-Pilot チャットコンポーネント（再利用可能）。"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import uuid
+from typing import Generator
+
+import duckdb
+import streamlit as st
+from openai import OpenAI
+
+from kabusys.ai.backtest_summarizer import load_latest_summary
+from kabusys.monitoring.monitoring_db import MonitoringDB
+
+_MODEL = "gpt-4o"
+
+_SYSTEM_PROMPT_TEMPLATE = """\
+あなたは KabuSys の戦略チューニング・アシスタントです。
+以下のバックテスト結果を踏まえ、購入ロジック（weights / threshold / sector パラメータ）および
+リスク・フィルターロジック（stop_loss / trailing_stop / gap / holding_days / topix パラメータ）の
+改善案を提案してください。回答は簡潔な日本語で行い、具体的な数値変更案を含めてください。
+
+{context}"""
+
+_NO_DATA_CONTEXT = (
+    "バックテスト結果がまだありません。一般的な戦略チューニングについて質問できます。"
+)
+
+
+def _stream_openai_response(
+    client: OpenAI,
+    messages: list[dict],
+) -> Generator[str, None, None]:
+    """OpenAI Chat Completions API をストリーミングで呼び出す。
+
+    テスト時は
+    unittest.mock.patch("kabusys.monitoring.components.ai_wizard._stream_openai_response")
+    で差し替える。
+
+    Yields:
+        各チャンクのテキスト断片（content が None のチャンクはスキップ）。
+    """
+    stream = client.chat.completions.create(
+        model=_MODEL,
+        messages=messages,
+        stream=True,
+    )
+    for chunk in stream:
+        content = chunk.choices[0].delta.content
+        if content:
+            yield content
+
+
+def render(
+    duckdb_conn: duckdb.DuckDBPyConnection,
+    sqlite_conn: sqlite3.Connection,
+) -> None:
+    """AI Co-Pilot チャット UI を Streamlit に描画する。
+
+    Args:
+        duckdb_conn: DuckDB 接続（read_only=True 推奨）。backtest_runs を参照する。
+        sqlite_conn: SQLite 接続（monitoring.db）。ai_wizard_messages を読み書きする。
+    """
+    if "wizard_session_id" not in st.session_state:
+        st.session_state["wizard_session_id"] = str(uuid.uuid4())
+    session_id: str = st.session_state["wizard_session_id"]
+
+    db = MonitoringDB(sqlite_conn)
+
+    with st.sidebar:
+        if st.button("🗑 履歴クリア", key="wizard_clear"):
+            db.clear_wizard_messages(session_id)
+            st.session_state["wizard_session_id"] = str(uuid.uuid4())
+            st.rerun()
+
+    # st.rerun() が呼ばれなかった場合 (= ボタンを押さなかった場合) でも
+    # session_state が更新されている可能性があるため、再取得する。
+    session_id = st.session_state["wizard_session_id"]
+
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        st.error("OPENAI_API_KEY が設定されていません。環境変数を設定してください。")
+        return
+
+    summary = load_latest_summary(duckdb_conn)
+    context = summary if summary is not None else _NO_DATA_CONTEXT
+    system_prompt = _SYSTEM_PROMPT_TEMPLATE.format(context=context)
+
+    history = db.load_wizard_messages(session_id)
+    for msg in history:
+        with st.chat_message(msg["role"]):
+            st.write(msg["content"])
+
+    user_input = st.chat_input("KabuSysの戦略について質問してください")
+    if not user_input:
+        return
+
+    with st.chat_message("user"):
+        st.write(user_input)
+    db.save_wizard_message(session_id, "user", user_input)
+
+    client = OpenAI(api_key=api_key)
+    messages: list[dict] = [{"role": "system", "content": system_prompt}]
+    messages += [{"role": m["role"], "content": m["content"]} for m in history]
+    messages.append({"role": "user", "content": user_input})
+
+    try:
+        with st.chat_message("assistant"):
+            response_text = st.write_stream(_stream_openai_response(client, messages))
+        db.save_wizard_message(session_id, "assistant", str(response_text))
+    except Exception as e:
+        st.error(f"OpenAI API エラー: {e}")

--- a/src/kabusys/monitoring/components/ai_wizard.py
+++ b/src/kabusys/monitoring/components/ai_wizard.py
@@ -71,20 +71,22 @@ def render(
 
     db = MonitoringDB(sqlite_conn)
 
-    with st.sidebar:
-        if st.button("🗑 履歴クリア", key="wizard_clear"):
-            db.clear_wizard_messages(session_id)
-            st.session_state["wizard_session_id"] = str(uuid.uuid4())
-            st.rerun()
-
-    # st.rerun() が呼ばれなかった場合 (= ボタンを押さなかった場合) でも
-    # session_state が更新されている可能性があるため、再取得する。
-    session_id = st.session_state["wizard_session_id"]
-
     api_key = os.environ.get("OPENAI_API_KEY") or st.secrets.get("OPENAI_API_KEY", None)
     if not api_key:
-        st.error("OPENAI_API_KEY が設定されていません。環境変数を設定してください。")
+        st.error(
+            "OPENAI_API_KEY が設定されていません。"
+            "環境変数または st.secrets に設定してください。"
+        )
         return
+
+    # 履歴クリアボタンをタブ内に配置（sidebar は全タブで常時表示されるため）
+    if st.button("🗑 履歴クリア", key="wizard_clear"):
+        db.clear_wizard_messages(session_id)
+        st.session_state["wizard_session_id"] = str(uuid.uuid4())
+        st.rerun()
+
+    # st.rerun() が呼ばれなかった場合でも session_state を再取得する
+    session_id = st.session_state["wizard_session_id"]
 
     summary = load_latest_summary(duckdb_conn)
     context = summary if summary is not None else _NO_DATA_CONTEXT
@@ -114,7 +116,9 @@ def render(
         if response_text:
             db.save_wizard_message(session_id, "assistant", str(response_text))
     except Exception:
-        _logger.exception("OpenAI API 呼び出しに失敗しました")
+        _logger.exception(
+            "OpenAI API 呼び出しに失敗しました (session_id=%s)", session_id
+        )
         st.error(
             "OpenAI API の呼び出しに失敗しました。しばらく経ってから再度お試しください。"
         )

--- a/src/kabusys/monitoring/components/ai_wizard.py
+++ b/src/kabusys/monitoring/components/ai_wizard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import sqlite3
 import uuid
@@ -14,6 +15,7 @@ from openai import OpenAI
 from kabusys.ai.backtest_summarizer import load_latest_summary
 from kabusys.monitoring.monitoring_db import MonitoringDB
 
+_logger = logging.getLogger(__name__)
 _MODEL = "gpt-4o"
 
 _SYSTEM_PROMPT_TEMPLATE = """\
@@ -79,7 +81,7 @@ def render(
     # session_state が更新されている可能性があるため、再取得する。
     session_id = st.session_state["wizard_session_id"]
 
-    api_key = os.environ.get("OPENAI_API_KEY")
+    api_key = os.environ.get("OPENAI_API_KEY") or st.secrets.get("OPENAI_API_KEY", None)
     if not api_key:
         st.error("OPENAI_API_KEY が設定されていません。環境変数を設定してください。")
         return
@@ -109,6 +111,10 @@ def render(
     try:
         with st.chat_message("assistant"):
             response_text = st.write_stream(_stream_openai_response(client, messages))
-        db.save_wizard_message(session_id, "assistant", str(response_text))
-    except Exception as e:
-        st.error(f"OpenAI API エラー: {e}")
+        if response_text:
+            db.save_wizard_message(session_id, "assistant", str(response_text))
+    except Exception:
+        _logger.exception("OpenAI API 呼び出しに失敗しました")
+        st.error(
+            "OpenAI API の呼び出しに失敗しました。しばらく経ってから再度お試しください。"
+        )

--- a/src/kabusys/monitoring/monitoring_db.py
+++ b/src/kabusys/monitoring/monitoring_db.py
@@ -77,6 +77,16 @@ def init_monitoring_db(conn: sqlite3.Connection) -> None:
             position_count   INTEGER NOT NULL,
             peak_value       REAL
         );
+
+        CREATE TABLE IF NOT EXISTS ai_wizard_messages (
+            id          INTEGER   PRIMARY KEY AUTOINCREMENT,
+            session_id  TEXT      NOT NULL,
+            role        TEXT      NOT NULL CHECK (role IN ('user', 'assistant', 'system')),
+            content     TEXT      NOT NULL,
+            created_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE INDEX IF NOT EXISTS idx_wizard_messages_session
+            ON ai_wizard_messages (session_id, created_at);
     """)
     conn.commit()
 
@@ -309,3 +319,32 @@ class MonitoringDB:
         cursor = self._conn.execute("SELECT * FROM dashboard WHERE id = 1")
         row = cursor.fetchone()
         return dict(row) if row else None
+
+    def save_wizard_message(self, session_id: str, role: str, content: str) -> None:
+        """AI ウィザードの発言を ai_wizard_messages テーブルに保存する。"""
+        self._conn.execute(
+            "INSERT INTO ai_wizard_messages (session_id, role, content) VALUES (?, ?, ?)",
+            (session_id, role, content),
+        )
+        self._conn.commit()
+
+    def load_wizard_messages(self, session_id: str) -> list[dict]:
+        """session_id に紐づく発言履歴を時系列順で返す。
+
+        Returns:
+            [{"role": "user"|"assistant", "content": "..."}, ...]
+        """
+        rows = self._conn.execute(
+            "SELECT role, content FROM ai_wizard_messages "
+            "WHERE session_id = ? ORDER BY created_at ASC",
+            (session_id,),
+        ).fetchall()
+        return [{"role": row["role"], "content": row["content"]} for row in rows]
+
+    def clear_wizard_messages(self, session_id: str) -> None:
+        """session_id に紐づく全発言を削除する。"""
+        self._conn.execute(
+            "DELETE FROM ai_wizard_messages WHERE session_id = ?",
+            (session_id,),
+        )
+        self._conn.commit()

--- a/src/kabusys/monitoring/monitoring_db.py
+++ b/src/kabusys/monitoring/monitoring_db.py
@@ -81,12 +81,14 @@ def init_monitoring_db(conn: sqlite3.Connection) -> None:
         CREATE TABLE IF NOT EXISTS ai_wizard_messages (
             id          INTEGER   PRIMARY KEY AUTOINCREMENT,
             session_id  TEXT      NOT NULL,
+            -- 現在は user/assistant のみ使用。system は将来の拡張用。
             role        TEXT      NOT NULL CHECK (role IN ('user', 'assistant', 'system')),
             content     TEXT      NOT NULL,
             created_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
         );
+        -- id は挿入順を保証するため ORDER BY id ASC で利用する
         CREATE INDEX IF NOT EXISTS idx_wizard_messages_session
-            ON ai_wizard_messages (session_id, created_at);
+            ON ai_wizard_messages (session_id, id);
     """)
     conn.commit()
 
@@ -336,7 +338,7 @@ class MonitoringDB:
         """
         rows = self._conn.execute(
             "SELECT role, content FROM ai_wizard_messages "
-            "WHERE session_id = ? ORDER BY created_at ASC",
+            "WHERE session_id = ? ORDER BY id ASC",
             (session_id,),
         ).fetchall()
         return [{"role": row["role"], "content": row["content"]} for row in rows]

--- a/src/kabusys/monitoring/monitoring_db.py
+++ b/src/kabusys/monitoring/monitoring_db.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta, timezone
 
 
 def init_monitoring_db(conn: sqlite3.Connection) -> None:
-    """5テーブル + インデックスを作成する（冪等）。"""
+    """6テーブル + インデックスを作成する（冪等）。"""
     conn.executescript("""
         CREATE TABLE IF NOT EXISTS system_status (
             id             INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/kabusys/monitoring/pages/10_Strategy_Lab.py
+++ b/src/kabusys/monitoring/pages/10_Strategy_Lab.py
@@ -9,6 +9,7 @@ import streamlit as st
 
 from kabusys.config import Settings
 from kabusys.monitoring.components.ai_wizard import render as render_wizard
+from kabusys.monitoring.monitoring_db import init_monitoring_db
 from kabusys.monitoring.strategy_lab_data import (
     load_ai_scores,
     load_market_regime,
@@ -78,6 +79,7 @@ try:
     with tab_copilot:
         sqlite_conn = sqlite3.connect(str(settings.sqlite_path))
         try:
+            init_monitoring_db(sqlite_conn)
             render_wizard(conn, sqlite_conn)
         finally:
             sqlite_conn.close()

--- a/src/kabusys/monitoring/pages/10_Strategy_Lab.py
+++ b/src/kabusys/monitoring/pages/10_Strategy_Lab.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import sqlite3
+
 import duckdb
 import streamlit as st
 
 from kabusys.config import Settings
+from kabusys.monitoring.components.ai_wizard import render as render_wizard
 from kabusys.monitoring.strategy_lab_data import (
     load_ai_scores,
     load_market_regime,
@@ -29,8 +32,8 @@ except Exception as e:
     st.stop()
 
 try:
-    tab_regime, tab_ai, tab_signals = st.tabs(
-        ["市場レジーム", "AI スコア", "シグナル推移"]
+    tab_regime, tab_ai, tab_signals, tab_copilot = st.tabs(
+        ["市場レジーム", "AI スコア", "シグナル推移", "🤖 AI Co-Pilot"]
     )
 
     with tab_regime:
@@ -71,5 +74,12 @@ try:
             col2.metric(f"売りシグナル合計（{days}日）", total_sell)
             st.subheader("日別シグナル件数")
             st.bar_chart(df.set_index("date")[["buy_count", "sell_count"]])
+
+    with tab_copilot:
+        sqlite_conn = sqlite3.connect(str(settings.sqlite_path))
+        try:
+            render_wizard(conn, sqlite_conn)
+        finally:
+            sqlite_conn.close()
 finally:
     conn.close()

--- a/src/kabusys/monitoring/pages/10_Strategy_Lab.py
+++ b/src/kabusys/monitoring/pages/10_Strategy_Lab.py
@@ -1,4 +1,4 @@
-"""pages/4_Strategy_Lab.py — 市場レジーム・AI スコア・戦略状態ビュー。"""
+"""pages/10_Strategy_Lab.py — 市場レジーム・AI スコア・戦略状態ビュー。"""
 
 from __future__ import annotations
 

--- a/tests/test_ai_wizard.py
+++ b/tests/test_ai_wizard.py
@@ -51,6 +51,7 @@ def _make_st_mock(session_state=None):
     mock_st.chat_message.return_value.__enter__ = MagicMock(return_value=None)
     mock_st.chat_message.return_value.__exit__ = MagicMock(return_value=False)
     mock_st.chat_input.return_value = None
+    mock_st.secrets.get.return_value = None  # API key not in st.secrets by default
     return mock_st
 
 
@@ -156,6 +157,33 @@ class TestRenderWithApiKey:
         assert msgs[0]["role"] == "user"
         assert msgs[0]["content"] == "ドローダウンを改善したい"
         assert msgs[1]["role"] == "assistant"
+
+    def test_no_assistant_saved_when_write_stream_returns_none(
+        self, wizard_duckdb, wizard_sqlite
+    ):
+        """write_stream が None を返した場合、assistant メッセージは SQLite に保存しない。"""
+        import kabusys.monitoring.components.ai_wizard as mod
+
+        state: dict = {}
+        mock_st = _make_st_mock(session_state=state)
+        mock_st.chat_input.return_value = "質問"
+        mock_st.write_stream.return_value = None  # simulate empty stream
+
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            with patch.object(mod, "st", mock_st):
+                with patch(
+                    "kabusys.monitoring.components.ai_wizard._stream_openai_response",
+                    return_value=iter([]),
+                ):
+                    with patch("kabusys.monitoring.components.ai_wizard.OpenAI"):
+                        mod.render(wizard_duckdb, wizard_sqlite)
+
+        session_id = state["wizard_session_id"]
+        db = MonitoringDB(wizard_sqlite)
+        msgs = db.load_wizard_messages(session_id)
+        # user は保存、assistant は保存しない
+        assert len(msgs) == 1
+        assert msgs[0]["role"] == "user"
 
 
 class TestHistoryClear:

--- a/tests/test_ai_wizard.py
+++ b/tests/test_ai_wizard.py
@@ -46,8 +46,6 @@ def _make_st_mock(session_state=None):
     """st モジュールのモックを生成する。"""
     mock_st = MagicMock()
     mock_st.session_state = session_state if session_state is not None else {}
-    mock_st.sidebar.__enter__ = MagicMock(return_value=None)
-    mock_st.sidebar.__exit__ = MagicMock(return_value=False)
     mock_st.chat_message.return_value.__enter__ = MagicMock(return_value=None)
     mock_st.chat_message.return_value.__exit__ = MagicMock(return_value=False)
     mock_st.chat_input.return_value = None

--- a/tests/test_ai_wizard.py
+++ b/tests/test_ai_wizard.py
@@ -154,3 +154,29 @@ class TestRenderWithApiKey:
         assert msgs[0]["role"] == "user"
         assert msgs[0]["content"] == "ドローダウンを改善したい"
         assert msgs[1]["role"] == "assistant"
+
+
+class TestHistoryClear:
+    def test_clear_button_deletes_session_messages(self, wizard_duckdb, wizard_sqlite):
+        """履歴クリアボタン押下 → SQLite の当該 session_id レコードが削除される。"""
+        import kabusys.monitoring.components.ai_wizard as mod
+
+        session_id = str(uuid.uuid4())
+        db = MonitoringDB(wizard_sqlite)
+        db.save_wizard_message(session_id, "user", "テストメッセージ")
+        assert len(db.load_wizard_messages(session_id)) == 1
+
+        state: dict = {"wizard_session_id": session_id}
+        mock_st = _make_st_mock(session_state=state)
+        mock_st.button.return_value = True  # simulate clear button click
+        mock_st.chat_input.return_value = None  # no user input
+
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            with patch.object(mod, "st", mock_st):
+                with patch(
+                    "kabusys.monitoring.components.ai_wizard.load_latest_summary",
+                    return_value=None,
+                ):
+                    mod.render(wizard_duckdb, wizard_sqlite)
+
+        assert db.load_wizard_messages(session_id) == []

--- a/tests/test_ai_wizard.py
+++ b/tests/test_ai_wizard.py
@@ -136,7 +136,9 @@ class TestRenderWithApiKey:
         state: dict = {}
         mock_st = _make_st_mock(session_state=state)
         mock_st.chat_input.return_value = "ドローダウンを改善したい"
-        mock_st.write_stream.return_value = "ATR乗数を2.0から2.5にすることを提案します。"
+        mock_st.write_stream.return_value = (
+            "ATR乗数を2.0から2.5にすることを提案します。"
+        )
 
         with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
             with patch.object(mod, "st", mock_st):

--- a/tests/test_ai_wizard.py
+++ b/tests/test_ai_wizard.py
@@ -1,0 +1,156 @@
+"""ai_wizard コンポーネント単体テスト（Issue #233）"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import uuid
+from unittest.mock import MagicMock, patch
+
+import duckdb
+import pytest
+
+from kabusys.monitoring.monitoring_db import MonitoringDB, init_monitoring_db
+
+
+@pytest.fixture
+def wizard_sqlite():
+    conn = sqlite3.connect(":memory:")
+    init_monitoring_db(conn)
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def wizard_duckdb():
+    conn = duckdb.connect(":memory:")
+    conn.execute("""
+        CREATE TABLE backtest_runs (
+            run_id VARCHAR PRIMARY KEY,
+            created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+            start_date DATE NOT NULL, end_date DATE NOT NULL,
+            initial_cash DECIMAL(18,2) NOT NULL, scope_mode VARCHAR NOT NULL,
+            scope_codes_json VARCHAR, params_json VARCHAR NOT NULL,
+            cagr DOUBLE, sharpe DOUBLE, max_drawdown DOUBLE,
+            win_rate DOUBLE, payoff_ratio DOUBLE, profit_factor DOUBLE,
+            annual_volatility DOUBLE, calmar_ratio DOUBLE,
+            avg_holding_days DOUBLE, total_trades INTEGER,
+            effective_universe_size INTEGER
+        )
+    """)
+    yield conn
+    conn.close()
+
+
+def _make_st_mock(session_state=None):
+    """st モジュールのモックを生成する。"""
+    mock_st = MagicMock()
+    mock_st.session_state = session_state if session_state is not None else {}
+    mock_st.sidebar.__enter__ = MagicMock(return_value=None)
+    mock_st.sidebar.__exit__ = MagicMock(return_value=False)
+    mock_st.chat_message.return_value.__enter__ = MagicMock(return_value=None)
+    mock_st.chat_message.return_value.__exit__ = MagicMock(return_value=False)
+    mock_st.chat_input.return_value = None
+    return mock_st
+
+
+class TestRenderApiKeyMissing:
+    def test_shows_error_when_no_api_key(self, wizard_duckdb, wizard_sqlite):
+        import kabusys.monitoring.components.ai_wizard as mod
+
+        mock_st = _make_st_mock()
+        env = {k: v for k, v in os.environ.items() if k != "OPENAI_API_KEY"}
+        with patch.dict(os.environ, env, clear=True):
+            with patch.object(mod, "st", mock_st):
+                mod.render(wizard_duckdb, wizard_sqlite)
+
+        mock_st.error.assert_called_once()
+        assert "OPENAI_API_KEY" in mock_st.error.call_args[0][0]
+
+    def test_returns_early_without_chat_input(self, wizard_duckdb, wizard_sqlite):
+        """API キー未設定時はチャット入力が表示されない（return early）。"""
+        import kabusys.monitoring.components.ai_wizard as mod
+
+        mock_st = _make_st_mock()
+        env = {k: v for k, v in os.environ.items() if k != "OPENAI_API_KEY"}
+        with patch.dict(os.environ, env, clear=True):
+            with patch.object(mod, "st", mock_st):
+                mod.render(wizard_duckdb, wizard_sqlite)
+
+        mock_st.chat_input.assert_not_called()
+
+
+class TestSessionIdInitialization:
+    def test_session_id_set_as_uuid(self, wizard_duckdb, wizard_sqlite):
+        """初回呼び出しで wizard_session_id が UUID として session_state に設定される。"""
+        import kabusys.monitoring.components.ai_wizard as mod
+
+        state: dict = {}
+        mock_st = _make_st_mock(session_state=state)
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            with patch.object(mod, "st", mock_st):
+                mod.render(wizard_duckdb, wizard_sqlite)
+
+        assert "wizard_session_id" in state
+        uuid.UUID(state["wizard_session_id"])  # 不正なら ValueError
+
+
+class TestStreamOpenaiResponse:
+    def test_yields_content_strings_and_skips_none(self):
+        """_stream_openai_response がコンテンツを yield し、None チャンクをスキップする。"""
+        from kabusys.monitoring.components.ai_wizard import _stream_openai_response
+
+        chunk1 = MagicMock()
+        chunk1.choices[0].delta.content = "テスト"
+        chunk2 = MagicMock()
+        chunk2.choices[0].delta.content = None
+        chunk3 = MagicMock()
+        chunk3.choices[0].delta.content = "回答"
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = [chunk1, chunk2, chunk3]
+
+        result = list(
+            _stream_openai_response(mock_client, [{"role": "user", "content": "test"}])
+        )
+        assert result == ["テスト", "回答"]
+
+    def test_calls_openai_with_stream_true(self):
+        """_stream_openai_response が stream=True で API を呼び出す。"""
+        from kabusys.monitoring.components.ai_wizard import _stream_openai_response
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = []
+
+        list(_stream_openai_response(mock_client, []))
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs.get("stream") is True
+
+
+class TestRenderWithApiKey:
+    def test_saves_user_and_assistant_to_sqlite(self, wizard_duckdb, wizard_sqlite):
+        """render でユーザー入力 → AI 応答が SQLite に保存される。"""
+        import kabusys.monitoring.components.ai_wizard as mod
+
+        state: dict = {}
+        mock_st = _make_st_mock(session_state=state)
+        mock_st.chat_input.return_value = "ドローダウンを改善したい"
+        mock_st.write_stream.return_value = "ATR乗数を2.0から2.5にすることを提案します。"
+
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            with patch.object(mod, "st", mock_st):
+                with patch(
+                    "kabusys.monitoring.components.ai_wizard._stream_openai_response",
+                    return_value=iter(["ATR乗数を2.0から2.5にすることを提案します。"]),
+                ):
+                    with patch("kabusys.monitoring.components.ai_wizard.OpenAI"):
+                        mod.render(wizard_duckdb, wizard_sqlite)
+
+        session_id = state["wizard_session_id"]
+        db = MonitoringDB(wizard_sqlite)
+        msgs = db.load_wizard_messages(session_id)
+        assert len(msgs) == 2
+        assert msgs[0]["role"] == "user"
+        assert msgs[0]["content"] == "ドローダウンを改善したい"
+        assert msgs[1]["role"] == "assistant"

--- a/tests/test_backtest_summarizer.py
+++ b/tests/test_backtest_summarizer.py
@@ -1,0 +1,143 @@
+"""backtest_summarizer 単体テスト（Issue #233）"""
+
+from __future__ import annotations
+
+import json
+
+import duckdb
+import pytest
+
+from kabusys.ai.backtest_summarizer import load_latest_summary
+
+_BACKTEST_RUNS_DDL = """
+    CREATE TABLE backtest_runs (
+        run_id                  VARCHAR       PRIMARY KEY,
+        created_at              TIMESTAMP     NOT NULL DEFAULT current_timestamp,
+        start_date              DATE          NOT NULL,
+        end_date                DATE          NOT NULL,
+        initial_cash            DECIMAL(18,2) NOT NULL,
+        scope_mode              VARCHAR       NOT NULL,
+        scope_codes_json        VARCHAR,
+        params_json             VARCHAR       NOT NULL,
+        cagr                    DOUBLE,
+        sharpe                  DOUBLE,
+        max_drawdown            DOUBLE,
+        win_rate                DOUBLE,
+        payoff_ratio            DOUBLE,
+        profit_factor           DOUBLE,
+        annual_volatility       DOUBLE,
+        calmar_ratio            DOUBLE,
+        avg_holding_days        DOUBLE,
+        total_trades            INTEGER,
+        effective_universe_size INTEGER
+    )
+"""
+
+_SAMPLE_PARAMS = {
+    "weights": {"momentum": 0.4, "value": 0.3, "quality": 0.2, "ai": 0.1},
+    "threshold": 0.60,
+    "sector_boost": 0.03,
+    "sector_quartile": 0.25,
+    "stop_loss_rate": -0.08,
+    "trailing_stop_atr_mult": 2.0,
+    "gap_up_threshold": 0.04,
+    "gap_down_threshold": -0.04,
+    "min_holding_days": 5,
+    "max_holding_days": 60,
+    "topix_drawdown_threshold": -0.15,
+    "topix_size_multiplier_bear": 0.5,
+}
+
+
+@pytest.fixture
+def bt_conn():
+    conn = duckdb.connect(":memory:")
+    conn.execute(_BACKTEST_RUNS_DDL)
+    yield conn
+    conn.close()
+
+
+def _insert_run(conn, run_id="r1", params=None):
+    p = params if params is not None else _SAMPLE_PARAMS
+    conn.execute(
+        """
+        INSERT INTO backtest_runs (
+            run_id, start_date, end_date, initial_cash, scope_mode, params_json,
+            cagr, sharpe, max_drawdown, win_rate, payoff_ratio, profit_factor, total_trades
+        ) VALUES (?, '2026-01-01', '2026-04-30', 1000000, 'default_universe', ?,
+                  0.123, 1.45, -0.082, 0.583, 1.82, 2.10, 142)
+        """,
+        [run_id, json.dumps(p)],
+    )
+
+
+class TestLoadLatestSummary:
+    def test_returns_none_when_empty(self, bt_conn):
+        assert load_latest_summary(bt_conn) is None
+
+    def test_contains_cagr(self, bt_conn):
+        _insert_run(bt_conn)
+        result = load_latest_summary(bt_conn)
+        assert result is not None
+        assert "+12.30%" in result
+
+    def test_contains_sharpe_and_drawdown(self, bt_conn):
+        _insert_run(bt_conn)
+        result = load_latest_summary(bt_conn)
+        assert "1.450" in result
+        assert "-8.20%" in result
+
+    def test_contains_win_rate_and_trades(self, bt_conn):
+        _insert_run(bt_conn)
+        result = load_latest_summary(bt_conn)
+        assert "58.30%" in result
+        assert "142" in result
+
+    def test_contains_buy_logic_params(self, bt_conn):
+        _insert_run(bt_conn)
+        result = load_latest_summary(bt_conn)
+        assert result is not None
+        assert "threshold=0.6" in result
+        assert "sector_boost=0.03" in result
+
+    def test_contains_risk_filter_params(self, bt_conn):
+        _insert_run(bt_conn)
+        result = load_latest_summary(bt_conn)
+        assert result is not None
+        assert "stop_loss_rate=-0.08" in result
+        assert "trailing_stop_atr_mult=2.0" in result
+        assert "topix_drawdown_threshold=-0.15" in result
+
+    def test_invalid_params_json_no_crash(self, bt_conn):
+        bt_conn.execute(
+            """
+            INSERT INTO backtest_runs (
+                run_id, start_date, end_date, initial_cash, scope_mode, params_json,
+                cagr, sharpe, max_drawdown, win_rate, payoff_ratio, profit_factor, total_trades
+            ) VALUES ('r_bad', '2026-01-01', '2026-04-30', 1000000, 'default_universe',
+                      'INVALID_JSON', 0.10, 1.0, -0.05, 0.5, 1.5, 1.8, 100)
+            """
+        )
+        result = load_latest_summary(bt_conn)
+        assert result is not None
+        assert "CAGR" in result
+
+    def test_returns_latest_when_multiple_runs(self, bt_conn):
+        _insert_run(bt_conn, run_id="r_old")
+        newer_params = dict(_SAMPLE_PARAMS, threshold=0.70)
+        bt_conn.execute(
+            """
+            INSERT INTO backtest_runs (
+                run_id, start_date, end_date, initial_cash, scope_mode, params_json,
+                cagr, sharpe, max_drawdown, win_rate, payoff_ratio, profit_factor,
+                total_trades, created_at
+            ) VALUES ('r_new', '2026-01-01', '2026-04-30', 1000000, 'default_universe',
+                      ?, 0.20, 1.8, -0.06, 0.60, 2.0, 2.5, 180,
+                      current_timestamp + INTERVAL 1 SECOND)
+            """,
+            [json.dumps(newer_params)],
+        )
+        result = load_latest_summary(bt_conn)
+        assert result is not None
+        assert "r_new" in result
+        assert "threshold=0.7" in result

--- a/tests/test_monitoring_db.py
+++ b/tests/test_monitoring_db.py
@@ -236,3 +236,39 @@ class TestUpsertDashboard:
         """レコードなし時は None を返す"""
         result = mdb.get_dashboard()
         assert result is None
+
+
+class TestWizardMessages:
+    def test_save_and_load_messages(self, monitoring_conn):
+        """save → load でメッセージが時系列順に返る。"""
+        db = MonitoringDB(monitoring_conn)
+        db.save_wizard_message("sess1", "user", "テスト質問")
+        db.save_wizard_message("sess1", "assistant", "テスト回答")
+        msgs = db.load_wizard_messages("sess1")
+        assert len(msgs) == 2
+        assert msgs[0] == {"role": "user", "content": "テスト質問"}
+        assert msgs[1] == {"role": "assistant", "content": "テスト回答"}
+
+    def test_load_empty_session(self, monitoring_conn):
+        """存在しない session_id は空リストを返す。"""
+        db = MonitoringDB(monitoring_conn)
+        assert db.load_wizard_messages("nonexistent") == []
+
+    def test_clear_removes_only_target_session(self, monitoring_conn):
+        """clear は対象 session_id のみ削除し、別セッションは残る。"""
+        db = MonitoringDB(monitoring_conn)
+        db.save_wizard_message("sess1", "user", "question")
+        db.save_wizard_message("sess2", "user", "other")
+        db.clear_wizard_messages("sess1")
+        assert db.load_wizard_messages("sess1") == []
+        assert len(db.load_wizard_messages("sess2")) == 1
+
+    def test_ai_wizard_messages_table_exists(self, monitoring_conn):
+        """init_monitoring_db 後に ai_wizard_messages テーブルが存在する。"""
+        tables = {
+            row[0]
+            for row in monitoring_conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        assert "ai_wizard_messages" in tables

--- a/tests/test_monitoring_db.py
+++ b/tests/test_monitoring_db.py
@@ -240,13 +240,20 @@ class TestUpsertDashboard:
 
 class TestWizardMessages:
     def test_save_and_load_messages(self, mdb, monitoring_conn):
-        """save → load でメッセージが時系列順に返る。"""
+        """save → load でメッセージが挿入順に返る。"""
         mdb.save_wizard_message("sess1", "user", "テスト質問")
         mdb.save_wizard_message("sess1", "assistant", "テスト回答")
         msgs = mdb.load_wizard_messages("sess1")
         assert len(msgs) == 2
         assert msgs[0] == {"role": "user", "content": "テスト質問"}
         assert msgs[1] == {"role": "assistant", "content": "テスト回答"}
+
+    def test_load_order_is_stable_within_same_second(self, mdb):
+        """同一秒内に挿入された複数メッセージが挿入順（id 順）で返る。"""
+        for i in range(5):
+            mdb.save_wizard_message("sess_order", "user", f"msg{i}")
+        msgs = mdb.load_wizard_messages("sess_order")
+        assert [m["content"] for m in msgs] == [f"msg{i}" for i in range(5)]
 
     def test_load_empty_session(self, mdb):
         """存在しない session_id は空リストを返す。"""

--- a/tests/test_monitoring_db.py
+++ b/tests/test_monitoring_db.py
@@ -14,7 +14,7 @@ def mdb(monitoring_conn):
 
 class TestInitMonitoringDb:
     def test_tables_created_idempotently(self, monitoring_conn):
-        """init_monitoring_db を2回呼んでもエラーなし、5テーブルが存在する"""
+        """init_monitoring_db を2回呼んでもエラーなし、6テーブルが存在する"""
         init_monitoring_db(monitoring_conn)  # 2回目の呼び出し
         tables = {
             row[0]
@@ -239,20 +239,18 @@ class TestUpsertDashboard:
 
 
 class TestWizardMessages:
-    def test_save_and_load_messages(self, monitoring_conn):
+    def test_save_and_load_messages(self, mdb, monitoring_conn):
         """save → load でメッセージが時系列順に返る。"""
-        db = MonitoringDB(monitoring_conn)
-        db.save_wizard_message("sess1", "user", "テスト質問")
-        db.save_wizard_message("sess1", "assistant", "テスト回答")
-        msgs = db.load_wizard_messages("sess1")
+        mdb.save_wizard_message("sess1", "user", "テスト質問")
+        mdb.save_wizard_message("sess1", "assistant", "テスト回答")
+        msgs = mdb.load_wizard_messages("sess1")
         assert len(msgs) == 2
         assert msgs[0] == {"role": "user", "content": "テスト質問"}
         assert msgs[1] == {"role": "assistant", "content": "テスト回答"}
 
-    def test_load_empty_session(self, monitoring_conn):
+    def test_load_empty_session(self, mdb):
         """存在しない session_id は空リストを返す。"""
-        db = MonitoringDB(monitoring_conn)
-        assert db.load_wizard_messages("nonexistent") == []
+        assert mdb.load_wizard_messages("nonexistent") == []
 
     def test_clear_removes_only_target_session(self, monitoring_conn):
         """clear は対象 session_id のみ削除し、別セッションは残る。"""


### PR DESCRIPTION
## Summary

- `ai_wizard_messages` テーブルを `monitoring.db` に追加し、`MonitoringDB` にセッション別チャット履歴 CRUD メソッドを追加
- `backtest_summarizer.py` を新規作成: DuckDB `backtest_runs` 最新1件から system prompt 用 Markdown を生成（指標7項目＋購入ロジック/リスクフィルター パラメータ）
- `components/ai_wizard.py` を新規作成: OpenAI GPT-4o ストリーミングチャット UI コンポーネント（セッション管理・履歴永続化・API key バリデーション）
- `10_Strategy_Lab.py` に「🤖 AI Co-Pilot」タブを追加してコンポーネントを統合

## Test Plan

- [ ] `pytest` が全 1716 テスト PASS することを確認
- [ ] `OPENAI_API_KEY` を設定せずに AI Co-Pilot タブを開くと `st.error` が表示される
- [ ] バックテスト実行後、チャットでパラメータ改善の提案を受け取れる
- [ ] 「🗑 履歴クリア」ボタンでチャット履歴が消える
- [ ] 初回起動時（Monitoring Engine 未起動）でもタブが正常に開く（`init_monitoring_db` によりテーブルが自動作成される）

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)