### PR TITLE
feat: Signal Queue キャンセル機能を追加（Streamlit UI + CLI）(Issue #300)

### DIFF
--- a/scripts/cancel_signal_queue.py
+++ b/scripts/cancel_signal_queue.py
@@ -1,0 +1,153 @@
+# scripts/cancel_signal_queue.py
+"""signal_queue の pending シグナルを status='cancelled' に変更するヘルパー。
+
+使い方:
+    python scripts/cancel_signal_queue.py --date 2026-05-12
+    python scripts/cancel_signal_queue.py --date 2026-05-12 --code 7203
+    python scripts/cancel_signal_queue.py --all
+
+用途:
+    誤ったシグナルが signal_queue に入った場合に手動でキャンセルする。
+    pending のみ対象（processing / filled は変更しない）。
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import date
+from pathlib import Path
+
+import duckdb
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+from kabusys.config import Settings
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def _fetch_targets(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date | None,
+    code: str | None,
+) -> list[dict]:
+    """status='pending' の対象レコードを返す。"""
+    conditions = ["status = 'pending'"]
+    params: list = []
+    if target_date is not None:
+        conditions.append("date = ?")
+        params.append(str(target_date))
+    if code is not None:
+        conditions.append("code = ?")
+        params.append(code)
+    where = " AND ".join(conditions)
+    rows = conn.execute(
+        f"""
+        SELECT signal_id, code, date, status, side, size
+        FROM signal_queue
+        WHERE {where}
+        ORDER BY date, code, signal_id
+        """,
+        params,
+    ).fetchall()
+    cols = ["signal_id", "code", "date", "status", "side", "size"]
+    return [dict(zip(cols, row)) for row in rows]
+
+
+def _print_records(records: list[dict]) -> None:
+    print(f"\n{'SIGNAL_ID':>36}  {'CODE':>6}  {'DATE':>12}  {'SIDE':>6}  {'SIZE':>8}")
+    print("-" * 80)
+    for r in records:
+        print(
+            f"{str(r['signal_id']):>36}  {r['code']:>6}  {str(r['date']):>12}  "
+            f"{str(r.get('side', '')):>6}  {r.get('size', ''):>8}"
+        )
+    print()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="signal_queue の pending シグナルを status='cancelled' に変更する"
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--date",
+        help="対象日付（YYYY-MM-DD 形式）。この日付の pending を全キャンセル",
+    )
+    group.add_argument(
+        "--all",
+        action="store_true",
+        help="pending の全件をキャンセル（日付を問わない）",
+    )
+    parser.add_argument(
+        "--code",
+        default=None,
+        help="銘柄コードで絞り込む（--date と組み合わせて使用）",
+    )
+    args = parser.parse_args()
+
+    if args.all and args.code:
+        parser.error("--all と --code は同時に指定できません")
+
+    target_date: date | None = None
+    if args.date:
+        try:
+            target_date = date.fromisoformat(args.date)
+        except ValueError:
+            logger.error("--date の形式が不正です（YYYY-MM-DD）: %s", args.date)
+            sys.exit(1)
+
+    settings = Settings()
+    if not settings.duckdb_path.exists():
+        logger.error("DuckDB ファイルが見つかりません: %s", settings.duckdb_path)
+        sys.exit(1)
+
+    conn = duckdb.connect(str(settings.duckdb_path))
+    try:
+        targets = _fetch_targets(conn, target_date, args.code)
+
+        if not targets:
+            logger.info("キャンセル対象の pending シグナルが見つかりませんでした。")
+            sys.exit(0)
+
+        print(f"以下の {len(targets)} 件を status='cancelled' に変更します:")
+        _print_records(targets)
+
+        answer = input("続行しますか？ [y/N]: ").strip().lower()
+        if answer != "y":
+            logger.info("ユーザーによりキャンセルされました。")
+            sys.exit(0)
+
+        signal_ids = [r["signal_id"] for r in targets]
+        placeholders = ", ".join(["?"] * len(signal_ids))
+        updated_rows = conn.execute(
+            f"UPDATE signal_queue SET status = 'cancelled'"
+            f" WHERE signal_id IN ({placeholders})"
+            f" AND status = 'pending'"
+            f" RETURNING signal_id",
+            signal_ids,
+        ).fetchall()
+        updated = len(updated_rows)
+        if updated != len(signal_ids):
+            logger.warning(
+                "%d 件を選択しましたが実際の更新は %d 件でした。"
+                "並行処理で status が変更済みの行があります。",
+                len(signal_ids),
+                updated,
+            )
+        logger.info(
+            "signal_queue を更新しました（%d 件を status='cancelled' に変更）。",
+            updated,
+        )
+
+    except Exception:
+        logger.exception("signal_queue の更新に失敗しました")
+        sys.exit(1)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/kabusys/monitoring/pages/6_Signal_Queue.py
+++ b/src/kabusys/monitoring/pages/6_Signal_Queue.py
@@ -1,4 +1,4 @@
-"""pages/2_Signal_Queue.py — 翌営業日の発注予定・シグナル確認ビュー。"""
+"""pages/6_Signal_Queue.py — 翌営業日の発注予定・シグナル確認ビュー。"""
 
 from __future__ import annotations
 
@@ -41,6 +41,77 @@ try:
             pending = df[df["status"] == "pending"]
             st.metric("pending 件数", len(pending))
             st.dataframe(df, use_container_width=True)
+
+        # --- キャンセル操作 ---
+        st.divider()
+        st.subheader("Pending シグナルのキャンセル")
+
+        if df.empty or pending.empty:
+            st.info("キャンセル可能な pending シグナルはありません。")
+        else:
+            pending_ids = pending["signal_id"].tolist()
+
+            # 個別選択キャンセル
+            selected = st.multiselect(
+                "キャンセルするシグナルを選択（signal_id）",
+                options=pending_ids,
+                help="pending ステータスのシグナルのみ表示されます",
+            )
+
+            col_sel, col_all = st.columns(2)
+
+            with col_sel:
+                if st.button(
+                    f"選択した {len(selected)} 件をキャンセル",
+                    disabled=len(selected) == 0,
+                    type="primary",
+                ):
+                    st.session_state["cancel_targets"] = selected
+                    st.session_state["cancel_mode"] = "selected"
+
+            with col_all:
+                if st.button(
+                    f"全 pending（{len(pending_ids)} 件）をキャンセル",
+                    type="secondary",
+                ):
+                    st.session_state["cancel_targets"] = pending_ids
+                    st.session_state["cancel_mode"] = "all"
+
+            # 確認ダイアログ
+            if "cancel_targets" in st.session_state:
+                targets = st.session_state["cancel_targets"]
+                mode_label = (
+                    f"選択した {len(targets)} 件"
+                    if st.session_state.get("cancel_mode") == "selected"
+                    else f"全 pending {len(targets)} 件"
+                )
+                st.warning(f"{mode_label} を `cancelled` に変更します。この操作は元に戻せません。")
+                confirm_col, abort_col = st.columns(2)
+                with confirm_col:
+                    if st.button("確定してキャンセル実行", type="primary"):
+                        try:
+                            write_conn = duckdb.connect(str(settings.duckdb_path))
+                            placeholders = ", ".join(["?" for _ in targets])
+                            updated = write_conn.execute(
+                                f"UPDATE signal_queue SET status = 'cancelled'"
+                                f" WHERE signal_id IN ({placeholders})"
+                                f" AND status = 'pending'"
+                                f" RETURNING signal_id",
+                                targets,
+                            ).fetchall()
+                            write_conn.close()
+                            count = len(updated)
+                            st.success(f"{count} 件を cancelled に変更しました。")
+                            del st.session_state["cancel_targets"]
+                            del st.session_state["cancel_mode"]
+                            st.rerun()
+                        except Exception as e:
+                            st.error(f"キャンセル処理に失敗しました: {e}")
+                with abort_col:
+                    if st.button("戻る"):
+                        del st.session_state["cancel_targets"]
+                        del st.session_state["cancel_mode"]
+                        st.rerun()
 
     with tab_targets:
         st.subheader("ポートフォリオ目標（最新日）")

--- a/src/kabusys/monitoring/pages/6_Signal_Queue.py
+++ b/src/kabusys/monitoring/pages/6_Signal_Queue.py
@@ -66,23 +66,23 @@ try:
                     disabled=len(selected) == 0,
                     type="primary",
                 ):
-                    st.session_state["cancel_targets"] = selected
-                    st.session_state["cancel_mode"] = "selected"
+                    st.session_state["sq_cancel_targets"] = selected
+                    st.session_state["sq_cancel_mode"] = "selected"
 
             with col_all:
                 if st.button(
                     f"全 pending（{len(pending_ids)} 件）をキャンセル",
                     type="secondary",
                 ):
-                    st.session_state["cancel_targets"] = pending_ids
-                    st.session_state["cancel_mode"] = "all"
+                    st.session_state["sq_cancel_targets"] = pending_ids
+                    st.session_state["sq_cancel_mode"] = "all"
 
             # 確認ダイアログ
-            if "cancel_targets" in st.session_state:
-                targets = st.session_state["cancel_targets"]
+            if "sq_cancel_targets" in st.session_state:
+                targets = st.session_state["sq_cancel_targets"]
                 mode_label = (
                     f"選択した {len(targets)} 件"
-                    if st.session_state.get("cancel_mode") == "selected"
+                    if st.session_state.get("sq_cancel_mode") == "selected"
                     else f"全 pending {len(targets)} 件"
                 )
                 st.warning(f"{mode_label} を `cancelled` に変更します。この操作は元に戻せません。")
@@ -90,27 +90,32 @@ try:
                 with confirm_col:
                     if st.button("確定してキャンセル実行", type="primary"):
                         try:
-                            write_conn = duckdb.connect(str(settings.duckdb_path))
                             placeholders = ", ".join(["?" for _ in targets])
-                            updated = write_conn.execute(
-                                f"UPDATE signal_queue SET status = 'cancelled'"
-                                f" WHERE signal_id IN ({placeholders})"
-                                f" AND status = 'pending'"
-                                f" RETURNING signal_id",
-                                targets,
-                            ).fetchall()
-                            write_conn.close()
-                            count = len(updated)
+                            with duckdb.connect(str(settings.duckdb_path)) as write_conn:
+                                updated = write_conn.execute(
+                                    f"UPDATE signal_queue SET status = 'cancelled'"
+                                    f" WHERE signal_id IN ({placeholders})"
+                                    f" AND status = 'pending'"
+                                    f" RETURNING signal_id",
+                                    targets,
+                                ).fetchall()
+                            updated_ids = {row[0] for row in updated}
+                            count = len(updated_ids)
                             st.success(f"{count} 件を cancelled に変更しました。")
-                            del st.session_state["cancel_targets"]
-                            del st.session_state["cancel_mode"]
+                            skipped = len(targets) - count
+                            if skipped > 0:
+                                st.warning(
+                                    f"{skipped} 件は既に pending ではなかったためスキップされました。"
+                                )
+                            del st.session_state["sq_cancel_targets"]
+                            del st.session_state["sq_cancel_mode"]
                             st.rerun()
                         except Exception as e:
                             st.error(f"キャンセル処理に失敗しました: {e}")
                 with abort_col:
                     if st.button("戻る"):
-                        del st.session_state["cancel_targets"]
-                        del st.session_state["cancel_mode"]
+                        del st.session_state["sq_cancel_targets"]
+                        del st.session_state["sq_cancel_mode"]
                         st.rerun()
 
     with tab_targets:

--- a/tests/test_cancel_signal_queue.py
+++ b/tests/test_cancel_signal_queue.py
@@ -174,8 +174,10 @@ def test_updates_cancelled_on_yes(tmp_path, monkeypatch):
     ):
         _run(["--date", "2026-05-12"])
 
-    sql_calls = [(str(c.args[0]), c.args[1] if len(c.args) > 1 else [])
-                 for c in conn_mock.execute.call_args_list]
+    sql_calls = [
+        (str(c.args[0]), c.args[1] if len(c.args) > 1 else [])
+        for c in conn_mock.execute.call_args_list
+    ]
     update_call = next(c for c in sql_calls if "UPDATE" in c[0])
     assert "cancelled" in update_call[0]
     assert "pending" in update_call[0]

--- a/tests/test_cancel_signal_queue.py
+++ b/tests/test_cancel_signal_queue.py
@@ -1,0 +1,232 @@
+# tests/test_cancel_signal_queue.py
+"""scripts/cancel_signal_queue.py の単体テスト"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+
+def _run(args: list[str]):
+    import cancel_signal_queue as m
+
+    with patch.object(sys, "argv", ["cancel_signal_queue.py"] + args):
+        return m.main()
+
+
+# ---------------------------------------------------------------------------
+# 引数バリデーション
+# ---------------------------------------------------------------------------
+
+
+def test_requires_date_or_all():
+    with pytest.raises(SystemExit) as exc:
+        _run([])
+    assert exc.value.code == 2
+
+
+def test_date_and_all_are_mutually_exclusive():
+    with pytest.raises(SystemExit) as exc:
+        _run(["--date", "2026-05-12", "--all"])
+    assert exc.value.code == 2
+
+
+def test_all_and_code_cannot_coexist(tmp_path):
+    duckdb_path = tmp_path / "kabusys.duckdb"
+    duckdb_path.write_bytes(b"fake")
+    settings_mock = MagicMock()
+    settings_mock.duckdb_path = duckdb_path
+    with patch("cancel_signal_queue.Settings", return_value=settings_mock):
+        with pytest.raises(SystemExit) as exc:
+            _run(["--all", "--code", "7203"])
+        assert exc.value.code == 2
+
+
+def test_invalid_date_format_exits(tmp_path):
+    duckdb_path = tmp_path / "kabusys.duckdb"
+    duckdb_path.write_bytes(b"fake")
+    settings_mock = MagicMock()
+    settings_mock.duckdb_path = duckdb_path
+    with patch("cancel_signal_queue.Settings", return_value=settings_mock):
+        with pytest.raises(SystemExit) as exc:
+            _run(["--date", "2026/05/12"])
+        assert exc.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# DuckDB ファイル不存在
+# ---------------------------------------------------------------------------
+
+
+def test_exits_when_duckdb_missing(tmp_path):
+    settings_mock = MagicMock()
+    settings_mock.duckdb_path = tmp_path / "nonexistent.duckdb"
+    with patch("cancel_signal_queue.Settings", return_value=settings_mock):
+        with pytest.raises(SystemExit) as exc:
+            _run(["--date", "2026-05-12"])
+        assert exc.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# 対象 0 件 → 正常終了（exit 0）
+# ---------------------------------------------------------------------------
+
+
+def test_exits_zero_when_no_targets(tmp_path):
+    duckdb_path = tmp_path / "kabusys.duckdb"
+    duckdb_path.write_bytes(b"fake")
+    settings_mock = MagicMock()
+    settings_mock.duckdb_path = duckdb_path
+    conn_mock = MagicMock()
+    conn_mock.execute.return_value.fetchall.return_value = []
+    with (
+        patch("cancel_signal_queue.Settings", return_value=settings_mock),
+        patch("cancel_signal_queue.duckdb.connect", return_value=conn_mock),
+    ):
+        with pytest.raises(SystemExit) as exc:
+            _run(["--date", "2026-05-12"])
+        assert exc.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# SELECT クエリが status='pending' のみを対象にしていること
+# ---------------------------------------------------------------------------
+
+
+def test_selects_pending_only(tmp_path):
+    duckdb_path = tmp_path / "kabusys.duckdb"
+    duckdb_path.write_bytes(b"fake")
+    settings_mock = MagicMock()
+    settings_mock.duckdb_path = duckdb_path
+    conn_mock = MagicMock()
+    conn_mock.execute.return_value.fetchall.return_value = []
+    with (
+        patch("cancel_signal_queue.Settings", return_value=settings_mock),
+        patch("cancel_signal_queue.duckdb.connect", return_value=conn_mock),
+    ):
+        with pytest.raises(SystemExit):
+            _run(["--date", "2026-05-12"])
+
+    select_sql = str(conn_mock.execute.call_args_list[0].args[0])
+    assert "pending" in select_sql
+    assert "processing" not in select_sql
+    assert "filled" not in select_sql
+
+
+# ---------------------------------------------------------------------------
+# ユーザーが "n" → UPDATE 実行なし・exit 0
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_on_user_no(tmp_path, monkeypatch):
+    duckdb_path = tmp_path / "kabusys.duckdb"
+    duckdb_path.write_bytes(b"fake")
+    settings_mock = MagicMock()
+    settings_mock.duckdb_path = duckdb_path
+    conn_mock = MagicMock()
+    conn_mock.execute.return_value.fetchall.return_value = [
+        ("sig-001", "7203", "2026-05-12", "pending", "buy", 100)
+    ]
+    monkeypatch.setattr("builtins.input", lambda prompt="": "n")
+    with (
+        patch("cancel_signal_queue.Settings", return_value=settings_mock),
+        patch("cancel_signal_queue.duckdb.connect", return_value=conn_mock),
+    ):
+        with pytest.raises(SystemExit) as exc:
+            _run(["--date", "2026-05-12"])
+        assert exc.value.code == 0
+
+    sql_calls = [str(c.args[0]) for c in conn_mock.execute.call_args_list]
+    assert not any("UPDATE" in s for s in sql_calls)
+
+
+# ---------------------------------------------------------------------------
+# 正常系: y 入力 → UPDATE cancelled が実行される
+# ---------------------------------------------------------------------------
+
+
+def test_updates_cancelled_on_yes(tmp_path, monkeypatch):
+    duckdb_path = tmp_path / "kabusys.duckdb"
+    duckdb_path.write_bytes(b"fake")
+    settings_mock = MagicMock()
+    settings_mock.duckdb_path = duckdb_path
+
+    select_result = MagicMock()
+    select_result.fetchall.return_value = [
+        ("sig-001", "7203", "2026-05-12", "pending", "buy", 100),
+        ("sig-002", "9984", "2026-05-12", "pending", "sell", 50),
+    ]
+    update_result = MagicMock()
+    update_result.fetchall.return_value = [("sig-001",), ("sig-002",)]
+    conn_mock = MagicMock()
+    conn_mock.execute.side_effect = [select_result, update_result]
+
+    monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+
+    with (
+        patch("cancel_signal_queue.Settings", return_value=settings_mock),
+        patch("cancel_signal_queue.duckdb.connect", return_value=conn_mock),
+    ):
+        _run(["--date", "2026-05-12"])
+
+    sql_calls = [(str(c.args[0]), c.args[1] if len(c.args) > 1 else [])
+                 for c in conn_mock.execute.call_args_list]
+    update_call = next(c for c in sql_calls if "UPDATE" in c[0])
+    assert "cancelled" in update_call[0]
+    assert "pending" in update_call[0]
+    assert "RETURNING" in update_call[0]
+    assert "sig-001" in update_call[1] and "sig-002" in update_call[1]
+    conn_mock.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# --date + --code の絞り込みクエリにコードが含まれること
+# ---------------------------------------------------------------------------
+
+
+def test_date_and_code_filter(tmp_path):
+    duckdb_path = tmp_path / "kabusys.duckdb"
+    duckdb_path.write_bytes(b"fake")
+    settings_mock = MagicMock()
+    settings_mock.duckdb_path = duckdb_path
+    conn_mock = MagicMock()
+    conn_mock.execute.return_value.fetchall.return_value = []
+    with (
+        patch("cancel_signal_queue.Settings", return_value=settings_mock),
+        patch("cancel_signal_queue.duckdb.connect", return_value=conn_mock),
+    ):
+        with pytest.raises(SystemExit):
+            _run(["--date", "2026-05-12", "--code", "7203"])
+
+    call_args = conn_mock.execute.call_args_list[0].args
+    assert "7203" in call_args[1]
+    assert "2026-05-12" in call_args[1]
+
+
+# ---------------------------------------------------------------------------
+# --all は日付条件なしで全 pending を対象にすること
+# ---------------------------------------------------------------------------
+
+
+def test_all_flag_no_date_filter(tmp_path):
+    duckdb_path = tmp_path / "kabusys.duckdb"
+    duckdb_path.write_bytes(b"fake")
+    settings_mock = MagicMock()
+    settings_mock.duckdb_path = duckdb_path
+    conn_mock = MagicMock()
+    conn_mock.execute.return_value.fetchall.return_value = []
+    with (
+        patch("cancel_signal_queue.Settings", return_value=settings_mock),
+        patch("cancel_signal_queue.duckdb.connect", return_value=conn_mock),
+    ):
+        with pytest.raises(SystemExit):
+            _run(["--all"])
+
+    call_args = conn_mock.execute.call_args_list[0]
+    params = call_args.args[1] if len(call_args.args) > 1 else []
+    assert len(params) == 0


### PR DESCRIPTION
## Summary

- `scripts/cancel_signal_queue.py` — pending シグナルを `status='cancelled'` に変更する CLI ヘルパーを新規追加
- `src/kabusys/monitoring/pages/6_Signal_Queue.py` — Streamlit の発注キュータブにキャンセル UI を追加
- `tests/test_cancel_signal_queue.py` — CLI の単体テスト 11 件を追加

## 変更詳細

### CLI (`scripts/cancel_signal_queue.py`)

```
python scripts/cancel_signal_queue.py --date 2026-05-12           # 特定日の全 pending
python scripts/cancel_signal_queue.py --date 2026-05-12 --code 7203  # 特定日・特定銘柄
python scripts/cancel_signal_queue.py --all                       # 全 pending
```

- `--date` / `--all` は排他オプション
- `--all` と `--code` は同時指定不可
- 実行前に対象一覧を表示し `[y/N]` 確認
- TOCTOU 対策: UPDATE 側にも `status = 'pending'` 条件を付与、`RETURNING` で実更新件数を検証

### Streamlit UI (`6_Signal_Queue.py`)

- 発注キュータブ下部にキャンセルセクションを追加
- multiselect で対象を個別選択 → 「選択した N 件をキャンセル」ボタン
- 「全 pending（N 件）をキャンセル」ボタン
- いずれもワンクリック後に確認ダイアログを表示してから実行
- 書き込み時のみ別の write_conn を開いて DuckDB 排他制御を回避

### 安全設計

- `pending` のみ対象。`processing` / `filled` は変更しない
- 物理 DELETE は行わず `status = 'cancelled'` へ変更（監査ログ保持）

## Test Plan

- [x] `pytest tests/test_cancel_signal_queue.py` 11 件すべてパス
- [x] `pytest tests/` 1818 件すべてパス

Closes #300