### PR TITLE
perf: bootstrap loaders を DuckDB read_csv() ネイティブ読み込みに切り替え (Issue #294)

### DIFF
--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -76,7 +76,7 @@ except APIConnectionError as exc:
     print(f"警告: OpenAI API への接続に失敗しました（スキップ）: {exc}")
     sys.exit(0)
 except APIStatusError as exc:
-    print(f"警告: OpenAI API がエラーを返しました（スキップ）: {exc.status_code} {exc.message}")
+    print(f"警告: OpenAI API がエラーを返しました（スキップ）: {exc.status_code} {str(exc)}")
     sys.exit(0)
 
 review = response.choices[0].message.content

--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -1,7 +1,8 @@
 import os
+import sys
 
 import requests
-from openai import OpenAI
+from openai import APIConnectionError, APIStatusError, OpenAI
 
 client = OpenAI(api_key=os.environ["OPENAI_API_KEY"].strip())
 model = os.environ.get("OPENAI_MODEL", "gpt-4o")
@@ -19,7 +20,7 @@ with open("diff.txt") as f:
 
 if not diff.strip():
     print("差分がありません。レビューをスキップします。")
-    exit(0)
+    sys.exit(0)
 
 # PRの詳細（タイトル・本文）を取得
 pr_url = f"https://api.github.com/repos/{repo}/pulls/{pr}"
@@ -63,13 +64,20 @@ prompt = f"""
 {diff}
 """
 
-response = client.chat.completions.create(
-    model=model,
-    messages=[
-        {"role": "system", "content": "You are a senior software engineer."},
-        {"role": "user", "content": prompt},
-    ],
-)
+try:
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": "You are a senior software engineer."},
+            {"role": "user", "content": prompt},
+        ],
+    )
+except APIConnectionError as exc:
+    print(f"警告: OpenAI API への接続に失敗しました（スキップ）: {exc}")
+    sys.exit(0)
+except APIStatusError as exc:
+    print(f"警告: OpenAI API がエラーを返しました（スキップ）: {exc.status_code} {exc.message}")
+    sys.exit(0)
 
 review = response.choices[0].message.content
 
@@ -85,4 +93,4 @@ if resp.status_code == 201:
     print("AIレビューコメントをPRに投稿しました。")
 else:
     print(f"コメント投稿に失敗しました: {resp.status_code} {resp.text}")
-    exit(1)
+    sys.exit(1)

--- a/src/kabusys/data/bootstrap/loaders.py
+++ b/src/kabusys/data/bootstrap/loaders.py
@@ -13,15 +13,21 @@ def _sql_path(csv_path: Path) -> str:
     return str(csv_path).replace("\\", "/").replace("'", "''")
 
 
-def load_prices(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool = False) -> int:
+def load_prices(
+    conn: duckdb.DuckDBPyConnection,
+    csv_path: Path,
+    bulk: bool = False,
+    outer_tx: bool = False,
+) -> int:
     """equities/bars/daily CSV → raw_prices & prices_daily
 
     DuckDB の read_csv() でネイティブ読み込みする。Python 側の CSV 解析を排除し
     ベクトル化バッチ処理による高速化を実現する。
 
-    bulk=True: 月次ファイル用。呼び出し元が対象月を事前 DELETE 済みであること。
-               ON CONFLICT DO NOTHING でバルク INSERT する。
+    bulk=True : 月次ファイル用。呼び出し元が対象月を事前 DELETE 済みであること。
+                ON CONFLICT DO NOTHING でバルク INSERT する。
     bulk=False: 日次ファイル用。ON CONFLICT DO UPDATE で差分 upsert する。
+    outer_tx  : True のとき BEGIN/COMMIT/ROLLBACK を行わない（呼び出し元がトランザクションを管理）。
     """
     path = _sql_path(csv_path)
 
@@ -45,7 +51,7 @@ def load_prices(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool = Fa
         )
     )
 
-    if bulk:
+    if not outer_tx:
         conn.execute("BEGIN")
     try:
         conn.execute(f"""
@@ -53,7 +59,7 @@ def load_prices(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool = Fa
                 (date, code, open, high, low, close, volume, turnover, adj_factor, fetched_at)
             SELECT
                 TRY_CAST("Date" AS DATE),
-                "Code",
+                TRIM("Code"),
                 TRY_CAST("O" AS DOUBLE),
                 TRY_CAST("H" AS DOUBLE),
                 TRY_CAST("L" AS DOUBLE),
@@ -64,7 +70,7 @@ def load_prices(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool = Fa
                 current_timestamp
             FROM read_csv('{path}', nullstr='', all_varchar=true)
             WHERE TRY_CAST("Date" AS DATE) IS NOT NULL
-              AND "Code" IS NOT NULL AND trim("Code") != ''
+              AND TRIM("Code") != ''
             {conflict_raw}
         """)
 
