### PR TITLE
feat: バッチスクリプトのログ出力改善（実行単位ファイル・START/ENDマーカー）(Issue #308)

### DIFF
--- a/scripts/run_ai_analysis.py
+++ b/scripts/run_ai_analysis.py
@@ -20,16 +20,18 @@ from kabusys.ai.regime_detector import score_regime
 from kabusys.config import Settings
 from kabusys.operations.job_run_recorder import write_job_result
 from kabusys.operations.night_batch_report import JobRunResult
-from kabusys.utils.logging_setup import setup_logging
+from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
 
 setup_logging(app_name="ai_analysis")
 logger = logging.getLogger(__name__)
 
 _JOB_NAME = "ai_analysis_job"
+_APP_NAME = "ai_analysis"
 
 
 def main() -> None:
     started_at = datetime.now(timezone.utc)
+    log_run_start(_APP_NAME)
     settings = Settings()
     conn = duckdb.connect(str(settings.duckdb_path))
     target_date = date.today()
@@ -77,6 +79,7 @@ def main() -> None:
     except Exception:
         logger.warning("JobRunResult の書き出しに失敗しました", exc_info=True)
 
+    log_run_end(_APP_NAME, status="failed" if _failed else "success", started_at=started_at)
     if _failed:
         sys.exit(1)
 

--- a/scripts/run_ai_analysis.py
+++ b/scripts/run_ai_analysis.py
@@ -32,15 +32,17 @@ _APP_NAME = "ai_analysis"
 def main() -> None:
     started_at = datetime.now(timezone.utc)
     log_run_start(_APP_NAME)
-    settings = Settings()
-    conn = duckdb.connect(str(settings.duckdb_path))
-    target_date = date.today()
-    api_key = getattr(settings, "openai_api_key", None)
+    conn = None
     _failed = False
     _errors: list[str] = []
     _updated_rows: dict[str, int] = {}
 
     try:
+        settings = Settings()
+        conn = duckdb.connect(str(settings.duckdb_path))
+        target_date = date.today()
+        api_key = getattr(settings, "openai_api_key", None)
+
         try:
             n_news = score_news(conn, target_date, api_key=api_key)
             _updated_rows["ai_scores"] = n_news
@@ -59,8 +61,13 @@ def main() -> None:
                 logger.exception("score_regime が失敗しました")
                 _errors.append(f"score_regime: {exc}")
                 _failed = True
+    except Exception as exc:
+        logger.exception("ai_analysis バッチが失敗しました")
+        _errors.append(str(exc))
+        _failed = True
     finally:
-        conn.close()
+        if conn is not None:
+            conn.close()
 
     finished_at = datetime.now(timezone.utc)
     try:

--- a/scripts/run_data_update.py
+++ b/scripts/run_data_update.py
@@ -33,14 +33,16 @@ _APP_NAME = "data_update"
 def main() -> None:
     started_at = datetime.now(timezone.utc)
     log_run_start(_APP_NAME)
-    settings = Settings()
-    conn = duckdb.connect(str(settings.duckdb_path))
+    conn = None
     _failed = False
     _has_warnings = False
     _errors: list[str] = []
     _updated_rows: dict[str, int] = {}
 
     try:
+        settings = Settings()
+        conn = duckdb.connect(str(settings.duckdb_path))
+
         result = run_daily_etl(conn)
         _updated_rows["prices_daily"] = result.prices_saved
         _updated_rows["fundamentals"] = result.financials_saved
@@ -67,7 +69,8 @@ def main() -> None:
         _errors.append(str(exc))
         _failed = True
     finally:
-        conn.close()
+        if conn is not None:
+            conn.close()
 
     finished_at = datetime.now(timezone.utc)
     try:

--- a/scripts/run_data_update.py
+++ b/scripts/run_data_update.py
@@ -21,16 +21,18 @@ from kabusys.data.breadth import calc_and_save_breadth
 from kabusys.data.pipeline import run_daily_etl
 from kabusys.operations.job_run_recorder import write_job_result
 from kabusys.operations.night_batch_report import JobRunResult
-from kabusys.utils.logging_setup import setup_logging
+from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
 
 setup_logging(app_name="data_update")
 logger = logging.getLogger(__name__)
 
 _JOB_NAME = "data_update_job"
+_APP_NAME = "data_update"
 
 
 def main() -> None:
     started_at = datetime.now(timezone.utc)
+    log_run_start(_APP_NAME)
     settings = Settings()
     conn = duckdb.connect(str(settings.duckdb_path))
     _failed = False
@@ -84,6 +86,11 @@ def main() -> None:
     except Exception:
         logger.warning("JobRunResult の書き出しに失敗しました", exc_info=True)
 
+    log_run_end(
+        _APP_NAME,
+        status="failed" if _failed else ("warning" if _has_warnings else "success"),
+        started_at=started_at,
+    )
     if _failed:
         sys.exit(1)
 

--- a/scripts/run_disclosure_classification.py
+++ b/scripts/run_disclosure_classification.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 import duckdb
@@ -15,26 +16,35 @@ import duckdb
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 from kabusys.config import Settings
 from kabusys.data.disclosure_classifier import run_disclosure_classification
-from kabusys.utils.logging_setup import setup_logging
+from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
 
 setup_logging(app_name="disclosure_classification")
 logger = logging.getLogger(__name__)
 
+_APP_NAME = "disclosure_classification"
+
 
 def main() -> None:
+    started_at = datetime.now(timezone.utc)
+    log_run_start(_APP_NAME)
     settings = Settings()
     if not settings.enable_tdnet:
         logger.info("TDnet 収集はオプション機能です（ENABLE_TDNET=false）。スキップします。")
+        log_run_end(_APP_NAME, status="success", started_at=started_at)
         return
     conn = duckdb.connect(str(settings.duckdb_path))
+    _failed = False
     try:
         saved = run_disclosure_classification(conn)
         logger.info("disclosure_classification 完了: saved=%d", saved)
     except Exception:
         logger.exception("disclosure_classification バッチが失敗しました")
-        sys.exit(1)
+        _failed = True
     finally:
         conn.close()
+    log_run_end(_APP_NAME, status="failed" if _failed else "success", started_at=started_at)
+    if _failed:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/run_disclosure_classification.py
+++ b/scripts/run_disclosure_classification.py
@@ -27,22 +27,23 @@ _APP_NAME = "disclosure_classification"
 def main() -> None:
     started_at = datetime.now(timezone.utc)
     log_run_start(_APP_NAME)
-    settings = Settings()
-    if not settings.enable_tdnet:
-        logger.info("TDnet 収集はオプション機能です（ENABLE_TDNET=false）。スキップします。")
-        log_run_end(_APP_NAME, status="success", started_at=started_at)
-        return
-    conn = duckdb.connect(str(settings.duckdb_path))
+    conn = None
     _failed = False
     try:
+        settings = Settings()
+        if not settings.enable_tdnet:
+            logger.info("TDnet 収集はオプション機能です（ENABLE_TDNET=false）。スキップします。")
+            return
+        conn = duckdb.connect(str(settings.duckdb_path))
         saved = run_disclosure_classification(conn)
         logger.info("disclosure_classification 完了: saved=%d", saved)
     except Exception:
         logger.exception("disclosure_classification バッチが失敗しました")
         _failed = True
     finally:
-        conn.close()
-    log_run_end(_APP_NAME, status="failed" if _failed else "success", started_at=started_at)
+        if conn is not None:
+            conn.close()
+        log_run_end(_APP_NAME, status="failed" if _failed else "success", started_at=started_at)
     if _failed:
         sys.exit(1)
 

--- a/scripts/run_edinet_collection.py
+++ b/scripts/run_edinet_collection.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 import duckdb
@@ -15,32 +16,42 @@ import duckdb
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 from kabusys.config import Settings
 from kabusys.data.edinet_collector import run_edinet_collection
-from kabusys.utils.logging_setup import setup_logging
+from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
 
 setup_logging(app_name="edinet_collection")
 logger = logging.getLogger(__name__)
 
+_APP_NAME = "edinet_collection"
+
 
 def main() -> None:
+    started_at = datetime.now(timezone.utc)
+    log_run_start(_APP_NAME)
     settings = Settings()
     if not settings.enable_edinet:
         logger.info("EDINET 収集はオプション機能です（ENABLE_EDINET=false）。スキップします。")
+        log_run_end(_APP_NAME, status="success", started_at=started_at)
         return
     if not settings.edinet_api_key:
         logger.error(
             "ENABLE_EDINET=true ですが EDINET_API_KEY が未設定です。"
             ".env に EDINET_API_KEY を設定してください。"
         )
+        log_run_end(_APP_NAME, status="failed", started_at=started_at)
         sys.exit(1)
     conn = duckdb.connect(str(settings.duckdb_path))
+    _failed = False
     try:
         saved = run_edinet_collection(conn, api_key=settings.edinet_api_key)
         logger.info("edinet_collection 完了: saved=%d", saved)
     except Exception:
         logger.exception("edinet_collection バッチが失敗しました")
-        sys.exit(1)
+        _failed = True
     finally:
         conn.close()
+    log_run_end(_APP_NAME, status="failed" if _failed else "success", started_at=started_at)
+    if _failed:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/run_edinet_collection.py
+++ b/scripts/run_edinet_collection.py
@@ -40,10 +40,10 @@ def main() -> None:
                 ".env に EDINET_API_KEY を設定してください。"
             )
             _failed = True
