### PR TITLE
fix: 検証環境で StockAccountWallet が null のとき get_available_cash() がクラッシュする問題を修正 (#317)

### DIFF
--- a/scripts/run_portfolio_construction.py
+++ b/scripts/run_portfolio_construction.py
@@ -132,7 +132,9 @@ def main() -> None:
                     }
 
                     pos_cur = conn.execute(
-                        "SELECT code, position_size FROM positions WHERE code IN (" + code_params + ")",
+                        "SELECT code, position_size FROM positions WHERE code IN ("
+                        + code_params
+                        + ")",
                         codes,
                     )
                     current_positions = {r[0]: int(r[1]) for r in pos_cur.fetchall()}

--- a/src/kabusys/data/jquants_client.py
+++ b/src/kabusys/data/jquants_client.py
@@ -477,9 +477,7 @@ def save_financial_statements(
             fetched_at,
         )
         for r in records
-        if r.get("Code")
-        and r.get("DiscDate")
-        and r.get("CurPerType")  # PK 欠損行はスキップ
+        if r.get("Code") and r.get("DiscDate") and r.get("CurPerType")  # PK 欠損行はスキップ
     ]
     skipped = len(records) - len(rows)
     if skipped:

--- a/src/kabusys/execution/kabu_client.py
+++ b/src/kabusys/execution/kabu_client.py
@@ -242,7 +242,8 @@ class KabuStationClient:
         resp = self._request("get", "/wallet/cash")
         if resp.status_code != 200:
             raise BrokerAPIError(f"余力照会失敗: {resp.status_code}", status_code=resp.status_code)
