### PR TITLE
fix: load_calendar の HalfDiv/SQDiv/HolName 列不在 Binder Error を修正 (Issue #298)

### DIFF
--- a/src/kabusys/data/bootstrap/loaders.py
+++ b/src/kabusys/data/bootstrap/loaders.py
@@ -264,13 +264,18 @@ def load_calendar(
         ).description
     }
 
+    if "HolDiv" not in csv_cols:
+        raise ValueError(f'markets/calendar CSV missing required "HolDiv" column: {csv_path}')
+
     # オプション列ごとに SQL 式を切り替える
     if "HalfDiv" in csv_cols:
         # 旧形式: 別列で半日フラグを持つ
+        logger.debug("load_calendar: using legacy format (HalfDiv present) for %s", csv_path)
         trading_expr = "coalesce(\"HolDiv\", '0') != '1'"
         half_expr = "coalesce(\"HalfDiv\", '0') = '1'"
     else:
         # 新形式: HolDiv の値で判定（1=通常取引日, 2=半日取引日）
+        logger.debug("load_calendar: using modern format (HolDiv only) for %s", csv_path)
         trading_expr = "\"HolDiv\" IN ('1', '2')"
         half_expr = "\"HolDiv\" = '2'"
 

--- a/src/kabusys/data/bootstrap/loaders.py
+++ b/src/kabusys/data/bootstrap/loaders.py
@@ -246,13 +246,40 @@ def load_calendar(
 ) -> int:
     """markets/calendar CSV → market_calendar
 
-    HolDiv="1" → is_trading_day=False（休日）
+    J-Quants の HolDiv エンコーディング:
+      0=休日, 1=通常取引日, 2=半日取引日（大発会・大納会等）, 3=振替休日
+    HalfDiv/SQDiv/HolName 列が存在する場合はそちらを優先する。
 
     bulk=True : 月次ファイル用。呼び出し元が対象月を事前 DELETE 済みであること。
     bulk=False: 日次ファイル用。ON CONFLICT DO UPDATE で差分 upsert する。
     outer_tx  : True のとき BEGIN/COMMIT/ROLLBACK を行わない。
     """
     path = _sql_path(csv_path)