-            return
-        conn = duckdb.connect(str(settings.duckdb_path))
-        saved = run_edinet_collection(conn, api_key=settings.edinet_api_key)
-        logger.info("edinet_collection 完了: saved=%d", saved)
+        else:
+            conn = duckdb.connect(str(settings.duckdb_path))
+            saved = run_edinet_collection(conn, api_key=settings.edinet_api_key)
+            logger.info("edinet_collection 完了: saved=%d", saved)
     except Exception:
         logger.exception("edinet_collection バッチが失敗しました")
         _failed = True
@@ -51,8 +51,8 @@ def main() -> None:
         if conn is not None:
             conn.close()
         log_run_end(_APP_NAME, status="failed" if _failed else "success", started_at=started_at)
-        if _failed:
-            sys.exit(1)
+    if _failed:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/run_edinet_collection.py
+++ b/scripts/run_edinet_collection.py
@@ -27,31 +27,32 @@ _APP_NAME = "edinet_collection"
 def main() -> None:
     started_at = datetime.now(timezone.utc)
     log_run_start(_APP_NAME)
-    settings = Settings()
-    if not settings.enable_edinet:
-        logger.info("EDINET 収集はオプション機能です（ENABLE_EDINET=false）。スキップします。")
-        log_run_end(_APP_NAME, status="success", started_at=started_at)
-        return
-    if not settings.edinet_api_key:
-        logger.error(
-            "ENABLE_EDINET=true ですが EDINET_API_KEY が未設定です。"
-            ".env に EDINET_API_KEY を設定してください。"
-        )
-        log_run_end(_APP_NAME, status="failed", started_at=started_at)
-        sys.exit(1)
-    conn = duckdb.connect(str(settings.duckdb_path))
+    conn = None
     _failed = False
     try:
+        settings = Settings()
+        if not settings.enable_edinet:
+            logger.info("EDINET 収集はオプション機能です（ENABLE_EDINET=false）。スキップします。")
+            return
+        if not settings.edinet_api_key:
+            logger.error(
+                "ENABLE_EDINET=true ですが EDINET_API_KEY が未設定です。"
+                ".env に EDINET_API_KEY を設定してください。"
+            )
+            _failed = True
+            return
+        conn = duckdb.connect(str(settings.duckdb_path))
         saved = run_edinet_collection(conn, api_key=settings.edinet_api_key)
         logger.info("edinet_collection 完了: saved=%d", saved)
     except Exception:
         logger.exception("edinet_collection バッチが失敗しました")
         _failed = True
     finally:
-        conn.close()
-    log_run_end(_APP_NAME, status="failed" if _failed else "success", started_at=started_at)
-    if _failed:
-        sys.exit(1)
+        if conn is not None:
+            conn.close()
+        log_run_end(_APP_NAME, status="failed" if _failed else "success", started_at=started_at)
+        if _failed:
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/run_feature_gen.py
+++ b/scripts/run_feature_gen.py
@@ -18,16 +18,18 @@ from kabusys.config import Settings
 from kabusys.operations.job_run_recorder import write_job_result
 from kabusys.operations.night_batch_report import JobRunResult
 from kabusys.strategy.feature_engineering import build_features
-from kabusys.utils.logging_setup import setup_logging
+from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
 
 setup_logging(app_name="feature_gen")
 logger = logging.getLogger(__name__)
 
 _JOB_NAME = "feature_generation_job"
+_APP_NAME = "feature_gen"
 
 
 def main() -> None:
     started_at = datetime.now(timezone.utc)
+    log_run_start(_APP_NAME)
     settings = Settings()
     conn = duckdb.connect(str(settings.duckdb_path))
     _failed = False
@@ -63,6 +65,7 @@ def main() -> None:
     except Exception:
         logger.warning("JobRunResult の書き出しに失敗しました", exc_info=True)
 
