### PR TITLE
fix: J-Quants API v2 フィールド名未追従によるテスト失敗とBPS抽出の修正

### DIFF
--- a/scripts/run_portfolio_construction.py
+++ b/scripts/run_portfolio_construction.py
@@ -132,7 +132,9 @@ def main() -> None:
                     }
 
                     pos_cur = conn.execute(
-                        "SELECT code, position_size FROM positions WHERE code IN (" + code_params + ")",
+                        "SELECT code, position_size FROM positions WHERE code IN ("
+                        + code_params
+                        + ")",
                         codes,
                     )
                     current_positions = {r[0]: int(r[1]) for r in pos_cur.fetchall()}

--- a/src/kabusys/data/jquants_client.py
+++ b/src/kabusys/data/jquants_client.py
@@ -473,7 +473,7 @@ def save_financial_statements(
             _to_float(r.get("NP")) / _to_float(r.get("Eq"))
             if _to_float(r.get("NP")) is not None and _to_float(r.get("Eq"))
             else None,
-            None,  # bps: /fins/summary に BPS 列なし
+            _to_float(r.get("BookValuePerShare")),
             fetched_at,
         )
         for r in records

--- a/src/kabusys/data/jquants_client.py
+++ b/src/kabusys/data/jquants_client.py
@@ -477,9 +477,7 @@ def save_financial_statements(
             fetched_at,
         )
         for r in records
-        if r.get("Code")
-        and r.get("DiscDate")
-        and r.get("CurPerType")  # PK 欠損行はスキップ
+        if r.get("Code") and r.get("DiscDate") and r.get("CurPerType")  # PK 欠損行はスキップ
     ]
     skipped = len(records) - len(rows)
     if skipped:

--- a/src/kabusys/execution/kabu_client.py
+++ b/src/kabusys/execution/kabu_client.py
@@ -242,7 +242,8 @@ class KabuStationClient:
         resp = self._request("get", "/wallet/cash")
         if resp.status_code != 200:
             raise BrokerAPIError(f"余力照会失敗: {resp.status_code}", status_code=resp.status_code)
-        return float(self._json(resp).get("StockAccountWallet", 0.0))
+        value = self._json(resp).get("StockAccountWallet")
+        return float(value) if value is not None else 0.0
 
     def stream_push(
         self,

--- a/tests/test_broker_factory.py
+++ b/tests/test_broker_factory.py
@@ -6,6 +6,12 @@ from kabusys.execution.broker_factory import BrokerClientFactory
 from kabusys.execution.mock_client import MockBrokerClient
 
 
+@pytest.fixture(autouse=True)
+def _clear_sandbox_env(monkeypatch):
+    """ローカル .env の KABU_USE_SANDBOX がテスト結果に影響しないよう除去する。"""
+    monkeypatch.delenv("KABU_USE_SANDBOX", raising=False)
+
+
 class TestPaperFillMode:
     def test_default_is_instant(self, monkeypatch):
         monkeypatch.delenv("PAPER_FILL_MODE", raising=False)

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -54,17 +54,17 @@ def _sample_financial_record(
     operating_profit: float = 100000.0,
     profit: float = 80000.0,
     eps: float = 120.5,
-    roe: float = 0.12,
+    equity: float = 666666.0,
 ) -> dict:
     return {
-        "LocalCode": code,
-        "DisclosedDate": disclosed_date,
-        "TypeOfDocument": type_of_doc,
-        "NetSales": net_sales,
-        "OperatingProfit": operating_profit,
-        "Profit": profit,
-        "EarningsPerShare": eps,
-        "ROE": roe,
+        "Code": code,
+        "DiscDate": disclosed_date,
+        "CurPerType": type_of_doc,
+        "Sales": net_sales,
+        "OP": operating_profit,
+        "NP": profit,
+        "EPS": eps,
+        "Eq": equity,
     }
 
 
@@ -229,7 +229,7 @@ class TestJQuantsClientMock:
         )
         result = jquants.fetch_financial_statements()
         assert len(result) == 1
-        assert result[0]["LocalCode"] == "7203"
+        assert result[0]["Code"] == "7203"
 
     def test_fetch_market_calendar(self, monkeypatch):
         """カレンダーデータを取得できることを確認。"""

--- a/tests/test_kabu_client.py
+++ b/tests/test_kabu_client.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from kabusys.execution.kabu_client import KabuStationClient
 
@@ -17,47 +17,54 @@ def _make_client(token_json: dict, cash_json: dict) -> KabuStationClient:
     mock_cash_resp.status_code = 200
     mock_cash_resp.json.return_value = cash_json
 
