### PR TITLE
feat: #291/#292 — lot_map 銘柄別売買単位・DiscrepancyKind 照合差分分類

### DIFF
--- a/scripts/verify_edinet_api.py
+++ b/scripts/verify_edinet_api.py
@@ -28,7 +28,6 @@ from pathlib import Path
 # プロジェクトルートを sys.path に追加
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
-import duckdb
 
 from kabusys.data.edinet_collector import (
     EDINET_DOCUMENTS_URL,
@@ -68,6 +67,7 @@ def warn(msg: str) -> None:
 # 生 API 呼び出し（実装を経由せず直接確認）
 # ---------------------------------------------------------------------------
 
+
 def _raw_api_call(target_date: date, api_key: str) -> dict:
     date_str = target_date.strftime("%Y-%m-%d")
     params: dict[str, str] = {"date": date_str, "type": "2"}
@@ -83,15 +83,20 @@ def _raw_api_call(target_date: date, api_key: str) -> dict:
 # メイン検証
 # ---------------------------------------------------------------------------
 
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="EDINET API 実動作検証")
     parser.add_argument("--api-key", default=os.environ.get("EDINET_API_KEY", ""))
-    parser.add_argument("--date", default=None, help="YYYY-MM-DD（省略時: 今日〜3日前で自動選択）")
+    parser.add_argument(
+        "--date", default=None, help="YYYY-MM-DD（省略時: 今日〜3日前で自動選択）"
+    )
     args = parser.parse_args()
 
     api_key: str = args.api_key
     if not api_key:
-        print("❌ ERROR: --api-key を指定するか EDINET_API_KEY 環境変数を設定してください")
+        print(
+            "❌ ERROR: --api-key を指定するか EDINET_API_KEY 環境変数を設定してください"
+        )
         sys.exit(1)
 
     print("=" * 65)
@@ -145,18 +150,22 @@ def main() -> None:
     metadata = raw_data.get("metadata", {})
     actual_status = str(metadata.get("status", ""))
     check(
-        f"metadata.status == '200'",
+        "metadata.status == '200'",
         actual_status == "200",
         f"実際の status: {actual_status!r}",
     )
 
     results: list[dict] = raw_data.get("results", [])
-    check("results が list 型", isinstance(results, list), f"型: {type(results).__name__}")
+    check(
+        "results が list 型", isinstance(results, list), f"型: {type(results).__name__}"
+    )
     info(f"results 総件数: {len(results)} 件")
 
     if not results:
         warn(f"{target_date} の results は 0 件（休場日または開示なし）")
-        warn("フィールド検証をスキップします（別の --date を指定して再試行してください）")
+        warn(
+            "フィールド検証をスキップします（別の --date を指定して再試行してください）"
+        )
 
     # ------------------------------------------------------------------
     # [3] results 要素フィールド（TypedDict と照合）
@@ -165,9 +174,16 @@ def main() -> None:
 
     # 実装で参照するフィールドのみ確認（API は他にも多数のフィールドを返す）
     EXPECTED_FIELDS = {
-        "docID", "edinetCode", "docTypeCode", "filerName",
-        "submitDateTime", "docDescription", "pdfFlag", "xbrlFlag", "withdrawalStatus",
-        "secCode",    # 銘柄コード（5桁 or None）
+        "docID",
+        "edinetCode",
+        "docTypeCode",
+        "filerName",
+        "submitDateTime",
+        "docDescription",
+        "pdfFlag",
+        "xbrlFlag",
+        "withdrawalStatus",
+        "secCode",  # 銘柄コード（5桁 or None）
         "seqNumber",  # 連番（int）
     }
 
@@ -188,13 +204,19 @@ def main() -> None:
 
         # seqNumber は int が正常（str でないことを確認）
         seq = sample.get("seqNumber")
-        check("seqNumber が int 型", isinstance(seq, int),
-              f"実際の型: {type(seq).__name__}")
+        check(
+            "seqNumber が int 型",
+            isinstance(seq, int),
+            f"実際の型: {type(seq).__name__}",
+        )
 
         # 文字列フィールドが str または None であることを確認（seqNumber 除く）
         str_fields = EXPECTED_FIELDS - {"seqNumber"}
