### PR TITLE
fix: load_financials の ROE Binder Error を修正 (Issue #296)

### DIFF
--- a/src/kabusys/data/bootstrap/loaders.py
+++ b/src/kabusys/data/bootstrap/loaders.py
@@ -197,7 +197,10 @@ def load_financials(
             TRY_CAST("OP" AS DOUBLE)          AS operating_profit,
             TRY_CAST("NP" AS DOUBLE)          AS net_income,
             TRY_CAST("EPS" AS DOUBLE)         AS eps,
-            TRY_CAST("ROE" AS DOUBLE)         AS roe
+            CASE WHEN TRY_CAST("Eq" AS DOUBLE) IS NOT NULL
+                      AND TRY_CAST("Eq" AS DOUBLE) != 0
+                 THEN TRY_CAST("NP" AS DOUBLE) / TRY_CAST("Eq" AS DOUBLE)
+                 ELSE NULL END                AS roe
         FROM read_csv('{path}', nullstr='', all_varchar=true)
         WHERE TRIM("Code") != ''
           AND TRY_CAST("DiscDate" AS DATE) IS NOT NULL

--- a/src/kabusys/data/bootstrap/loaders.py
+++ b/src/kabusys/data/bootstrap/loaders.py
@@ -197,10 +197,8 @@ def load_financials(
             TRY_CAST("OP" AS DOUBLE)          AS operating_profit,
             TRY_CAST("NP" AS DOUBLE)          AS net_income,
             TRY_CAST("EPS" AS DOUBLE)         AS eps,
-            CASE WHEN TRY_CAST("Eq" AS DOUBLE) IS NOT NULL
-                      AND TRY_CAST("Eq" AS DOUBLE) != 0
-                 THEN TRY_CAST("NP" AS DOUBLE) / TRY_CAST("Eq" AS DOUBLE)
-                 ELSE NULL END                AS roe
+            -- fins_summary CSV に ROE 列は存在しない。NP/Eq（純資産）から算出する。
+            TRY_CAST("NP" AS DOUBLE) / NULLIF(TRY_CAST("Eq" AS DOUBLE), 0) AS roe
         FROM read_csv('{path}', nullstr='', all_varchar=true)
         WHERE TRIM("Code") != ''
           AND TRY_CAST("DiscDate" AS DATE) IS NOT NULL

--- a/tests/test_bootstrap_loaders.py
+++ b/tests/test_bootstrap_loaders.py
@@ -227,7 +227,25 @@ def test_load_financials_inserts_raw_and_processed(conn, tmp_path):
     assert conn.execute("SELECT COUNT(*) FROM fundamentals").fetchone()[0] == 1
     roe = conn.execute("SELECT roe FROM fundamentals WHERE code='7203'").fetchone()[0]
     assert roe is not None
-    assert abs(float(roe) - 800000 / 4000000) < 1e-9
+    assert float(roe) == pytest.approx(800000 / 4000000)
+
+
+def test_load_financials_roe_null_when_eq_zero(conn, tmp_path):
+    rows = [{"Code": "7203", "DiscDate": "2024-01-10", "CurPerType": "FY",
+             "Sales": "1", "OP": "1", "NP": "100000", "Eq": "0", "EPS": "1"}]
+    path = _gz(rows, tmp_path, "fins_eq0.csv.gz")
+    load_financials(conn, path)
+    roe = conn.execute("SELECT roe FROM fundamentals WHERE code='7203'").fetchone()[0]
+    assert roe is None
+
+
+def test_load_financials_roe_null_when_eq_missing(conn, tmp_path):
+    rows = [{"Code": "7203", "DiscDate": "2024-01-10", "CurPerType": "FY",
+             "Sales": "1", "OP": "1", "NP": "100000", "Eq": "", "EPS": "1"}]
+    path = _gz(rows, tmp_path, "fins_eq_empty.csv.gz")
+    load_financials(conn, path)
+    roe = conn.execute("SELECT roe FROM fundamentals WHERE code='7203'").fetchone()[0]
+    assert roe is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bootstrap_loaders.py
+++ b/tests/test_bootstrap_loaders.py
@@ -207,6 +207,7 @@ def test_load_master_inserts_stocks(conn, tmp_path):
 
 
 def test_load_financials_inserts_raw_and_processed(conn, tmp_path):
+    # J-Quants fins_summary CSV に ROE 列は存在しない。ROE は NP/Eq から計算する。
     rows = [
         {
             "Code": "7203",
@@ -215,8 +216,8 @@ def test_load_financials_inserts_raw_and_processed(conn, tmp_path):
             "Sales": "10000000",
             "OP": "1000000",
             "NP": "800000",
+            "Eq": "4000000",
             "EPS": "120.5",
-            "ROE": "0.12",
         }
     ]
     path = _gz(rows, tmp_path, "fins.csv.gz")
@@ -224,6 +225,9 @@ def test_load_financials_inserts_raw_and_processed(conn, tmp_path):
     assert count == 1
     assert conn.execute("SELECT COUNT(*) FROM raw_financials").fetchone()[0] == 1
     assert conn.execute("SELECT COUNT(*) FROM fundamentals").fetchone()[0] == 1
+    roe = conn.execute("SELECT roe FROM fundamentals WHERE code='7203'").fetchone()[0]
+    assert roe is not None
+    assert abs(float(roe) - 800000 / 4000000) < 1e-9
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 原因

J-Quants \`fins_summary\` CSV に \`ROE\` 列は存在しない（107列構成、\`Eq\`, \`NP\` は存在）。

DuckDB 1.5.0 では存在しない列 \`"ROE"\` を lateral column alias で解決しようとし、SELECT で定義中の alias \`roe\` との循環参照として Binder Error を投げる：

```
Binder Error: Column "ROE" referenced that exists in the SELECT clause
              - but this column cannot be referenced before it is defined
```

旧 Python 実装は \`row.get("ROE", "")\` → \`None\` で無音スキップしていた（ROE は常に NULL）。

## 修正内容

\`TRY_CAST("ROE" AS DOUBLE) AS roe\` を削除し、CSV に実在する \`NP\`（当期純利益）/ \`Eq\`（純資産）から ROE を計算：

```sql
CASE WHEN TRY_CAST("Eq" AS DOUBLE) IS NOT NULL
          AND TRY_CAST("Eq" AS DOUBLE) != 0
     THEN TRY_CAST("NP" AS DOUBLE) / TRY_CAST("Eq" AS DOUBLE)
     ELSE NULL END AS roe
```

実データ検証: \`fins_summary_201605.csv.gz\` → 3125件ロード成功、ROE≈10.3%, 3.0%, 10.1% など正常計算を確認。

## Test plan
- [x] `pytest tests/test_bootstrap_loaders.py tests/test_bootstrap_runner.py` — 36/36 pass
- [x] 実 CSV \`fins_summary_201605.csv.gz\` で手動確認 (3125件、ROE 計算値正常)

Closes #296