### PR TITLE
docs: 設計書・README を最新実装に同期（AI モジュール・Signal Queue フィルター・config/backups）

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,12 +592,14 @@ touch data/stop_requested.flag
       - 3_Pre_Market.py            — 朝の READY/BLOCKED 判定・データ鮮度確認
       - 4_Execution_Startup.py     — 起動直後のリコンシリエーション差分確認
       - 5_Intraday_Monitor.py      — ザラ場監視（自動更新）・Kill Switch 確認
-      - 6_Signal_Queue.py          — 発注キュー・シグナル確認（参照専用。キャンセル・削除は CLI コマンドを表示）
+      - 6_Signal_Queue.py          — 発注キュー・シグナル確認（参照専用。ステータスフィルター付き、デフォルト: cancelled 除外。キャンセル・削除は CLI コマンドを表示）
       - 7_Performance.py           — エクイティカーブ・ポジション・取引履歴・Paper Verification
       - 8_Failure_Recovery.py      — 障害イベント集約・復旧ガイド
       - 9_WebManual.py             — 運用マニュアル閲覧ビュー
       - 10_Strategy_Lab.py         — 市場レジーム・AI スコア・シグナル推移・AI Co-Pilot
   - ai/
+    - news_nlp.py                — ニュース NLP スコアリング（GPT-4o-mini 呼び出し）
+    - regime_detector.py         — 市場レジーム判定（ETF/LLM ハイブリッド）
     - backtest_summarizer.py     — DuckDB backtest_runs 最新結果 → system prompt 用 Markdown 生成
     - param_extractor.py         — AI 返答の JSON ブロック抽出・ホワイトリスト検証（許可キー 12種 + weights 5因子）
     - config_manager.py          — strategy_config.yaml へのパラメータ適用・バックアップ・ロールバック
@@ -608,6 +610,7 @@ touch data/stop_requested.flag
     - process_priority.py
 - config/
   - risk_config.yaml（等の YAML 設定ファイル）
+  - backups/（AI Co-Pilot がパラメータ適用時に自動生成する strategy_config.yaml のバックアップ）
 - data/
   - monitoring.db（デフォルト）
   - kabusys.duckdb（デフォルト: data/kabusys.duckdb）

--- a/documents/00_Architecture/RepositoryStructure.md
+++ b/documents/00_Architecture/RepositoryStructure.md
@@ -56,7 +56,9 @@
     ├ system_config.yaml
     ├ trading_config.yaml
     ├ universe_config.yaml
-    └ risk_config.yaml
+    ├ risk_config.yaml
+    └ backups/                        ← strategy_config.yaml の自動バックアップ（AI Co-Pilot 適用時）
+        └ strategy_config_YYYYMMDD_HHMMSS.yaml
 
 内容:
 
@@ -64,6 +66,7 @@
 -   戦略パラメータ
 -   リスク制限
 -   ユニバース設定
+-   `backups/`: AI Co-Pilot がパラメータを適用する際に自動生成する strategy_config.yaml のバックアップ。ロールバック時にも参照する
 
 ------------------------------------------------------------------------
 
@@ -160,18 +163,20 @@
 
 ## ai/
 
-AI関連コード。
+AI関連コード。実際のコードは `src/kabusys/ai/` に配置される。
 
-    ai/
-    ├ news_sentiment.py
-    ├ regime_model.py
-    └ ai_features.py
+    src/kabusys/ai/
+    ├ news_nlp.py            ← ニュース NLP スコアリング（GPT-4o-mini 呼び出し）
+    ├ regime_detector.py     ← 市場レジーム判定（ETF/LLM ハイブリッド）
+    ├ backtest_summarizer.py ← DuckDB backtest_runs → system prompt 用 Markdown 生成
+    ├ param_extractor.py     ← AI 返答から JSON ブロック抽出・ホワイトリスト検証
+    └ config_manager.py      ← strategy_config.yaml バックアップ・適用・ロールバック
 
 用途:
 