-    with patch("kabusys.execution.kabu_client.httpx.Client") as mock_cls:
-        mock_http = MagicMock()
-        mock_cls.return_value = mock_http
-        mock_http.post.return_value = mock_token_resp
-        mock_http.get.return_value = mock_cash_resp
-        client = KabuStationClient.__new__(KabuStationClient)
-        client._api_password = "test_pass"
-        client._trade_password = "test_pass"
-        client._base_url = "http://localhost:18081/kabusapi"
-        client._timeout = 10.0
-        client._token = None
-        client._client = mock_http
+    mock_http = MagicMock()
+    mock_http.post.return_value = mock_token_resp
+    mock_http.get.return_value = mock_cash_resp
 
-    return client, mock_http, mock_token_resp, mock_cash_resp
+    client = KabuStationClient.__new__(KabuStationClient)
+    client._api_password = "test_pass"
+    client._trade_password = "test_pass"
+    client._base_url = "http://localhost:18081/kabusapi"
+    client._timeout = 10.0
+    client._token = None
+    client._client = mock_http
+
+    return client
 
 
 def test_get_available_cash_returns_zero_when_stock_account_wallet_is_null():
     """検証環境で StockAccountWallet が null のとき 0.0 を返す（TypeError を raise しない）。"""
-    token_json = {"Token": "test_token"}
-    cash_json = {
-        "StockAccountWallet": None,
-        "AuKCStockAccountWallet": None,
-        "AuJbnStockAccountWallet": None,
-    }
-    client, _, _, _ = _make_client(token_json, cash_json)
+    client = _make_client(
+        {"Token": "test_token"},
+        {
+            "StockAccountWallet": None,
+            "AuKCStockAccountWallet": None,
+            "AuJbnStockAccountWallet": None,
+        },
+    )
 
-    result = client.get_available_cash()
-
-    assert result == 0.0
+    assert client.get_available_cash() == 0.0
 
 
 def test_get_available_cash_returns_value_when_stock_account_wallet_is_set():
     """本番環境で StockAccountWallet が数値のとき、その値を返す。"""
-    token_json = {"Token": "test_token"}
-    cash_json = {
-        "StockAccountWallet": 1_000_000.0,
-        "AuKCStockAccountWallet": 1_000_000.0,
-        "AuJbnStockAccountWallet": 0.0,
-    }
-    client, _, _, _ = _make_client(token_json, cash_json)
+    client = _make_client(
+        {"Token": "test_token"},
+        {
+            "StockAccountWallet": 1_000_000.0,
+            "AuKCStockAccountWallet": 1_000_000.0,
+            "AuJbnStockAccountWallet": 0.0,
+        },
+    )
 
-    result = client.get_available_cash()
+    assert client.get_available_cash() == 1_000_000.0
 
-    assert result == 1_000_000.0
+
+def test_get_available_cash_returns_zero_when_stock_account_wallet_key_missing():
+    """StockAccountWallet キー自体が存在しないとき 0.0 を返す。"""
+    client = _make_client(
+        {"Token": "test_token"},
+        {"AuKCStockAccountWallet": None, "AuJbnStockAccountWallet": None},
+    )
+
+    assert client.get_available_cash() == 0.0