-        non_str = {k: type(sample[k]).__name__ for k in str_fields
-                   if k in sample and not isinstance(sample[k], (str, type(None)))}
+        non_str = {
+            k: type(sample[k]).__name__
+            for k in str_fields
+            if k in sample and not isinstance(sample[k], (str, type(None)))
+        }
         check(
             "文字列フィールドが str または None 型（seqNumber 除く）",
             not non_str,
@@ -256,7 +278,8 @@ def main() -> None:
 
     # 件数の一致確認（取り下げ済み除外 + 種別フィルタ後の期待値）
     expected_count = sum(
-        1 for doc in results
+        1
+        for doc in results
         if str(doc.get("withdrawalStatus", "0")) == "0"
         and str(doc.get("docTypeCode", "")) in _TARGET_DOC_TYPES
         and doc.get("docID", "")
@@ -270,13 +293,17 @@ def main() -> None:
     if disclosures:
         d0 = disclosures[0]
 
-        check("source == 'edinet'", d0["source"] == "edinet",
-              f"実際: {d0['source']!r}")
-        check("code is None（銘柄コード非対応）", d0["code"] is None,
-              f"実際: {d0['code']!r}")
+        check("source == 'edinet'", d0["source"] == "edinet", f"実際: {d0['source']!r}")
+        check(
+            "code is None（銘柄コード非対応）",
+            d0["code"] is None,
+            f"実際: {d0['code']!r}",
+        )
         check(
             "document_url が EDINET API ドメインで始まる",
-            (d0.get("document_url") or "").startswith("https://api.edinet-fsa.go.jp/api/v2/documents/"),
+            (d0.get("document_url") or "").startswith(
+                "https://api.edinet-fsa.go.jp/api/v2/documents/"
+            ),
             f"実際: {d0.get('document_url')!r}",
         )
         check(
@@ -302,7 +329,9 @@ def main() -> None:
         info(f"サンプル document_url : {d0['document_url']!r}")
 
         # PDF フラグと URL の type パラメータ一致確認
-        pdf_map = {str(doc.get("docID", "")): doc.get("pdfFlag", "0") for doc in results}
+        pdf_map = {
+            str(doc.get("docID", "")): doc.get("pdfFlag", "0") for doc in results
+        }
         type_mismatch = []
         for disc in disclosures:
             doc_id = disc["id"]

--- a/src/kabusys/execution/reconciler.py
+++ b/src/kabusys/execution/reconciler.py
@@ -20,7 +20,9 @@ logger = logging.getLogger(__name__)
 
 class DiscrepancyKind(str, Enum):
     AMOUNT_MISMATCH = "AMOUNT_MISMATCH"  # 数量不一致（異常の可能性）
-    CLOSED_STATE_CONSTRAINT = "CLOSED_STATE_CONSTRAINT"  # Closed 未実装に起因する既知制約
+    CLOSED_STATE_CONSTRAINT = (
+        "CLOSED_STATE_CONSTRAINT"  # Closed 未実装に起因する既知制約
+    )
 
 
 @dataclass

--- a/src/kabusys/execution/reconciler.py
+++ b/src/kabusys/execution/reconciler.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from enum import Enum
 
 from kabusys.execution.broker_api import BrokerAPIError, BrokerAPIProtocol
 from kabusys.execution.order_manager import OrderManager
@@ -17,12 +18,18 @@ from kabusys.execution.order_repository import OrderRepository
 logger = logging.getLogger(__name__)
 
 
+class DiscrepancyKind(str, Enum):
+    AMOUNT_MISMATCH = "AMOUNT_MISMATCH"  # 数量不一致（異常の可能性）
+    CLOSED_STATE_CONSTRAINT = "CLOSED_STATE_CONSTRAINT"  # Closed 未実装に起因する既知制約
+
+
 @dataclass
 class PositionDiscrepancy:
     code: str
     broker_qty: int  # ブローカー側の保有数量
     local_qty: int  # ローカルDB推定値（注文履歴から集計）
     diff: int  # broker_qty - local_qty
+    kind: DiscrepancyKind = DiscrepancyKind.AMOUNT_MISMATCH
 
 
 @dataclass
@@ -132,6 +139,7 @@ class Reconciler:
         # ※ Closed 状態（ポジションクローズ済）は list_active() では取得できないため対象外。
         #   現フェーズでは Filled → Closed 遷移は未実装のため、Filled buy - Filled sell のネットが
         #   現在保有数量に相当する。将来 Closed 遷移を実装する際は再検討が必要。
+        #   broker_qty==0 かつ local_qty>0 の差分は DiscrepancyKind.CLOSED_STATE_CONSTRAINT として分類される。
         local_map: dict[str, int] = {}
         try:
             active_orders = self._repo.list_active()
@@ -165,16 +173,21 @@ class Reconciler:
             local_qty = local_map.get(code, 0)
             diff = broker_qty - local_qty
             if diff != 0:
-                result.position_discrepancies.append(
-                    PositionDiscrepancy(
-                        code=code,
-                        broker_qty=broker_qty,
-                        local_qty=local_qty,
-                        diff=diff,
-                    )
+                if broker_qty == 0 and local_qty > 0:
+                    kind = DiscrepancyKind.CLOSED_STATE_CONSTRAINT
+                else:
+                    kind = DiscrepancyKind.AMOUNT_MISMATCH
+                discrepancy = PositionDiscrepancy(
+                    code=code,
+                    broker_qty=broker_qty,
+                    local_qty=local_qty,
+                    diff=diff,
+                    kind=kind,
                 )
+                result.position_discrepancies.append(discrepancy)
                 logger.warning(
-                    "ポジション差分検出: code=%s, broker=%d, local=%d, diff=%+d",
+                    "ポジション差分検出 [%s]: code=%s, broker=%d, local=%d, diff=%+d",
+                    discrepancy.kind.value,
                     code,
                     broker_qty,
                     local_qty,

--- a/src/kabusys/portfolio/position_sizing.py
+++ b/src/kabusys/portfolio/position_sizing.py
@@ -25,6 +25,7 @@ def calc_position_sizes(
     max_position_pct: float = 0.10,
     max_utilization: float = 0.70,
     lot_size: int = 100,
+    lot_map: dict[str, int] | None = None,
     cost_buffer: float = 0.0,
 ) -> dict[str, int]:
     """allocation_method に応じて各銘柄の発注株数を計算する。
@@ -41,9 +42,10 @@ def calc_position_sizes(
         stop_loss_pct:     損切り率（risk_based 時）
         max_position_pct:  1銘柄上限（総資産比）
         max_utilization:   投下資金上限（総資産比）
-        lot_size:          単元株数（現状は全銘柄共通で 100 を想定）
-                           TODO: 将来的には stocks マスタに lot_size を持たせ、
-                                 銘柄別 lot_map: dict[str, int] を受け取る設計に拡張する
+        lot_size:          単元株数のデフォルト値。lot_map が None の場合は全銘柄に適用される。
+        lot_map:           銘柄別の単元株数 {code: lot_size}。指定した銘柄はこの値を使用し、
+                           未指定の銘柄は lot_size にフォールバックする。
+                           None の場合は全銘柄に lot_size を適用する。
         cost_buffer:       手数料・スリッページ見積り係数。aggregate cap 判定の際に
                            price に (1 + cost_buffer) を掛けて保守的に見積もる。
                            slippage_rate + commission_rate 程度を推奨。
@@ -53,6 +55,9 @@ def calc_position_sizes(
     """
     if not candidates:
         return {}
+
+    def _lot(code: str) -> int:
+        return lot_map.get(code, lot_size) if lot_map is not None else lot_size
 
     def _max_per_stock(price: float) -> int:
         if price <= 0:
@@ -75,7 +80,7 @@ def calc_position_sizes(
                 portfolio_value * risk_pct / (price * stop_loss_pct)
             )
             target_shares = min(base_shares, _max_per_stock(price))
-            target_shares = (target_shares // lot_size) * lot_size
+            target_shares = (target_shares // _lot(code)) * _lot(code)
 
             current = current_positions.get(code, 0)
             add_shares = max(0, target_shares - current)
@@ -102,7 +107,7 @@ def calc_position_sizes(
             alloc = portfolio_value * w * max_utilization
             base_shares = math.floor(alloc / price)
             target_shares = min(base_shares, _max_per_stock(price))
-            target_shares = (target_shares // lot_size) * lot_size
+            target_shares = (target_shares // _lot(code)) * _lot(code)
 
             current = current_positions.get(code, 0)
             add_shares = max(0, target_shares - current)
@@ -130,12 +135,12 @@ def calc_position_sizes(
                 if price <= 0:
                     continue
                 scaled_f = shares * scale
-                new_shares = (math.floor(scaled_f) // lot_size) * lot_size
+                new_shares = (math.floor(scaled_f) // _lot(code)) * _lot(code)
                 if new_shares > 0:
                     scaled[code] = new_shares
                     committed_cost += new_shares * price * price_factor
                 # fractional_remainder = lot_size 単位での端数部分
-                frac = (scaled_f / lot_size) - math.floor(scaled_f / lot_size)
+                frac = (scaled_f / _lot(code)) - math.floor(scaled_f / _lot(code))
                 remainders.append((frac, code))
 
             # 残余キャッシュで fractional 残差が大きい順に lot_size 単位を追加配分
@@ -147,8 +152,8 @@ def calc_position_sizes(
                 price = open_prices.get(code, 0)
                 if price <= 0:
                     continue
-                lot_cost = lot_size * price * price_factor
-                candidate_new = scaled.get(code, 0) + lot_size
+                lot_cost = _lot(code) * price * price_factor
+                candidate_new = scaled.get(code, 0) + _lot(code)
                 max_allowed = min(raw_shares.get(code, 0), _max_per_stock(price))
                 if remaining_cash >= lot_cost and candidate_new <= max_allowed:
                     scaled[code] = candidate_new

--- a/tests/test_portfolio_construction.py
+++ b/tests/test_portfolio_construction.py
@@ -951,3 +951,108 @@ def test_calc_position_sizes_greedy_does_not_exceed_raw_shares():
 
     # 結果は raw_shares（≒600株）以内であること
     assert result.get("A", 0) <= 600
+
+
+# ---------------------------------------------------------------------------
+# Issue #291: lot_map による銘柄別売買単位
+# ---------------------------------------------------------------------------
+
+
+def test_calc_position_sizes_lot_map_per_symbol():
+    """lot_map を渡すと銘柄ごとの単元株で丸められる。
+
+    A: lot=100 (デフォルト), B: lot=1000
+    portfolio_value=10_000_000, price=1000
+    A: floor(10M*0.005 / (1000*0.08)) = 625 → (625 // 100) * 100 = 600 株
+    B: 625 → (625 // 1000) * 1000 = 0 株（資金が 1000株単位に満たない）
+    """
+    from kabusys.portfolio.position_sizing import calc_position_sizes
+
+    result = calc_position_sizes(
+        weights={},
+        candidates=[
+            {"code": "A", "score": 0.9, "signal_rank": 1},
+            {"code": "B", "score": 0.8, "signal_rank": 2},
+        ],
+        portfolio_value=10_000_000,
+        available_cash=10_000_000,
+        current_positions={},
+        open_prices={"A": 1000.0, "B": 1000.0},
+        allocation_method="risk_based",
+        risk_pct=0.005,
+        stop_loss_pct=0.08,
+        max_position_pct=0.10,
+        max_utilization=0.70,
+        lot_size=100,
+        lot_map={"B": 1000},
+    )
+    # A は lot=100 → 600 株
+    assert result.get("A", 0) == 600
+    assert result.get("A", 0) % 100 == 0
+    # B は lot=1000 → raw=625 < 1000 のため 0 株（lot に満たない）
+    assert result.get("B", 0) == 0
+
+
+def test_calc_position_sizes_lot_map_fallback_to_lot_size():
+    """lot_map にないコードは lot_size にフォールバックする。
+
+    lot_map={"C": 500} で、A と B は lot_map に未登録 → lot_size=100 が使われる。
+    portfolio_value=10_000_000, price=1000
+    A, B: floor(10M*0.005 / (1000*0.08)) = 625 → (625 // 100) * 100 = 600 株
+    C: 625 → (625 // 500) * 500 = 500 株
+    """
+    from kabusys.portfolio.position_sizing import calc_position_sizes
+
+    result = calc_position_sizes(
+        weights={},
+        candidates=[
+            {"code": "A", "score": 0.9, "signal_rank": 1},
+            {"code": "B", "score": 0.8, "signal_rank": 2},
+            {"code": "C", "score": 0.7, "signal_rank": 3},
+        ],
+        portfolio_value=10_000_000,
+        available_cash=10_000_000,
+        current_positions={},
+        open_prices={"A": 1000.0, "B": 1000.0, "C": 1000.0},
+        allocation_method="risk_based",
+        risk_pct=0.005,
+        stop_loss_pct=0.08,
+        max_position_pct=0.10,
+        max_utilization=0.70,
+        lot_size=100,
+        lot_map={"C": 500},
+    )
+    # A, B: lot_map に未登録 → lot_size=100 → 600 株
+    assert result.get("A", 0) == 600
+    assert result.get("B", 0) == 600
+    # C: lot_map["C"]=500 → (625 // 500) * 500 = 500 株
+    assert result.get("C", 0) == 500
+    assert result.get("C", 0) % 500 == 0
+
+
+def test_calc_position_sizes_lot_map_zero_when_below_lot():
+    """資金が単元に満たない場合は 0 株（発注なし）になる。
+
+    portfolio_value=500_000 (小規模), price=1000, lot=1000
+    base_shares = floor(500_000 * 0.005 / (1000 * 0.08)) = floor(2500/80) = floor(31.25) = 31
+    (31 // 1000) * 1000 = 0 → 発注なし
+    """
+    from kabusys.portfolio.position_sizing import calc_position_sizes
+
+    result = calc_position_sizes(
+        weights={},
+        candidates=[{"code": "X", "score": 0.9, "signal_rank": 1}],
+        portfolio_value=500_000,
+        available_cash=500_000,
+        current_positions={},
+        open_prices={"X": 1000.0},
+        allocation_method="risk_based",
+        risk_pct=0.005,
+        stop_loss_pct=0.08,
+        max_position_pct=0.10,
+        max_utilization=0.70,
+        lot_size=100,
+        lot_map={"X": 1000},
+    )
+    # 31 株計算されるが lot=1000 に満たないため 0
+    assert result.get("X", 0) == 0

--- a/tests/test_reconciler.py
+++ b/tests/test_reconciler.py
@@ -472,6 +472,39 @@ class TestReconcilePositions:
         # broker 合計 100 == local 100 → 差分なし
         assert result.position_discrepancies == []
 
+    def test_reconcile_positions_closed_state_constraint_kind(self, repo):
+        """broker_qty==0, local_qty>0 → CLOSED_STATE_CONSTRAINT に分類される。"""
+        from kabusys.execution.reconciler import DiscrepancyKind
+
+        # local に Filled buy 100株、broker には保有なし（broker_qty=0）
+        self._insert_filled_order(repo, "1234", "buy", 100, "pos-kind-closed-001")
+        broker = MockBrokerClient()  # ポジションなし → broker_qty=0
+        reconciler = _make_reconciler(broker, repo)
+        result = reconciler.run()
+        assert len(result.position_discrepancies) == 1
+        d = result.position_discrepancies[0]
+        assert d.broker_qty == 0
+        assert d.local_qty == 100
+        assert d.kind == DiscrepancyKind.CLOSED_STATE_CONSTRAINT
+
+    def test_reconcile_positions_amount_mismatch_kind(self, repo):
+        """broker_qty>0, local_qty と一致しない → AMOUNT_MISMATCH に分類される。"""
+        from kabusys.execution.broker_api import Position
+        from kabusys.execution.reconciler import DiscrepancyKind
+
+        # local 80株、broker 100株 → diff=+20
+        self._insert_filled_order(repo, "5678", "buy", 80, "pos-kind-mismatch-001")
+        broker = MockBrokerClient(
+            initial_positions=[Position(code="5678", qty=100, avg_price=1500.0)]
+        )
+        reconciler = _make_reconciler(broker, repo)
+        result = reconciler.run()
+        assert len(result.position_discrepancies) == 1
+        d = result.position_discrepancies[0]
+        assert d.broker_qty == 100
+        assert d.local_qty == 80
+        assert d.kind == DiscrepancyKind.AMOUNT_MISMATCH
+
 
 class TestExecutionEngineIntegration:
     def test_run_session_calls_reconciler_before_signal_processing(


### PR DESCRIPTION
## Summary

- **Issue #291**: `calc_position_sizes` に `lot_map: dict[str, int] | None = None` を追加。銘柄ごとの売買単位でロット丸めを行えるようにし、未指定銘柄は `lot_size` にフォールバック
- **Issue #292**: `PositionDiscrepancy` に `DiscrepancyKind` enum を追加。`broker_qty==0 and local_qty>0` を `CLOSED_STATE_CONSTRAINT`（Closed 未実装起因の既知制約）、それ以外を `AMOUNT_MISMATCH` に分類。警告ログに kind を含める

## Test Plan

- [ ] 1784 tests all pass (`pytest tests/ -q`)
- [ ] `lot_map={"B": 1000}` で B が lot=1000 単位に丸められることを確認（`test_calc_position_sizes_lot_map_per_symbol`）
- [ ] `lot_map` 未指定時は既存動作と同一であることを確認（後方互換性）
- [ ] `broker_qty=0, local_qty>0` の差分が `CLOSED_STATE_CONSTRAINT` に分類されることを確認
- [ ] その他差分が `AMOUNT_MISMATCH` に分類されることを確認

Closes #291
Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)