--   ニュース解析
--   センチメント分析
+-   ニュース解析・センチメント分析
 -   市場レジーム判定
+-   AI Co-Pilot パラメータ提案・適用・ロールバック（Issue #233, #279）
 
 ------------------------------------------------------------------------
 

--- a/documents/08_Operations/Monitoring.md
+++ b/documents/08_Operations/Monitoring.md
@@ -203,7 +203,7 @@ Core コードは返り値の型を意識せず `.send(message)` を呼ぶだけ
 | Pre-Market | `pages/3_Pre_Market.py` | 朝の READY/BLOCKED 判定・データ鮮度・停止フラグ確認 |
 | Execution Startup | `pages/4_Execution_Startup.py` | 起動直後のリコンシリエーション差分・ポジション整合確認 |
 | Intraday Monitor | `pages/5_Intraday_Monitor.py` | ザラ場監視（自動更新）・Kill Switch 状態・注文エラー・ドローダウン |
-| Signal Queue | `pages/6_Signal_Queue.py` | 発注キュー・ポートフォリオ目標・シグナル（直近7日）。**参照専用**。キャンセル・削除操作は CLI コマンドを画面上に表示するため、ターミナルで実行する |
+| Signal Queue | `pages/6_Signal_Queue.py` | 発注キュー・ポートフォリオ目標・シグナル（直近7日）。**参照専用**。ステータスフィルター（multiselect）で表示を絞り込める（デフォルト: `cancelled` を除外）。キャンセル・削除操作は CLI コマンドを画面上に表示するため、ターミナルで実行する |
 | Performance | `pages/7_Performance.py` | エクイティカーブ・ポジション・取引履歴・Paper Verification |
 | Failure Recovery | `pages/8_Failure_Recovery.py` | 障害イベント集約・復旧ガイド |
 | WebManual | `pages/9_WebManual.py` | 運用マニュアル閲覧ビュー |
@@ -481,7 +481,7 @@ python -m streamlit run src/kabusys/monitoring/streamlit_dashboard.py -- --db da
 | `pages/3_Pre_Market.py` | 朝の READY/BLOCKED 判定・データ鮮度・停止フラグ確認 |
 | `pages/4_Execution_Startup.py` | 起動直後のリコンシリエーション差分・ポジション整合確認 |
 | `pages/5_Intraday_Monitor.py` | ザラ場監視（自動更新）・Kill Switch 状態・注文エラー・ドローダウン |
-| `pages/6_Signal_Queue.py` | 発注キュー・ポートフォリオ目標・シグナル確認 |
+| `pages/6_Signal_Queue.py` | 発注キュー・ポートフォリオ目標・シグナル確認。ステータスフィルター（デフォルト: `cancelled` 除外） |
 | `pages/7_Performance.py` | エクイティカーブ・ポジション・取引履歴・Paper Verification |
 | `pages/8_Failure_Recovery.py` | 障害イベント集約・復旧ガイド |
 | `pages/9_WebManual.py` | 運用マニュアル閲覧ビュー |


### PR DESCRIPTION
## 概要

最近マージされた PR の実装に合わせて設計書・README を更新。

## 変更内容

### `documents/00_Architecture/RepositoryStructure.md`
- `ai/` セクション: 旧称ファイル名（`news_sentiment.py` 等）→ 実際のファイル構成（`news_nlp.py`, `regime_detector.py`, `param_extractor.py`, `config_manager.py`, `backtest_summarizer.py`）に更新（Issue #233, #279 実装済み）
- `config/` セクション: `backups/` サブディレクトリを追記（AI Co-Pilot パラメータ適用時の自動バックアップ先、Issue #279）

### `documents/08_Operations/Monitoring.md`
- Signal Queue ページ説明にステータスフィルター情報を追記（multiselect、デフォルト: `cancelled` 除外、Issue #302）

### `README.md`
- `ai/` モジュールリストに `news_nlp.py` / `regime_detector.py` を追記
- `config/backups/` を追記
- Signal Queue ページ説明にステータスフィルター情報を追記