--- a/tests/test_kabu_client.py
+++ b/tests/test_kabu_client.py
@@ -1,0 +1,65 @@
+"""KabuStationClient のユニットテスト。httpx をモックして kabu station 不要で実行可能。"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kabusys.execution.kabu_client import KabuStationClient
+
+
+def _make_client(token_json: dict, cash_json: dict) -> KabuStationClient:
+    """httpx.Client をモックした KabuStationClient を返す。"""
+    mock_token_resp = MagicMock()
+    mock_token_resp.status_code = 200
+    mock_token_resp.json.return_value = token_json
+
+    mock_cash_resp = MagicMock()
+    mock_cash_resp.status_code = 200
+    mock_cash_resp.json.return_value = cash_json
+
+    with patch("kabusys.execution.kabu_client.httpx.Client") as mock_cls:
+        mock_http = MagicMock()
+        mock_cls.return_value = mock_http
+        mock_http.post.return_value = mock_token_resp
+        mock_http.get.return_value = mock_cash_resp
+        client = KabuStationClient.__new__(KabuStationClient)
+        client._api_password = "test_pass"
+        client._trade_password = "test_pass"
+        client._base_url = "http://localhost:18081/kabusapi"
+        client._timeout = 10.0
+        client._token = None
+        client._client = mock_http
+
+    return client, mock_http, mock_token_resp, mock_cash_resp
+
+
+def test_get_available_cash_returns_zero_when_stock_account_wallet_is_null():
+    """検証環境で StockAccountWallet が null のとき 0.0 を返す（TypeError を raise しない）。"""
+    token_json = {"Token": "test_token"}
+    cash_json = {
+        "StockAccountWallet": None,
+        "AuKCStockAccountWallet": None,
+        "AuJbnStockAccountWallet": None,
+    }
+    client, _, _, _ = _make_client(token_json, cash_json)
+
+    result = client.get_available_cash()
+
+    assert result == 0.0
+
+
+def test_get_available_cash_returns_value_when_stock_account_wallet_is_set():
+    """本番環境で StockAccountWallet が数値のとき、その値を返す。"""
+    token_json = {"Token": "test_token"}
+    cash_json = {
+        "StockAccountWallet": 1_000_000.0,
+        "AuKCStockAccountWallet": 1_000_000.0,
+        "AuJbnStockAccountWallet": 0.0,
+    }
+    client, _, _, _ = _make_client(token_json, cash_json)
+
+    result = client.get_available_cash()
+
+    assert result == 1_000_000.0

--- a/tests/test_kabu_client.py
+++ b/tests/test_kabu_client.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from kabusys.execution.kabu_client import KabuStationClient
 
 

--- a/tests/test_pbr_div_yield.py
+++ b/tests/test_pbr_div_yield.py
@@ -88,14 +88,14 @@ class TestBpsExtraction:
         conn = init_schema(":memory:")
         records = [
             {
-                "LocalCode": "72030",
-                "DisclosedDate": "2024-03-31",
-                "TypeOfDocument": "Q4",
-                "NetSales": "1000000",
-                "OperatingProfit": "200000",
-                "Profit": "150000",
-                "EarningsPerShare": "100.0",
-                "ROE": "0.15",
+                "Code": "72030",
+                "DiscDate": "2024-03-31",
+                "CurPerType": "Q4",
+                "Sales": "1000000",
+                "OP": "200000",
+                "NP": "150000",
+                "EPS": "100.0",
+                "Eq": "1000000",
                 "BookValuePerShare": "1500.0",
             }
         ]
@@ -111,11 +111,12 @@ class TestBpsExtraction:
         conn = init_schema(":memory:")
         records = [
             {
-                "LocalCode": "72031",
-                "DisclosedDate": "2024-03-31",
-                "TypeOfDocument": "Q4",
-                "EarningsPerShare": "50.0",
-                "ROE": "0.10",
+                "Code": "72031",
+                "DiscDate": "2024-03-31",
+                "CurPerType": "Q4",
+                "EPS": "50.0",
+                "NP": "50000",
+                "Eq": "500000",
                 # BookValuePerShare なし
             }
         ]


### PR DESCRIPTION
## 根本原因

コミット `994e2162` で `jquants_client.py` を J-Quants API v2 フィールド名に変更した際に、以下の2点が未対応のまま残っていた。

### 問題1: テストが旧フィールド名のまま

| v1 (旧) | v2 (新) |
|---------|---------|
| `LocalCode` | `Code` |
| `DisclosedDate` | `DiscDate` |
| `TypeOfDocument` | `CurPerType` |
| `NetSales` | `Sales` |
| `OperatingProfit` | `OP` |
| `Profit` | `NP` |
| `EarningsPerShare` | `EPS` |

テストレコードに `Code` / `DiscDate` / `CurPerType` が含まれないため、PK 欠損チェック (`r.get("Code") and r.get("DiscDate") and r.get("CurPerType")`) で全レコードがスキップされ `saved == 0` になっていた。

### 問題2: BPS 抽出が `None` にハードコードされていた

同コミットで `BookValuePerShare → bps` のマッピングが `None,  # bps: /fins/summary に BPS 列なし` に固定され、PBR 計算に必要な BPS が永久に保存されなくなっていた。

### 問題3: `.env` の `KABU_USE_SANDBOX=true` がテストに影響

ローカル `.env` に `KABU_USE_SANDBOX=true` が設定されているため、`paper_trading` モードのテストで `MockBrokerClient` ではなく `KabuStationClient` が返されていた。

## 変更内容

- `jquants_client.py`: `bps` を `None` 固定から `BookValuePerShare` の値を使用するよう復元
- `test_data_pipeline.py`: `_sample_financial_record()` を v2 フィールド名に更新
- `test_pbr_div_yield.py`: `TestBpsExtraction` のテストレコードを v2 フィールド名に更新
- `test_broker_factory.py`: `autouse` fixture で `KABU_USE_SANDBOX` を除去（ファイルスコープ）

## テスト結果

- 修正前: 8 failed（3件 + 5件）
- 修正後: **1855 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)