@@ -73,7 +79,7 @@ def load_prices(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool = Fa
             INSERT INTO prices_daily (date, code, open, high, low, close, volume, turnover)
             SELECT
                 TRY_CAST("Date" AS DATE),
-                "Code",
+                TRIM("Code"),
                 TRY_CAST("O" AS DOUBLE),
                 TRY_CAST("H" AS DOUBLE),
                 TRY_CAST("L" AS DOUBLE),
@@ -82,7 +88,7 @@ def load_prices(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool = Fa
                 TRY_CAST("Va" AS DOUBLE)
             FROM read_csv('{path}', nullstr='', all_varchar=true)
             WHERE TRY_CAST("Date" AS DATE) IS NOT NULL
-              AND "Code" IS NOT NULL AND trim("Code") != ''
+              AND TRIM("Code") != ''
               AND TRY_CAST("O" AS DOUBLE) IS NOT NULL
               AND TRY_CAST("H" AS DOUBLE) IS NOT NULL
               AND TRY_CAST("L" AS DOUBLE) IS NOT NULL
@@ -93,10 +99,10 @@ def load_prices(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool = Fa
         """)
         loaded = conn.execute("SELECT COUNT(*) FROM prices_daily").fetchone()[0] - before
 
-        if bulk:
+        if not outer_tx:
             conn.execute("COMMIT")
     except Exception:
-        if bulk:
+        if not outer_tx:
             conn.execute("ROLLBACK")
         raise
 
@@ -104,39 +110,61 @@ def load_prices(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool = Fa
     return loaded
 
 
-def load_master(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool = False) -> int:
+def load_master(
+    conn: duckdb.DuckDBPyConnection,
+    csv_path: Path,
+    bulk: bool = False,
+    outer_tx: bool = False,
+) -> int:
     """equities/master CSV → stocks
 
     bulk 引数は互換性のために受け付けるが無視する（master は常に upsert）。
+    outer_tx: True のとき BEGIN/COMMIT/ROLLBACK を行わない。
     """
     path = _sql_path(csv_path)
 
-    before = conn.execute("SELECT COUNT(*) FROM stocks").fetchone()[0]
-    conn.execute(f"""
-        INSERT INTO stocks (code, name, market, sector, updated_at)
-        SELECT
-            "Code",
-            "CoName",
-            "MktNm",
-            "S33Nm",
-            current_timestamp
-        FROM read_csv('{path}', nullstr='', all_varchar=true)
-        WHERE "Code" IS NOT NULL AND trim("Code") != ''
-        ON CONFLICT (code) DO UPDATE SET
-            name=EXCLUDED.name, market=EXCLUDED.market, sector=EXCLUDED.sector,
-            updated_at=EXCLUDED.updated_at
-    """)
-    loaded = conn.execute("SELECT COUNT(*) FROM stocks").fetchone()[0] - before
+    if not outer_tx:
+        conn.execute("BEGIN")
+    try:
+        before = conn.execute("SELECT COUNT(*) FROM stocks").fetchone()[0]
+        conn.execute(f"""
+            INSERT INTO stocks (code, name, market, sector, updated_at)
+            SELECT
+                TRIM("Code"),
+                "CoName",
+                "MktNm",
+                "S33Nm",
+                current_timestamp
+            FROM read_csv('{path}', nullstr='', all_varchar=true)
+            WHERE TRIM("Code") != ''
+            ON CONFLICT (code) DO UPDATE SET
+                name=EXCLUDED.name, market=EXCLUDED.market, sector=EXCLUDED.sector,
+                updated_at=EXCLUDED.updated_at
+        """)
+        loaded = conn.execute("SELECT COUNT(*) FROM stocks").fetchone()[0] - before
+
+        if not outer_tx:
+            conn.execute("COMMIT")
+    except Exception:
+        if not outer_tx:
+            conn.execute("ROLLBACK")
+        raise
 
     logger.info("load_master: %d 件ロード (%s)", loaded, csv_path.name)
     return loaded
 
 
-def load_financials(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool = False) -> int:
+def load_financials(
+    conn: duckdb.DuckDBPyConnection,
+    csv_path: Path,
+    bulk: bool = False,
+    outer_tx: bool = False,
+) -> int:
     """fins/summary CSV → raw_financials & fundamentals
 
-    bulk=True: 月次ファイル用。呼び出し元が対象月を事前 DELETE 済みであること。
+    bulk=True : 月次ファイル用。呼び出し元が対象月を事前 DELETE 済みであること。
     bulk=False: 日次ファイル用。ON CONFLICT DO UPDATE で差分 upsert する。
+    outer_tx  : True のとき BEGIN/COMMIT/ROLLBACK を行わない。
     """
     path = _sql_path(csv_path)
 
@@ -160,7 +188,7 @@ def load_financials(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool 
         )
     )
 
-    if bulk:
+    if not outer_tx:
         conn.execute("BEGIN")
     try:
         conn.execute(f"""
@@ -168,9 +196,9 @@ def load_financials(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool 
                 (code, report_date, period_type, revenue, operating_profit, net_income,
                  eps, roe, fetched_at)
             SELECT
-                "Code",
+                TRIM("Code"),
                 TRY_CAST("DiscDate" AS DATE),
-                "CurPerType",
+                TRIM("CurPerType"),
                 TRY_CAST("Sales" AS DOUBLE),
                 TRY_CAST("OP" AS DOUBLE),
                 TRY_CAST("NP" AS DOUBLE),
@@ -178,9 +206,9 @@ def load_financials(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool 
                 TRY_CAST("ROE" AS DOUBLE),
                 current_timestamp
             FROM read_csv('{path}', nullstr='', all_varchar=true)
-            WHERE "Code" IS NOT NULL AND trim("Code") != ''
+            WHERE TRIM("Code") != ''
               AND TRY_CAST("DiscDate" AS DATE) IS NOT NULL
-              AND "CurPerType" IS NOT NULL AND trim("CurPerType") != ''
+              AND TRIM("CurPerType") != ''
             {conflict_raw}
         """)
 
@@ -189,26 +217,26 @@ def load_financials(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool 
             INSERT INTO fundamentals
                 (code, report_date, period_type, revenue, operating_profit, net_income, eps, roe)
             SELECT
-                "Code",
+                TRIM("Code"),
                 TRY_CAST("DiscDate" AS DATE),
-                "CurPerType",
+                TRIM("CurPerType"),
                 TRY_CAST("Sales" AS DOUBLE),
                 TRY_CAST("OP" AS DOUBLE),
                 TRY_CAST("NP" AS DOUBLE),
                 TRY_CAST("EPS" AS DOUBLE),
                 TRY_CAST("ROE" AS DOUBLE)
             FROM read_csv('{path}', nullstr='', all_varchar=true)
-            WHERE "Code" IS NOT NULL AND trim("Code") != ''
+            WHERE TRIM("Code") != ''
               AND TRY_CAST("DiscDate" AS DATE) IS NOT NULL
-              AND "CurPerType" IS NOT NULL AND trim("CurPerType") != ''
+              AND TRIM("CurPerType") != ''
             {conflict_proc}
         """)
         loaded = conn.execute("SELECT COUNT(*) FROM fundamentals").fetchone()[0] - before
 
-        if bulk:
+        if not outer_tx:
             conn.execute("COMMIT")
     except Exception:
-        if bulk:
+        if not outer_tx:
             conn.execute("ROLLBACK")
         raise
 
@@ -216,13 +244,19 @@ def load_financials(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool 
     return loaded
 
 
-def load_calendar(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool = False) -> int:
+def load_calendar(
+    conn: duckdb.DuckDBPyConnection,
+    csv_path: Path,
+    bulk: bool = False,
+    outer_tx: bool = False,
+) -> int:
     """markets/calendar CSV → market_calendar
 
     HolDiv="1" → is_trading_day=False（休日）
 
-    bulk=True: 月次ファイル用。呼び出し元が対象月を事前 DELETE 済みであること。
+    bulk=True : 月次ファイル用。呼び出し元が対象月を事前 DELETE 済みであること。
     bulk=False: 日次ファイル用。ON CONFLICT DO UPDATE で差分 upsert する。
+    outer_tx  : True のとき BEGIN/COMMIT/ROLLBACK を行わない。
     """
     path = _sql_path(csv_path)
 
@@ -236,7 +270,7 @@ def load_calendar(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool = 
         )
     )
 
-    if bulk:
+    if not outer_tx:
         conn.execute("BEGIN")
     try:
         before = conn.execute("SELECT COUNT(*) FROM market_calendar").fetchone()[0]
@@ -255,10 +289,10 @@ def load_calendar(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool = 
         """)
         loaded = conn.execute("SELECT COUNT(*) FROM market_calendar").fetchone()[0] - before
 
-        if bulk:
+        if not outer_tx:
             conn.execute("COMMIT")
     except Exception:
-        if bulk:
+        if not outer_tx:
             conn.execute("ROLLBACK")
         raise
 
@@ -266,11 +300,17 @@ def load_calendar(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool = 
     return loaded
 
 
-def load_topix(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool = False) -> int:
+def load_topix(
+    conn: duckdb.DuckDBPyConnection,
+    csv_path: Path,
+    bulk: bool = False,
+    outer_tx: bool = False,
+) -> int:
     """indices/bars/daily/topix CSV → topix_daily
 
-    bulk=True: 月次ファイル用。呼び出し元が対象月を事前 DELETE 済みであること。
+    bulk=True : 月次ファイル用。呼び出し元が対象月を事前 DELETE 済みであること。
     bulk=False: 日次ファイル用。ON CONFLICT DO UPDATE で差分 upsert する。
+    outer_tx  : True のとき BEGIN/COMMIT/ROLLBACK を行わない。
     """
     path = _sql_path(csv_path)
 
@@ -283,7 +323,7 @@ def load_topix(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool = Fal
         )
     )
 
-    if bulk:
+    if not outer_tx:
         conn.execute("BEGIN")
     try:
         before = conn.execute("SELECT COUNT(*) FROM topix_daily").fetchone()[0]
@@ -306,10 +346,10 @@ def load_topix(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool = Fal
         """)
         loaded = conn.execute("SELECT COUNT(*) FROM topix_daily").fetchone()[0] - before
 
-        if bulk:
+        if not outer_tx:
             conn.execute("COMMIT")
     except Exception:
-        if bulk:
+        if not outer_tx:
             conn.execute("ROLLBACK")
         raise
 

--- a/src/kabusys/data/bootstrap/loaders.py
+++ b/src/kabusys/data/bootstrap/loaders.py
@@ -7,6 +7,9 @@ import duckdb
 
 logger = logging.getLogger(__name__)
 
+# 全ローダーで共用する一時テーブル名（bootstrap は逐次実行なので名前衝突なし）
+_TMP = "_bld_src"
+
 
 def _sql_path(csv_path: Path) -> str:
     """Path を SQL 文字列リテラルとして安全に埋め込む（シングルクォートをエスケープ）。"""
@@ -21,13 +24,12 @@ def load_prices(
 ) -> int:
     """equities/bars/daily CSV → raw_prices & prices_daily
 
-    DuckDB の read_csv() でネイティブ読み込みする。Python 側の CSV 解析を排除し
-    ベクトル化バッチ処理による高速化を実現する。
+    CSV を TEMP TABLE に一度だけ読み込み（gzip 展開・型変換を1回に抑制）、
+    raw と processed の両 INSERT でその TEMP TABLE を参照する。
 
     bulk=True : 月次ファイル用。呼び出し元が対象月を事前 DELETE 済みであること。
-                ON CONFLICT DO NOTHING でバルク INSERT する。
     bulk=False: 日次ファイル用。ON CONFLICT DO UPDATE で差分 upsert する。
-    outer_tx  : True のとき BEGIN/COMMIT/ROLLBACK を行わない（呼び出し元がトランザクションを管理）。
+    outer_tx  : True のとき BEGIN/COMMIT/ROLLBACK を行わない（呼び出し元がトランザクション管理）。
     """
     path = _sql_path(csv_path)
 
@@ -51,60 +53,56 @@ def load_prices(
         )
     )
 
-    if not outer_tx:
-        conn.execute("BEGIN")
+    # CSV を一度だけ展開・型変換してメモリ上の TEMP TABLE に格納
+    conn.execute(f"""
+        CREATE OR REPLACE TEMP TABLE {_TMP} AS
+        SELECT
+            TRY_CAST("Date" AS DATE)     AS date,
+            TRIM("Code")                 AS code,
+            TRY_CAST("O" AS DOUBLE)      AS open,
+            TRY_CAST("H" AS DOUBLE)      AS high,
+            TRY_CAST("L" AS DOUBLE)      AS low,
+            TRY_CAST("C" AS DOUBLE)      AS close,
+            TRY_CAST("Vo" AS BIGINT)     AS volume,
+            TRY_CAST("Va" AS DOUBLE)     AS turnover,
+            TRY_CAST("AdjFactor" AS DOUBLE) AS adj_factor
+        FROM read_csv('{path}', nullstr='', all_varchar=true)
+        WHERE TRY_CAST("Date" AS DATE) IS NOT NULL AND TRIM("Code") != ''
+    """)
     try:
-        conn.execute(f"""
-            INSERT INTO raw_prices
-                (date, code, open, high, low, close, volume, turnover, adj_factor, fetched_at)
-            SELECT
-                TRY_CAST("Date" AS DATE),
-                TRIM("Code"),
-                TRY_CAST("O" AS DOUBLE),
-                TRY_CAST("H" AS DOUBLE),
-                TRY_CAST("L" AS DOUBLE),
-                TRY_CAST("C" AS DOUBLE),
-                TRY_CAST("Vo" AS BIGINT),
-                TRY_CAST("Va" AS DOUBLE),
-                TRY_CAST("AdjFactor" AS DOUBLE),
-                current_timestamp
-            FROM read_csv('{path}', nullstr='', all_varchar=true)
-            WHERE TRY_CAST("Date" AS DATE) IS NOT NULL
-              AND TRIM("Code") != ''
-            {conflict_raw}
-        """)
-
-        before = conn.execute("SELECT COUNT(*) FROM prices_daily").fetchone()[0]
-        conn.execute(f"""
-            INSERT INTO prices_daily (date, code, open, high, low, close, volume, turnover)
-            SELECT
-                TRY_CAST("Date" AS DATE),
-                TRIM("Code"),
-                TRY_CAST("O" AS DOUBLE),
-                TRY_CAST("H" AS DOUBLE),
-                TRY_CAST("L" AS DOUBLE),
-                TRY_CAST("C" AS DOUBLE),
-                TRY_CAST("Vo" AS BIGINT),
-                TRY_CAST("Va" AS DOUBLE)
-            FROM read_csv('{path}', nullstr='', all_varchar=true)
-            WHERE TRY_CAST("Date" AS DATE) IS NOT NULL
-              AND TRIM("Code") != ''
-              AND TRY_CAST("O" AS DOUBLE) IS NOT NULL
-              AND TRY_CAST("H" AS DOUBLE) IS NOT NULL
-              AND TRY_CAST("L" AS DOUBLE) IS NOT NULL
-              AND TRY_CAST("C" AS DOUBLE) IS NOT NULL
-              AND TRY_CAST("Vo" AS BIGINT) IS NOT NULL
-              AND TRY_CAST("L" AS DOUBLE) <= TRY_CAST("H" AS DOUBLE)
-            {conflict_proc}
-        """)
-        loaded = conn.execute("SELECT COUNT(*) FROM prices_daily").fetchone()[0] - before
-
         if not outer_tx:
-            conn.execute("COMMIT")
-    except Exception:
-        if not outer_tx:
-            conn.execute("ROLLBACK")
-        raise
+            conn.execute("BEGIN")
+        try:
+            conn.execute(f"""
+                INSERT INTO raw_prices
+                    (date, code, open, high, low, close, volume, turnover, adj_factor, fetched_at)
+                SELECT date, code, open, high, low, close, volume, turnover, adj_factor,
+                       current_timestamp
+                FROM {_TMP}
+                {conflict_raw}
+            """)
+            conn.execute(f"""
+                INSERT INTO prices_daily (date, code, open, high, low, close, volume, turnover)
+                SELECT date, code, open, high, low, close, volume, turnover
+                FROM {_TMP}
+                WHERE open IS NOT NULL AND high IS NOT NULL AND low IS NOT NULL
+                  AND close IS NOT NULL AND volume IS NOT NULL AND low <= high
+                {conflict_proc}
+            """)
+            # TEMP TABLE への COUNT は prices_daily の全表走査より大幅に安価
+            loaded = conn.execute(f"""
+                SELECT COUNT(*) FROM {_TMP}
+                WHERE open IS NOT NULL AND high IS NOT NULL AND low IS NOT NULL
+                  AND close IS NOT NULL AND volume IS NOT NULL AND low <= high
+            """).fetchone()[0]
+            if not outer_tx:
+                conn.execute("COMMIT")
+        except Exception:
+            if not outer_tx:
+                conn.execute("ROLLBACK")
+            raise
+    finally:
+        conn.execute(f"DROP TABLE IF EXISTS {_TMP}")
 
     logger.info("load_prices: %d 件ロード (%s)", loaded, csv_path.name)
     return loaded
@@ -119,36 +117,37 @@ def load_master(
     """equities/master CSV → stocks
 
     bulk 引数は互換性のために受け付けるが無視する（master は常に upsert）。
-    outer_tx: True のとき BEGIN/COMMIT/ROLLBACK を行わない。
+    outer_tx  : True のとき BEGIN/COMMIT/ROLLBACK を行わない。
     """
     path = _sql_path(csv_path)
 
-    if not outer_tx:
-        conn.execute("BEGIN")
+    conn.execute(f"""
+        CREATE OR REPLACE TEMP TABLE {_TMP} AS
+        SELECT TRIM("Code") AS code, "CoName" AS name, "MktNm" AS market, "S33Nm" AS sector
+        FROM read_csv('{path}', nullstr='', all_varchar=true)
+        WHERE TRIM("Code") != ''
+    """)
     try:
-        before = conn.execute("SELECT COUNT(*) FROM stocks").fetchone()[0]
-        conn.execute(f"""
-            INSERT INTO stocks (code, name, market, sector, updated_at)
-            SELECT
-                TRIM("Code"),
-                "CoName",
-                "MktNm",
-                "S33Nm",
-                current_timestamp
-            FROM read_csv('{path}', nullstr='', all_varchar=true)
-            WHERE TRIM("Code") != ''
-            ON CONFLICT (code) DO UPDATE SET
-                name=EXCLUDED.name, market=EXCLUDED.market, sector=EXCLUDED.sector,
-                updated_at=EXCLUDED.updated_at
-        """)
-        loaded = conn.execute("SELECT COUNT(*) FROM stocks").fetchone()[0] - before
-
         if not outer_tx:
-            conn.execute("COMMIT")
-    except Exception:
-        if not outer_tx:
-            conn.execute("ROLLBACK")
-        raise
+            conn.execute("BEGIN")
+        try:
+            conn.execute(f"""
+                INSERT INTO stocks (code, name, market, sector, updated_at)
+                SELECT code, name, market, sector, current_timestamp
+                FROM {_TMP}
+                ON CONFLICT (code) DO UPDATE SET
+                    name=EXCLUDED.name, market=EXCLUDED.market, sector=EXCLUDED.sector,
+                    updated_at=EXCLUDED.updated_at
+            """)
+            loaded = conn.execute(f"SELECT COUNT(*) FROM {_TMP}").fetchone()[0]
+            if not outer_tx:
+                conn.execute("COMMIT")
+        except Exception:
+            if not outer_tx:
+                conn.execute("ROLLBACK")
+            raise
+    finally:
+        conn.execute(f"DROP TABLE IF EXISTS {_TMP}")
 
     logger.info("load_master: %d 件ロード (%s)", loaded, csv_path.name)
     return loaded
@@ -188,57 +187,51 @@ def load_financials(
         )
     )
 
-    if not outer_tx:
-        conn.execute("BEGIN")
+    conn.execute(f"""
+        CREATE OR REPLACE TEMP TABLE {_TMP} AS
+        SELECT
+            TRIM("Code")                      AS code,
+            TRY_CAST("DiscDate" AS DATE)      AS report_date,
+            TRIM("CurPerType")                AS period_type,
+            TRY_CAST("Sales" AS DOUBLE)       AS revenue,
+            TRY_CAST("OP" AS DOUBLE)          AS operating_profit,
+            TRY_CAST("NP" AS DOUBLE)          AS net_income,
+            TRY_CAST("EPS" AS DOUBLE)         AS eps,
+            TRY_CAST("ROE" AS DOUBLE)         AS roe
+        FROM read_csv('{path}', nullstr='', all_varchar=true)
+        WHERE TRIM("Code") != ''
+          AND TRY_CAST("DiscDate" AS DATE) IS NOT NULL
+          AND TRIM("CurPerType") != ''
+    """)
     try:
-        conn.execute(f"""
-            INSERT INTO raw_financials
-                (code, report_date, period_type, revenue, operating_profit, net_income,
-                 eps, roe, fetched_at)
-            SELECT
-                TRIM("Code"),
-                TRY_CAST("DiscDate" AS DATE),
-                TRIM("CurPerType"),
-                TRY_CAST("Sales" AS DOUBLE),
-                TRY_CAST("OP" AS DOUBLE),
-                TRY_CAST("NP" AS DOUBLE),
-                TRY_CAST("EPS" AS DOUBLE),
-                TRY_CAST("ROE" AS DOUBLE),
-                current_timestamp
-            FROM read_csv('{path}', nullstr='', all_varchar=true)
-            WHERE TRIM("Code") != ''
-              AND TRY_CAST("DiscDate" AS DATE) IS NOT NULL
-              AND TRIM("CurPerType") != ''
-            {conflict_raw}
-        """)
-
-        before = conn.execute("SELECT COUNT(*) FROM fundamentals").fetchone()[0]
-        conn.execute(f"""
-            INSERT INTO fundamentals
-                (code, report_date, period_type, revenue, operating_profit, net_income, eps, roe)
-            SELECT
-                TRIM("Code"),
-                TRY_CAST("DiscDate" AS DATE),
-                TRIM("CurPerType"),
-                TRY_CAST("Sales" AS DOUBLE),
-                TRY_CAST("OP" AS DOUBLE),
-                TRY_CAST("NP" AS DOUBLE),
-                TRY_CAST("EPS" AS DOUBLE),
-                TRY_CAST("ROE" AS DOUBLE)
-            FROM read_csv('{path}', nullstr='', all_varchar=true)
-            WHERE TRIM("Code") != ''
-              AND TRY_CAST("DiscDate" AS DATE) IS NOT NULL
-              AND TRIM("CurPerType") != ''
-            {conflict_proc}
-        """)
-        loaded = conn.execute("SELECT COUNT(*) FROM fundamentals").fetchone()[0] - before
-
         if not outer_tx:
-            conn.execute("COMMIT")
-    except Exception:
-        if not outer_tx:
-            conn.execute("ROLLBACK")
-        raise
+            conn.execute("BEGIN")
+        try:
+            conn.execute(f"""
+                INSERT INTO raw_financials
+                    (code, report_date, period_type, revenue, operating_profit, net_income,
+                     eps, roe, fetched_at)
+                SELECT code, report_date, period_type, revenue, operating_profit, net_income,
+                       eps, roe, current_timestamp
+                FROM {_TMP}
+                {conflict_raw}
+            """)
+            conn.execute(f"""
+                INSERT INTO fundamentals
+                    (code, report_date, period_type, revenue, operating_profit, net_income, eps, roe)
+                SELECT code, report_date, period_type, revenue, operating_profit, net_income, eps, roe
+                FROM {_TMP}
+                {conflict_proc}
+            """)
+            loaded = conn.execute(f"SELECT COUNT(*) FROM {_TMP}").fetchone()[0]
+            if not outer_tx:
+                conn.execute("COMMIT")
+        except Exception:
+            if not outer_tx:
+                conn.execute("ROLLBACK")
+            raise
+    finally:
+        conn.execute(f"DROP TABLE IF EXISTS {_TMP}")
 
     logger.info("load_financials: %d 件ロード (%s)", loaded, csv_path.name)
     return loaded
@@ -270,31 +263,38 @@ def load_calendar(
         )
     )
 
-    if not outer_tx:
-        conn.execute("BEGIN")
+    conn.execute(f"""
+        CREATE OR REPLACE TEMP TABLE {_TMP} AS
+        SELECT
+            TRY_CAST("Date" AS DATE) AS date,
+            coalesce("HolDiv", '0') != '1'  AS is_trading_day,
+            coalesce("HalfDiv", '0') = '1'  AS is_half_day,
+            coalesce("SQDiv", '0') = '1'    AS is_sq_day,
+            CASE WHEN "HolName" IS NULL OR trim("HolName") = '' THEN NULL ELSE "HolName" END
+                AS holiday_name
+        FROM read_csv('{path}', nullstr='', all_varchar=true)
+        WHERE TRY_CAST("Date" AS DATE) IS NOT NULL
+    """)
     try:
-        before = conn.execute("SELECT COUNT(*) FROM market_calendar").fetchone()[0]
-        conn.execute(f"""
-            INSERT INTO market_calendar
-                (date, is_trading_day, is_half_day, is_sq_day, holiday_name)
-            SELECT
-                TRY_CAST("Date" AS DATE),
-                coalesce("HolDiv", '0') != '1',
-                coalesce("HalfDiv", '0') = '1',
-                coalesce("SQDiv", '0') = '1',
-                CASE WHEN "HolName" IS NULL OR trim("HolName") = '' THEN NULL ELSE "HolName" END
-            FROM read_csv('{path}', nullstr='', all_varchar=true)
-            WHERE TRY_CAST("Date" AS DATE) IS NOT NULL
-            {conflict}
-        """)
-        loaded = conn.execute("SELECT COUNT(*) FROM market_calendar").fetchone()[0] - before
-
         if not outer_tx:
-            conn.execute("COMMIT")
-    except Exception:
-        if not outer_tx:
-            conn.execute("ROLLBACK")
-        raise
+            conn.execute("BEGIN")
+        try:
+            conn.execute(f"""
+                INSERT INTO market_calendar
+                    (date, is_trading_day, is_half_day, is_sq_day, holiday_name)
+                SELECT date, is_trading_day, is_half_day, is_sq_day, holiday_name
+                FROM {_TMP}
+                {conflict}
+            """)
+            loaded = conn.execute(f"SELECT COUNT(*) FROM {_TMP}").fetchone()[0]
+            if not outer_tx:
+                conn.execute("COMMIT")
+        except Exception:
+            if not outer_tx:
+                conn.execute("ROLLBACK")
+            raise
+    finally:
+        conn.execute(f"DROP TABLE IF EXISTS {_TMP}")
 
     logger.info("load_calendar: %d 件ロード (%s)", loaded, csv_path.name)
     return loaded
@@ -323,35 +323,41 @@ def load_topix(
         )
     )
 
-    if not outer_tx:
-        conn.execute("BEGIN")
+    conn.execute(f"""
+        CREATE OR REPLACE TEMP TABLE {_TMP} AS
+        SELECT
+            TRY_CAST("Date" AS DATE) AS date,
+            TRY_CAST("O" AS DOUBLE)  AS open,
+            TRY_CAST("H" AS DOUBLE)  AS high,
+            TRY_CAST("L" AS DOUBLE)  AS low,
+            TRY_CAST("C" AS DOUBLE)  AS close
+        FROM read_csv('{path}', nullstr='', all_varchar=true)
+        WHERE TRY_CAST("Date" AS DATE) IS NOT NULL
+          AND TRY_CAST("O" AS DOUBLE) IS NOT NULL
+          AND TRY_CAST("H" AS DOUBLE) IS NOT NULL
+          AND TRY_CAST("L" AS DOUBLE) IS NOT NULL
+          AND TRY_CAST("C" AS DOUBLE) IS NOT NULL
+          AND TRY_CAST("L" AS DOUBLE) <= TRY_CAST("H" AS DOUBLE)
+    """)
     try:
-        before = conn.execute("SELECT COUNT(*) FROM topix_daily").fetchone()[0]
-        conn.execute(f"""
-            INSERT INTO topix_daily (date, open, high, low, close)
-            SELECT
-                TRY_CAST("Date" AS DATE),
-                TRY_CAST("O" AS DOUBLE),
-                TRY_CAST("H" AS DOUBLE),
-                TRY_CAST("L" AS DOUBLE),
-                TRY_CAST("C" AS DOUBLE)
-            FROM read_csv('{path}', nullstr='', all_varchar=true)
-            WHERE TRY_CAST("Date" AS DATE) IS NOT NULL
-              AND TRY_CAST("O" AS DOUBLE) IS NOT NULL
-              AND TRY_CAST("H" AS DOUBLE) IS NOT NULL
-              AND TRY_CAST("L" AS DOUBLE) IS NOT NULL
-              AND TRY_CAST("C" AS DOUBLE) IS NOT NULL
-              AND TRY_CAST("L" AS DOUBLE) <= TRY_CAST("H" AS DOUBLE)
-            {conflict}
-        """)
-        loaded = conn.execute("SELECT COUNT(*) FROM topix_daily").fetchone()[0] - before
-
         if not outer_tx:
-            conn.execute("COMMIT")
-    except Exception:
-        if not outer_tx:
-            conn.execute("ROLLBACK")
-        raise
+            conn.execute("BEGIN")
+        try:
+            conn.execute(f"""
+                INSERT INTO topix_daily (date, open, high, low, close)
+                SELECT date, open, high, low, close
+                FROM {_TMP}
+                {conflict}
+            """)
+            loaded = conn.execute(f"SELECT COUNT(*) FROM {_TMP}").fetchone()[0]
+            if not outer_tx:
+                conn.execute("COMMIT")
+        except Exception:
+            if not outer_tx:
+                conn.execute("ROLLBACK")
+            raise
+    finally:
+        conn.execute(f"DROP TABLE IF EXISTS {_TMP}")
 
     logger.info("load_topix: %d 件ロード (%s)", loaded, csv_path.name)
     return loaded

--- a/src/kabusys/data/bootstrap/loaders.py
+++ b/src/kabusys/data/bootstrap/loaders.py
@@ -1,297 +1,317 @@
 from __future__ import annotations
 
-import csv
-import gzip
 import logging
-from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 
 import duckdb
 
 logger = logging.getLogger(__name__)
 
-_CHUNK = 10_000
+
+def _sql_path(csv_path: Path) -> str:
+    """Path を SQL 文字列リテラルとして安全に埋め込む（シングルクォートをエスケープ）。"""
+    return str(csv_path).replace("\\", "/").replace("'", "''")
 
 
-def _to_float(v: Any) -> float | None:
-    if v is None or str(v).strip() == "":
-        return None
-    try:
-        return float(v)
-    except (ValueError, TypeError):
-        return None
-
-
-def _to_int(v: Any) -> int | None:
-    if v is None or str(v).strip() == "":
-        return None
-    try:
-        return int(float(v))
-    except (ValueError, TypeError):
-        return None
-
-
-def _now() -> datetime:
-    return datetime.now(timezone.utc)
-
-
-def _iter_gz(csv_path: Path):
-    """gzip CSV を行ごとに dict で yield する。"""
-    with gzip.open(csv_path, "rt", encoding="utf-8") as f:
-        reader = csv.DictReader(f)
-        for row in reader:
-            yield row
-
-
-def load_prices(conn: duckdb.DuckDBPyConnection, csv_path: Path) -> int:
+def load_prices(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool = False) -> int:
     """equities/bars/daily CSV → raw_prices & prices_daily
 
-    Bulk CSV カラム: Date, Code, O, H, L, C, Vo, Va, AdjFactor
-    （UL, LL, AdjO/H/L/C/Vo は保存しない）
+    DuckDB の read_csv() でネイティブ読み込みする。Python 側の CSV 解析を排除し
+    ベクトル化バッチ処理による高速化を実現する。
+
+    bulk=True: 月次ファイル用。呼び出し元が対象月を事前 DELETE 済みであること。
+               ON CONFLICT DO NOTHING でバルク INSERT する。
+    bulk=False: 日次ファイル用。ON CONFLICT DO UPDATE で差分 upsert する。
     """
-    loaded = 0
-    buf_raw: list[tuple] = []
-    buf_proc: list[tuple] = []
-    fetched_at = _now()
+    path = _sql_path(csv_path)
 
-    def _flush():
-        nonlocal loaded
-        if buf_raw:
-            conn.executemany(
-                "INSERT INTO raw_prices (date, code, open, high, low, close, volume, turnover, adj_factor, fetched_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
-                "ON CONFLICT (date, code) DO UPDATE SET "
-                "open=EXCLUDED.open, high=EXCLUDED.high, low=EXCLUDED.low, close=EXCLUDED.close, "
-                "volume=EXCLUDED.volume, turnover=EXCLUDED.turnover, adj_factor=EXCLUDED.adj_factor, "
-                "fetched_at=EXCLUDED.fetched_at",
-                buf_raw,
-            )
-        if buf_proc:
-            conn.executemany(
-                "INSERT INTO prices_daily (date, code, open, high, low, close, volume, turnover) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
-                "ON CONFLICT (date, code) DO UPDATE SET "
-                "open=EXCLUDED.open, high=EXCLUDED.high, low=EXCLUDED.low, close=EXCLUDED.close, "
-                "volume=EXCLUDED.volume, turnover=EXCLUDED.turnover",
-                buf_proc,
-            )
-        loaded += len(buf_proc)
-        buf_raw.clear()
-        buf_proc.clear()
+    conflict_raw = (
+        "ON CONFLICT (date, code) DO NOTHING"
+        if bulk
+        else (
+            "ON CONFLICT (date, code) DO UPDATE SET "
+            "open=EXCLUDED.open, high=EXCLUDED.high, low=EXCLUDED.low, close=EXCLUDED.close, "
+            "volume=EXCLUDED.volume, turnover=EXCLUDED.turnover, adj_factor=EXCLUDED.adj_factor, "
+            "fetched_at=EXCLUDED.fetched_at"
+        )
+    )
+    conflict_proc = (
+        "ON CONFLICT (date, code) DO NOTHING"
+        if bulk
+        else (
+            "ON CONFLICT (date, code) DO UPDATE SET "
+            "open=EXCLUDED.open, high=EXCLUDED.high, low=EXCLUDED.low, close=EXCLUDED.close, "
+            "volume=EXCLUDED.volume, turnover=EXCLUDED.turnover"
+        )
+    )
 
-    for row in _iter_gz(csv_path):
-        date = row.get("Date", "").strip()
-        code = row.get("Code", "").strip()
-        if not date or not code:
-            logger.warning("load_prices: PK 欠損行をスキップ: %s", row)
-            continue
+    if bulk:
+        conn.execute("BEGIN")
+    try:
+        conn.execute(f"""
+            INSERT INTO raw_prices
+                (date, code, open, high, low, close, volume, turnover, adj_factor, fetched_at)
+            SELECT
+                TRY_CAST("Date" AS DATE),
+                "Code",
+                TRY_CAST("O" AS DOUBLE),
+                TRY_CAST("H" AS DOUBLE),
+                TRY_CAST("L" AS DOUBLE),
+                TRY_CAST("C" AS DOUBLE),
+                TRY_CAST("Vo" AS BIGINT),
+                TRY_CAST("Va" AS DOUBLE),
+                TRY_CAST("AdjFactor" AS DOUBLE),
+                current_timestamp
+            FROM read_csv('{path}', nullstr='', all_varchar=true)
+            WHERE TRY_CAST("Date" AS DATE) IS NOT NULL
+              AND "Code" IS NOT NULL AND trim("Code") != ''
+            {conflict_raw}
+        """)
 
-        o = _to_float(row.get("O"))
-        h = _to_float(row.get("H"))
-        lo = _to_float(row.get("L"))
-        c = _to_float(row.get("C"))
-        vol = _to_int(row.get("Vo"))
-        va = _to_float(row.get("Va"))
-        adj = _to_float(row.get("AdjFactor"))
+        before = conn.execute("SELECT COUNT(*) FROM prices_daily").fetchone()[0]
+        conn.execute(f"""
+            INSERT INTO prices_daily (date, code, open, high, low, close, volume, turnover)
+            SELECT
+                TRY_CAST("Date" AS DATE),
+                "Code",
+                TRY_CAST("O" AS DOUBLE),
+                TRY_CAST("H" AS DOUBLE),
+                TRY_CAST("L" AS DOUBLE),
+                TRY_CAST("C" AS DOUBLE),
+                TRY_CAST("Vo" AS BIGINT),
+                TRY_CAST("Va" AS DOUBLE)
+            FROM read_csv('{path}', nullstr='', all_varchar=true)
+            WHERE TRY_CAST("Date" AS DATE) IS NOT NULL
+              AND "Code" IS NOT NULL AND trim("Code") != ''
+              AND TRY_CAST("O" AS DOUBLE) IS NOT NULL
+              AND TRY_CAST("H" AS DOUBLE) IS NOT NULL
+              AND TRY_CAST("L" AS DOUBLE) IS NOT NULL
+              AND TRY_CAST("C" AS DOUBLE) IS NOT NULL
+              AND TRY_CAST("Vo" AS BIGINT) IS NOT NULL
+              AND TRY_CAST("L" AS DOUBLE) <= TRY_CAST("H" AS DOUBLE)
+            {conflict_proc}
+        """)
+        loaded = conn.execute("SELECT COUNT(*) FROM prices_daily").fetchone()[0] - before
 
-        buf_raw.append((date, code, o, h, lo, c, vol, va, adj, fetched_at))
+        if bulk:
+            conn.execute("COMMIT")
+    except Exception:
+        if bulk:
+            conn.execute("ROLLBACK")
+        raise
 
-        # prices_daily: NOT NULL OHLCV 必須 / low <= high
-        if None in (o, h, lo, c, vol) or lo > h:  # type: ignore[operator]
-            if len(buf_raw) >= _CHUNK:
-                _flush()
-            continue
-
-        buf_proc.append((date, code, o, h, lo, c, vol, va))
-        if len(buf_raw) >= _CHUNK:
-            _flush()
-
-    _flush()
     logger.info("load_prices: %d 件ロード (%s)", loaded, csv_path.name)
     return loaded
 
 
-def load_master(conn: duckdb.DuckDBPyConnection, csv_path: Path) -> int:
+def load_master(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool = False) -> int:
     """equities/master CSV → stocks
 
-    Bulk CSV カラム: Code, CoName, MktNm, S33Nm
+    bulk 引数は互換性のために受け付けるが無視する（master は常に upsert）。
     """
-    loaded = 0
-    buf: list[tuple] = []
+    path = _sql_path(csv_path)
 
-    def _flush():
-        nonlocal loaded
-        if buf:
-            conn.executemany(
-                "INSERT INTO stocks (code, name, market, sector, updated_at) "
-                "VALUES (?, ?, ?, ?, ?) "
-                "ON CONFLICT (code) DO UPDATE SET "
-                "name=EXCLUDED.name, market=EXCLUDED.market, sector=EXCLUDED.sector, "
-                "updated_at=EXCLUDED.updated_at",
-                buf,
-            )
-            loaded += len(buf)
-            buf.clear()
+    before = conn.execute("SELECT COUNT(*) FROM stocks").fetchone()[0]
+    conn.execute(f"""
+        INSERT INTO stocks (code, name, market, sector, updated_at)
+        SELECT
+            "Code",
+            "CoName",
+            "MktNm",
+            "S33Nm",
+            current_timestamp
+        FROM read_csv('{path}', nullstr='', all_varchar=true)
+        WHERE "Code" IS NOT NULL AND trim("Code") != ''
+        ON CONFLICT (code) DO UPDATE SET
+            name=EXCLUDED.name, market=EXCLUDED.market, sector=EXCLUDED.sector,
+            updated_at=EXCLUDED.updated_at
+    """)
+    loaded = conn.execute("SELECT COUNT(*) FROM stocks").fetchone()[0] - before
 
-    now = _now()
-    for row in _iter_gz(csv_path):
-        code = row.get("Code", "").strip()
-        if not code:
-            logger.warning("load_master: code 欠損行をスキップ: %s", row)
-            continue
-        buf.append((code, row.get("CoName"), row.get("MktNm"), row.get("S33Nm"), now))
-        if len(buf) >= _CHUNK:
-            _flush()
-
-    _flush()
     logger.info("load_master: %d 件ロード (%s)", loaded, csv_path.name)
     return loaded
 
 
-def load_financials(conn: duckdb.DuckDBPyConnection, csv_path: Path) -> int:
+def load_financials(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool = False) -> int:
     """fins/summary CSV → raw_financials & fundamentals
 
-    Bulk CSV カラム: Code, DiscDate, CurPerType, Sales, OP, NP, EPS, ROE
+    bulk=True: 月次ファイル用。呼び出し元が対象月を事前 DELETE 済みであること。
+    bulk=False: 日次ファイル用。ON CONFLICT DO UPDATE で差分 upsert する。
     """
-    loaded = 0
-    buf_raw: list[tuple] = []
-    buf_proc: list[tuple] = []
-    fetched_at = _now()
+    path = _sql_path(csv_path)
 
-    def _flush():
-        nonlocal loaded
-        if buf_raw:
-            conn.executemany(
-                "INSERT INTO raw_financials (code, report_date, period_type, revenue, "
-                "operating_profit, net_income, eps, roe, fetched_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
-                "ON CONFLICT (code, report_date, period_type) DO UPDATE SET "
-                "revenue=EXCLUDED.revenue, operating_profit=EXCLUDED.operating_profit, "
-                "net_income=EXCLUDED.net_income, eps=EXCLUDED.eps, roe=EXCLUDED.roe, "
-                "fetched_at=EXCLUDED.fetched_at",
-                buf_raw,
-            )
-        if buf_proc:
-            conn.executemany(
-                "INSERT INTO fundamentals (code, report_date, period_type, revenue, "
-                "operating_profit, net_income, eps, roe) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
-                "ON CONFLICT (code, report_date, period_type) DO UPDATE SET "
-                "revenue=EXCLUDED.revenue, operating_profit=EXCLUDED.operating_profit, "
-                "net_income=EXCLUDED.net_income, eps=EXCLUDED.eps, roe=EXCLUDED.roe",
-                buf_proc,
-            )
-        loaded += len(buf_proc)
-        buf_raw.clear()
-        buf_proc.clear()
+    conflict_raw = (
+        "ON CONFLICT (code, report_date, period_type) DO NOTHING"
+        if bulk
+        else (
+            "ON CONFLICT (code, report_date, period_type) DO UPDATE SET "
+            "revenue=EXCLUDED.revenue, operating_profit=EXCLUDED.operating_profit, "
+            "net_income=EXCLUDED.net_income, eps=EXCLUDED.eps, roe=EXCLUDED.roe, "
+            "fetched_at=EXCLUDED.fetched_at"
+        )
+    )
+    conflict_proc = (
+        "ON CONFLICT (code, report_date, period_type) DO NOTHING"
+        if bulk
+        else (
+            "ON CONFLICT (code, report_date, period_type) DO UPDATE SET "
+            "revenue=EXCLUDED.revenue, operating_profit=EXCLUDED.operating_profit, "
+            "net_income=EXCLUDED.net_income, eps=EXCLUDED.eps, roe=EXCLUDED.roe"
+        )
+    )
 
-    for row in _iter_gz(csv_path):
-        code = row.get("Code", "").strip()
-        report_date = row.get("DiscDate", "").strip()
-        period_type = row.get("CurPerType", "").strip()
-        if not code or not report_date or not period_type:
-            logger.warning("load_financials: PK 欠損行をスキップ: %s", row)
-            continue
+    if bulk:
+        conn.execute("BEGIN")
+    try:
+        conn.execute(f"""
+            INSERT INTO raw_financials
+                (code, report_date, period_type, revenue, operating_profit, net_income,
+                 eps, roe, fetched_at)
+            SELECT
+                "Code",
+                TRY_CAST("DiscDate" AS DATE),
+                "CurPerType",
+                TRY_CAST("Sales" AS DOUBLE),
+                TRY_CAST("OP" AS DOUBLE),
+                TRY_CAST("NP" AS DOUBLE),
+                TRY_CAST("EPS" AS DOUBLE),
+                TRY_CAST("ROE" AS DOUBLE),
+                current_timestamp
+            FROM read_csv('{path}', nullstr='', all_varchar=true)
+            WHERE "Code" IS NOT NULL AND trim("Code") != ''
+              AND TRY_CAST("DiscDate" AS DATE) IS NOT NULL
+              AND "CurPerType" IS NOT NULL AND trim("CurPerType") != ''
+            {conflict_raw}
+        """)
 
-        revenue = _to_float(row.get("Sales"))
-        op = _to_float(row.get("OP"))
-        np_ = _to_float(row.get("NP"))
-        eps = _to_float(row.get("EPS"))
-        roe = _to_float(row.get("ROE"))
+        before = conn.execute("SELECT COUNT(*) FROM fundamentals").fetchone()[0]
+        conn.execute(f"""
+            INSERT INTO fundamentals
+                (code, report_date, period_type, revenue, operating_profit, net_income, eps, roe)
+            SELECT
+                "Code",
+                TRY_CAST("DiscDate" AS DATE),
+                "CurPerType",
+                TRY_CAST("Sales" AS DOUBLE),
+                TRY_CAST("OP" AS DOUBLE),
+                TRY_CAST("NP" AS DOUBLE),
+                TRY_CAST("EPS" AS DOUBLE),
+                TRY_CAST("ROE" AS DOUBLE)
+            FROM read_csv('{path}', nullstr='', all_varchar=true)
+            WHERE "Code" IS NOT NULL AND trim("Code") != ''
+              AND TRY_CAST("DiscDate" AS DATE) IS NOT NULL
+              AND "CurPerType" IS NOT NULL AND trim("CurPerType") != ''
+            {conflict_proc}
+        """)
+        loaded = conn.execute("SELECT COUNT(*) FROM fundamentals").fetchone()[0] - before
 
-        buf_raw.append((code, report_date, period_type, revenue, op, np_, eps, roe, fetched_at))
-        buf_proc.append((code, report_date, period_type, revenue, op, np_, eps, roe))
+        if bulk:
+            conn.execute("COMMIT")
+    except Exception:
+        if bulk:
+            conn.execute("ROLLBACK")
+        raise
 
-        if len(buf_raw) >= _CHUNK:
-            _flush()
-
-    _flush()
     logger.info("load_financials: %d 件ロード (%s)", loaded, csv_path.name)
     return loaded
 
 
-def load_calendar(conn: duckdb.DuckDBPyConnection, csv_path: Path) -> int:
+def load_calendar(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool = False) -> int:
     """markets/calendar CSV → market_calendar
 
-    Bulk CSV カラム: Date, HolDiv, HalfDiv, SQDiv, HolName
     HolDiv="1" → is_trading_day=False（休日）
+
+    bulk=True: 月次ファイル用。呼び出し元が対象月を事前 DELETE 済みであること。
+    bulk=False: 日次ファイル用。ON CONFLICT DO UPDATE で差分 upsert する。
     """
-    loaded = 0
-    buf: list[tuple] = []
+    path = _sql_path(csv_path)
 
-    def _flush():
-        nonlocal loaded
-        if buf:
-            conn.executemany(
-                "INSERT INTO market_calendar (date, is_trading_day, is_half_day, is_sq_day, holiday_name) "
-                "VALUES (?, ?, ?, ?, ?) "
-                "ON CONFLICT (date) DO UPDATE SET "
-                "is_trading_day=EXCLUDED.is_trading_day, is_half_day=EXCLUDED.is_half_day, "
-                "is_sq_day=EXCLUDED.is_sq_day, holiday_name=EXCLUDED.holiday_name",
-                buf,
-            )
-            loaded += len(buf)
-            buf.clear()
+    conflict = (
+        "ON CONFLICT (date) DO NOTHING"
+        if bulk
+        else (
+            "ON CONFLICT (date) DO UPDATE SET "
+            "is_trading_day=EXCLUDED.is_trading_day, is_half_day=EXCLUDED.is_half_day, "
+            "is_sq_day=EXCLUDED.is_sq_day, holiday_name=EXCLUDED.holiday_name"
+        )
+    )
 
-    for row in _iter_gz(csv_path):
-        date = row.get("Date", "").strip()
-        if not date:
-            logger.warning("load_calendar: date 欠損行をスキップ: %s", row)
-            continue
-        is_trading = row.get("HolDiv", "0").strip() != "1"
-        is_half = row.get("HalfDiv", "0").strip() == "1"
-        is_sq = row.get("SQDiv", "0").strip() == "1"
-        holiday_name = row.get("HolName", "").strip() or None
-        buf.append((date, is_trading, is_half, is_sq, holiday_name))
-        if len(buf) >= _CHUNK:
-            _flush()
+    if bulk:
+        conn.execute("BEGIN")
+    try:
+        before = conn.execute("SELECT COUNT(*) FROM market_calendar").fetchone()[0]
+        conn.execute(f"""
+            INSERT INTO market_calendar
+                (date, is_trading_day, is_half_day, is_sq_day, holiday_name)
+            SELECT
+                TRY_CAST("Date" AS DATE),
+                coalesce("HolDiv", '0') != '1',
+                coalesce("HalfDiv", '0') = '1',
+                coalesce("SQDiv", '0') = '1',
+                CASE WHEN "HolName" IS NULL OR trim("HolName") = '' THEN NULL ELSE "HolName" END
+            FROM read_csv('{path}', nullstr='', all_varchar=true)
+            WHERE TRY_CAST("Date" AS DATE) IS NOT NULL
+            {conflict}
+        """)
+        loaded = conn.execute("SELECT COUNT(*) FROM market_calendar").fetchone()[0] - before
 
-    _flush()
+        if bulk:
+            conn.execute("COMMIT")
+    except Exception:
+        if bulk:
+            conn.execute("ROLLBACK")
+        raise
+
     logger.info("load_calendar: %d 件ロード (%s)", loaded, csv_path.name)
     return loaded
 
 
-def load_topix(conn: duckdb.DuckDBPyConnection, csv_path: Path) -> int:
+def load_topix(conn: duckdb.DuckDBPyConnection, csv_path: Path, bulk: bool = False) -> int:
     """indices/bars/daily/topix CSV → topix_daily
 
-    Bulk CSV カラム: Date, O, H, L, C
+    bulk=True: 月次ファイル用。呼び出し元が対象月を事前 DELETE 済みであること。
+    bulk=False: 日次ファイル用。ON CONFLICT DO UPDATE で差分 upsert する。
     """
-    loaded = 0
-    buf: list[tuple] = []
+    path = _sql_path(csv_path)
 
-    def _flush():
-        nonlocal loaded
-        if buf:
-            conn.executemany(
-                "INSERT INTO topix_daily (date, open, high, low, close) "
-                "VALUES (?, ?, ?, ?, ?) "
-                "ON CONFLICT (date) DO UPDATE SET "
-                "open=EXCLUDED.open, high=EXCLUDED.high, low=EXCLUDED.low, close=EXCLUDED.close",
-                buf,
-            )
-            loaded += len(buf)
-            buf.clear()
+    conflict = (
+        "ON CONFLICT (date) DO NOTHING"
+        if bulk
+        else (
+            "ON CONFLICT (date) DO UPDATE SET "
+            "open=EXCLUDED.open, high=EXCLUDED.high, low=EXCLUDED.low, close=EXCLUDED.close"
+        )
+    )
 
-    for row in _iter_gz(csv_path):
-        date = row.get("Date", "").strip()
-        if not date:
-            logger.warning("load_topix: date 欠損行をスキップ: %s", row)
-            continue
-        o = _to_float(row.get("O"))
-        h = _to_float(row.get("H"))
-        lo = _to_float(row.get("L"))
-        c = _to_float(row.get("C"))
-        if None in (o, h, lo, c):
-            logger.warning("load_topix: OHLC 欠損行をスキップ: %s", row)
-            continue
-        if lo > h:  # type: ignore[operator]
-            logger.warning("load_topix: low > high の行をスキップ: %s", row)
-            continue
-        buf.append((date, o, h, lo, c))
-        if len(buf) >= _CHUNK:
-            _flush()
+    if bulk:
+        conn.execute("BEGIN")
+    try:
+        before = conn.execute("SELECT COUNT(*) FROM topix_daily").fetchone()[0]
+        conn.execute(f"""
+            INSERT INTO topix_daily (date, open, high, low, close)
+            SELECT
+                TRY_CAST("Date" AS DATE),
+                TRY_CAST("O" AS DOUBLE),
+                TRY_CAST("H" AS DOUBLE),
+                TRY_CAST("L" AS DOUBLE),
+                TRY_CAST("C" AS DOUBLE)
+            FROM read_csv('{path}', nullstr='', all_varchar=true)
+            WHERE TRY_CAST("Date" AS DATE) IS NOT NULL
+              AND TRY_CAST("O" AS DOUBLE) IS NOT NULL
+              AND TRY_CAST("H" AS DOUBLE) IS NOT NULL
+              AND TRY_CAST("L" AS DOUBLE) IS NOT NULL
+              AND TRY_CAST("C" AS DOUBLE) IS NOT NULL
+              AND TRY_CAST("L" AS DOUBLE) <= TRY_CAST("H" AS DOUBLE)
+            {conflict}
+        """)
+        loaded = conn.execute("SELECT COUNT(*) FROM topix_daily").fetchone()[0] - before
 
-    _flush()
+        if bulk:
+            conn.execute("COMMIT")
+    except Exception:
+        if bulk:
+            conn.execute("ROLLBACK")
+        raise
+
     logger.info("load_topix: %d 件ロード (%s)", loaded, csv_path.name)
     return loaded

--- a/src/kabusys/data/bootstrap/runner.py
+++ b/src/kabusys/data/bootstrap/runner.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import argparse
 import logging
+import re
 import shutil
 import sys
 import urllib.error
+from calendar import monthrange
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
@@ -43,6 +45,14 @@ _LOADER_MAP = {
     "/fins/summary": load_financials,
     "/markets/calendar": load_calendar,
     "/indices/bars/daily/topix": load_topix,
+}
+
+# エンドポイントごとの日付カラムと管理テーブル（月次 DELETE に使用）
+_ENDPOINT_DATE_TABLES: dict[str, tuple[str, list[str]]] = {
+    "/equities/bars/daily": ("date", ["raw_prices", "prices_daily"]),
+    "/fins/summary": ("report_date", ["raw_financials", "fundamentals"]),
+    "/markets/calendar": ("date", ["market_calendar"]),
+    "/indices/bars/daily/topix": ("date", ["topix_daily"]),
 }
 
 
@@ -116,6 +126,41 @@ def _truncate_data(conn: duckdb.DuckDBPyConnection) -> None:
         conn.execute(f"DELETE FROM {table}")
         logger.info("テーブルをクリア: %s", table)
     logger.info("bootstrap データテーブルを全削除しました")
+
+
+def _parse_file_date(filename: str) -> tuple[str, int, int] | None:
+    """ファイル名から日付情報を抽出する。
+
+    Returns: ("monthly", year, month) or ("daily", year, month) or None
+    YYYYMMDD (8桁) を先に試みることで YYYYMM の誤検知を防ぐ。
+    """
+    m = re.search(r"_(\d{4})(\d{2})\d{2}\.csv\.gz$", filename)
+    if m:
+        return ("daily", int(m.group(1)), int(m.group(2)))
+    m = re.search(r"_(\d{4})(\d{2})\.csv\.gz$", filename)
+    if m:
+        return ("monthly", int(m.group(1)), int(m.group(2)))
+    return None
+
+
+def _pre_delete_month(
+    conn: duckdb.DuckDBPyConnection, endpoint: str, year: int, month: int
+) -> None:
+    """月次ファイルのロード前に対象月のデータを DELETE する。"""
+    date_col_tables = _ENDPOINT_DATE_TABLES.get(endpoint)
+    if date_col_tables is None:
+        return
+    date_col, tables = date_col_tables
+    last_day = monthrange(year, month)[1]
+    month_start = f"{year:04d}-{month:02d}-01"
+    month_end = f"{year:04d}-{month:02d}-{last_day:02d}"
+    for table in tables:
+        conn.execute(
+            f"DELETE FROM {table} WHERE {date_col} BETWEEN ? AND ?",
+            [month_start, month_end],
+        )
+        logger.debug("pre_delete: %s [%s..%s]", table, month_start, month_end)
+    logger.info("pre_delete 完了: %s %04d-%02d", endpoint, year, month)
 
 
 def _endpoint_to_file_prefix(endpoint: str) -> str:
@@ -276,9 +321,23 @@ def run_bootstrap(
                     result.failed_files += 1
                     continue
 
+            file_date = _parse_file_date(file_name)
+            bulk = (
+                file_date is not None
+                and file_date[0] == "monthly"
+                and endpoint in _ENDPOINT_DATE_TABLES
+            )
+            if bulk:
+                _, year, month = file_date
+                _pre_delete_month(conn, endpoint, year, month)
+                print(
+                    f"  [{idx}/{len(files)}] 月次削除完了: {year:04d}-{month:02d}",
+                    flush=True,
+                )
+
             print(f"  [{idx}/{len(files)}] ロード中: {file_name}", flush=True)
             try:
-                n = loader(conn, dest)
+                n = loader(conn, dest, bulk=bulk)
                 rows_ep += n
                 _record(conn, file_key, endpoint, file_name, "loaded", row_count=n)
                 result.loaded_files += 1

--- a/src/kabusys/data/bootstrap/runner.py
+++ b/src/kabusys/data/bootstrap/runner.py
@@ -327,17 +327,26 @@ def run_bootstrap(
                 and file_date[0] == "monthly"
                 and endpoint in _ENDPOINT_DATE_TABLES
             )
-            if bulk:
-                _, year, month = file_date
-                _pre_delete_month(conn, endpoint, year, month)
-                print(
-                    f"  [{idx}/{len(files)}] 月次削除完了: {year:04d}-{month:02d}",
-                    flush=True,
-                )
 
             print(f"  [{idx}/{len(files)}] ロード中: {file_name}", flush=True)
             try:
-                n = loader(conn, dest, bulk=bulk)
+                if bulk:
+                    # pre-delete と INSERT を同一トランザクションで実行
+                    _, year, month = file_date
+                    conn.execute("BEGIN")
+                    try:
+                        _pre_delete_month(conn, endpoint, year, month)
+                        n = loader(conn, dest, bulk=True, outer_tx=True)
+                        conn.execute("COMMIT")
+                    except Exception:
+                        conn.execute("ROLLBACK")
+                        raise
+                    print(
+                        f"  [{idx}/{len(files)}] 月次({year:04d}-{month:02d}) 削除→挿入完了",
+                        flush=True,
+                    )
+                else:
+                    n = loader(conn, dest, bulk=False)
                 rows_ep += n
                 _record(conn, file_key, endpoint, file_name, "loaded", row_count=n)
                 result.loaded_files += 1

--- a/tests/test_bootstrap_loaders.py
+++ b/tests/test_bootstrap_loaders.py
@@ -175,10 +175,9 @@ def test_load_prices_idempotent(conn, tmp_path):
     ]
     path = _gz(rows, tmp_path, "prices_idem.csv.gz")
     load_prices(conn, path)
-    count = load_prices(conn, path)
+    load_prices(conn, path)  # 2回目: 重複挿入なし
     assert conn.execute("SELECT COUNT(*) FROM raw_prices").fetchone()[0] == 1
     assert conn.execute("SELECT COUNT(*) FROM prices_daily").fetchone()[0] == 1
-    assert count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -10,6 +10,8 @@ import pytest
 from kabusys.data.bootstrap.runner import (
     BootstrapResult,
     _local_files,
+    _parse_file_date,
+    _pre_delete_month,
     _reset_bootstrap,
     _safe_errmsg,
     _safe_filename,
@@ -478,6 +480,144 @@ def test_run_bootstrap_local_mode_flat_structure(conn, tmp_path):
 # ---------------------------------------------------------------------------
 # _truncate_data
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# _parse_file_date
+# ---------------------------------------------------------------------------
+
+
+def test_parse_file_date_monthly():
+    assert _parse_file_date("equities_bars_daily_202401.csv.gz") == ("monthly", 2024, 1)
+    assert _parse_file_date("fins_summary_202312.csv.gz") == ("monthly", 2023, 12)
+
+
+def test_parse_file_date_daily():
+    assert _parse_file_date("equities_bars_daily_20240115.csv.gz") == ("daily", 2024, 1)
+    assert _parse_file_date("equities_bars_daily_20231201.csv.gz") == ("daily", 2023, 12)
+
+
+def test_parse_file_date_daily_not_confused_with_monthly():
+    # YYYYMMDD ファイルは "monthly" と誤判定してはならない
+    result = _parse_file_date("equities_bars_daily_20240115.csv.gz")
+    assert result is not None
+    assert result[0] == "daily"
+
+
+def test_parse_file_date_unknown():
+    assert _parse_file_date("some_random_file.csv.gz") is None
+    assert _parse_file_date("equities_bars_daily.csv.gz") is None
+
+
+# ---------------------------------------------------------------------------
+# _pre_delete_month
+# ---------------------------------------------------------------------------
+
+
+def test_pre_delete_month_prices(conn):
+    # 2024-01 のデータを投入
+    conn.execute(
+        "INSERT INTO raw_prices (date, code, open, high, low, close, volume, fetched_at) "
+        "VALUES ('2024-01-10', '7203', 100, 110, 90, 105, 1000, current_timestamp)"
+    )
+    conn.execute(
+        "INSERT INTO prices_daily (date, code, open, high, low, close, volume) "
+        "VALUES ('2024-01-10', '7203', 100, 110, 90, 105, 1000)"
+    )
+    # 2024-02 のデータも投入（削除されないことを確認）
+    conn.execute(
+        "INSERT INTO raw_prices (date, code, open, high, low, close, volume, fetched_at) "
+        "VALUES ('2024-02-01', '7203', 100, 110, 90, 105, 1000, current_timestamp)"
+    )
+
+    _pre_delete_month(conn, "/equities/bars/daily", 2024, 1)
+
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM raw_prices WHERE date BETWEEN '2024-01-01' AND '2024-01-31'"
+        ).fetchone()[0]
+        == 0
+    )
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM prices_daily WHERE date BETWEEN '2024-01-01' AND '2024-01-31'"
+        ).fetchone()[0]
+        == 0
+    )
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM raw_prices WHERE date BETWEEN '2024-02-01' AND '2024-02-28'"
+        ).fetchone()[0]
+        == 1
+    )
+
+
+def test_pre_delete_month_no_op_for_master(conn):
+    # /equities/master は _ENDPOINT_DATE_TABLES に含まれないため何もしない
+    conn.execute("INSERT INTO stocks (code, name, updated_at) VALUES ('7203', 'Toyota', now())")
+    _pre_delete_month(conn, "/equities/master", 2024, 1)
+    assert conn.execute("SELECT COUNT(*) FROM stocks").fetchone()[0] == 1
+
+
+# ---------------------------------------------------------------------------
+# run_bootstrap bulk mode (monthly pre-delete)
+# ---------------------------------------------------------------------------
+
+
+def test_run_bootstrap_monthly_file_triggers_pre_delete(conn, tmp_path):
+    """月次ファイル（YYYYMM）のロード時に対象月のデータが事前削除されることを確認。"""
+    ep_dir = tmp_path / "equities" / "bars" / "daily"
+    ep_dir.mkdir(parents=True)
+    gz_path = ep_dir / "equities_bars_daily_202401.csv.gz"
+    gz_path.write_bytes(_gz_prices(tmp_path))
+
+    # 2024-01 に既存データを投入（上書きされるべき）
+    conn.execute(
+        "INSERT INTO raw_prices (date, code, open, high, low, close, volume, fetched_at) "
+        "VALUES ('2024-01-05', '9999', 100, 110, 90, 105, 500, current_timestamp)"
+    )
+
+    result = run_bootstrap(
+        conn=conn,
+        api_key="unused",
+        raw_dir=tmp_path,
+        endpoints=["/equities/bars/daily"],
+        local=True,
+    )
+
+    assert result.loaded_files == 1
+    # 事前削除されたため 9999 は消え、CSV の 7203 のみ残る
+    codes = {r[0] for r in conn.execute("SELECT code FROM raw_prices").fetchall()}
+    assert "9999" not in codes
+    assert "7203" in codes
+
+
+def test_run_bootstrap_daily_file_no_pre_delete(conn, tmp_path):
+    """日次ファイル（YYYYMMDD）のロード時には事前削除しない（既存データ保持）。"""
+    ep_dir = tmp_path / "equities" / "bars" / "daily"
+    ep_dir.mkdir(parents=True)
+    gz_path = ep_dir / "equities_bars_daily_20240110.csv.gz"
+    gz_path.write_bytes(_gz_prices(tmp_path))
+
+    # 2024-01-15 の既存データ（削除されないはず）
+    conn.execute(
+        "INSERT INTO raw_prices (date, code, open, high, low, close, volume, fetched_at) "
+        "VALUES ('2024-01-15', '9999', 100, 110, 90, 105, 500, current_timestamp)"
+    )
+
+    result = run_bootstrap(
+        conn=conn,
+        api_key="unused",
+        raw_dir=tmp_path,
+        endpoints=["/equities/bars/daily"],
+        local=True,
+    )
+
+    assert result.loaded_files == 1
+    # 日次モードでは事前削除しないため 9999 は残る
+    codes = {r[0] for r in conn.execute("SELECT code FROM raw_prices").fetchall()}
+    assert "9999" in codes
+    assert "7203" in codes
 
 
 def test_truncate_data_clears_all_tables(conn, tmp_path):


