### PR TITLE
feat: Signal Queue — ステータスフィルター・cancelled 物理削除機能を追加 (Issue #302)

### DIFF
--- a/scripts/cancel_signal_queue.py
+++ b/scripts/cancel_signal_queue.py
@@ -5,10 +5,12 @@
     python scripts/cancel_signal_queue.py --date 2026-05-12
     python scripts/cancel_signal_queue.py --date 2026-05-12 --code 7203
     python scripts/cancel_signal_queue.py --all
+    python scripts/cancel_signal_queue.py --delete-cancelled
 
 用途:
     誤ったシグナルが signal_queue に入った場合に手動でキャンセルする。
     pending のみ対象（processing / filled は変更しない）。
+    --delete-cancelled は cancelled レコードを物理削除する（監査ログ不要になった後の掃除用）。
 """
 
 from __future__ import annotations
@@ -67,6 +69,26 @@ def _print_records(records: list[dict]) -> None:
     print()
 
 
+def _run_delete_cancelled(conn: duckdb.DuckDBPyConnection) -> None:
+    """status='cancelled' のレコードを物理削除する。"""
+    count = conn.execute("SELECT COUNT(*) FROM signal_queue WHERE status = 'cancelled'").fetchone()[
+        0
+    ]
+
+    if count == 0:
+        logger.info("削除対象の cancelled レコードが見つかりませんでした。")
+        sys.exit(0)
+
+    print(f"cancelled レコードが {count} 件あります。完全削除します。")
+    answer = input("続行しますか？ [y/N]: ").strip().lower()
+    if answer != "y":
+        logger.info("ユーザーによりキャンセルされました。")
+        sys.exit(0)
+
+    result = conn.execute("DELETE FROM signal_queue WHERE status = 'cancelled'")
+    logger.info("signal_queue から cancelled レコードを %d 件削除しました。", result.rowcount)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="signal_queue の pending シグナルを status='cancelled' に変更する"
@@ -81,6 +103,11 @@ def main() -> None:
         action="store_true",
         help="pending の全件をキャンセル（日付を問わない）",
     )
+    group.add_argument(
+        "--delete-cancelled",
+        action="store_true",
+        help="status='cancelled' のレコードを物理削除する",
+    )
     parser.add_argument(
         "--code",
         default=None,
@@ -90,6 +117,8 @@ def main() -> None:
 
     if args.all and args.code:
         parser.error("--all と --code は同時に指定できません")
+    if args.delete_cancelled and args.code:
+        parser.error("--delete-cancelled と --code は同時に指定できません")
 
     target_date: date | None = None
     if args.date:
@@ -106,6 +135,10 @@ def main() -> None:
 
     conn = duckdb.connect(str(settings.duckdb_path))
     try:
+        if args.delete_cancelled:
+            _run_delete_cancelled(conn)
+            return
+
         targets = _fetch_targets(conn, target_date, args.code)
 
         if not targets:

--- a/scripts/cancel_signal_queue.py
+++ b/scripts/cancel_signal_queue.py
@@ -85,7 +85,8 @@ def _run_delete_cancelled(conn: duckdb.DuckDBPyConnection) -> None:
         logger.info("ユーザーによりキャンセルされました。")
         sys.exit(0)
 
-    result = conn.execute("DELETE FROM signal_queue WHERE status = 'cancelled'")
+    result = conn.execute("DELETE FROM signal_queue WHERE status = ?", ["cancelled"])
+    conn.commit()
     logger.info("signal_queue から cancelled レコードを %d 件削除しました。", result.rowcount)
 
 

--- a/src/kabusys/monitoring/pages/6_Signal_Queue.py
+++ b/src/kabusys/monitoring/pages/6_Signal_Queue.py
@@ -1,4 +1,4 @@
-"""pages/6_Signal_Queue.py — 翌営業日の発注予定・シグナル確認ビュー。"""
+"""pages/6_Signal_Queue.py — 翌営業日の発注予定・シグナル確認ビュー（参照専用）。"""
 
 from __future__ import annotations
 
@@ -24,34 +24,6 @@ with st.sidebar:
         st.rerun()
 
 # ---------------------------------------------------------------------------
-# 書き込みフェーズ（ページ先頭で瞬時に処理し接続を閉じる）
-# read_only 接続を開く前に完結させることで CLI との接続競合を防ぐ。
-# ---------------------------------------------------------------------------
-_write_result: dict | None = None
-
-if "sq_write_op" in st.session_state:
-    op = st.session_state.pop("sq_write_op")
-    try:
-        with duckdb.connect(str(settings.duckdb_path)) as wc:
-            if op["type"] == "cancel":
-                ids = op["ids"]
-                placeholders = ", ".join(["?" for _ in ids])
-                rows = wc.execute(
-                    f"UPDATE signal_queue SET status = 'cancelled'"
-                    f" WHERE signal_id IN ({placeholders}) AND status = 'pending'"
-                    f" RETURNING signal_id",
-                    ids,
-                ).fetchall()
-                updated = len(rows)
-                skipped = len(ids) - updated
-                _write_result = {"type": "cancel", "updated": updated, "skipped": skipped}
-            elif op["type"] == "delete_cancelled":
-                cursor = wc.execute("DELETE FROM signal_queue WHERE status = 'cancelled'")
-                _write_result = {"type": "delete_cancelled", "deleted": cursor.rowcount}
-    except Exception as e:
-        _write_result = {"type": "error", "msg": str(e)}
-
-# ---------------------------------------------------------------------------
 # 表示フェーズ（read_only=True — CLI の書き込みをブロックしない）
 # ---------------------------------------------------------------------------
 try:
@@ -59,19 +31,6 @@ try:
 except Exception as e:
     st.error(f"DuckDB 接続失敗: {e}")
     st.stop()
-
-# 書き込み結果をここで表示（接続確立後に描画）
-if _write_result:
-    if _write_result["type"] == "cancel":
-        st.success(f"{_write_result['updated']} 件を cancelled に変更しました。")
-        if _write_result["skipped"] > 0:
-            st.warning(
-                f"{_write_result['skipped']} 件は既に pending ではなかったためスキップされました。"
-            )
-    elif _write_result["type"] == "delete_cancelled":
-        st.success(f"{_write_result['deleted']} 件を削除しました。")
-    elif _write_result["type"] == "error":
-        st.error(f"処理に失敗しました: {_write_result['msg']}")
 
 try:
     tab_queue, tab_targets, tab_signals = st.tabs(
@@ -102,94 +61,51 @@ try:
             filtered_df = df[df["status"].isin(selected_statuses)]
             st.dataframe(filtered_df, use_container_width=True)
 
-        # --- キャンセル操作 ---
+        # --- キャンセル操作（CLIコマンド案内）---
         st.divider()
         st.subheader("Pending シグナルのキャンセル")
+        st.info(
+            "このページは参照専用です。ステータス変更は **CLI** で実行してください。"
+            "以下のコマンドをターミナルにコピーして実行します。"
+        )
 
         if df.empty or pending.empty:
-            st.info("キャンセル可能な pending シグナルはありません。")
+            st.caption("キャンセル可能な pending シグナルはありません。")
         else:
-            pending_ids = pending["signal_id"].tolist()
+            pending_dates = sorted(pending["date"].astype(str).unique().tolist())
 
-            selected = st.multiselect(
-                "キャンセルするシグナルを選択（signal_id）",
-                options=pending_ids,
-                help="pending ステータスのシグナルのみ表示されます",
+            for d in pending_dates:
+                n = len(pending[pending["date"].astype(str) == d])
+                st.caption(f"**{d}（{n} 件）をキャンセル:**")
+                st.code(
+                    f"python scripts/cancel_signal_queue.py --date {d}",
+                    language="bash",
+                )
+
+            st.caption("**全 pending をキャンセル（日付問わず）:**")
+            st.code("python scripts/cancel_signal_queue.py --all", language="bash")
+
+            st.caption("**銘柄コードで絞り込む場合**（`--date` と組み合わせ）:")
+            st.code(
+                f"python scripts/cancel_signal_queue.py --date {pending_dates[0]} --code <銘柄コード>",
+                language="bash",
             )
 
-            col_sel, col_all = st.columns(2)
-
-            with col_sel:
-                if st.button(
-                    f"選択した {len(selected)} 件をキャンセル",
-                    disabled=len(selected) == 0,
-                    type="primary",
-                ):
-                    st.session_state["sq_cancel_targets"] = selected
-                    st.session_state["sq_cancel_mode"] = "selected"
-
-            with col_all:
-                if st.button(
-                    f"全 pending（{len(pending_ids)} 件）をキャンセル",
-                    type="secondary",
-                ):
-                    st.session_state["sq_cancel_targets"] = pending_ids
-                    st.session_state["sq_cancel_mode"] = "all"
-
-            if "sq_cancel_targets" in st.session_state:
-                targets = st.session_state["sq_cancel_targets"]
-                mode_label = (
-                    f"選択した {len(targets)} 件"
-                    if st.session_state.get("sq_cancel_mode") == "selected"
-                    else f"全 pending {len(targets)} 件"
-                )
-                st.warning(f"{mode_label} を `cancelled` に変更します。この操作は元に戻せません。")
-                confirm_col, abort_col = st.columns(2)
-                with confirm_col:
-                    if st.button("確定してキャンセル実行", type="primary"):
-                        st.session_state["sq_write_op"] = {
-                            "type": "cancel",
-                            "ids": targets,
-                        }
-                        del st.session_state["sq_cancel_targets"]
-                        del st.session_state["sq_cancel_mode"]
-                        st.rerun()
-                with abort_col:
-                    if st.button("戻る"):
-                        del st.session_state["sq_cancel_targets"]
-                        del st.session_state["sq_cancel_mode"]
-                        st.rerun()
-
-        # --- cancelled 物理削除 ---
+        # --- cancelled 物理削除（CLIコマンド案内）---
         st.divider()
         st.subheader("Cancelled レコードの削除")
+        st.info("このページは参照専用です。レコードの削除は **CLI** で実行してください。")
 
         cancelled_count = len(df[df["status"] == "cancelled"]) if not df.empty else 0
 
         if cancelled_count == 0:
-            st.info("削除可能な cancelled レコードはありません。")
+            st.caption("削除可能な cancelled レコードはありません。")
         else:
             st.caption(f"cancelled レコード: {cancelled_count} 件")
-            if st.button(f"cancelled {cancelled_count} 件を完全削除", type="secondary"):
-                st.session_state["sq_delete_cancelled"] = True
-
-            if st.session_state.get("sq_delete_cancelled"):
-                st.warning(
-                    f"cancelled レコード {cancelled_count} 件を完全削除します。"
-                    "この操作は元に戻せません。"
-                )
-                del_col, abort_col = st.columns(2)
-                with del_col:
-                    if st.button(
-                        "確定して削除実行", type="primary", key="confirm_delete_cancelled"
-                    ):
-                        st.session_state["sq_write_op"] = {"type": "delete_cancelled"}
-                        st.session_state.pop("sq_delete_cancelled", None)
-                        st.rerun()
-                with abort_col:
-                    if st.button("戻る", key="abort_delete"):
-                        st.session_state.pop("sq_delete_cancelled", None)
-                        st.rerun()
+            st.code(
+                "python scripts/cancel_signal_queue.py --delete-cancelled",
+                language="bash",
+            )
 
     with tab_targets:
         st.subheader("ポートフォリオ目標（最新日）")

--- a/src/kabusys/monitoring/pages/6_Signal_Queue.py
+++ b/src/kabusys/monitoring/pages/6_Signal_Queue.py
@@ -12,8 +12,7 @@ from kabusys.monitoring.dashboard_data import (
     load_signals,
 )
 
-_ALL_STATUSES = ["pending", "processing", "filled", "cancelled", "error", "failed"]
-_DEFAULT_STATUSES = ["pending", "processing", "filled", "error", "failed"]  # cancelled を除外
+_KNOWN_STATUSES = ["pending", "processing", "filled", "cancelled", "error", "failed"]
 
 st.set_page_config(page_title="Signal Queue", layout="wide", page_icon="📋")
 st.title("📋 Signal Queue — 発注予定・シグナル確認")
@@ -38,21 +37,26 @@ try:
     with tab_queue:
         st.subheader("Signal Queue（全件）")
 
-        # ステータスフィルター
+        df = load_signal_queue(conn)
+        pending = df[df["status"] == "pending"] if not df.empty else df.iloc[0:0]
+
+        # ステータスフィルター — 実データと既知ステータスのユニオンでオプションを構築
+        actual_statuses = sorted(df["status"].unique().tolist()) if not df.empty else []
+        all_options = sorted(set(_KNOWN_STATUSES) | set(actual_statuses))
+        default_statuses = [s for s in all_options if s != "cancelled"]
         selected_statuses = st.multiselect(
             "表示するステータス",
-            options=_ALL_STATUSES,
-            default=_DEFAULT_STATUSES,
-            help="cancelled はデフォルトで非表示。チェックを入れると表示されます。",
+            options=all_options,
+            default=default_statuses,
+            help="cancelled はデフォルトで非表示。チェックを入れると表示されます。全解除すると0件表示になります。",
         )
 
-        df = load_signal_queue(conn)
         if df.empty:
             st.info("発注キューにシグナルはありません。")
         else:
-            pending = df[df["status"] == "pending"]
-            st.metric("pending 件数", len(pending))
-            filtered_df = df[df["status"].isin(selected_statuses)] if selected_statuses else df
+            st.metric("pending 件数（全体）", len(pending))
+            # 空リスト時は意図通り0件表示（falsy 判定を使わず常に isin を適用）
+            filtered_df = df[df["status"].isin(selected_statuses)]
             st.dataframe(filtered_df, use_container_width=True)
 
         # --- キャンセル操作 ---
@@ -152,13 +156,15 @@ try:
                 )
                 del_col, abort_col = st.columns(2)
                 with del_col:
-                    if st.button("確定して削除実行", type="primary"):
+                    if st.button(
+                        "確定して削除実行", type="primary", key="confirm_delete_cancelled"
+                    ):
                         try:
-                            deleted = conn.execute(
+                            cursor = conn.execute(
                                 "DELETE FROM signal_queue WHERE status = 'cancelled'"
-                                " RETURNING signal_id"
-                            ).fetchall()
-                            st.success(f"{len(deleted)} 件を削除しました。")
+                            )
+                            deleted_count = cursor.rowcount
+                            st.success(f"{deleted_count} 件を削除しました。")
                             st.session_state.pop("sq_delete_cancelled", None)
                             st.rerun()
                         except Exception as e:

--- a/src/kabusys/monitoring/pages/6_Signal_Queue.py
+++ b/src/kabusys/monitoring/pages/6_Signal_Queue.py
@@ -44,7 +44,7 @@ try:
         pending = df[df["status"] == "pending"] if not df.empty else df.iloc[0:0]
 
         # ステータスフィルター — 実データと既知ステータスのユニオンでオプションを構築
-        actual_statuses = sorted(df["status"].unique().tolist()) if not df.empty else []
+        actual_statuses = sorted(df["status"].dropna().unique().tolist()) if not df.empty else []
         all_options = sorted(set(_KNOWN_STATUSES) | set(actual_statuses))
         default_statuses = [s for s in all_options if s != "cancelled"]
         selected_statuses = st.multiselect(

--- a/src/kabusys/monitoring/pages/6_Signal_Queue.py
+++ b/src/kabusys/monitoring/pages/6_Signal_Queue.py
@@ -23,11 +23,55 @@ with st.sidebar:
     if st.button("🔄 Refresh"):
         st.rerun()
 
+# ---------------------------------------------------------------------------
+# 書き込みフェーズ（ページ先頭で瞬時に処理し接続を閉じる）
+# read_only 接続を開く前に完結させることで CLI との接続競合を防ぐ。
+# ---------------------------------------------------------------------------
+_write_result: dict | None = None
+
+if "sq_write_op" in st.session_state:
+    op = st.session_state.pop("sq_write_op")
+    try:
+        with duckdb.connect(str(settings.duckdb_path)) as wc:
+            if op["type"] == "cancel":
+                ids = op["ids"]
+                placeholders = ", ".join(["?" for _ in ids])
+                rows = wc.execute(
+                    f"UPDATE signal_queue SET status = 'cancelled'"
+                    f" WHERE signal_id IN ({placeholders}) AND status = 'pending'"
+                    f" RETURNING signal_id",
+                    ids,
+                ).fetchall()
+                updated = len(rows)
+                skipped = len(ids) - updated
+                _write_result = {"type": "cancel", "updated": updated, "skipped": skipped}
+            elif op["type"] == "delete_cancelled":
+                cursor = wc.execute("DELETE FROM signal_queue WHERE status = 'cancelled'")
+                _write_result = {"type": "delete_cancelled", "deleted": cursor.rowcount}
+    except Exception as e:
+        _write_result = {"type": "error", "msg": str(e)}
+
+# ---------------------------------------------------------------------------
+# 表示フェーズ（read_only=True — CLI の書き込みをブロックしない）
+# ---------------------------------------------------------------------------
 try:
-    conn = duckdb.connect(str(settings.duckdb_path))
+    conn = duckdb.connect(str(settings.duckdb_path), read_only=True)
 except Exception as e:
     st.error(f"DuckDB 接続失敗: {e}")
     st.stop()
+
+# 書き込み結果をここで表示（接続確立後に描画）
+if _write_result:
+    if _write_result["type"] == "cancel":
+        st.success(f"{_write_result['updated']} 件を cancelled に変更しました。")
+        if _write_result["skipped"] > 0:
+            st.warning(
+                f"{_write_result['skipped']} 件は既に pending ではなかったためスキップされました。"
+            )
+    elif _write_result["type"] == "delete_cancelled":
+        st.success(f"{_write_result['deleted']} 件を削除しました。")
+    elif _write_result["type"] == "error":
+        st.error(f"処理に失敗しました: {_write_result['msg']}")
 
 try:
     tab_queue, tab_targets, tab_signals = st.tabs(
@@ -55,7 +99,6 @@ try:
             st.info("発注キューにシグナルはありません。")
         else:
             st.metric("pending 件数（全体）", len(pending))
-            # 空リスト時は意図通り0件表示（falsy 判定を使わず常に isin を適用）
             filtered_df = df[df["status"].isin(selected_statuses)]
             st.dataframe(filtered_df, use_container_width=True)
 
@@ -104,28 +147,13 @@ try:
                 confirm_col, abort_col = st.columns(2)
                 with confirm_col:
                     if st.button("確定してキャンセル実行", type="primary"):
-                        try:
-                            placeholders = ", ".join(["?" for _ in targets])
-                            updated = conn.execute(
-                                f"UPDATE signal_queue SET status = 'cancelled'"
-                                f" WHERE signal_id IN ({placeholders})"
-                                f" AND status = 'pending'"
-                                f" RETURNING signal_id",
-                                targets,
-                            ).fetchall()
-                            updated_ids = {row[0] for row in updated}
-                            count = len(updated_ids)
-                            st.success(f"{count} 件を cancelled に変更しました。")
-                            skipped = len(targets) - count
-                            if skipped > 0:
-                                st.warning(
-                                    f"{skipped} 件は既に pending ではなかったためスキップされました。"
-                                )
-                            del st.session_state["sq_cancel_targets"]
-                            del st.session_state["sq_cancel_mode"]
-                            st.rerun()
-                        except Exception as e:
-                            st.error(f"キャンセル処理に失敗しました: {e}")
+                        st.session_state["sq_write_op"] = {
+                            "type": "cancel",
+                            "ids": targets,
+                        }
+                        del st.session_state["sq_cancel_targets"]
+                        del st.session_state["sq_cancel_mode"]
+                        st.rerun()
                 with abort_col:
                     if st.button("戻る"):
                         del st.session_state["sq_cancel_targets"]
@@ -136,17 +164,13 @@ try:
         st.divider()
         st.subheader("Cancelled レコードの削除")
 
-        cancelled_df = df[df["status"] == "cancelled"] if not df.empty else df
-        cancelled_count = len(cancelled_df)
+        cancelled_count = len(df[df["status"] == "cancelled"]) if not df.empty else 0
 
         if cancelled_count == 0:
             st.info("削除可能な cancelled レコードはありません。")
         else:
             st.caption(f"cancelled レコード: {cancelled_count} 件")
-            if st.button(
-                f"cancelled {cancelled_count} 件を完全削除",
-                type="secondary",
-            ):
+            if st.button(f"cancelled {cancelled_count} 件を完全削除", type="secondary"):
                 st.session_state["sq_delete_cancelled"] = True
 
             if st.session_state.get("sq_delete_cancelled"):
@@ -159,16 +183,9 @@ try:
                     if st.button(
                         "確定して削除実行", type="primary", key="confirm_delete_cancelled"
                     ):
-                        try:
-                            cursor = conn.execute(
-                                "DELETE FROM signal_queue WHERE status = 'cancelled'"
-                            )
-                            deleted_count = cursor.rowcount
-                            st.success(f"{deleted_count} 件を削除しました。")
-                            st.session_state.pop("sq_delete_cancelled", None)
-                            st.rerun()
-                        except Exception as e:
-                            st.error(f"削除処理に失敗しました: {e}")
+                        st.session_state["sq_write_op"] = {"type": "delete_cancelled"}
+                        st.session_state.pop("sq_delete_cancelled", None)
+                        st.rerun()
                 with abort_col:
                     if st.button("戻る", key="abort_delete"):
                         st.session_state.pop("sq_delete_cancelled", None)

--- a/src/kabusys/monitoring/pages/6_Signal_Queue.py
+++ b/src/kabusys/monitoring/pages/6_Signal_Queue.py
@@ -12,6 +12,9 @@ from kabusys.monitoring.dashboard_data import (
     load_signals,
 )
 
+_ALL_STATUSES = ["pending", "processing", "filled", "cancelled", "error", "failed"]
+_DEFAULT_STATUSES = ["pending", "processing", "filled", "error", "failed"]  # cancelled を除外
+
 st.set_page_config(page_title="Signal Queue", layout="wide", page_icon="📋")
 st.title("📋 Signal Queue — 発注予定・シグナル確認")
 
@@ -34,13 +37,23 @@ try:
 
     with tab_queue:
         st.subheader("Signal Queue（全件）")
+
+        # ステータスフィルター
+        selected_statuses = st.multiselect(
+            "表示するステータス",
+            options=_ALL_STATUSES,
+            default=_DEFAULT_STATUSES,
+            help="cancelled はデフォルトで非表示。チェックを入れると表示されます。",
+        )
+
         df = load_signal_queue(conn)
         if df.empty:
             st.info("発注キューにシグナルはありません。")
         else:
             pending = df[df["status"] == "pending"]
             st.metric("pending 件数", len(pending))
-            st.dataframe(df, use_container_width=True)
+            filtered_df = df[df["status"].isin(selected_statuses)] if selected_statuses else df
+            st.dataframe(filtered_df, use_container_width=True)
 
         # --- キャンセル操作 ---
         st.divider()
@@ -51,7 +64,6 @@ try:
         else:
             pending_ids = pending["signal_id"].tolist()
 
-            # 個別選択キャンセル
             selected = st.multiselect(
                 "キャンセルするシグナルを選択（signal_id）",
                 options=pending_ids,
@@ -77,7 +89,6 @@ try:
                     st.session_state["sq_cancel_targets"] = pending_ids
                     st.session_state["sq_cancel_mode"] = "all"
 
-            # 確認ダイアログ
             if "sq_cancel_targets" in st.session_state:
                 targets = st.session_state["sq_cancel_targets"]
                 mode_label = (
@@ -115,6 +126,46 @@ try:
                     if st.button("戻る"):
                         del st.session_state["sq_cancel_targets"]
                         del st.session_state["sq_cancel_mode"]
+                        st.rerun()
+
+        # --- cancelled 物理削除 ---
+        st.divider()
+        st.subheader("Cancelled レコードの削除")
+
+        cancelled_df = df[df["status"] == "cancelled"] if not df.empty else df
+        cancelled_count = len(cancelled_df)
+
+        if cancelled_count == 0:
+            st.info("削除可能な cancelled レコードはありません。")
+        else:
+            st.caption(f"cancelled レコード: {cancelled_count} 件")
+            if st.button(
+                f"cancelled {cancelled_count} 件を完全削除",
+                type="secondary",
+            ):
+                st.session_state["sq_delete_cancelled"] = True
+
+            if st.session_state.get("sq_delete_cancelled"):
+                st.warning(
+                    f"cancelled レコード {cancelled_count} 件を完全削除します。"
+                    "この操作は元に戻せません。"
+                )
+                del_col, abort_col = st.columns(2)
+                with del_col:
+                    if st.button("確定して削除実行", type="primary"):
+                        try:
+                            deleted = conn.execute(
+                                "DELETE FROM signal_queue WHERE status = 'cancelled'"
+                                " RETURNING signal_id"
+                            ).fetchall()
+                            st.success(f"{len(deleted)} 件を削除しました。")
+                            st.session_state.pop("sq_delete_cancelled", None)
+                            st.rerun()
+                        except Exception as e:
+                            st.error(f"削除処理に失敗しました: {e}")
+                with abort_col:
+                    if st.button("戻る", key="abort_delete"):
+                        st.session_state.pop("sq_delete_cancelled", None)
                         st.rerun()
 
     with tab_targets:

--- a/tests/test_cancel_signal_queue.py
+++ b/tests/test_cancel_signal_queue.py
@@ -211,6 +211,99 @@ def test_date_and_code_filter(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# --delete-cancelled と --code は同時指定不可
+# ---------------------------------------------------------------------------
+
+
+def test_delete_cancelled_and_code_cannot_coexist(tmp_path):
+    duckdb_path = tmp_path / "kabusys.duckdb"
+    duckdb_path.write_bytes(b"fake")
+    settings_mock = MagicMock()
+    settings_mock.duckdb_path = duckdb_path
+    with patch("cancel_signal_queue.Settings", return_value=settings_mock):
+        with pytest.raises(SystemExit) as exc:
+            _run(["--delete-cancelled", "--code", "7203"])
+        assert exc.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# --delete-cancelled: 対象 0 件 → exit 0
+# ---------------------------------------------------------------------------
+
+
+def test_delete_cancelled_exits_zero_when_none(tmp_path):
+    duckdb_path = tmp_path / "kabusys.duckdb"
+    duckdb_path.write_bytes(b"fake")
+    settings_mock = MagicMock()
+    settings_mock.duckdb_path = duckdb_path
+    conn_mock = MagicMock()
+    conn_mock.execute.return_value.fetchone.return_value = (0,)
+    with (
+        patch("cancel_signal_queue.Settings", return_value=settings_mock),
+        patch("cancel_signal_queue.duckdb.connect", return_value=conn_mock),
+    ):
+        with pytest.raises(SystemExit) as exc:
+            _run(["--delete-cancelled"])
+        assert exc.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# --delete-cancelled: ユーザーが "n" → DELETE 実行なし・exit 0
+# ---------------------------------------------------------------------------
+
+
+def test_delete_cancelled_on_user_no(tmp_path, monkeypatch):
+    duckdb_path = tmp_path / "kabusys.duckdb"
+    duckdb_path.write_bytes(b"fake")
+    settings_mock = MagicMock()
+    settings_mock.duckdb_path = duckdb_path
+    conn_mock = MagicMock()
+    conn_mock.execute.return_value.fetchone.return_value = (3,)
+    monkeypatch.setattr("builtins.input", lambda prompt="": "n")
+    with (
+        patch("cancel_signal_queue.Settings", return_value=settings_mock),
+        patch("cancel_signal_queue.duckdb.connect", return_value=conn_mock),
+    ):
+        with pytest.raises(SystemExit) as exc:
+            _run(["--delete-cancelled"])
+        assert exc.value.code == 0
+
+    sql_calls = [str(c.args[0]) for c in conn_mock.execute.call_args_list]
+    assert not any("DELETE" in s for s in sql_calls)
+
+
+# ---------------------------------------------------------------------------
+# --delete-cancelled: ユーザーが "y" → DELETE 実行される
+# ---------------------------------------------------------------------------
+
+
+def test_delete_cancelled_on_user_yes(tmp_path, monkeypatch):
+    duckdb_path = tmp_path / "kabusys.duckdb"
+    duckdb_path.write_bytes(b"fake")
+    settings_mock = MagicMock()
+    settings_mock.duckdb_path = duckdb_path
+
+    count_result = MagicMock()
+    count_result.fetchone.return_value = (3,)
+    delete_result = MagicMock()
+    delete_result.rowcount = 3
+    conn_mock = MagicMock()
+    conn_mock.execute.side_effect = [count_result, delete_result]
+
+    monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+
+    with (
+        patch("cancel_signal_queue.Settings", return_value=settings_mock),
+        patch("cancel_signal_queue.duckdb.connect", return_value=conn_mock),
+    ):
+        _run(["--delete-cancelled"])
+
+    sql_calls = [str(c.args[0]) for c in conn_mock.execute.call_args_list]
+    assert any("DELETE" in s and "cancelled" in s for s in sql_calls)
+    conn_mock.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
 # --all は日付条件なしで全 pending を対象にすること
 # ---------------------------------------------------------------------------
 

--- a/tests/test_cancel_signal_queue.py
+++ b/tests/test_cancel_signal_queue.py
@@ -298,8 +298,11 @@ def test_delete_cancelled_on_user_yes(tmp_path, monkeypatch):
     ):
         _run(["--delete-cancelled"])
 
-    sql_calls = [str(c.args[0]) for c in conn_mock.execute.call_args_list]
-    assert any("DELETE" in s and "cancelled" in s for s in sql_calls)
+    delete_call = next(c for c in conn_mock.execute.call_args_list if "DELETE" in str(c.args[0]))
+    assert "cancelled" in str(delete_call.args[0]) or "cancelled" in str(
+        delete_call.args[1] if len(delete_call.args) > 1 else []
+    )
+    conn_mock.commit.assert_called_once()
     conn_mock.close.assert_called_once()
 
 


### PR DESCRIPTION
## Summary

- **ステータスフィルター**: 表示する status を multiselect で選択可能に（デフォルト: cancelled を除外）
- **cancelled 物理削除**: CLI コマンド `--delete-cancelled` で実行（Streamlit は参照専用）

## 変更詳細

### ステータスフィルター（Streamlit）

- 全件表示の上部に multiselect を追加
- デフォルトは `cancelled` 以外の全ステータスを表示
- `cancelled` を表示したい場合はフィルターで手動追加
- 全解除すると 0 件表示（空 DataFrame）

### cancelled 物理削除・Pending キャンセル（CLI）

Streamlit ダッシュボードは `read_only=True` 接続のみ使用（書き込み操作なし）。
DuckDB への書き込みは CLI で行い、Streamlit はコマンド案内のみ表示する。

```bash
# 日付指定でキャンセル
python scripts/cancel_signal_queue.py --date 2026-05-12

# 全 pending をキャンセル
python scripts/cancel_signal_queue.py --all

# cancelled を物理削除（確認プロンプトあり）
python scripts/cancel_signal_queue.py --delete-cancelled
```

### アーキテクチャ方針

| 機能 | 実装 |
|---|---|
| ステータスフィルター（表示） | Streamlit（read_only=True） |
| Pending キャンセル | CLI `--date` / `--all` |
| Cancelled 物理削除 | CLI `--delete-cancelled` |

Streamlit からの書き込みを排除した理由: DuckDB の read-write 接続が保持されると CLI からの書き込み（夜間バッチ、execution engine）がブロックされるため。

## Test Plan

- [x] `pytest tests/test_cancel_signal_queue.py` 15 件すべてパス

Closes #302