-        return float(self._json(resp).get("StockAccountWallet", 0.0))
+        value = self._json(resp).get("StockAccountWallet")
+        return float(value) if value is not None else 0.0
 
     def stream_push(
         self,

--- a/tests/test_kabu_client.py
+++ b/tests/test_kabu_client.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from kabusys.execution.kabu_client import KabuStationClient
 
@@ -17,47 +17,54 @@ def _make_client(token_json: dict, cash_json: dict) -> KabuStationClient:
     mock_cash_resp.status_code = 200
     mock_cash_resp.json.return_value = cash_json
 
-    with patch("kabusys.execution.kabu_client.httpx.Client") as mock_cls:
-        mock_http = MagicMock()
-        mock_cls.return_value = mock_http
-        mock_http.post.return_value = mock_token_resp
-        mock_http.get.return_value = mock_cash_resp
-        client = KabuStationClient.__new__(KabuStationClient)
-        client._api_password = "test_pass"
-        client._trade_password = "test_pass"
-        client._base_url = "http://localhost:18081/kabusapi"
-        client._timeout = 10.0
-        client._token = None
-        client._client = mock_http
+    mock_http = MagicMock()
+    mock_http.post.return_value = mock_token_resp
+    mock_http.get.return_value = mock_cash_resp
 
-    return client, mock_http, mock_token_resp, mock_cash_resp
+    client = KabuStationClient.__new__(KabuStationClient)
+    client._api_password = "test_pass"
+    client._trade_password = "test_pass"
+    client._base_url = "http://localhost:18081/kabusapi"
+    client._timeout = 10.0
+    client._token = None
+    client._client = mock_http
+
+    return client
 
 
 def test_get_available_cash_returns_zero_when_stock_account_wallet_is_null():
     """検証環境で StockAccountWallet が null のとき 0.0 を返す（TypeError を raise しない）。"""
-    token_json = {"Token": "test_token"}
-    cash_json = {
-        "StockAccountWallet": None,
-        "AuKCStockAccountWallet": None,
-        "AuJbnStockAccountWallet": None,
-    }
-    client, _, _, _ = _make_client(token_json, cash_json)
+    client = _make_client(
+        {"Token": "test_token"},
+        {
+            "StockAccountWallet": None,
+            "AuKCStockAccountWallet": None,
+            "AuJbnStockAccountWallet": None,
+        },
+    )
 
-    result = client.get_available_cash()
-
-    assert result == 0.0
+    assert client.get_available_cash() == 0.0
 
 
 def test_get_available_cash_returns_value_when_stock_account_wallet_is_set():
     """本番環境で StockAccountWallet が数値のとき、その値を返す。"""
-    token_json = {"Token": "test_token"}
-    cash_json = {
-        "StockAccountWallet": 1_000_000.0,
-        "AuKCStockAccountWallet": 1_000_000.0,
-        "AuJbnStockAccountWallet": 0.0,
-    }
-    client, _, _, _ = _make_client(token_json, cash_json)
+    client = _make_client(
+        {"Token": "test_token"},
+        {
+            "StockAccountWallet": 1_000_000.0,
+            "AuKCStockAccountWallet": 1_000_000.0,
+            "AuJbnStockAccountWallet": 0.0,
+        },
+    )
 
-    result = client.get_available_cash()
+    assert client.get_available_cash() == 1_000_000.0
 
-    assert result == 1_000_000.0
+
+def test_get_available_cash_returns_zero_when_stock_account_wallet_key_missing():
+    """StockAccountWallet キー自体が存在しないとき 0.0 を返す。"""
+    client = _make_client(
+        {"Token": "test_token"},
+        {"AuKCStockAccountWallet": None, "AuJbnStockAccountWallet": None},
+    )
+
+    assert client.get_available_cash() == 0.0

--- a/tests/test_kabu_client.py
+++ b/tests/test_kabu_client.py
@@ -1,0 +1,65 @@
+"""KabuStationClient のユニットテスト。httpx をモックして kabu station 不要で実行可能。"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kabusys.execution.kabu_client import KabuStationClient
+
+
+def _make_client(token_json: dict, cash_json: dict) -> KabuStationClient:
+    """httpx.Client をモックした KabuStationClient を返す。"""
+    mock_token_resp = MagicMock()
+    mock_token_resp.status_code = 200
+    mock_token_resp.json.return_value = token_json
+
+    mock_cash_resp = MagicMock()
+    mock_cash_resp.status_code = 200
+    mock_cash_resp.json.return_value = cash_json
+
+    with patch("kabusys.execution.kabu_client.httpx.Client") as mock_cls:
+        mock_http = MagicMock()
+        mock_cls.return_value = mock_http
+        mock_http.post.return_value = mock_token_resp
+        mock_http.get.return_value = mock_cash_resp
+        client = KabuStationClient.__new__(KabuStationClient)
+        client._api_password = "test_pass"
+        client._trade_password = "test_pass"
+        client._base_url = "http://localhost:18081/kabusapi"
+        client._timeout = 10.0
+        client._token = None
+        client._client = mock_http
+
+    return client, mock_http, mock_token_resp, mock_cash_resp
+
+
+def test_get_available_cash_returns_zero_when_stock_account_wallet_is_null():
+    """検証環境で StockAccountWallet が null のとき 0.0 を返す（TypeError を raise しない）。"""
+    token_json = {"Token": "test_token"}
+    cash_json = {
+        "StockAccountWallet": None,
+        "AuKCStockAccountWallet": None,
+        "AuJbnStockAccountWallet": None,
+    }
+    client, _, _, _ = _make_client(token_json, cash_json)
+
+    result = client.get_available_cash()
+
+    assert result == 0.0
+
+
+def test_get_available_cash_returns_value_when_stock_account_wallet_is_set():
+    """本番環境で StockAccountWallet が数値のとき、その値を返す。"""
+    token_json = {"Token": "test_token"}
+    cash_json = {
+        "StockAccountWallet": 1_000_000.0,
+        "AuKCStockAccountWallet": 1_000_000.0,
+        "AuJbnStockAccountWallet": 0.0,
+    }
+    client, _, _, _ = _make_client(token_json, cash_json)
+
+    result = client.get_available_cash()
+
+    assert result == 1_000_000.0

--- a/tests/test_kabu_client.py
+++ b/tests/test_kabu_client.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from kabusys.execution.kabu_client import KabuStationClient
 
 


### PR DESCRIPTION
## Summary

- `kabu_client.py:245` で `.get("StockAccountWallet", 0.0)` が `None` を返した際に `float(None)` でクラッシュしていた問題を修正
- キーが存在するが値が `null` の場合、`None` を `0.0` にフォールバックするよう変更
- 新規テストファイル `tests/test_kabu_client.py` を追加（TDD で実装）

## Root Cause

kabu station 検証環境（port 18081）の `/wallet/cash` は以下を返す：
```json
{"StockAccountWallet": null, "AuKCStockAccountWallet": null, "AuJbnStockAccountWallet": null}
```

`.get("StockAccountWallet", 0.0)` はキーが**存在しない**場合のみデフォルト値を返す。
値が `null` の場合はキーが存在するため `None` を返し、`float(None)` で `TypeError` が発生していた。

## Changes

- `src/kabusys/execution/kabu_client.py` — `get_available_cash()` で `None` を `0.0` にフォールバック
- `tests/test_kabu_client.py` — `null` 返却時と正常値返却時の2ケースを追加

## Test Plan

- [x] `test_get_available_cash_returns_zero_when_stock_account_wallet_is_null` — null → 0.0 を確認
- [x] `test_get_available_cash_returns_value_when_stock_account_wallet_is_set` — 正常値のリグレッションなし
- [x] 関連テスト 77 件すべてパス

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)