+    log_run_end(_APP_NAME, status="failed" if _failed else "success", started_at=started_at)
     if _failed:
         sys.exit(1)
 

--- a/scripts/run_feature_gen.py
+++ b/scripts/run_feature_gen.py
@@ -30,13 +30,14 @@ _APP_NAME = "feature_gen"
 def main() -> None:
     started_at = datetime.now(timezone.utc)
     log_run_start(_APP_NAME)
-    settings = Settings()
-    conn = duckdb.connect(str(settings.duckdb_path))
+    conn = None
     _failed = False
     _errors: list[str] = []
     _updated_rows: dict[str, int] = {}
 
     try:
+        settings = Settings()
+        conn = duckdb.connect(str(settings.duckdb_path))
         target_date = date.today()
         n = build_features(conn, target_date)
         _updated_rows["features"] = n
@@ -46,7 +47,8 @@ def main() -> None:
         _errors.append(str(exc))
         _failed = True
     finally:
-        conn.close()
+        if conn is not None:
+            conn.close()
 
     finished_at = datetime.now(timezone.utc)
     try:

--- a/scripts/run_night_batch_report.py
+++ b/scripts/run_night_batch_report.py
@@ -181,45 +181,48 @@ def main() -> None:
             except ValueError:
                 logger.error("--date の形式が不正です: %s (YYYY-MM-DD が必要です)", args.date)
                 _failed = True
-                return
         else:
             run_date = date.today()
-        logger.info("レポート生成開始: run_date=%s", run_date)
 
-        # --- JobRunResult 読み込み ---
-        job_runs_base = Path(args.job_runs_dir) if args.job_runs_dir else None
-        job_results = load_job_results_or_empty(run_date, base_dir=job_runs_base)
-        logger.info("JobRunResult 読み込み: %d 件", len(job_results))
+        if not _failed:
+            logger.info("レポート生成開始: run_date=%s", run_date)
 
-        # --- DB クエリ ---
-        db_path = args.db or str(Settings().duckdb_path)
-        target_date: date = run_date + timedelta(days=1)
-        conn = duckdb.connect(db_path)
-        update_counts = collect_update_counts(conn, run_date)
-        next_day = collect_next_day_summary(conn, run_date)
-        try:
-            row = conn.execute(
-                "SELECT MIN(date) FROM prices_daily WHERE date > ?", [run_date]
-            ).fetchone()
-            if row and row[0]:
-                target_date = row[0]
-        except Exception:
-            logger.warning("翌営業日の取得に失敗しました。run_date+1 を使用します。", exc_info=True)
+            # --- JobRunResult 読み込み ---
+            job_runs_base = Path(args.job_runs_dir) if args.job_runs_dir else None
+            job_results = load_job_results_or_empty(run_date, base_dir=job_runs_base)
+            logger.info("JobRunResult 読み込み: %d 件", len(job_results))
 
-        # --- レポート構築・保存 ---
-        report = build_report(
-            job_results,
-            update_counts,
-            next_day,
-            run_date=run_date,
-            target_date=target_date,
-        )
+            # --- DB クエリ ---
+            db_path = args.db or str(Settings().duckdb_path)
+            target_date: date = run_date + timedelta(days=1)
+            conn = duckdb.connect(db_path)
+            update_counts = collect_update_counts(conn, run_date)
+            next_day = collect_next_day_summary(conn, run_date)
+            try:
+                row = conn.execute(
+                    "SELECT MIN(date) FROM prices_daily WHERE date > ?", [run_date]
+                ).fetchone()
+                if row and row[0]:
+                    target_date = row[0]
+            except Exception:
+                logger.warning(
+                    "翌営業日の取得に失敗しました。run_date+1 を使用します。", exc_info=True
+                )
 
-        output_dir = Path(args.output_dir) if args.output_dir else Path("artifacts/reports")
-        saved_path = save_report(report, output_dir)
-        logger.info("レポート保存: %s", saved_path)
+            # --- レポート構築・保存 ---
+            report = build_report(
+                job_results,
+                update_counts,
+                next_day,
+                run_date=run_date,
+                target_date=target_date,
+            )
 
-        print(format_cli_summary(report))
+            output_dir = Path(args.output_dir) if args.output_dir else Path("artifacts/reports")
+            saved_path = save_report(report, output_dir)
+            logger.info("レポート保存: %s", saved_path)
+
+            print(format_cli_summary(report))
     except Exception:
         logger.exception("night_batch_report バッチが失敗しました")
         _failed = True
@@ -227,8 +230,8 @@ def main() -> None:
         if conn is not None:
             conn.close()
         log_run_end(_APP_NAME, status="failed" if _failed else "success", started_at=started_at)
-        if _failed:
-            sys.exit(1)
+    if _failed:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/run_night_batch_report.py
+++ b/scripts/run_night_batch_report.py
@@ -169,30 +169,32 @@ def _parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
+    args = _parse_args()  # argparse の --help / バリデーションエラーはマーカー出力前に終了
     started_at = datetime.now(timezone.utc)
     log_run_start(_APP_NAME)
-    args = _parse_args()
-
-    if args.date:
-        try:
-            run_date = date.fromisoformat(args.date)
-        except ValueError:
-            logger.error("--date の形式が不正です: %s (YYYY-MM-DD が必要です)", args.date)
-            sys.exit(1)
-    else:
-        run_date = date.today()
-    logger.info("レポート生成開始: run_date=%s", run_date)
-
-    # --- JobRunResult 読み込み ---
-    job_runs_base = Path(args.job_runs_dir) if args.job_runs_dir else None
-    job_results = load_job_results_or_empty(run_date, base_dir=job_runs_base)
-    logger.info("JobRunResult 読み込み: %d 件", len(job_results))
-
-    # --- DB クエリ ---
-    db_path = args.db or str(Settings().duckdb_path)
-    target_date: date = run_date + timedelta(days=1)
-    conn = duckdb.connect(db_path)
+    conn = None
+    _failed = False
     try:
+        if args.date:
+            try:
+                run_date = date.fromisoformat(args.date)
+            except ValueError:
+                logger.error("--date の形式が不正です: %s (YYYY-MM-DD が必要です)", args.date)
+                _failed = True
+                return
+        else:
+            run_date = date.today()
+        logger.info("レポート生成開始: run_date=%s", run_date)
+
+        # --- JobRunResult 読み込み ---
+        job_runs_base = Path(args.job_runs_dir) if args.job_runs_dir else None
+        job_results = load_job_results_or_empty(run_date, base_dir=job_runs_base)
+        logger.info("JobRunResult 読み込み: %d 件", len(job_results))
+
+        # --- DB クエリ ---
+        db_path = args.db or str(Settings().duckdb_path)
+        target_date: date = run_date + timedelta(days=1)
+        conn = duckdb.connect(db_path)
         update_counts = collect_update_counts(conn, run_date)
         next_day = collect_next_day_summary(conn, run_date)
         try:
@@ -203,24 +205,30 @@ def main() -> None:
                 target_date = row[0]
         except Exception:
             logger.warning("翌営業日の取得に失敗しました。run_date+1 を使用します。", exc_info=True)
+
+        # --- レポート構築・保存 ---
+        report = build_report(
+            job_results,
+            update_counts,
+            next_day,
+            run_date=run_date,
+            target_date=target_date,
+        )
+
+        output_dir = Path(args.output_dir) if args.output_dir else Path("artifacts/reports")
+        saved_path = save_report(report, output_dir)
+        logger.info("レポート保存: %s", saved_path)
+
+        print(format_cli_summary(report))
+    except Exception:
+        logger.exception("night_batch_report バッチが失敗しました")
+        _failed = True
     finally:
-        conn.close()
-
-    # --- レポート構築・保存 ---
-    report = build_report(
-        job_results,
-        update_counts,
-        next_day,
-        run_date=run_date,
-        target_date=target_date,
-    )
-
-    output_dir = Path(args.output_dir) if args.output_dir else Path("artifacts/reports")
-    saved_path = save_report(report, output_dir)
-    logger.info("レポート保存: %s", saved_path)
-
-    print(format_cli_summary(report))
-    log_run_end(_APP_NAME, status="success", started_at=started_at)
+        if conn is not None:
+            conn.close()
+        log_run_end(_APP_NAME, status="failed" if _failed else "success", started_at=started_at)
+        if _failed:
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/run_night_batch_report.py
+++ b/scripts/run_night_batch_report.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 import duckdb
@@ -28,10 +28,12 @@ from kabusys.operations.night_batch_report import (
     format_cli_summary,
     save_report,
 )
-from kabusys.utils.logging_setup import setup_logging
+from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
 
 setup_logging(app_name="night_batch_report")
 logger = logging.getLogger(__name__)
+
+_APP_NAME = "night_batch_report"
 
 
 # ---------------------------------------------------------------------------
@@ -167,6 +169,8 @@ def _parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
+    started_at = datetime.now(timezone.utc)
+    log_run_start(_APP_NAME)
     args = _parse_args()
 
     if args.date:
@@ -216,6 +220,7 @@ def main() -> None:
     logger.info("レポート保存: %s", saved_path)
 
     print(format_cli_summary(report))
+    log_run_end(_APP_NAME, status="success", started_at=started_at)
 
 
 if __name__ == "__main__":