+
+    # CSV 列名を DuckDB で取得（Python gzip/csv を使わず済ませる）
+    csv_cols = {
+        col[0]
+        for col in conn.execute(
+            f"SELECT * FROM read_csv('{path}', nullstr='', all_varchar=true) LIMIT 0"
+        ).description
+    }
+
+    # オプション列ごとに SQL 式を切り替える
+    if "HalfDiv" in csv_cols:
+        # 旧形式: 別列で半日フラグを持つ
+        trading_expr = "coalesce(\"HolDiv\", '0') != '1'"
+        half_expr = "coalesce(\"HalfDiv\", '0') = '1'"
+    else:
+        # 新形式: HolDiv の値で判定（1=通常取引日, 2=半日取引日）
+        trading_expr = "\"HolDiv\" IN ('1', '2')"
+        half_expr = "\"HolDiv\" = '2'"
+
+    sq_expr = "coalesce(\"SQDiv\", '0') = '1'" if "SQDiv" in csv_cols else "false"
+    name_expr = (
+        "CASE WHEN \"HolName\" IS NULL OR trim(\"HolName\") = '' THEN NULL ELSE \"HolName\" END"
+        if "HolName" in csv_cols
+        else "CAST(NULL AS VARCHAR)"
+    )
 
     conflict = (
         "ON CONFLICT (date) DO NOTHING"
@@ -268,11 +295,10 @@ def load_calendar(
         CREATE OR REPLACE TEMP TABLE {_TMP} AS
         SELECT
             TRY_CAST("Date" AS DATE) AS date,
-            coalesce("HolDiv", '0') != '1'  AS is_trading_day,
-            coalesce("HalfDiv", '0') = '1'  AS is_half_day,
-            coalesce("SQDiv", '0') = '1'    AS is_sq_day,
-            CASE WHEN "HolName" IS NULL OR trim("HolName") = '' THEN NULL ELSE "HolName" END
-                AS holiday_name
+            {trading_expr}  AS is_trading_day,
+            {half_expr}     AS is_half_day,
+            {sq_expr}       AS is_sq_day,
+            {name_expr}     AS holiday_name
         FROM read_csv('{path}', nullstr='', all_varchar=true)
         WHERE TRY_CAST("Date" AS DATE) IS NOT NULL
     """)

--- a/src/kabusys/data/bootstrap/loaders.py
+++ b/src/kabusys/data/bootstrap/loaders.py
@@ -276,7 +276,7 @@ def load_calendar(
 
     sq_expr = "coalesce(\"SQDiv\", '0') = '1'" if "SQDiv" in csv_cols else "false"
     name_expr = (
-        "CASE WHEN \"HolName\" IS NULL OR trim(\"HolName\") = '' THEN NULL ELSE \"HolName\" END"
+        'CASE WHEN "HolName" IS NULL OR trim("HolName") = \'\' THEN NULL ELSE "HolName" END'
         if "HolName" in csv_cols
         else "CAST(NULL AS VARCHAR)"
     )

--- a/tests/test_bootstrap_loaders.py
+++ b/tests/test_bootstrap_loaders.py
@@ -254,21 +254,10 @@ def test_load_financials_roe_null_when_eq_missing(conn, tmp_path):
 
 
 def test_load_calendar_inserts_market_calendar(conn, tmp_path):
+    # 旧形式: HalfDiv/SQDiv/HolName を持つフル列構成
     rows = [
-        {
-            "Date": "2024-01-04",
-            "HolDiv": "0",
-            "HalfDiv": "0",
-            "SQDiv": "0",
-            "HolName": "",
-        },
-        {
-            "Date": "2024-01-08",
-            "HolDiv": "1",
-            "HalfDiv": "0",
-            "SQDiv": "0",
-            "HolName": "成人の日",
-        },
+        {"Date": "2024-01-04", "HolDiv": "0", "HalfDiv": "0", "SQDiv": "0", "HolName": ""},
+        {"Date": "2024-01-08", "HolDiv": "1", "HalfDiv": "0", "SQDiv": "0", "HolName": "成人の日"},
     ]
     path = _gz(rows, tmp_path, "cal.csv.gz")
     count = load_calendar(conn, path)
@@ -278,6 +267,35 @@ def test_load_calendar_inserts_market_calendar(conn, tmp_path):
     ).fetchone()
     assert row[0] is False
     assert row[1] == "成人の日"
+
+
+def test_load_calendar_holdiv_only_new_format(conn, tmp_path):
+    # 新形式: Date + HolDiv のみ（J-Quants 実データ形式）
+    # HolDiv: 0=休日, 1=通常取引日, 2=半日取引日, 3=振替休日
+    rows = [
+        {"Date": "2024-01-01", "HolDiv": "0"},
+        {"Date": "2024-01-04", "HolDiv": "1"},
+        {"Date": "2024-01-05", "HolDiv": "2"},
+        {"Date": "2024-01-06", "HolDiv": "3"},
+    ]
+    path = _gz(rows, tmp_path, "cal_new.csv.gz")
+    count = load_calendar(conn, path)
+    assert count == 4
+
+    def get(date):
+        return conn.execute(
+            "SELECT is_trading_day, is_half_day, is_sq_day, holiday_name "
+            "FROM market_calendar WHERE date=?", [date]
+        ).fetchone()
+
+    r = get("2024-01-01")
+    assert r[0] is False and r[1] is False and r[2] is False and r[3] is None  # 休日
+    r = get("2024-01-04")
+    assert r[0] is True and r[1] is False  # 通常取引日
+    r = get("2024-01-05")
+    assert r[0] is True and r[1] is True   # 半日取引日
+    r = get("2024-01-06")
+    assert r[0] is False and r[1] is False  # 振替休日
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bootstrap_loaders.py
+++ b/tests/test_bootstrap_loaders.py
@@ -278,15 +278,31 @@ def test_load_calendar_inserts_market_calendar(conn, tmp_path):
     rows = [
         {"Date": "2024-01-04", "HolDiv": "0", "HalfDiv": "0", "SQDiv": "0", "HolName": ""},
         {"Date": "2024-01-08", "HolDiv": "1", "HalfDiv": "0", "SQDiv": "0", "HolName": "成人の日"},
+        {"Date": "2024-01-09", "HolDiv": "0", "HalfDiv": "1", "SQDiv": "0", "HolName": ""},
     ]
     path = _gz(rows, tmp_path, "cal.csv.gz")
     count = load_calendar(conn, path)
-    assert count == 2
-    row = conn.execute(
-        "SELECT is_trading_day, holiday_name FROM market_calendar WHERE date='2024-01-08'"
+    assert count == 3
+
+    # 通常取引日 (HolDiv=0 = 旧形式で is_trading_day=True)
+    r = conn.execute(
+        "SELECT is_trading_day, is_half_day, is_sq_day, holiday_name "
+        "FROM market_calendar WHERE date='2024-01-04'"
     ).fetchone()
-    assert row[0] is False
-    assert row[1] == "成人の日"
+    assert r[0] is True and r[1] is False and r[2] is False and r[3] is None
+
+    # 休日 (HolDiv=1 = 旧形式で is_trading_day=False)
+    r = conn.execute(
+        "SELECT is_trading_day, is_half_day, is_sq_day, holiday_name "
+        "FROM market_calendar WHERE date='2024-01-08'"
+    ).fetchone()
+    assert r[0] is False and r[1] is False and r[2] is False and r[3] == "成人の日"
+
+    # 半日取引日 (HalfDiv=1)
+    r = conn.execute(
+        "SELECT is_trading_day, is_half_day FROM market_calendar WHERE date='2024-01-09'"
+    ).fetchone()
+    assert r[0] is True and r[1] is True
 
 
 def test_load_calendar_holdiv_only_new_format(conn, tmp_path):

--- a/tests/test_bootstrap_loaders.py
+++ b/tests/test_bootstrap_loaders.py
@@ -231,8 +231,18 @@ def test_load_financials_inserts_raw_and_processed(conn, tmp_path):
 
 
 def test_load_financials_roe_null_when_eq_zero(conn, tmp_path):
-    rows = [{"Code": "7203", "DiscDate": "2024-01-10", "CurPerType": "FY",
-             "Sales": "1", "OP": "1", "NP": "100000", "Eq": "0", "EPS": "1"}]
+    rows = [
+        {
+            "Code": "7203",
+            "DiscDate": "2024-01-10",
+            "CurPerType": "FY",
+            "Sales": "1",
+            "OP": "1",
+            "NP": "100000",
+            "Eq": "0",
+            "EPS": "1",
+        }
+    ]
     path = _gz(rows, tmp_path, "fins_eq0.csv.gz")
     load_financials(conn, path)
     roe = conn.execute("SELECT roe FROM fundamentals WHERE code='7203'").fetchone()[0]
@@ -240,8 +250,18 @@ def test_load_financials_roe_null_when_eq_zero(conn, tmp_path):
 
 
 def test_load_financials_roe_null_when_eq_missing(conn, tmp_path):
-    rows = [{"Code": "7203", "DiscDate": "2024-01-10", "CurPerType": "FY",
-             "Sales": "1", "OP": "1", "NP": "100000", "Eq": "", "EPS": "1"}]
+    rows = [
+        {
+            "Code": "7203",
+            "DiscDate": "2024-01-10",
+            "CurPerType": "FY",
+            "Sales": "1",
+            "OP": "1",
+            "NP": "100000",
+            "Eq": "",
+            "EPS": "1",
+        }
+    ]
     path = _gz(rows, tmp_path, "fins_eq_empty.csv.gz")
     load_financials(conn, path)
     roe = conn.execute("SELECT roe FROM fundamentals WHERE code='7203'").fetchone()[0]
@@ -285,7 +305,8 @@ def test_load_calendar_holdiv_only_new_format(conn, tmp_path):
     def get(date):
         return conn.execute(
             "SELECT is_trading_day, is_half_day, is_sq_day, holiday_name "
-            "FROM market_calendar WHERE date=?", [date]
+            "FROM market_calendar WHERE date=?",
+            [date],
         ).fetchone()
 
     r = get("2024-01-01")
@@ -293,7 +314,7 @@ def test_load_calendar_holdiv_only_new_format(conn, tmp_path):
     r = get("2024-01-04")
     assert r[0] is True and r[1] is False  # 通常取引日
     r = get("2024-01-05")
-    assert r[0] is True and r[1] is True   # 半日取引日
+    assert r[0] is True and r[1] is True  # 半日取引日
     r = get("2024-01-06")
     assert r[0] is False and r[1] is False  # 振替休日
 


### PR DESCRIPTION
## 原因

J-Quants `markets/calendar` CSV は `Date` と `HolDiv` の2列のみで構成される。
`load_calendar` が参照する `HalfDiv`, `SQDiv`, `HolName` 列が存在せず Binder Error が発生。

```
Binder Error: Referenced column "HalfDiv" not found in FROM clause!
Candidate bindings: "HolDiv"
```

## HolDiv エンコーディング（実データ調査結果）

| HolDiv | 意味 | is_trading_day | is_half_day |
|--------|------|----------------|-------------|
| 0 | 休日 | false | false |
| 1 | 通常取引日 | true | false |
| 2 | 半日取引日（大発会・大納会等） | true | true |
| 3 | 振替休日 | false | false |

## 修正内容

CSV 列名を DuckDB (`LIMIT 0`) で動的に取得し、列の有無に応じて SQL 式を切り替える。

- `HalfDiv` 不在 → `HolDiv IN ('1','2')` で `is_trading_day`、`HolDiv = '2'` で `is_half_day`
- `SQDiv` 不在 → `is_sq_day = false`
- `HolName` 不在 → `holiday_name = NULL`
- 旧形式（全列あり）の後方互換を維持

## Test plan
- [x] `pytest tests/test_bootstrap_loaders.py tests/test_bootstrap_runner.py` — 39/39 pass
- [x] `HolDiv` 全4値の動作検証テスト追加（`test_load_calendar_holdiv_only_new_format`）
- [x] 実データ `markets_calendar.csv.gz` 7305件ロード成功（休日2416/通常取引4886/半日3件）

Closes #298