### PR TITLE
feat: stdout/stderr を実行単位ログファイルに tee キャプチャ (Issue #309)

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,4 +640,5 @@ touch data/stop_requested.flag
   - 各スクリプトは `setup_logging` により 3 種類のハンドラを設定します: stdout（コンソール）、`logs/<app_name>.log`（日次ローテーション・30日保持）、`logs/<app_name>_YYYYMMDD_HHMMSS_<PID>.log`（実行単位ファイル）。
   - 実行単位ファイルは UTC タイムスタンプ + PID でファイル名を一意化するため、並行起動時もファイルが衝突しません。バッチ失敗後の原因調査に使用してください。
   - 各バッチスクリプトは START / END マーカー（`===== <app> START (PID=xxxx) =====` / `===== <app> END status=success/failed duration=Xs =====`）を出力します。Settings 初期化失敗時でも END マーカーが確実に出力されます。
+  - 夜間バッチスクリプト（`scripts/run_*.py`）と `run_execution.py` は `capture_stdio=True` で起動します。`print()` や DuckDB 等の C拡張が stderr に出力するメッセージも実行単位ログファイルに記録されます（コンソール出力は従来通り維持）。
   - `LOG_LEVEL` を `.env` で調整できます（`DEBUG`/`INFO`/`WARNING`/`ERROR`/`CRITICAL`）。`LOG_DIR` でログディレクトリの場所を変更できます（デフォルト: `logs/`）。

--- a/documents/08_Operations/Monitoring.md
+++ b/documents/08_Operations/Monitoring.md
@@ -269,6 +269,23 @@ Get-ChildItem logs\data_update_*.log | Sort-Object LastWriteTime -Desc | Select-
 Select-String -Path logs\*.log -Pattern "END status=failed"
 ```
 
+**stdio キャプチャ（capture_stdio=True）:**
+
+夜間バッチスクリプト（`scripts/run_*.py`）と `run_execution.py` は `capture_stdio=True` で起動する。
+これにより `print()` / C拡張ライブラリ（DuckDB の WARNING など）の stdout / stderr 出力も実行単位ログファイルに記録される。
+
+仕組み:
+- `sys.stdout` / `sys.stderr` を `_TeeWriter` オブジェクトに置き換える（コンソール出力は従来通り維持）
+- `_TeeWriter` は改行単位で `kabusys.stdio.<app_name>.stdout` / `stderr` ロガーへ転送し、実行単位 FileHandler がファイルへ書き込む
+- `kabusys.stdio.*` ロガーは `propagate=False` のため root ロガーの StreamHandler を経由せず、コンソール二重出力は発生しない
+
+ファイル内での見分け方:
+```
+2026-05-12T17:30:01 INFO     kabusys.data.prices_daily: ...   ← 通常の logging 出力
+2026-05-12T17:30:02 INFO     kabusys.stdio.data_update.stdout: ...   ← print() の出力
+2026-05-12T17:30:03 WARNING  kabusys.stdio.data_update.stderr: ...   ← stderr への出力
+```
+
 **保存期間:**
 - 集約ファイル（`<app_name>.log`）: 30日（`TimedRotatingFileHandler` による自動ローテーション）
 - 実行単位ファイル（`<app_name>_*.log`）: 手動管理。蓄積量に注意すること

--- a/scripts/run_ai_analysis.py
+++ b/scripts/run_ai_analysis.py
@@ -22,7 +22,7 @@ from kabusys.operations.job_run_recorder import write_job_result
 from kabusys.operations.night_batch_report import JobRunResult
 from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
 
-setup_logging(app_name="ai_analysis")
+setup_logging(app_name="ai_analysis", capture_stdio=True)
 logger = logging.getLogger(__name__)
 
 _JOB_NAME = "ai_analysis_job"

--- a/scripts/run_data_update.py
+++ b/scripts/run_data_update.py
@@ -23,7 +23,7 @@ from kabusys.operations.job_run_recorder import write_job_result
 from kabusys.operations.night_batch_report import JobRunResult
 from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
 
-setup_logging(app_name="data_update")
+setup_logging(app_name="data_update", capture_stdio=True)
 logger = logging.getLogger(__name__)
 
 _JOB_NAME = "data_update_job"

--- a/scripts/run_disclosure_classification.py
+++ b/scripts/run_disclosure_classification.py
@@ -18,7 +18,7 @@ from kabusys.config import Settings
 from kabusys.data.disclosure_classifier import run_disclosure_classification
 from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
 
-setup_logging(app_name="disclosure_classification")
+setup_logging(app_name="disclosure_classification", capture_stdio=True)
 logger = logging.getLogger(__name__)
 
 _APP_NAME = "disclosure_classification"

--- a/scripts/run_edinet_collection.py
+++ b/scripts/run_edinet_collection.py
@@ -18,7 +18,7 @@ from kabusys.config import Settings
 from kabusys.data.edinet_collector import run_edinet_collection
 from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
 
-setup_logging(app_name="edinet_collection")
+setup_logging(app_name="edinet_collection", capture_stdio=True)
 logger = logging.getLogger(__name__)
 
 _APP_NAME = "edinet_collection"

--- a/scripts/run_feature_gen.py
+++ b/scripts/run_feature_gen.py
@@ -20,7 +20,7 @@ from kabusys.operations.night_batch_report import JobRunResult
 from kabusys.strategy.feature_engineering import build_features
 from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
 
-setup_logging(app_name="feature_gen")
+setup_logging(app_name="feature_gen", capture_stdio=True)
 logger = logging.getLogger(__name__)
 
 _JOB_NAME = "feature_generation_job"

--- a/scripts/run_night_batch_report.py
+++ b/scripts/run_night_batch_report.py
@@ -30,7 +30,7 @@ from kabusys.operations.night_batch_report import (
 )
 from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
 
-setup_logging(app_name="night_batch_report")
+setup_logging(app_name="night_batch_report", capture_stdio=True)
 logger = logging.getLogger(__name__)
 
 _APP_NAME = "night_batch_report"

--- a/scripts/run_portfolio_construction.py
+++ b/scripts/run_portfolio_construction.py
@@ -41,7 +41,7 @@ from kabusys.portfolio.portfolio_builder import calc_score_weights, select_candi
 from kabusys.portfolio.position_sizing import calc_position_sizes
 from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
 
-setup_logging(app_name="portfolio_construction")
+setup_logging(app_name="portfolio_construction", capture_stdio=True)
 logger = logging.getLogger(__name__)
 
 _DEFAULT_PORTFOLIO_VALUE = 10_000_000

--- a/scripts/run_strategy_signal.py
+++ b/scripts/run_strategy_signal.py
@@ -20,7 +20,7 @@ from kabusys.operations.night_batch_report import JobRunResult
 from kabusys.strategy.signal_generator import generate_signals
 from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
 
-setup_logging(app_name="strategy_signal")
+setup_logging(app_name="strategy_signal", capture_stdio=True)
 logger = logging.getLogger(__name__)
 
 _JOB_NAME = "strategy_signal_job"

--- a/scripts/run_tdnet_collection.py
+++ b/scripts/run_tdnet_collection.py
@@ -18,7 +18,7 @@ from kabusys.config import Settings
 from kabusys.data.tdnet_collector import run_tdnet_collection
 from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
 
-setup_logging(app_name="tdnet_collection")
+setup_logging(app_name="tdnet_collection", capture_stdio=True)
 logger = logging.getLogger(__name__)
 
 _APP_NAME = "tdnet_collection"

--- a/scripts/run_yahoonews_collection.py
+++ b/scripts/run_yahoonews_collection.py
@@ -19,7 +19,7 @@ from kabusys.config import Settings
 from kabusys.data.news_collector import run_news_collection
 from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
 
-setup_logging(app_name="yahoonews_collection")
+setup_logging(app_name="yahoonews_collection", capture_stdio=True)
 logger = logging.getLogger(__name__)
 
 _APP_NAME = "yahoonews_collection"

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -232,7 +232,7 @@ _APP_NAME = "execution"
 
 
 def main() -> None:
-    setup_logging(app_name=_APP_NAME)
+    setup_logging(app_name=_APP_NAME, capture_stdio=True)
     started_at = datetime.now(timezone.utc)
     log_run_start(_APP_NAME)
     # 1. プロセス優先度を High に設定（最初に実行）

--- a/src/kabusys/utils/logging_setup.py
+++ b/src/kabusys/utils/logging_setup.py
@@ -67,10 +67,10 @@ class _TeeWriter:
             self.write(line)
 
     def flush(self) -> None:
-        stripped = self._buf.strip()
-        if stripped:
+        buf, self._buf = self._buf, ""
+        stripped = buf.rstrip("\r")
+        if stripped.strip():
             self._logger_fn(stripped)
-            self._buf = ""
         self._orig.flush()
 
     @property
@@ -85,7 +85,13 @@ class _TeeWriter:
         return bool(getattr(self._orig, "isatty", lambda: False)())
 
     def fileno(self) -> int:
-        return self._orig.fileno()
+        fn = getattr(self._orig, "fileno", None)
+        if fn is None:
+            raise OSError("fileno not supported")
+        return fn()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._orig, name)
 
 
 def setup_logging(
@@ -242,7 +248,10 @@ def _install_stdio_tee(
     stderr_logger = logging.getLogger(f"kabusys.stdio.{app_name}.stderr")
 
     for lg in (stdout_logger, stderr_logger):
-        lg.setLevel(level)
+        # DEBUG に固定して stdio ロガー自身はレベルフィルタをかけない。
+        # NOTSET だと getEffectiveLevel() が親チェーンを辿り root の ERROR が適用されるため、
+        # LOG_LEVEL=ERROR 設定時に print() 出力が消えてしまう。
+        lg.setLevel(logging.DEBUG)
         lg.propagate = False
         for h in list(lg.handlers):
             h.close()
@@ -252,7 +261,7 @@ def _install_stdio_tee(
     # root ロガーの run_file_handler とは別オブジェクトで同一ファイルに追記する
     try:
         fh_out = logging.FileHandler(run_log_file, mode="a", encoding="utf-8")
-        fh_out.setLevel(level)
+        fh_out.setLevel(logging.DEBUG)
         fh_out.setFormatter(formatter)
         stdout_logger.addHandler(fh_out)
     except Exception as e:
@@ -261,16 +270,18 @@ def _install_stdio_tee(
 
     try:
         fh_err = logging.FileHandler(run_log_file, mode="a", encoding="utf-8")
-        fh_err.setLevel(logging.WARNING)
+        fh_err.setLevel(logging.DEBUG)
         fh_err.setFormatter(formatter)
         stderr_logger.addHandler(fh_err)
     except Exception as e:
         logger.warning("stderr キャプチャ用ハンドラの作成に失敗しました: %s", e)
 
+    # sys.stdout / sys.stderr を使用（sys.__stdout__ ではなく）:
+    # pytest capsys など他フレームワークのラッパーを保持するため
     if not isinstance(sys.stdout, _TeeWriter):
-        sys.stdout = _TeeWriter(sys.__stdout__, stdout_logger.info)
+        sys.stdout = _TeeWriter(sys.stdout, stdout_logger.info)
     if not isinstance(sys.stderr, _TeeWriter):
-        sys.stderr = _TeeWriter(sys.__stderr__, stderr_logger.warning)
+        sys.stderr = _TeeWriter(sys.stderr, stderr_logger.warning)
 
 
 def log_run_start(app_name: str) -> None:

--- a/src/kabusys/utils/logging_setup.py
+++ b/src/kabusys/utils/logging_setup.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+import threading
 from datetime import datetime, timezone
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
@@ -36,30 +37,49 @@ _BACKUP_COUNT = 30  # 日次ローテーション・30日分保持
 logger = logging.getLogger(__name__)
 
 
+_LINE_SEP_RE = __import__("re").compile(r"\r\n|\r|\n")
+
+
 class _TeeWriter:
     """sys.stdout / sys.stderr をオリジナルストリームとロガーの両方に出力する tee ライター。
 
     write() で受け取ったメッセージを:
       1. オリジナルストリームへ書き込む（コンソール出力を維持）
-      2. 改行区切りで logger_fn を呼び出してログファイルにも記録する
+      2. \\n / \\r\\n / \\r 区切りで logger_fn を呼び出してログファイルにも記録する
+         （プログレスバー等の CR 更新もバッファに溜まらず都度ログ化される）
 
-    部分行（改行なしの断片）はバッファリングし flush() 時に書き出す。
-    これにより print() / C拡張ライブラリの stdio 出力もログファイルに残せる。
+    部分行（区切り文字なしの断片）はバッファリングし flush() 時に書き出す。
+    logger_fn 内でハンドラ障害が起きた場合の再帰ループは再入防止フラグで防ぐ。
     """
 
     def __init__(self, orig_stream: Any, logger_fn: Callable[[str], None]) -> None:
         self._orig = orig_stream
         self._logger_fn = logger_fn
         self._buf = ""
+        self._local = threading.local()
+
+    def _safe_log(self, msg: str) -> None:
+        """再帰ループを防ぎつつ logger_fn を呼ぶ。
+
+        FileHandler の emit 失敗 → handleError が sys.stderr に書く → _TeeWriter.write
+        → stderr_logger.warning → 同じハンドラで再失敗、という無限再帰を防ぐ。
+        """
+        if getattr(self._local, "active", False):
+            return
+        self._local.active = True
+        try:
+            self._logger_fn(msg)
+        finally:
+            self._local.active = False
 
     def write(self, msg: str) -> int:
         n = self._orig.write(msg)
         self._buf += msg
-        while "\n" in self._buf:
-            line, self._buf = self._buf.split("\n", 1)
-            stripped = line.rstrip("\r")
-            if stripped:
-                self._logger_fn(stripped)
+        parts = _LINE_SEP_RE.split(self._buf)
+        for line in parts[:-1]:
+            if line.strip():
+                self._safe_log(line)
+        self._buf = parts[-1]
         return n if n is not None else len(msg)
 
     def writelines(self, lines: Any) -> None:
@@ -68,9 +88,9 @@ class _TeeWriter:
 
     def flush(self) -> None:
         buf, self._buf = self._buf, ""
-        stripped = buf.rstrip("\r")
+        stripped = buf.rstrip("\r\n")
         if stripped.strip():
-            self._logger_fn(stripped)
+            self._safe_log(stripped)
         self._orig.flush()
 
     @property
@@ -224,7 +244,7 @@ def setup_logging(
     )
 
     if capture_stdio and run_log_file is not None:
-        _install_stdio_tee(app_name, run_log_file, numeric_level, formatter)
+        _install_stdio_tee(app_name, run_log_file, formatter)
 
     return run_log_file
 
@@ -232,7 +252,6 @@ def setup_logging(
 def _install_stdio_tee(
     app_name: str,
     run_log_file: Path,
-    level: int,
     formatter: logging.Formatter,
 ) -> None:
     """sys.stdout / sys.stderr を _TeeWriter に置き換えて run_log_file にも出力する。

--- a/src/kabusys/utils/logging_setup.py
+++ b/src/kabusys/utils/logging_setup.py
@@ -8,7 +8,7 @@ FileHandler（実行単位のログファイル）をルートロガーに設定
 使い方:
     from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
 
-    setup_logging(app_name="execution")
+    setup_logging(app_name="execution", capture_stdio=True)
 
     def main() -> None:
         started_at = datetime.now(timezone.utc)
@@ -25,6 +25,7 @@ import sys
 from datetime import datetime, timezone
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
+from typing import Any, Callable
 
 _LOG_FORMAT = "%(asctime)s %(levelname)-8s %(name)s: %(message)s"
 _DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
@@ -35,10 +36,63 @@ _BACKUP_COUNT = 30  # 日次ローテーション・30日分保持
 logger = logging.getLogger(__name__)
 
 
+class _TeeWriter:
+    """sys.stdout / sys.stderr をオリジナルストリームとロガーの両方に出力する tee ライター。
+
+    write() で受け取ったメッセージを:
+      1. オリジナルストリームへ書き込む（コンソール出力を維持）
+      2. 改行区切りで logger_fn を呼び出してログファイルにも記録する
+
+    部分行（改行なしの断片）はバッファリングし flush() 時に書き出す。
+    これにより print() / C拡張ライブラリの stdio 出力もログファイルに残せる。
+    """
+
+    def __init__(self, orig_stream: Any, logger_fn: Callable[[str], None]) -> None:
+        self._orig = orig_stream
+        self._logger_fn = logger_fn
+        self._buf = ""
+
+    def write(self, msg: str) -> int:
+        n = self._orig.write(msg)
+        self._buf += msg
+        while "\n" in self._buf:
+            line, self._buf = self._buf.split("\n", 1)
+            stripped = line.rstrip("\r")
+            if stripped:
+                self._logger_fn(stripped)
+        return n if n is not None else len(msg)
+
+    def writelines(self, lines: Any) -> None:
+        for line in lines:
+            self.write(line)
+
+    def flush(self) -> None:
+        stripped = self._buf.strip()
+        if stripped:
+            self._logger_fn(stripped)
+            self._buf = ""
+        self._orig.flush()
+
+    @property
+    def encoding(self) -> str:
+        return getattr(self._orig, "encoding", "utf-8")
+
+    @property
+    def errors(self) -> str:
+        return getattr(self._orig, "errors", "replace")
+
+    def isatty(self) -> bool:
+        return bool(getattr(self._orig, "isatty", lambda: False)())
+
+    def fileno(self) -> int:
+        return self._orig.fileno()
+
+
 def setup_logging(
     app_name: str = "kabusys",
     log_dir: Path | None = None,
     level: str | int | None = None,
+    capture_stdio: bool = False,
 ) -> Path | None:
     """ロギングを設定する。
 
@@ -60,10 +114,13 @@ def setup_logging(
       3. デフォルト ``"logs/"``
 
     Args:
-        app_name: ログファイル名のプレフィックス（例: ``"execution"`` → ``logs/execution.log``）。
-        log_dir:  ログファイルの保存ディレクトリ。None の場合は上記解決順を使用。
-        level:    ログレベル文字列（"DEBUG"/"INFO"/"WARNING"/"ERROR"/"CRITICAL"）または
-                  整数値（例: ``logging.DEBUG``）。None の場合は上記解決順を使用。
+        app_name:      ログファイル名のプレフィックス（例: ``"execution"`` → ``logs/execution.log``）。
+        log_dir:       ログファイルの保存ディレクトリ。None の場合は上記解決順を使用。
+        level:         ログレベル文字列（"DEBUG"/"INFO"/"WARNING"/"ERROR"/"CRITICAL"）または
+                       整数値（例: ``logging.DEBUG``）。None の場合は上記解決順を使用。
+        capture_stdio: True の場合、sys.stdout / sys.stderr を ``_TeeWriter`` で置き換え、
+                       print() や C拡張ライブラリの出力も実行単位ログファイルに記録する。
+                       コンソール出力は従来通り維持（tee 動作）。
 
     Returns:
         実行単位ログファイルのパス（``<app_name>_YYYYMMDD_HHMMSS.log``）。
@@ -160,7 +217,60 @@ def setup_logging(
         run_log_file,
     )
 
+    if capture_stdio and run_log_file is not None:
+        _install_stdio_tee(app_name, run_log_file, numeric_level, formatter)
+
     return run_log_file
+
+
+def _install_stdio_tee(
+    app_name: str,
+    run_log_file: Path,
+    level: int,
+    formatter: logging.Formatter,
+) -> None:
+    """sys.stdout / sys.stderr を _TeeWriter に置き換えて run_log_file にも出力する。
+
+    stdout / stderr それぞれに専用の FileHandler（append mode）を作成して
+    ``kabusys.stdio.<app_name>.stdout`` / ``kabusys.stdio.<app_name>.stderr``
+    ロガーに登録する。これらのロガーは propagate=False のため
+    root ロガーの StreamHandler には流れず、コンソール二重出力が発生しない。
+
+    既に _TeeWriter に置き換え済みの場合はスキップする（二重ネスト防止）。
+    """
+    stdout_logger = logging.getLogger(f"kabusys.stdio.{app_name}.stdout")
+    stderr_logger = logging.getLogger(f"kabusys.stdio.{app_name}.stderr")
+
+    for lg in (stdout_logger, stderr_logger):
+        lg.setLevel(level)
+        lg.propagate = False
+        for h in list(lg.handlers):
+            h.close()
+            lg.removeHandler(h)
+
+    # 実行単位ログファイルへの専用 FileHandler（append）
+    # root ロガーの run_file_handler とは別オブジェクトで同一ファイルに追記する
+    try:
+        fh_out = logging.FileHandler(run_log_file, mode="a", encoding="utf-8")
+        fh_out.setLevel(level)
+        fh_out.setFormatter(formatter)
+        stdout_logger.addHandler(fh_out)
+    except Exception as e:
+        logger.warning("stdout キャプチャ用ハンドラの作成に失敗しました: %s", e)
+        return
+
+    try:
+        fh_err = logging.FileHandler(run_log_file, mode="a", encoding="utf-8")
+        fh_err.setLevel(logging.WARNING)
+        fh_err.setFormatter(formatter)
+        stderr_logger.addHandler(fh_err)
+    except Exception as e:
+        logger.warning("stderr キャプチャ用ハンドラの作成に失敗しました: %s", e)
+
+    if not isinstance(sys.stdout, _TeeWriter):
+        sys.stdout = _TeeWriter(sys.__stdout__, stdout_logger.info)
+    if not isinstance(sys.stderr, _TeeWriter):
+        sys.stderr = _TeeWriter(sys.__stderr__, stderr_logger.warning)
 
 
 def log_run_start(app_name: str) -> None:

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -337,6 +337,35 @@ class TestTeeWriter:
         tee = _TeeWriter(orig, lambda x: None)
         assert tee.encoding == "utf-16"
 
+    def test_cr_treated_as_line_delimiter(self):
+        """`\\r` だけの行区切りでも logger_fn が呼ばれる（プログレスバー対応）。"""
+        logged = []
+        orig = type(
+            "S", (), {"write": lambda s, m: len(m), "flush": lambda s: None, "encoding": "utf-8"}
+        )()
+        tee = _TeeWriter(orig, logged.append)
+        tee.write("step1\rstep2\r")
+        assert "step1" in logged
+        assert "step2" in logged
+
+    def test_reentrancy_guard_prevents_recursion(self):
+        """logger_fn 内から再び write() を呼んでも再帰ループしない。"""
+        orig = type(
+            "S", (), {"write": lambda s, m: len(m), "flush": lambda s: None, "encoding": "utf-8"}
+        )()
+        call_count = []
+
+        def recursive_logger(msg):
+            call_count.append(msg)
+            # logger_fn 内から tee.write を呼ぶ（FileHandler 障害時の handleError 相当）
+            tee.write("inner\n")
+
+        tee = _TeeWriter(orig, recursive_logger)
+        tee.write("outer\n")
+        # recursive_logger は1回だけ呼ばれ、内部の tee.write は再入防止でスキップされる
+        assert len(call_count) == 1
+        assert call_count[0] == "outer"
+
 
 class TestCaptureStdio:
     """capture_stdio=True の統合テスト（Issue #309）"""

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,5 +1,5 @@
 # tests/test_logging_setup.py
-"""logging_setup モジュールのユニットテスト（Issue #55 / #308）"""
+"""logging_setup モジュールのユニットテスト（Issue #55 / #308 / #309）"""
 
 from __future__ import annotations
 
@@ -11,18 +11,31 @@ from unittest.mock import patch
 
 import pytest
 
-from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
+from kabusys.utils.logging_setup import _TeeWriter, log_run_end, log_run_start, setup_logging
 
 
 @pytest.fixture(autouse=True)
 def reset_root_logger():
     """各テスト後にルートロガーのハンドラとレベルをリセットしてテスト間の独立性を保つ。"""
+    orig_stdout = sys.stdout
+    orig_stderr = sys.stderr
     yield
+    # capture_stdio テストが sys.stdout/stderr を置き換えた場合に復元する
+    sys.stdout = orig_stdout
+    sys.stderr = orig_stderr
+    # ルートロガーをリセット
     root = logging.getLogger()
     for h in list(root.handlers):
         h.close()
         root.removeHandler(h)
     root.setLevel(logging.WARNING)
+    # stdio キャプチャ用ロガーをリセット
+    for name in list(logging.Logger.manager.loggerDict.keys()):
+        if "kabusys.stdio" in name:
+            lg = logging.getLogger(name)
+            for h in list(lg.handlers):
+                h.close()
+                lg.removeHandler(h)
 
 
 class TestSetupLogging:
@@ -250,3 +263,126 @@ class TestLogRunBoundaries:
         with caplog.at_level(logging.INFO, logger=self._LOGGER):
             log_run_end("my_job", status="success", started_at=started)
         assert any("duration=" in r.message for r in caplog.records)
+
+
+class TestTeeWriter:
+    """_TeeWriter の単体テスト（Issue #309）"""
+
+    def test_write_forwards_to_orig_stream(self):
+        """write() はオリジナルストリームへ書き込む。"""
+        calls = []
+
+        class FakeStream:
+            encoding = "utf-8"
+
+            def write(self, msg):
+                calls.append(msg)
+                return len(msg)
+
+            def flush(self):
+                pass
+
+        logged = []
+        tee = _TeeWriter(FakeStream(), logged.append)
+        tee.write("hello\n")
+        assert "hello\n" in calls
+
+    def test_write_calls_logger_fn_on_newline(self):
+        """改行区切りで logger_fn が呼ばれる。"""
+        logged = []
+        orig = type(
+            "S", (), {"write": lambda s, m: len(m), "flush": lambda s: None, "encoding": "utf-8"}
+        )()
+        tee = _TeeWriter(orig, logged.append)
+        tee.write("line1\nline2\n")
+        assert "line1" in logged
+        assert "line2" in logged
+
+    def test_write_buffers_partial_lines(self):
+        """改行なしの書き込みはバッファリングされ logger_fn を呼ばない。"""
+        logged = []
+        orig = type(
+            "S", (), {"write": lambda s, m: len(m), "flush": lambda s: None, "encoding": "utf-8"}
+        )()
+        tee = _TeeWriter(orig, logged.append)
+        tee.write("partial")
+        assert logged == []
+
+    def test_flush_drains_buffer(self):
+        """flush() がバッファ内の残行を logger_fn に流す。"""
+        logged = []
+        orig = type(
+            "S", (), {"write": lambda s, m: len(m), "flush": lambda s: None, "encoding": "utf-8"}
+        )()
+        tee = _TeeWriter(orig, logged.append)
+        tee.write("partial")
+        tee.flush()
+        assert "partial" in logged
+
+    def test_write_skips_empty_lines(self):
+        """空行（改行のみ）では logger_fn を呼ばない。"""
+        logged = []
+        orig = type(
+            "S", (), {"write": lambda s, m: len(m), "flush": lambda s: None, "encoding": "utf-8"}
+        )()
+        tee = _TeeWriter(orig, logged.append)
+        tee.write("\n")
+        assert logged == []
+
+    def test_encoding_attribute(self):
+        """encoding 属性がオリジナルストリームの値を返す。"""
+        orig = type(
+            "S", (), {"encoding": "utf-16", "write": lambda s, m: len(m), "flush": lambda s: None}
+        )()
+        tee = _TeeWriter(orig, lambda x: None)
+        assert tee.encoding == "utf-16"
+
+
+class TestCaptureStdio:
+    """capture_stdio=True の統合テスト（Issue #309）"""
+
+    def test_stdout_replaced_with_tee_writer(self, tmp_path):
+        """capture_stdio=True で sys.stdout が _TeeWriter に置き換えられる。"""
+        setup_logging(app_name="test", log_dir=tmp_path, capture_stdio=True)
+        assert isinstance(sys.stdout, _TeeWriter)
+
+    def test_stderr_replaced_with_tee_writer(self, tmp_path):
+        """capture_stdio=True で sys.stderr が _TeeWriter に置き換えられる。"""
+        setup_logging(app_name="test", log_dir=tmp_path, capture_stdio=True)
+        assert isinstance(sys.stderr, _TeeWriter)
+
+    def test_stdout_unchanged_when_capture_false(self, tmp_path):
+        """capture_stdio=False（デフォルト）では sys.stdout は変わらない。"""
+        orig = sys.stdout
+        setup_logging(app_name="test", log_dir=tmp_path)
+        assert sys.stdout is orig
+
+    def test_print_captured_to_run_log(self, tmp_path):
+        """capture_stdio=True でのprint()出力が実行単位ログファイルに記録される。"""
+        run_log = setup_logging(app_name="test", log_dir=tmp_path, capture_stdio=True)
+        assert run_log is not None
+        print("hello from print")
+        sys.stdout.flush()
+        content = run_log.read_text(encoding="utf-8")
+        assert "hello from print" in content
+
+    def test_stderr_captured_to_run_log(self, tmp_path):
+        """capture_stdio=True での sys.stderr 出力が実行単位ログファイルに記録される。"""
+        run_log = setup_logging(app_name="test", log_dir=tmp_path, capture_stdio=True)
+        assert run_log is not None
+        sys.stderr.write("err output\n")
+        sys.stderr.flush()
+        content = run_log.read_text(encoding="utf-8")
+        assert "err output" in content
+
+    def test_second_setup_call_no_nested_tee(self, tmp_path):
+        """2回目の setup_logging でも TeeWriter の二重ネストにならない。"""
+        setup_logging(app_name="test", log_dir=tmp_path, capture_stdio=True)
+        setup_logging(app_name="test", log_dir=tmp_path, capture_stdio=True)
+        assert not isinstance(sys.stdout._orig, _TeeWriter)  # type: ignore[union-attr]
+
+    def test_capture_stdio_false_by_default(self, tmp_path):
+        """capture_stdio 引数のデフォルトは False。"""
+        orig = sys.stdout
+        setup_logging(app_name="test", log_dir=tmp_path)
+        assert sys.stdout is orig

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -386,3 +386,27 @@ class TestCaptureStdio:
         orig = sys.stdout
         setup_logging(app_name="test", log_dir=tmp_path)
         assert sys.stdout is orig
+
+    def test_high_log_level_still_captures_print(self, tmp_path):
+        """LOG_LEVEL=ERROR 設定時も print() 出力は実行単位ログに記録される。"""
+        run_log = setup_logging(
+            app_name="test", log_dir=tmp_path, level="ERROR", capture_stdio=True
+        )
+        assert run_log is not None
+        print("captured despite error level")
+        sys.stdout.flush()
+        content = run_log.read_text(encoding="utf-8")
+        assert "captured despite error level" in content
+
+    def test_flush_clears_whitespace_only_buffer(self):
+        """flush() で空白のみのバッファを呼び出してもバッファがクリアされ logger_fn を呼ばない。"""
+        logged = []
+        orig = type(
+            "S", (), {"write": lambda s, m: len(m), "flush": lambda s: None, "encoding": "utf-8"}
+        )()
+        tee = _TeeWriter(orig, logged.append)
+        tee.write("   ")  # whitespace only, no newline
+        tee.flush()
+        assert logged == []
+        # バッファがクリアされていること
+        assert tee._buf == ""


### PR DESCRIPTION
## 概要

- `setup_logging()` に `capture_stdio=True` パラメータを追加
- `_TeeWriter` クラスで sys.stdout / sys.stderr をラップし、print() や外部ライブラリの出力を実行単位ログファイルに記録
- コンソール出力は従来通り維持（tee 動作）
- 全起動スクリプト（scripts/run_*.py, src/kabusys/run_execution.py）に `capture_stdio=True` を適用

## 変更ファイル

- `src/kabusys/utils/logging_setup.py` — `_TeeWriter`, `_install_stdio_tee()`, `capture_stdio` パラメータ追加
- `tests/test_logging_setup.py` — TestTeeWriter / TestCaptureStdio クラス追加（42テスト）
- `scripts/run_*.py`, `src/kabusys/run_execution.py` — `capture_stdio=True` 適用
- 設計書・README 更新

## テスト

- 全1846テスト pass 確認済み

Closes #309