--- a/scripts/run_portfolio_construction.py
+++ b/scripts/run_portfolio_construction.py
@@ -39,7 +39,7 @@ from kabusys.operations.performance_collector import (
 from kabusys.operations.performance_report import build_report
 from kabusys.portfolio.portfolio_builder import calc_score_weights, select_candidates
 from kabusys.portfolio.position_sizing import calc_position_sizes
-from kabusys.utils.logging_setup import setup_logging
+from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
 
 setup_logging(app_name="portfolio_construction")
 logger = logging.getLogger(__name__)
@@ -47,6 +47,7 @@ logger = logging.getLogger(__name__)
 _DEFAULT_PORTFOLIO_VALUE = 10_000_000
 _MAX_UTILIZATION = 0.70
 _JOB_NAME = "portfolio_construction_job"
+_APP_NAME = "portfolio_construction"
 
 
 def _get_today_return(conn: duckdb.DuckDBPyConnection, target_date: date, env: str) -> float | None:
@@ -61,6 +62,7 @@ def _get_today_return(conn: duckdb.DuckDBPyConnection, target_date: date, env: s
 
 def main() -> None:
     started_at = datetime.now(timezone.utc)
+    log_run_start(_APP_NAME)
     settings = Settings()
     conn = duckdb.connect(str(settings.duckdb_path))
     target_date = date.today()
@@ -263,6 +265,7 @@ def main() -> None:
     except Exception:
         logger.warning("JobRunResult の書き出しに失敗しました", exc_info=True)
 
+    log_run_end(_APP_NAME, status="failed" if _failed else "success", started_at=started_at)
     if _failed:
         sys.exit(1)
 

--- a/scripts/run_portfolio_construction.py
+++ b/scripts/run_portfolio_construction.py
@@ -63,14 +63,15 @@ def _get_today_return(conn: duckdb.DuckDBPyConnection, target_date: date, env: s
 def main() -> None:
     started_at = datetime.now(timezone.utc)
     log_run_start(_APP_NAME)
-    settings = Settings()
-    conn = duckdb.connect(str(settings.duckdb_path))
+    conn = None
     target_date = date.today()
     _failed = False
     _errors: list[str] = []
     _updated_rows: dict[str, int] = {}
 
     try:
+        settings = Settings()
+        conn = duckdb.connect(str(settings.duckdb_path))
         portfolio_value_str = os.environ.get("PORTFOLIO_VALUE", str(_DEFAULT_PORTFOLIO_VALUE))
         try:
             portfolio_value = float(portfolio_value_str)
@@ -246,7 +247,8 @@ def main() -> None:
         _errors.append(str(exc))
         _failed = True
     finally:
-        conn.close()
+        if conn is not None:
+            conn.close()
 
     finished_at = datetime.now(timezone.utc)
     try:

--- a/scripts/run_strategy_signal.py
+++ b/scripts/run_strategy_signal.py
@@ -30,13 +30,14 @@ _APP_NAME = "strategy_signal"
 def main() -> None:
     started_at = datetime.now(timezone.utc)
     log_run_start(_APP_NAME)
-    settings = Settings()
-    conn = duckdb.connect(str(settings.duckdb_path))
+    conn = None
     _failed = False
     _errors: list[str] = []
     _updated_rows: dict[str, int] = {}
 
     try:
+        settings = Settings()
+        conn = duckdb.connect(str(settings.duckdb_path))
         target_date = date.today()
         n = generate_signals(conn, target_date)
         _updated_rows["signals"] = n
@@ -46,7 +47,8 @@ def main() -> None:
         _errors.append(str(exc))
         _failed = True
     finally:
-        conn.close()
+        if conn is not None:
+            conn.close()
 
     finished_at = datetime.now(timezone.utc)
     try:

--- a/scripts/run_strategy_signal.py
+++ b/scripts/run_strategy_signal.py
@@ -18,16 +18,18 @@ from kabusys.config import Settings
 from kabusys.operations.job_run_recorder import write_job_result
 from kabusys.operations.night_batch_report import JobRunResult
 from kabusys.strategy.signal_generator import generate_signals
-from kabusys.utils.logging_setup import setup_logging
+from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
 
 setup_logging(app_name="strategy_signal")
 logger = logging.getLogger(__name__)
 
 _JOB_NAME = "strategy_signal_job"
+_APP_NAME = "strategy_signal"
 
 
 def main() -> None:
     started_at = datetime.now(timezone.utc)
+    log_run_start(_APP_NAME)
     settings = Settings()
     conn = duckdb.connect(str(settings.duckdb_path))
     _failed = False
@@ -63,6 +65,7 @@ def main() -> None:
     except Exception:
         logger.warning("JobRunResult の書き出しに失敗しました", exc_info=True)
 
+    log_run_end(_APP_NAME, status="failed" if _failed else "success", started_at=started_at)
     if _failed:
         sys.exit(1)
 

--- a/scripts/run_tdnet_collection.py
+++ b/scripts/run_tdnet_collection.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 import duckdb
@@ -15,26 +16,35 @@ import duckdb
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 from kabusys.config import Settings
 from kabusys.data.tdnet_collector import run_tdnet_collection
-from kabusys.utils.logging_setup import setup_logging
+from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
 
 setup_logging(app_name="tdnet_collection")
 logger = logging.getLogger(__name__)
 
+_APP_NAME = "tdnet_collection"
+
 
 def main() -> None:
+    started_at = datetime.now(timezone.utc)
+    log_run_start(_APP_NAME)
     settings = Settings()
     if not settings.enable_tdnet:
         logger.info("TDnet 収集はオプション機能です（ENABLE_TDNET=false）。スキップします。")
+        log_run_end(_APP_NAME, status="success", started_at=started_at)
         return
     conn = duckdb.connect(str(settings.duckdb_path))
+    _failed = False
     try:
         saved = run_tdnet_collection(conn)
         logger.info("tdnet_collection 完了: saved=%d", saved)
     except Exception:
         logger.exception("tdnet_collection バッチが失敗しました")
-        sys.exit(1)
+        _failed = True
     finally:
         conn.close()
+    log_run_end(_APP_NAME, status="failed" if _failed else "success", started_at=started_at)
+    if _failed:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/run_tdnet_collection.py
+++ b/scripts/run_tdnet_collection.py
@@ -27,22 +27,23 @@ _APP_NAME = "tdnet_collection"
 def main() -> None:
     started_at = datetime.now(timezone.utc)
     log_run_start(_APP_NAME)
-    settings = Settings()
-    if not settings.enable_tdnet:
-        logger.info("TDnet 収集はオプション機能です（ENABLE_TDNET=false）。スキップします。")
-        log_run_end(_APP_NAME, status="success", started_at=started_at)
-        return
-    conn = duckdb.connect(str(settings.duckdb_path))
+    conn = None
     _failed = False
     try:
+        settings = Settings()
+        if not settings.enable_tdnet:
+            logger.info("TDnet 収集はオプション機能です（ENABLE_TDNET=false）。スキップします。")
+            return
+        conn = duckdb.connect(str(settings.duckdb_path))
         saved = run_tdnet_collection(conn)
         logger.info("tdnet_collection 完了: saved=%d", saved)
     except Exception:
         logger.exception("tdnet_collection バッチが失敗しました")
         _failed = True
     finally:
-        conn.close()
-    log_run_end(_APP_NAME, status="failed" if _failed else "success", started_at=started_at)
+        if conn is not None:
+            conn.close()
+        log_run_end(_APP_NAME, status="failed" if _failed else "success", started_at=started_at)
     if _failed:
         sys.exit(1)
 

--- a/scripts/run_yahoonews_collection.py
+++ b/scripts/run_yahoonews_collection.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 import duckdb
@@ -16,10 +17,12 @@ import duckdb
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 from kabusys.config import Settings
 from kabusys.data.news_collector import run_news_collection
-from kabusys.utils.logging_setup import setup_logging
+from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
 
 setup_logging(app_name="yahoonews_collection")
 logger = logging.getLogger(__name__)
+
+_APP_NAME = "yahoonews_collection"
 
 
 def _fetch_known_codes(conn: duckdb.DuckDBPyConnection) -> list[str]:
@@ -36,13 +39,17 @@ def _fetch_known_codes(conn: duckdb.DuckDBPyConnection) -> list[str]:
 
 
 def main() -> None:
+    started_at = datetime.now(timezone.utc)
+    log_run_start(_APP_NAME)
     settings = Settings()
     if not settings.enable_yahoonews:
         logger.info(
             "Yahoo News 収集はオプション機能です（ENABLE_YAHOONEWS=false）。スキップします。"
         )
+        log_run_end(_APP_NAME, status="success", started_at=started_at)
         return
     conn = None
+    _failed = False
     try:
         conn = duckdb.connect(str(settings.duckdb_path))
         known_codes = _fetch_known_codes(conn)
@@ -53,10 +60,13 @@ def main() -> None:
         logger.info("yahoonews_collection 完了: saved=%d", saved)
     except Exception:
         logger.exception("yahoonews_collection バッチが失敗しました")
-        sys.exit(1)
+        _failed = True
     finally:
         if conn is not None:
             conn.close()
+    log_run_end(_APP_NAME, status="failed" if _failed else "success", started_at=started_at)
+    if _failed:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/run_yahoonews_collection.py
+++ b/scripts/run_yahoonews_collection.py
@@ -41,16 +41,15 @@ def _fetch_known_codes(conn: duckdb.DuckDBPyConnection) -> list[str]:
 def main() -> None:
     started_at = datetime.now(timezone.utc)
     log_run_start(_APP_NAME)
-    settings = Settings()
-    if not settings.enable_yahoonews:
-        logger.info(
-            "Yahoo News 収集はオプション機能です（ENABLE_YAHOONEWS=false）。スキップします。"
-        )
-        log_run_end(_APP_NAME, status="success", started_at=started_at)
-        return
     conn = None
     _failed = False
     try:
+        settings = Settings()
+        if not settings.enable_yahoonews:
+            logger.info(
+                "Yahoo News 収集はオプション機能です（ENABLE_YAHOONEWS=false）。スキップします。"
+            )
+            return
         conn = duckdb.connect(str(settings.duckdb_path))
         known_codes = _fetch_known_codes(conn)
         saved = run_news_collection(
@@ -64,7 +63,7 @@ def main() -> None:
     finally:
         if conn is not None:
             conn.close()
-    log_run_end(_APP_NAME, status="failed" if _failed else "success", started_at=started_at)
+        log_run_end(_APP_NAME, status="failed" if _failed else "success", started_at=started_at)
     if _failed:
         sys.exit(1)
 

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 import sqlite3
 import threading
-from datetime import date
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 import duckdb
@@ -37,7 +37,7 @@ from kabusys.operations.execution_startup_report import (  # noqa: E402
 )
 from kabusys.operations.line_reports import format_morning_message  # noqa: E402
 from kabusys.operations.notifier import build_notifier  # noqa: E402
-from kabusys.utils.logging_setup import setup_logging  # noqa: E402
+from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging  # noqa: E402
 from kabusys.utils.process_priority import set_process_priority  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -228,8 +228,13 @@ def _pos_value(p: object) -> float:
     return float(p.qty) * float(price)  # type: ignore[attr-defined]
 
 
+_APP_NAME = "execution"
+
+
 def main() -> None:
-    setup_logging(app_name="execution")
+    setup_logging(app_name=_APP_NAME)
+    started_at = datetime.now(timezone.utc)
+    log_run_start(_APP_NAME)
     # 1. プロセス優先度を High に設定（最初に実行）
     set_process_priority("high")
 
@@ -332,6 +337,10 @@ def main() -> None:
                 break
             thread.join(timeout=1.0)
         thread.join(timeout=30.0)
+        log_run_end(_APP_NAME, status="success", started_at=started_at)
+    except Exception:
+        log_run_end(_APP_NAME, status="failed", started_at=started_at)
+        raise
     finally:
         sqlite_conn.close()
         duckdb_conn.close()

--- a/src/kabusys/utils/logging_setup.py
+++ b/src/kabusys/utils/logging_setup.py
@@ -1,12 +1,20 @@
 # src/kabusys/utils/logging_setup.py
 """logging_setup.py — ログ設定ユーティリティ。
 
-StreamHandler（コンソール stdout）と TimedRotatingFileHandler（日次ローテーション）を
-ルートロガーに設定する。全起動スクリプトから呼び出して統一的なログ管理を実現する。
+StreamHandler（コンソール stdout）、TimedRotatingFileHandler（日次ローテーション）、
+FileHandler（実行単位のログファイル）をルートロガーに設定する。
+全起動スクリプトから呼び出して統一的なログ管理を実現する。
 
 使い方:
-    from kabusys.utils.logging_setup import setup_logging
+    from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
+
     setup_logging(app_name="execution")
+
+    def main() -> None:
+        started_at = datetime.now(timezone.utc)
+        log_run_start("execution")
+        ...
+        log_run_end("execution", status="success", started_at=started_at)
 """
 
 from __future__ import annotations
@@ -14,6 +22,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from datetime import datetime, timezone
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
 
@@ -30,12 +39,13 @@ def setup_logging(
     app_name: str = "kabusys",
     log_dir: Path | None = None,
     level: str | int | None = None,
-) -> None:
+) -> Path | None:
     """ロギングを設定する。
 
-    ルートロガーに以下の2ハンドラを設定する:
+    ルートロガーに以下の3ハンドラを設定する:
       - StreamHandler: コンソール（stdout）出力
       - TimedRotatingFileHandler: ``<log_dir>/<app_name>.log`` への日次ローテーション出力
+      - FileHandler: ``<log_dir>/<app_name>_YYYYMMDD_HHMMSS.log`` への実行単位出力
 
     既にハンドラが設定されている場合は一度クリアしてから再設定する（二重設定防止）。
 
@@ -54,6 +64,10 @@ def setup_logging(
         log_dir:  ログファイルの保存ディレクトリ。None の場合は上記解決順を使用。
         level:    ログレベル文字列（"DEBUG"/"INFO"/"WARNING"/"ERROR"/"CRITICAL"）または
                   整数値（例: ``logging.DEBUG``）。None の場合は上記解決順を使用。
+
+    Returns:
+        実行単位ログファイルのパス（``<app_name>_YYYYMMDD_HHMMSS.log``）。
+        ファイルハンドラの作成に失敗した場合は None を返す。
     """
     # ログレベル解決（int / str の両形式を受け入れる）
     if isinstance(level, int):
@@ -100,10 +114,12 @@ def setup_logging(
     stream_handler.setFormatter(formatter)
     root.addHandler(stream_handler)
 
-    # TimedRotatingFileHandler（日次ローテーション・30日保持）
-    # ディレクトリ作成またはファイル作成に失敗した場合は StreamHandler のみで継続する
-    log_file = resolved_dir / f"{app_name}.log"
+    run_log_file: Path | None = None
+
     if _dir_ok:
+        # TimedRotatingFileHandler（日次ローテーション・30日保持）
+        # 全実行ログを集約したファイル。`tail -f` での監視に適する。
+        log_file = resolved_dir / f"{app_name}.log"
         try:
             file_handler = TimedRotatingFileHandler(
                 log_file,
@@ -120,8 +136,50 @@ def setup_logging(
                 e,
             )
 
+        # FileHandler（実行単位ログファイル）
+        # 実行ごとに独立したファイルを生成し、特定の実行ログを追跡しやすくする。
+        run_ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        run_log_file = resolved_dir / f"{app_name}_{run_ts}.log"
+        try:
+            run_file_handler = logging.FileHandler(run_log_file, encoding="utf-8")
+            run_file_handler.setLevel(numeric_level)
+            run_file_handler.setFormatter(formatter)
+            root.addHandler(run_file_handler)
+        except Exception as e:
+            logger.warning(
+                "実行単位ファイルハンドラの作成に失敗しました: %s",
+                e,
+            )
+            run_log_file = None
+
     logger.debug(
-        "ロギングを設定しました: level=%s, log_file=%s",
+        "ロギングを設定しました: level=%s, log_file=%s_%s.log",
         logging.getLevelName(numeric_level),
-        log_file,
+        app_name,
+        datetime.now().strftime("%Y%m%d_%H%M%S"),
+    )
+
+    return run_log_file
+
+
+def log_run_start(app_name: str) -> None:
+    """実行開始マーカーをログに出力する。
+
+    Args:
+        app_name: スクリプト名（例: ``"data_update"``）。
+    """
+    logging.getLogger(__name__).info("===== %s START (PID=%d) =====", app_name, os.getpid())
+
+
+def log_run_end(app_name: str, status: str, started_at: datetime) -> None:
+    """実行終了マーカーをログに出力する。
+
+    Args:
+        app_name:   スクリプト名（例: ``"data_update"``）。
+        status:     終了ステータス（``"success"`` / ``"warning"`` / ``"failed"``）。
+        started_at: 実行開始時刻（``datetime.now(timezone.utc)``）。
+    """
+    duration = (datetime.now(timezone.utc) - started_at).total_seconds()
+    logging.getLogger(__name__).info(
+        "===== %s END status=%s duration=%.1fs =====", app_name, status, duration
     )

--- a/src/kabusys/utils/logging_setup.py
+++ b/src/kabusys/utils/logging_setup.py
@@ -138,8 +138,9 @@ def setup_logging(
 
         # FileHandler（実行単位ログファイル）
         # 実行ごとに独立したファイルを生成し、特定の実行ログを追跡しやすくする。
-        run_ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-        run_log_file = resolved_dir / f"{app_name}_{run_ts}.log"
+        # UTC + PID でファイル名を一意化し、同一秒の並行起動での衝突を防ぐ。
+        run_ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        run_log_file = resolved_dir / f"{app_name}_{run_ts}_{os.getpid()}.log"
         try:
             run_file_handler = logging.FileHandler(run_log_file, encoding="utf-8")
             run_file_handler.setLevel(numeric_level)
@@ -153,10 +154,10 @@ def setup_logging(
             run_log_file = None
 
     logger.debug(
-        "ロギングを設定しました: level=%s, log_file=%s_%s.log",
+        "ロギングを設定しました: level=%s, rotating=%s, run_log=%s",
         logging.getLevelName(numeric_level),
-        app_name,
-        datetime.now().strftime("%Y%m%d_%H%M%S"),
+        resolved_dir / f"{app_name}.log" if _dir_ok else None,
+        run_log_file,
     )
 
     return run_log_file
@@ -179,6 +180,8 @@ def log_run_end(app_name: str, status: str, started_at: datetime) -> None:
         status:     終了ステータス（``"success"`` / ``"warning"`` / ``"failed"``）。
         started_at: 実行開始時刻（``datetime.now(timezone.utc)``）。
     """
+    if started_at.tzinfo is None:
+        started_at = started_at.replace(tzinfo=timezone.utc)
     duration = (datetime.now(timezone.utc) - started_at).total_seconds()
     logging.getLogger(__name__).info(
         "===== %s END status=%s duration=%.1fs =====", app_name, status, duration

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,16 +1,17 @@
 # tests/test_logging_setup.py
-"""logging_setup モジュールのユニットテスト（Issue #55）"""
+"""logging_setup モジュールのユニットテスト（Issue #55 / #308）"""
 
 from __future__ import annotations
 
 import logging
 import sys
+from datetime import datetime, timezone
 from logging.handlers import TimedRotatingFileHandler
 from unittest.mock import patch
 
 import pytest
 
-from kabusys.utils.logging_setup import setup_logging
+from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
 
 
 @pytest.fixture(autouse=True)
@@ -26,9 +27,32 @@ def reset_root_logger():
 
 class TestSetupLogging:
     def test_creates_log_file(self, tmp_path):
-        """setup_logging() でログファイルが作成される。"""
+        """setup_logging() でローテーションログファイルが作成される。"""
         setup_logging(app_name="test_app", log_dir=tmp_path)
         assert (tmp_path / "test_app.log").exists()
+
+    def test_creates_run_log_file(self, tmp_path):
+        """setup_logging() で実行単位ログファイル（YYYYMMDD_HHMMSS サフィックス）が作成される。"""
+        run_log = setup_logging(app_name="test_app", log_dir=tmp_path)
+        assert run_log is not None
+        assert run_log.exists()
+        assert run_log.name.startswith("test_app_")
+        assert run_log.suffix == ".log"
+
+    def test_returns_run_log_path(self, tmp_path):
+        """setup_logging() は実行単位ログファイルのパスを返す。"""
+        run_log = setup_logging(app_name="myapp", log_dir=tmp_path)
+        assert run_log is not None
+        assert run_log.parent == tmp_path
+        assert run_log.name.startswith("myapp_")
+
+    def test_returns_none_when_dir_fails(self, tmp_path):
+        """ディレクトリ作成失敗時は None を返す。"""
+        with patch.object(
+            type(tmp_path), "mkdir", side_effect=PermissionError("permission denied")
+        ):
+            run_log = setup_logging(app_name="test", log_dir=tmp_path)
+        assert run_log is None
 
     def test_creates_log_dir_if_missing(self, tmp_path):
         """存在しないディレクトリは自動作成される。"""
@@ -38,12 +62,13 @@ class TestSetupLogging:
         assert (log_dir / "test.log").exists()
 
     def test_stream_and_file_handlers_added(self, tmp_path):
-        """StreamHandler と TimedRotatingFileHandler の2つが追加される。"""
+        """StreamHandler と TimedRotatingFileHandler と FileHandler の3つが追加される。"""
         setup_logging(app_name="test", log_dir=tmp_path)
         root = logging.getLogger()
         handler_types = {type(h) for h in root.handlers}
         assert logging.StreamHandler in handler_types
         assert TimedRotatingFileHandler in handler_types
+        assert logging.FileHandler in handler_types
 
     def test_stream_handler_uses_stdout(self, tmp_path):
         """StreamHandler が sys.stdout を使用する。"""
@@ -53,16 +78,16 @@ class TestSetupLogging:
         assert len(stream_handlers) == 1
         assert stream_handlers[0].stream is sys.stdout
 
-    def test_handler_count_is_two(self, tmp_path):
-        """ハンドラ数がちょうど2（stream + file）。"""
+    def test_handler_count_is_three(self, tmp_path):
+        """ハンドラ数がちょうど3（stream + rotating + run file）。"""
         setup_logging(app_name="test", log_dir=tmp_path)
-        assert len(logging.getLogger().handlers) == 2
+        assert len(logging.getLogger().handlers) == 3
 
     def test_no_duplicate_handlers_on_second_call(self, tmp_path):
-        """2回呼んでもハンドラが重複しない。"""
+        """2回呼んでもハンドラが重複しない（3個のまま）。"""
         setup_logging(app_name="test", log_dir=tmp_path)
         setup_logging(app_name="test", log_dir=tmp_path)
-        assert len(logging.getLogger().handlers) == 2
+        assert len(logging.getLogger().handlers) == 3
 
     def test_log_level_from_argument(self, tmp_path):
         """引数 level が反映される。"""
@@ -120,16 +145,18 @@ class TestSetupLogging:
         assert (tmp_path / "my_service.log").exists()
         assert not (tmp_path / "kabusys.log").exists()
 
-    def test_file_handler_failure_falls_back_to_stream_only(self, tmp_path):
-        """FileHandler 作成失敗時も StreamHandler のみで継続する。"""
+    def test_rotating_handler_failure_still_creates_run_log(self, tmp_path):
+        """TimedRotatingFileHandler 作成失敗時も StreamHandler + 実行単位 FileHandler で継続する。"""
         with patch(
             "kabusys.utils.logging_setup.TimedRotatingFileHandler",
             side_effect=OSError("permission denied"),
         ):
-            setup_logging(app_name="test", log_dir=tmp_path)
+            run_log = setup_logging(app_name="test", log_dir=tmp_path)
         root = logging.getLogger()
-        assert len(root.handlers) == 1
-        assert type(root.handlers[0]) is logging.StreamHandler
+        # stream + run file handler
+        assert len(root.handlers) == 2
+        assert any(type(h) is logging.StreamHandler for h in root.handlers)
+        assert run_log is not None
 
     def test_mkdir_failure_falls_back_to_stream_only(self, tmp_path):
         """ログディレクトリ作成失敗時も StreamHandler のみで継続する。"""
@@ -165,3 +192,47 @@ class TestSetupLogging:
         setup_logging(app_name="test", log_dir=tmp_path)
 
         assert len(closed) == len(first_handlers)
+
+
+class TestLogRunBoundaries:
+    # setup_logging を呼ばない: caplog は root logger のハンドラを使うが、
+    # setup_logging が既存ハンドラを全削除するため caplog のハンドラが消えてしまう。
+    # caplog.at_level(..., logger=LOGGER_NAME) でそのロガーのキャプチャレベルだけ設定する。
+
+    _LOGGER = "kabusys.utils.logging_setup"
+
+    def test_log_run_start_emits_start_marker(self, caplog):
+        """log_run_start() が START マーカーをログに出力する。"""
+        with caplog.at_level(logging.INFO, logger=self._LOGGER):
+            log_run_start("my_job")
+        assert any("my_job START" in r.message for r in caplog.records)
+
+    def test_log_run_start_includes_pid(self, caplog):
+        """log_run_start() のメッセージに PID が含まれる。"""
+        import os
+
+        with caplog.at_level(logging.INFO, logger=self._LOGGER):
+            log_run_start("my_job")
+        combined = " ".join(r.message for r in caplog.records)
+        assert str(os.getpid()) in combined
+
+    def test_log_run_end_emits_end_marker(self, caplog):
+        """log_run_end() が END マーカーをログに出力する。"""
+        started = datetime.now(timezone.utc)
+        with caplog.at_level(logging.INFO, logger=self._LOGGER):
+            log_run_end("my_job", status="success", started_at=started)
+        assert any("my_job END" in r.message for r in caplog.records)
+
+    def test_log_run_end_includes_status(self, caplog):
+        """log_run_end() のメッセージにステータスが含まれる。"""
+        started = datetime.now(timezone.utc)
+        with caplog.at_level(logging.INFO, logger=self._LOGGER):
+            log_run_end("my_job", status="failed", started_at=started)
+        assert any("status=failed" in r.message for r in caplog.records)
+
+    def test_log_run_end_includes_duration(self, caplog):
+        """log_run_end() のメッセージに duration が含まれる。"""
+        started = datetime.now(timezone.utc)
+        with caplog.at_level(logging.INFO, logger=self._LOGGER):
+            log_run_end("my_job", status="success", started_at=started)
+        assert any("duration=" in r.message for r in caplog.records)

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -32,12 +32,19 @@ class TestSetupLogging:
         assert (tmp_path / "test_app.log").exists()
 
     def test_creates_run_log_file(self, tmp_path):
-        """setup_logging() で実行単位ログファイル（YYYYMMDD_HHMMSS サフィックス）が作成される。"""
+        """setup_logging() で実行単位ログファイル（YYYYMMDD_HHMMSS_PID サフィックス）が作成される。"""
+        import os
+        import re
+
         run_log = setup_logging(app_name="test_app", log_dir=tmp_path)
         assert run_log is not None
         assert run_log.exists()
         assert run_log.name.startswith("test_app_")
         assert run_log.suffix == ".log"
+        assert re.search(r"_\d{8}_\d{6}_\d+\.log$", run_log.name), (
+            "ファイル名に YYYYMMDD_HHMMSS_PID が含まれること"
+        )
+        assert str(os.getpid()) in run_log.name
 
     def test_returns_run_log_path(self, tmp_path):
         """setup_logging() は実行単位ログファイルのパスを返す。"""
@@ -233,6 +240,13 @@ class TestLogRunBoundaries:
     def test_log_run_end_includes_duration(self, caplog):
         """log_run_end() のメッセージに duration が含まれる。"""
         started = datetime.now(timezone.utc)
+        with caplog.at_level(logging.INFO, logger=self._LOGGER):
+            log_run_end("my_job", status="success", started_at=started)
+        assert any("duration=" in r.message for r in caplog.records)
+
+    def test_log_run_end_accepts_naive_datetime(self, caplog):
+        """log_run_end() に naive datetime を渡しても TypeError にならない。"""
+        started = datetime.now()  # naive (tzinfo=None)
         with caplog.at_level(logging.INFO, logger=self._LOGGER):
             log_run_end("my_job", status="success", started_at=started)
         assert any("duration=" in r.message for r in caplog.records)


### PR DESCRIPTION
## 概要

Issue #308 の対応。バッチスクリプトの実行ログを追跡しやすくするため、実行単位ログファイルの追加と START/END マーカーを実装。

## 変更内容

### `src/kabusys/utils/logging_setup.py`
- **実行単位 FileHandler 追加**: `logs/<app_name>_YYYYMMDD_HHMMSS.log` を実行ごとに生成
  - 従来の `TimedRotatingFileHandler`（全実行集約）と併存する 3 ハンドラ構成
  - 手動再実行・リトライ時のログが混在しなくなる
- **戻り値を `Path | None` に変更**: 実行単位ログのパスを返す（Issue #309 のプロセス登録で活用予定）
- **`log_run_start(app_name)` 追加**: `===== data_update START (PID=12345) =====`
- **`log_run_end(app_name, status, started_at)` 追加**: `===== data_update END status=success duration=134.2s =====`

### バッチスクリプト（10 ファイル）
全スクリプトに `log_run_start` / `log_run_end` を追加:
- `run_data_update`, `run_feature_gen`, `run_strategy_signal`, `run_ai_analysis`, `run_portfolio_construction`
- `run_yahoonews_collection`, `run_tdnet_collection`, `run_edinet_collection`, `run_disclosure_classification`, `run_night_batch_report`
- `src/kabusys/run_execution.py`: `except` ブロックで `status="failed"` を記録

### `tests/test_logging_setup.py`
- 新規テスト 10 件追加（実行単位ログファイル生成・戻り値・START/END マーカー内容）
- 既存テストを 3 ハンドラ構成に合わせて更新

## テスト結果

```
1830 passed in 108.62s
```

## 関連 Issue

Closes #308