### PR DESCRIPTION
## Summary

- Python 側の gzip/csv 行単位処理・`executemany` を廃止し、DuckDB の `read_csv()` に統一
- 月次ファイル（YYYYMM）: 対象月を事前 DELETE → `bulk=True` (`ON CONFLICT DO NOTHING` + transaction)
- 日次ファイル（YYYYMMDD）: `ON CONFLICT DO UPDATE` (upsert) で引き続き差分更新
- `runner.py` に `_parse_file_date()` / `_pre_delete_month()` を追加しファイル種別を自動判定

## 変更の詳細

### `loaders.py` (全面書き直し)
- `gzip`, `csv`, `io` インポートを完全削除
- `_to_float`, `_to_int`, `_iter_gz`, `_CHUNK` を削除
- 全5ローダーを `read_csv(all_varchar=true, nullstr='')` + `TRY_CAST` に統一
- データ検証 (`low <= high` 等) を Python ループから SQL `WHERE` 句に移行
- `fetched_at` を Python `datetime.now()` から SQL `current_timestamp` に変更

### `runner.py`
- `_parse_file_date(filename)`: YYYYMMDD / YYYYMM の正規表現判定
- `_pre_delete_month(conn, endpoint, year, month)`: 月次 INSERT 前の対象月 DELETE
- `run_bootstrap()`: ファイル名から bulk フラグを決定し、月次時に事前 DELETE

### `tests/`
- `_parse_file_date`, `_pre_delete_month`, bulk mode の新規テスト追加
- idempotent テストを新しいカウント意味論に合わせて修正

## 期待される効果

| アプローチ | 速度 |
|-----------|------|
| Python `executemany`（旧） | 基準 |
| `read_csv()` ネイティブ（本PR） | さらに高速（ベクトル化バッチ処理） |

## Test plan
- [x] `pytest tests/test_bootstrap_loaders.py tests/test_bootstrap_runner.py` — 36/36 pass
- [x] `pytest` (全体) — 1801/1801 pass
- [x] `ruff check .` — no errors
- [x] `ruff format --check .` — all formatted

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)