### PR TITLE
fix: position_entries を SQLite に移管し DuckDB 並行アクセス問題を根本解決 (#320)

### DIFF
--- a/scripts/migrate_position_entries.py
+++ b/scripts/migrate_position_entries.py
@@ -35,8 +35,7 @@ def migrate(dry_run: bool = False) -> None:
     try:
         # DuckDB に position_entries テーブルが存在するか確認
         tables = duckdb_conn.execute(
-            "SELECT table_name FROM information_schema.tables"
-            " WHERE table_name = 'position_entries'"
+            "SELECT table_name FROM information_schema.tables WHERE table_name = 'position_entries'"
         ).fetchall()
         if not tables:
             print("DuckDB に position_entries テーブルが存在しません。移行不要です。")

--- a/scripts/migrate_position_entries.py
+++ b/scripts/migrate_position_entries.py
@@ -1,0 +1,85 @@
+# scripts/migrate_position_entries.py
+"""DuckDB の position_entries テーブルを SQLite に移行するワンタイムスクリプト。
+
+Issue #320 対応: position_entries を DuckDB から SQLite に移管した際、
+既存の DuckDB データを SQLite へコピーするために使用する。
+
+使い方:
+    python scripts/migrate_position_entries.py [--dry-run]
+
+オプション:
+    --dry-run   実際の書き込みを行わず、移行件数のみ表示する。
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+import duckdb
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+from kabusys.config import Settings
+from kabusys.execution.order_repository import init_position_entries_db
+
+
+def migrate(dry_run: bool = False) -> None:
+    settings = Settings()
+
+    duckdb_conn = duckdb.connect(str(settings.duckdb_path), read_only=True)
+    sqlite_path = settings.paper_sqlite_path if settings.is_paper else settings.sqlite_path
+    sqlite_conn = sqlite3.connect(str(sqlite_path), timeout=30.0)
+
+    try:
+        # DuckDB に position_entries テーブルが存在するか確認
+        tables = duckdb_conn.execute(
+            "SELECT table_name FROM information_schema.tables"
+            " WHERE table_name = 'position_entries'"
+        ).fetchall()
+        if not tables:
+            print("DuckDB に position_entries テーブルが存在しません。移行不要です。")
+            return
+
+        rows = duckdb_conn.execute(
+            "SELECT code, entry_date::TEXT, sell_date::TEXT FROM position_entries"
+        ).fetchall()
+
+        print(f"DuckDB から {len(rows)} 件を取得しました。")
+        if dry_run:
+            print("[dry-run] 書き込みをスキップします。")
+            return
+
+        init_position_entries_db(sqlite_conn)
+
+        inserted = 0
+        skipped = 0
+        for code, entry_date, sell_date in rows:
+            cur = sqlite_conn.execute(
+                "INSERT OR IGNORE INTO position_entries (code, entry_date, sell_date)"
+                " VALUES (?, ?, ?)",
+                [code, entry_date, sell_date],
+            )
+            if cur.rowcount > 0:
+                inserted += 1
+            else:
+                skipped += 1
+
+        sqlite_conn.commit()
+        print(f"移行完了: 挿入 {inserted} 件 / スキップ（既存） {skipped} 件")
+
+    finally:
+        duckdb_conn.close()
+        sqlite_conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="DuckDB position_entries → SQLite 移行")
+    parser.add_argument("--dry-run", action="store_true", help="書き込みを行わずに件数のみ確認する")
+    args = parser.parse_args()
+    migrate(dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_strategy_signal.py
+++ b/scripts/run_strategy_signal.py
@@ -47,7 +47,7 @@ def main() -> None:
     try:
         settings = Settings()
         conn = duckdb.connect(str(settings.duckdb_path))
-        sqlite_conn = sqlite3.connect(str(settings.sqlite_path))
+        sqlite_conn = sqlite3.connect(str(settings.sqlite_path), timeout=30.0)
         init_position_entries_db(sqlite_conn)
         target_date = date.today()
         n = generate_signals(conn, target_date, sqlite_conn=sqlite_conn)

--- a/scripts/run_strategy_signal.py
+++ b/scripts/run_strategy_signal.py
@@ -7,6 +7,7 @@ Task Scheduler から 20:00 に起動される。
 from __future__ import annotations
 
 import logging
+import sqlite3
 import sys
 from datetime import date, datetime, timezone
 from pathlib import Path
@@ -15,6 +16,7 @@ import duckdb
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 from kabusys.config import Settings
+from kabusys.execution.order_repository import init_position_entries_db
 from kabusys.operations.job_run_recorder import write_job_result
 from kabusys.operations.night_batch_report import JobRunResult
 from kabusys.operations.process_registry import register_process, update_process
@@ -41,11 +43,14 @@ def main() -> None:
     _errors: list[str] = []
     _updated_rows: dict[str, int] = {}
 
+    sqlite_conn = None
     try:
         settings = Settings()
         conn = duckdb.connect(str(settings.duckdb_path))
+        sqlite_conn = sqlite3.connect(str(settings.sqlite_path))
+        init_position_entries_db(sqlite_conn)
         target_date = date.today()
-        n = generate_signals(conn, target_date)
+        n = generate_signals(conn, target_date, sqlite_conn=sqlite_conn)
         _updated_rows["signals"] = n
         logger.info("シグナル生成完了: %d 件 (date=%s)", n, target_date)
     except Exception as exc:
@@ -55,6 +60,8 @@ def main() -> None:
     finally:
         if conn is not None:
             conn.close()
+        if sqlite_conn is not None:
+            sqlite_conn.close()
 
     finished_at = datetime.now(timezone.utc)
     try:

--- a/src/kabusys/execution/execution_engine.py
+++ b/src/kabusys/execution/execution_engine.py
@@ -181,19 +181,20 @@ class ExecutionEngine:
             # fill_date: 発注当日の翌営業日（バックテストと整合させるため）
             # BUY pending も記録する（発注確約済みとして扱う。キャンセル時はリコンシリエーションで回収）
             # SELL pending は記録しない（保有中のポジションのクローズ確定前のため）
+            # NOTE: _process_signals はメインスレッドからのみ呼び出される。
+            #       sqlite_conn は check_same_thread=True（デフォルト）のため他スレッドからアクセス不可。
             if _order_sent and self._sqlite_conn is not None:
                 try:
                     fill_date = next_trading_day(self._duckdb_conn, self._config.target_date)
                     if side == "buy":
                         self._sqlite_conn.execute(
-                            """
-                            INSERT OR IGNORE INTO position_entries (code, entry_date)
-                            VALUES (?, ?)
-                            """,
+                            # INSERT OR IGNORE: 同一 (code, entry_date) の重複エントリーは無視する
+                            "INSERT OR IGNORE INTO position_entries (code, entry_date) VALUES (?, ?)",
                             [code, str(fill_date)],
                         )
                         self._sqlite_conn.commit()
                     elif side == "sell" and not _order_pending:
+                        # 1銘柄1エントリー設計のため sell_date IS NULL のエントリーは常に1件以下
                         self._sqlite_conn.execute(
                             "UPDATE position_entries SET sell_date = ? "
                             "WHERE code = ? AND sell_date IS NULL",

--- a/src/kabusys/execution/execution_engine.py
+++ b/src/kabusys/execution/execution_engine.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 import os
 import queue
+import sqlite3
 import threading
 import time as _time_module
 from dataclasses import dataclass
@@ -48,6 +49,7 @@ class ExecutionEngine:
         order_manager: OrderManager,
         duckdb_conn: duckdb.DuckDBPyConnection,
         config: EngineConfig,
+        sqlite_conn: sqlite3.Connection | None = None,
         reconciler: Reconciler | None = None,
         pid_file: Path | None = None,
         monitoring_db: MonitoringDB | None = None,
@@ -57,6 +59,7 @@ class ExecutionEngine:
         self._risk_manager = risk_manager
         self._order_manager = order_manager
         self._duckdb_conn = duckdb_conn
+        self._sqlite_conn = sqlite_conn
         self._config = config
         self._reconciler = reconciler
         self._pid_file: Path | None = pid_file
@@ -178,24 +181,25 @@ class ExecutionEngine:
             # fill_date: 発注当日の翌営業日（バックテストと整合させるため）
             # BUY pending も記録する（発注確約済みとして扱う。キャンセル時はリコンシリエーションで回収）
             # SELL pending は記録しない（保有中のポジションのクローズ確定前のため）
-            if _order_sent:
+            if _order_sent and self._sqlite_conn is not None:
                 try:
                     fill_date = next_trading_day(self._duckdb_conn, self._config.target_date)
                     if side == "buy":
-                        self._duckdb_conn.execute(
+                        self._sqlite_conn.execute(
                             """
-                            INSERT INTO position_entries (code, entry_date)
+                            INSERT OR IGNORE INTO position_entries (code, entry_date)
                             VALUES (?, ?)
-                            ON CONFLICT DO NOTHING
                             """,
-                            [code, fill_date],
+                            [code, str(fill_date)],
                         )
+                        self._sqlite_conn.commit()
                     elif side == "sell" and not _order_pending:
-                        self._duckdb_conn.execute(
+                        self._sqlite_conn.execute(
                             "UPDATE position_entries SET sell_date = ? "
                             "WHERE code = ? AND sell_date IS NULL",
-                            [fill_date, code],
+                            [str(fill_date), code],
                         )
+                        self._sqlite_conn.commit()
                 except Exception as _pe_exc:
                     logger.warning("position_entries 書き込み失敗（発注フローは継続）: %s", _pe_exc)
 

--- a/src/kabusys/execution/order_repository.py
+++ b/src/kabusys/execution/order_repository.py
@@ -25,6 +25,8 @@ _TERMINAL_STATES = frozenset(
 def init_position_entries_db(conn: sqlite3.Connection) -> None:
     """position_entries テーブルとインデックスを作成する（冪等）。"""
     conn.executescript("""
+        PRAGMA journal_mode=WAL;
+        PRAGMA busy_timeout=30000;
         CREATE TABLE IF NOT EXISTS position_entries (
             code        TEXT NOT NULL,
             entry_date  TEXT NOT NULL,

--- a/src/kabusys/execution/order_repository.py
+++ b/src/kabusys/execution/order_repository.py
@@ -22,6 +22,23 @@ _TERMINAL_STATES = frozenset(
 )
 
 
+def init_position_entries_db(conn: sqlite3.Connection) -> None:
+    """position_entries テーブルとインデックスを作成する（冪等）。"""
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS position_entries (
+            code        TEXT NOT NULL,
+            entry_date  TEXT NOT NULL,
+            sell_date   TEXT,
+            PRIMARY KEY (code, entry_date)
+        );
+        CREATE INDEX IF NOT EXISTS idx_position_entries_code_sell
+            ON position_entries(code, sell_date);
+        CREATE INDEX IF NOT EXISTS idx_position_entries_code_entry
+            ON position_entries(code, entry_date);
+    """)
+    conn.commit()
+
+
 def init_orders_db(conn: sqlite3.Connection) -> None:
     """orders テーブルとインデックスを作成する（冪等）。"""
     conn.executescript("""

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -26,7 +26,10 @@ _RISK_CONFIG = _PROJECT_ROOT / "config" / "risk_config.yaml"
 from kabusys.execution.broker_factory import BrokerClientFactory  # noqa: E402
 from kabusys.execution.execution_engine import EngineConfig, ExecutionEngine  # noqa: E402
 from kabusys.execution.order_manager import OrderManager  # noqa: E402
-from kabusys.execution.order_repository import OrderRepository  # noqa: E402
+from kabusys.execution.order_repository import (  # noqa: E402
+    OrderRepository,
+    init_position_entries_db,
+)
 from kabusys.execution.reconciler import Reconciler  # noqa: E402
 from kabusys.execution.risk_manager import RiskConfig, RiskManager  # noqa: E402
 from kabusys.monitoring.monitoring_db import init_monitoring_db  # noqa: E402
@@ -253,7 +256,8 @@ def main() -> None:
     sqlite_path = settings.paper_sqlite_path if settings.is_paper else settings.sqlite_path
     sqlite_conn = sqlite3.connect(str(sqlite_path))
     init_monitoring_db(sqlite_conn)  # 監視テーブルが存在することを保証（冪等）
-    duckdb_conn = duckdb.connect(str(settings.duckdb_path))
+    init_position_entries_db(sqlite_conn)  # position_entries テーブルが存在することを保証（冪等）
+    duckdb_conn = duckdb.connect(str(settings.duckdb_path), read_only=True)
 
     try:
         # 3. ブローカークライアント（paper mode かつ非サンドボックスは前回状態を復元）
@@ -327,6 +331,7 @@ def main() -> None:
             risk_manager=risk_manager,
             order_manager=order_manager,
             duckdb_conn=duckdb_conn,
+            sqlite_conn=sqlite_conn,
             config=EngineConfig(target_date=today),
             reconciler=None,
             pid_file=_EXECUTION_PID,

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -254,7 +254,7 @@ def main() -> None:
 
     # 2. DB 接続 — paper_trading は専用 DB で本番と分離
     sqlite_path = settings.paper_sqlite_path if settings.is_paper else settings.sqlite_path
-    sqlite_conn = sqlite3.connect(str(sqlite_path))
+    sqlite_conn = sqlite3.connect(str(sqlite_path), timeout=30.0)
     init_monitoring_db(sqlite_conn)  # 監視テーブルが存在することを保証（冪等）
     init_position_entries_db(sqlite_conn)  # position_entries テーブルが存在することを保証（冪等）
     duckdb_conn = duckdb.connect(str(settings.duckdb_path), read_only=True)

--- a/src/kabusys/run_monitoring.py
+++ b/src/kabusys/run_monitoring.py
@@ -58,7 +58,7 @@ def main() -> None:
     logger.info("起動環境: KABUSYS_ENV=%s", settings.env)
 
     # 2. DB 接続（monitoring は環境にかかわらず本番 sqlite_path を使用）
-    sqlite_conn = sqlite3.connect(str(settings.sqlite_path))
+    sqlite_conn = sqlite3.connect(str(settings.sqlite_path), timeout=30.0)
     init_monitoring_db(sqlite_conn)
     duckdb_conn = duckdb.connect(str(settings.duckdb_path), read_only=True)
 

--- a/src/kabusys/run_monitoring.py
+++ b/src/kabusys/run_monitoring.py
@@ -60,7 +60,7 @@ def main() -> None:
     # 2. DB 接続（monitoring は環境にかかわらず本番 sqlite_path を使用）
     sqlite_conn = sqlite3.connect(str(settings.sqlite_path))
     init_monitoring_db(sqlite_conn)
-    duckdb_conn = duckdb.connect(str(settings.duckdb_path))
+    duckdb_conn = duckdb.connect(str(settings.duckdb_path), read_only=True)
 
     # 3. SystemMonitor 初期化
     monitor = SystemMonitor(

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import logging
 import math
+import sqlite3
 from datetime import date
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -720,32 +721,53 @@ def _peak_close(
     conn: duckdb.DuckDBPyConnection,
     code: str,
     target_date: date,
+    sqlite_conn: sqlite3.Connection | None = None,
 ) -> float | None:
     """すべてのオープンエントリーの最古のエントリー日以降 target_date までの最高 close を返す。
 
     オープンな position_entries が存在しない場合は None を返す。
+    sqlite_conn が指定された場合は position_entries を SQLite から取得する（ライブ実行用）。
+    sqlite_conn が None の場合は DuckDB conn から取得する（バックテスト互換）。
     """
-    row = conn.execute(
-        """
-        WITH first_entry AS (
-            SELECT MIN(entry_date) AS entry_date
-            FROM position_entries
-            WHERE code = ?
-              AND sell_date IS NULL
-        )
-        SELECT MAX(pd.close)
-        FROM first_entry fe
-        JOIN prices_daily pd
-          ON pd.date >= fe.entry_date
-         AND pd.date <= ?
-         AND pd.code = ?
-        WHERE fe.entry_date IS NOT NULL
-        """,
-        [code, target_date, code],
-    ).fetchone()
-    if row is None or row[0] is None:
-        return None
-    return float(row[0])
+    if sqlite_conn is not None:
+        # SQLite から最古の未クローズ entry_date を取得
+        row = sqlite_conn.execute(
+            "SELECT MIN(entry_date) FROM position_entries WHERE code = ? AND sell_date IS NULL",
+            [code],
+        ).fetchone()
+        if row is None or row[0] is None:
+            return None
+        first_entry_date = date.fromisoformat(str(row[0]))
+        # DuckDB から当該期間の最高 close を取得
+        price_row = conn.execute(
+            "SELECT MAX(close) FROM prices_daily WHERE code = ? AND date >= ? AND date <= ?",
+            [code, first_entry_date, target_date],
+        ).fetchone()
+        if price_row is None or price_row[0] is None:
+            return None
+        return float(price_row[0])
+    else:
+        row = conn.execute(
+            """
+            WITH first_entry AS (
+                SELECT MIN(entry_date) AS entry_date
+                FROM position_entries
+                WHERE code = ?
+                  AND sell_date IS NULL
+            )
+            SELECT MAX(pd.close)
+            FROM first_entry fe
+            JOIN prices_daily pd
+              ON pd.date >= fe.entry_date
+             AND pd.date <= ?
+             AND pd.code = ?
+            WHERE fe.entry_date IS NOT NULL
+            """,
+            [code, target_date, code],
+        ).fetchone()
+        if row is None or row[0] is None:
+            return None
+        return float(row[0])
 
 
 # ---------------------------------------------------------------------------
@@ -757,19 +779,25 @@ def _held_days(
     conn: duckdb.DuckDBPyConnection,
     code: str,
     target_date: date,
+    sqlite_conn: sqlite3.Connection | None = None,
 ) -> int | None:
     """position_entries から最新の未クローズ entry_date を取得し、
     entry_date 〜 target_date の営業日数を返す（entry_date 当日 = 0）。
     レコードなし → None（チェックスキップ・安全側）。
+    sqlite_conn が指定された場合は SQLite から取得する（ライブ実行用）。
     """
-    row = conn.execute(
-        """
-        SELECT entry_date FROM position_entries
-        WHERE code = ? AND sell_date IS NULL
-        ORDER BY entry_date DESC LIMIT 1
-        """,
-        [code],
-    ).fetchone()
+    if sqlite_conn is not None:
+        row = sqlite_conn.execute(
+            "SELECT entry_date FROM position_entries WHERE code = ? AND sell_date IS NULL "
+            "ORDER BY entry_date DESC LIMIT 1",
+            [code],
+        ).fetchone()
+    else:
+        row = conn.execute(
+            "SELECT entry_date FROM position_entries WHERE code = ? AND sell_date IS NULL "
+            "ORDER BY entry_date DESC LIMIT 1",
+            [code],
+        ).fetchone()
     if row is None:
         return None
     entry_date = row[0] if isinstance(row[0], date) else date.fromisoformat(str(row[0]))
@@ -784,18 +812,24 @@ def _is_reentry_blocked(
     code: str,
     target_date: date,
     cooldown_days: int = _REENTRY_COOLDOWN_DAYS,
+    sqlite_conn: sqlite3.Connection | None = None,
 ) -> bool:
     """最新の sell_date から target_date までの営業日数が cooldown_days 未満なら True。
     sell_date が NULL またはレコードなしは False（制限なし）。
+    sqlite_conn が指定された場合は SQLite から取得する（ライブ実行用）。
     """
-    row = conn.execute(
-        """
-        SELECT sell_date FROM position_entries
-        WHERE code = ? AND sell_date IS NOT NULL
-        ORDER BY sell_date DESC LIMIT 1
-        """,
-        [code],
-    ).fetchone()
+    if sqlite_conn is not None:
+        row = sqlite_conn.execute(
+            "SELECT sell_date FROM position_entries WHERE code = ? AND sell_date IS NOT NULL "
+            "ORDER BY sell_date DESC LIMIT 1",
+            [code],
+        ).fetchone()
+    else:
+        row = conn.execute(
+            "SELECT sell_date FROM position_entries WHERE code = ? AND sell_date IS NOT NULL "
+            "ORDER BY sell_date DESC LIMIT 1",
+            [code],
+        ).fetchone()
     if row is None or row[0] is None:
         return False
     sell_date = row[0] if isinstance(row[0], date) else date.fromisoformat(str(row[0]))
@@ -844,6 +878,7 @@ def _generate_sell_signals(
     max_holding_days: int = _MAX_HOLDING_DAYS,
     trailing_stop_atr: float = _TRAILING_STOP_ATR_MULT,
     stop_loss_rate: float = _STOP_LOSS_RATE,
+    sqlite_conn: sqlite3.Connection | None = None,
 ) -> list[dict[str, Any]]:
     """保有ポジションに対してエグジット条件を判定し、SELL シグナルを返す。
 
@@ -948,7 +983,7 @@ def _generate_sell_signals(
 
         # トレーリングストップ（含み益保護）: min_holding_days を無視して発火
         # peak_close > avg_price のとき（含み益あり）のみ適用
-        peak = _peak_close(conn, code, target_date)
+        peak = _peak_close(conn, code, target_date, sqlite_conn=sqlite_conn)
         if peak is not None and peak > avg_price:
             atr = _atr_20d(conn, code, target_date)
             if atr is not None and close < peak - trailing_stop_atr * atr:
@@ -972,7 +1007,7 @@ def _generate_sell_signals(
                 continue
 
         # 時間決済（最大保有期間超過）: min_holding_days を無視して発火
-        held = _held_days(conn, code, target_date)
+        held = _held_days(conn, code, target_date, sqlite_conn=sqlite_conn)
         if held is not None and held >= max_holding_days:
             logger.debug(
                 "_generate_sell_signals: %s 保有 %d 営業日 >= max %d — time_exit date=%s",
@@ -1039,6 +1074,7 @@ def generate_signals(
     trailing_stop_atr: float | None = None,
     *,
     regime_provider: RegimeProvider | None = None,
+    sqlite_conn: sqlite3.Connection | None = None,
 ) -> int:
     """features テーブルを読み込み、売買シグナルを生成して signals テーブルへ書き込む。
 
@@ -1322,6 +1358,7 @@ def generate_signals(
                 r["code"],
                 target_date,
                 cooldown_days=_cfg["reentry_cooldown_days"],
+                sqlite_conn=sqlite_conn,
             ):
                 logger.debug("reentry blocked: %s — date=%s", r["code"], target_date)
                 reentry_suppressed += 1
@@ -1372,6 +1409,7 @@ def generate_signals(
         max_holding_days=max_holding_days,
         trailing_stop_atr=trailing_stop_atr,
         stop_loss_rate=_cfg["stop_loss_rate"],
+        sqlite_conn=sqlite_conn,
     )
 
     # SELL 対象銘柄は BUY から除外し、ランクを連番で再付与（SELL 優先ポリシー）

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ import sqlite3
 import duckdb
 import pytest
 
-from kabusys.execution.order_repository import init_orders_db
+from kabusys.execution.order_repository import init_orders_db, init_position_entries_db
 from kabusys.monitoring.monitoring_db import init_monitoring_db
 
 # テスト対象テーブルのみ作成（FK CASCADE/SET NULL を持つテーブルは除外）
@@ -69,6 +69,7 @@ def mem_db():
 def sqlite_conn():
     c = sqlite3.connect(":memory:")
     init_orders_db(c)
+    init_position_entries_db(c)
     yield c
     c.close()
 

--- a/tests/test_execution_engine.py
+++ b/tests/test_execution_engine.py
@@ -454,7 +454,7 @@ class TestPositionEntriesOnFill:
         rows = sqlite_conn.execute(
             "SELECT entry_date FROM position_entries WHERE code = '7777'"
         ).fetchall()
-        assert len(rows) == 1, "ON CONFLICT DO NOTHING により重複挿入されないこと"
+        assert len(rows) == 1, "INSERT OR IGNORE により重複挿入されないこと"
 
     def test_sell_signal_updates_sell_date(self, sqlite_conn, duckdb_conn):
         """SELL 発注成功 → position_entries（SQLite）の sell_date が更新される。"""

--- a/tests/test_execution_engine.py
+++ b/tests/test_execution_engine.py
@@ -34,6 +34,7 @@ def _make_engine(
         risk_manager=rm,
         order_manager=order_manager,
         duckdb_conn=duckdb_conn,
+        sqlite_conn=sqlite_conn,
         config=cfg,
         monitoring_db=monitoring_db,
     )
@@ -411,7 +412,7 @@ class TestPositionEntriesOnFill:
     """BUY/SELL 発注成功時に position_entries が記録される。"""
 
     def test_buy_signal_inserts_position_entry(self, sqlite_conn, duckdb_conn):
-        """BUY 発注成功 → position_entries に entry_date が挿入される。"""
+        """BUY 発注成功 → position_entries（SQLite）に entry_date が挿入される。"""
         _insert_signal(duckdb_conn, "9999", side="buy")
         _insert_target(duckdb_conn, "9999", qty=100, price=1000.0)
         broker = MockBrokerClient(available_cash=5_000_000.0, fill_mode="instant")
@@ -419,14 +420,14 @@ class TestPositionEntriesOnFill:
 
         engine._process_signals()
 
-        row = duckdb_conn.execute(
+        row = sqlite_conn.execute(
             "SELECT entry_date FROM position_entries WHERE code = '9999'"
         ).fetchone()
         assert row is not None, "BUY 発注後に position_entries が挿入されるべき"
-        assert row[0] == FILL_DATE, "entry_date は約定日（翌営業日）であるべき"
+        assert str(row[0]) == str(FILL_DATE), "entry_date は約定日（翌営業日）であるべき"
 
     def test_buy_signal_pending_inserts_position_entry(self, sqlite_conn, duckdb_conn):
-        """BUY 発注保留（OrderSentPendingError）でも position_entries に entry_date が挿入される。"""
+        """BUY 発注保留（OrderSentPendingError）でも position_entries（SQLite）に entry_date が挿入される。"""
         _insert_signal(duckdb_conn, "8888", side="buy")
         _insert_target(duckdb_conn, "8888", qty=100, price=1000.0)
         broker = MockBrokerClient(available_cash=5_000_000.0, fill_mode="never")
@@ -434,14 +435,14 @@ class TestPositionEntriesOnFill:
 
         engine._process_signals()
 
-        row = duckdb_conn.execute(
+        row = sqlite_conn.execute(
             "SELECT entry_date FROM position_entries WHERE code = '8888'"
         ).fetchone()
         assert row is not None, "発注保留（pending）後も position_entries が挿入されるべき"
-        assert row[0] == FILL_DATE, "entry_date は約定日（翌営業日）であるべき"
+        assert str(row[0]) == str(FILL_DATE), "entry_date は約定日（翌営業日）であるべき"
 
     def test_buy_signal_idempotent(self, sqlite_conn, duckdb_conn):
-        """同一 code/date の BUY を2回処理しても position_entries は1行のみ（冪等性）。"""
+        """同一 code/date の BUY を2回処理しても position_entries（SQLite）は1行のみ（冪等性）。"""
         _insert_signal(duckdb_conn, "7777", side="buy")
         _insert_target(duckdb_conn, "7777", qty=100, price=1000.0)
         broker = MockBrokerClient(available_cash=5_000_000.0, fill_mode="instant")
@@ -450,17 +451,18 @@ class TestPositionEntriesOnFill:
         engine._process_signals()
         engine._process_signals()  # 2回目: DuplicateOrderError でスキップされるが position_entries は変わらない
 
-        rows = duckdb_conn.execute(
+        rows = sqlite_conn.execute(
             "SELECT entry_date FROM position_entries WHERE code = '7777'"
         ).fetchall()
         assert len(rows) == 1, "ON CONFLICT DO NOTHING により重複挿入されないこと"
 
     def test_sell_signal_updates_sell_date(self, sqlite_conn, duckdb_conn):
-        """SELL 発注成功 → position_entries の sell_date が更新される。"""
-        duckdb_conn.execute(
+        """SELL 発注成功 → position_entries（SQLite）の sell_date が更新される。"""
+        sqlite_conn.execute(
             "INSERT INTO position_entries (code, entry_date) VALUES ('6666', ?)",
-            [TARGET_DATE],
+            [str(TARGET_DATE)],
         )
+        sqlite_conn.commit()
         _insert_signal(duckdb_conn, "6666", side="sell")
         _insert_target(duckdb_conn, "6666", qty=100, price=1000.0)
         broker = MockBrokerClient(available_cash=5_000_000.0, fill_mode="instant")
@@ -468,18 +470,19 @@ class TestPositionEntriesOnFill:
 
         engine._process_signals()
 
-        row = duckdb_conn.execute(
+        row = sqlite_conn.execute(
             "SELECT sell_date FROM position_entries WHERE code = '6666'"
         ).fetchone()
         assert row is not None
-        assert row[0] == FILL_DATE, "sell_date は約定日（翌営業日）であるべき"
+        assert str(row[0]) == str(FILL_DATE), "sell_date は約定日（翌営業日）であるべき"
 
     def test_sell_signal_pending_does_not_update_sell_date(self, sqlite_conn, duckdb_conn):
         """SELL 発注保留（pending）では sell_date を書かない（ポジションはまだ保有中）。"""
-        duckdb_conn.execute(
+        sqlite_conn.execute(
             "INSERT INTO position_entries (code, entry_date) VALUES ('5555', ?)",
-            [TARGET_DATE],
+            [str(TARGET_DATE)],
         )
+        sqlite_conn.commit()
         _insert_signal(duckdb_conn, "5555", side="sell")
         _insert_target(duckdb_conn, "5555", qty=100, price=1000.0)
         broker = MockBrokerClient(available_cash=5_000_000.0, fill_mode="never")
@@ -487,7 +490,7 @@ class TestPositionEntriesOnFill:
 
         engine._process_signals()
 
-        row = duckdb_conn.execute(
+        row = sqlite_conn.execute(
             "SELECT sell_date FROM position_entries WHERE code = '5555'"
         ).fetchone()
         assert row is not None

--- a/tests/test_run_monitoring.py
+++ b/tests/test_run_monitoring.py
@@ -49,7 +49,7 @@ class TestRunMonitoringMain:
     def test_uses_sqlite_path(self):
         _, mock_sqlite, _ = _run_main()
         settings = _make_settings()
-        mock_sqlite.assert_called_once_with(str(settings.sqlite_path))
+        mock_sqlite.assert_called_once_with(str(settings.sqlite_path), timeout=30.0)
 
 
 def test_run_monitoring_stops_on_flag(tmp_path):

--- a/tests/test_scripts_batch.py
+++ b/tests/test_scripts_batch.py
@@ -91,9 +91,12 @@ def test_run_strategy_signal_calls_generate_signals():
     with (
         patch("run_strategy_signal.Settings") as mock_settings,
         patch("run_strategy_signal.duckdb.connect"),
+        patch("run_strategy_signal.sqlite3.connect"),
+        patch("run_strategy_signal.init_position_entries_db"),
         patch("run_strategy_signal.generate_signals", return_value=10) as mock_fn,
     ):
         mock_settings.return_value.duckdb_path = Path("/fake.duckdb")
+        mock_settings.return_value.sqlite_path = Path("/fake.db")
         run_strategy_signal.main()
 
     mock_fn.assert_called_once()


### PR DESCRIPTION
## Summary

- `position_entries` テーブルを DuckDB から SQLite に移管し、`run_execution` + `run_monitoring` 同時起動時の `IOException` を根本解決
- ランタイムプロセス（`run_execution`・`run_monitoring`・Streamlit 監視ページ）が DuckDB を `read_only=True` で使用するよう変更。DuckDB への書き込みは夜間バッチのみに限定
- バックテストエンジンは DuckDB の `position_entries` を引き続き使用（変更なし）。`sqlite_conn=None` 時は DuckDB fallback で互換性を維持

## Test plan

- [x] `TestPositionEntriesOnFill` が SQLite を読み書きすることをテストで確認（RED→GREEN）
- [x] `test_run_strategy_signal_calls_generate_signals` を `sqlite3.connect` モック対応に更新
- [x] 全テスト 1873 件パス（pre-existing の jquants 3 件のみ失敗 — 本 PR と無関係）

## Closes

- Closes #320
- Closes #304, #305, #306, #307 （Streamlit 監視ページの DuckDB ロック競合問題）

🤖 Generated with [Claude Code](https://claude.com/claude-code)