### PR TITLE
feat: UTC タイムスタンプを JST に変換して表示 (#327)

### DIFF
--- a/src/kabusys/monitoring/pages/11_Process_Monitor.py
+++ b/src/kabusys/monitoring/pages/11_Process_Monitor.py
@@ -11,6 +11,7 @@ import streamlit as st
 from kabusys.config import Settings
 from kabusys.monitoring.monitoring_db import MonitoringDB
 from kabusys.operations.process_registry import is_pid_alive
+from kabusys.utils.datetime_utils import to_jst_str
 
 st.set_page_config(page_title="Process Monitor", layout="wide", page_icon="🖥️")
 st.title("🖥️ Process Monitor — プロセス実行状況")
@@ -80,7 +81,7 @@ if alive_running:
             {
                 "ジョブ名": r["job_name"],
                 "PID": r["pid"] or "-",
-                "開始": r["started_at"][:19],
+                "開始": to_jst_str(r["started_at"]),
                 "経過": _elapsed(r["started_at"]),
                 "ログ": r.get("log_file") or "",
             }
@@ -100,7 +101,7 @@ if orphaned:
             {
                 "ジョブ名": r["job_name"],
                 "PID": r["pid"] or "-",
-                "開始": r["started_at"][:19],
+                "開始": to_jst_str(r["started_at"]),
                 "経過": _elapsed(r["started_at"]),
                 "ログ": r.get("log_file") or "",
             }
@@ -118,8 +119,8 @@ if completed:
             {
                 "ジョブ名": r["job_name"],
                 "ステータス": _STATUS_BADGE.get(r["status"], f"❓ {r['status']}"),
-                "開始": r["started_at"][:19],
-                "終了": r["finished_at"][:19] if r["finished_at"] else "?",
+                "開始": to_jst_str(r["started_at"]),
+                "終了": to_jst_str(r["finished_at"]) if r["finished_at"] else "N/A",
                 "経過": _elapsed(r["started_at"], r["finished_at"]),
                 "エラー": r.get("error_msg") or "",
             }

--- a/src/kabusys/monitoring/pages/11_Process_Monitor.py
+++ b/src/kabusys/monitoring/pages/11_Process_Monitor.py
@@ -120,7 +120,7 @@ if completed:
                 "ジョブ名": r["job_name"],
                 "ステータス": _STATUS_BADGE.get(r["status"], f"❓ {r['status']}"),
                 "開始": to_jst_str(r["started_at"]),
-                "終了": to_jst_str(r["finished_at"]) if r["finished_at"] else "N/A",
+                "終了": to_jst_str(r["finished_at"]),
                 "経過": _elapsed(r["started_at"], r["finished_at"]),
                 "エラー": r.get("error_msg") or "",
             }

--- a/src/kabusys/monitoring/pages/3_Pre_Market.py
+++ b/src/kabusys/monitoring/pages/3_Pre_Market.py
@@ -15,6 +15,7 @@ from kabusys.operations.pre_market_report import (
     STATUS_READY,
     STATUS_READY_WITH_WARNINGS,
 )
+from kabusys.utils.datetime_utils import to_jst_str
 
 st.set_page_config(page_title="Pre-Market", layout="wide", page_icon="🌅")
 st.title("🌅 Pre-Market — 朝の確認")
@@ -97,7 +98,7 @@ with col4:
 with col5:
     st.metric("保有ポジション", f"📊 {result['position_count']}銘柄")
 with col6:
-    st.caption(f"生成: {result['generated_at']}")
+    st.caption(f"生成: {to_jst_str(result['generated_at'])}")
 
 if result["warnings"]:
     st.divider()

--- a/src/kabusys/monitoring/pages/4_Execution_Startup.py
+++ b/src/kabusys/monitoring/pages/4_Execution_Startup.py
@@ -14,6 +14,7 @@ from kabusys.operations.execution_startup_report import (
     STATUS_READY,
     STATUS_READY_WITH_WARNINGS,
 )
+from kabusys.utils.datetime_utils import to_jst_str
 
 st.set_page_config(page_title="Execution Startup", layout="wide", page_icon="🚀")
 st.title("🚀 Execution Startup — 起動確認")
@@ -63,4 +64,4 @@ if warnings:
     for w in warnings:
         st.warning(w)
 
-st.caption(f"生成: {report_data.get('generated_at', 'N/A')}")
+st.caption(f"生成: {to_jst_str(report_data.get('generated_at'))}")

--- a/src/kabusys/monitoring/pages/5_Intraday_Monitor.py
+++ b/src/kabusys/monitoring/pages/5_Intraday_Monitor.py
@@ -15,6 +15,7 @@ from kabusys.operations.intraday_collector import (
     check_kill_switch,
     check_pid_file,
 )
+from kabusys.utils.datetime_utils import to_jst_str
 
 st.set_page_config(page_title="Intraday Monitor", layout="wide", page_icon="📡")
 st.title("📡 Intraday Monitor — ザラ場監視")
@@ -74,7 +75,10 @@ try:
             "SELECT event_type, metric_name, metric_value, threshold, detail, logged_at FROM risk_logs ORDER BY logged_at DESC LIMIT 50"
         ).fetchall()
         if rows:
-            st.dataframe([dict(r) for r in rows], use_container_width=True)
+            st.dataframe(
+                [{**dict(r), "logged_at": to_jst_str(r["logged_at"])} for r in rows],
+                use_container_width=True,
+            )
         else:
             st.success("リスクイベントはありません。")
         conn.row_factory = None
@@ -85,7 +89,10 @@ try:
             "SELECT event_type, client_order_id, code, side, qty, price, filled_qty, state, logged_at FROM trade_logs ORDER BY logged_at DESC LIMIT 50"
         ).fetchall()
         if rows:
-            st.dataframe([dict(r) for r in rows], use_container_width=True)
+            st.dataframe(
+                [{**dict(r), "logged_at": to_jst_str(r["logged_at"])} for r in rows],
+                use_container_width=True,
+            )
         else:
             st.info("取引ログはありません。")
         conn.row_factory = None

--- a/src/kabusys/utils/datetime_utils.py
+++ b/src/kabusys/utils/datetime_utils.py
@@ -3,27 +3,38 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
-_JST = ZoneInfo("Asia/Tokyo")
+try:
+    _JST = ZoneInfo("Asia/Tokyo")
+except Exception:
+    _JST = timezone(timedelta(hours=9))  # tzdata 未インストール環境向けフォールバック
 
 
-def to_jst_str(iso_utc: str | None) -> str:
+def to_jst_str(iso_utc: str | datetime | None) -> str:
     """UTC ISO 文字列を JST 表示文字列に変換する。
 
-    - タイムゾーン情報なし（naive）の文字列は UTC として扱う。
+    - 'Z' 末尾の文字列は '+00:00' に正規化する（Python 3.10 互換）。
+    - datetime オブジェクトはそのまま変換する。
+    - タイムゾーン情報なし（naive）の文字列・datetime は UTC として扱う。
     - None または空文字列は 'N/A' を返す。
-    - パース失敗時は元の文字列をそのまま返す（表示が壊れない）。
+    - パース失敗時は元の値を文字列化して返す（表示が壊れない）。
 
     返り値フォーマット: "YYYY-MM-DD HH:MM:SS JST"
     """
-    if not iso_utc:
+    if iso_utc is None or iso_utc == "":
         return "N/A"
     try:
-        dt = datetime.fromisoformat(iso_utc)
+        if isinstance(iso_utc, datetime):
+            dt = iso_utc
+        else:
+            s = str(iso_utc).strip()
+            if s.endswith("Z"):
+                s = s[:-1] + "+00:00"
+            dt = datetime.fromisoformat(s)
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=timezone.utc)
         return dt.astimezone(_JST).strftime("%Y-%m-%d %H:%M:%S JST")
-    except (ValueError, TypeError):
-        return iso_utc
+    except (ValueError, TypeError, AttributeError):
+        return str(iso_utc)

--- a/src/kabusys/utils/datetime_utils.py
+++ b/src/kabusys/utils/datetime_utils.py
@@ -1,0 +1,29 @@
+# src/kabusys/utils/datetime_utils.py
+"""日時ユーティリティ。表示層での UTC → JST 変換に使用する。"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+_JST = ZoneInfo("Asia/Tokyo")
+
+
+def to_jst_str(iso_utc: str | None) -> str:
+    """UTC ISO 文字列を JST 表示文字列に変換する。
+
+    - タイムゾーン情報なし（naive）の文字列は UTC として扱う。
+    - None または空文字列は 'N/A' を返す。
+    - パース失敗時は元の文字列をそのまま返す（表示が壊れない）。
+
+    返り値フォーマット: "YYYY-MM-DD HH:MM:SS JST"
+    """
+    if not iso_utc:
+        return "N/A"
+    try:
+        dt = datetime.fromisoformat(iso_utc)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(_JST).strftime("%Y-%m-%d %H:%M:%S JST")
+    except (ValueError, TypeError):
+        return iso_utc

--- a/tests/test_datetime_utils.py
+++ b/tests/test_datetime_utils.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from kabusys.utils.datetime_utils import to_jst_str
 
 
@@ -12,8 +14,12 @@ class TestToJstStr:
         assert to_jst_str("2026-05-13T06:00:00+00:00") == "2026-05-13 15:00:00 JST"
 
     def test_utc_z_suffix(self):
-        """Z 末尾の UTC 文字列を JST に変換する。"""
+        """Z 末尾の UTC 文字列を JST に変換する（Python 3.10 互換）。"""
         assert to_jst_str("2026-05-13T06:00:00Z") == "2026-05-13 15:00:00 JST"
+
+    def test_utc_z_suffix_with_microseconds(self):
+        """Z 末尾 + マイクロ秒の文字列も正しく変換する。"""
+        assert to_jst_str("2026-05-13T06:00:00.123456Z") == "2026-05-13 15:00:00 JST"
 
     def test_midnight_utc_crosses_date(self):
         """UTC 00:00 は JST 09:00（日付変わらず）。"""
@@ -42,3 +48,13 @@ class TestToJstStr:
     def test_invalid_string_returns_original(self):
         """パース不能な文字列はそのまま返す（表示が壊れない）。"""
         assert to_jst_str("not-a-datetime") == "not-a-datetime"
+
+    def test_datetime_object_input(self):
+        """datetime オブジェクトを直接渡しても変換できる。"""
+        dt = datetime(2026, 5, 13, 6, 0, 0, tzinfo=timezone.utc)
+        assert to_jst_str(dt) == "2026-05-13 15:00:00 JST"
+
+    def test_datetime_object_naive_treated_as_utc(self):
+        """naive な datetime オブジェクトは UTC として扱う。"""
+        dt = datetime(2026, 5, 13, 6, 0, 0)
+        assert to_jst_str(dt) == "2026-05-13 15:00:00 JST"

--- a/tests/test_datetime_utils.py
+++ b/tests/test_datetime_utils.py
@@ -1,0 +1,46 @@
+# tests/test_datetime_utils.py
+"""to_jst_str のユニットテスト。"""
+
+from __future__ import annotations
+
+import pytest
+
+from kabusys.utils.datetime_utils import to_jst_str
+
+
+class TestToJstStr:
+    def test_utc_offset_string(self):
+        """UTC+00:00 の ISO 文字列を JST に変換する。"""
+        assert to_jst_str("2026-05-13T06:00:00+00:00") == "2026-05-13 15:00:00 JST"
+
+    def test_utc_z_suffix(self):
+        """Z 末尾の UTC 文字列を JST に変換する。"""
+        assert to_jst_str("2026-05-13T06:00:00Z") == "2026-05-13 15:00:00 JST"
+
+    def test_midnight_utc_crosses_date(self):
+        """UTC 00:00 は JST 09:00（日付変わらず）。"""
+        assert to_jst_str("2026-05-13T00:00:00+00:00") == "2026-05-13 09:00:00 JST"
+
+    def test_utc_1500_crosses_midnight(self):
+        """UTC 15:00 は JST 翌日 00:00（日付が変わる）。"""
+        assert to_jst_str("2026-05-13T15:00:00+00:00") == "2026-05-14 00:00:00 JST"
+
+    def test_naive_datetime_treated_as_utc(self):
+        """タイムゾーン情報なしの文字列は UTC として扱う。"""
+        assert to_jst_str("2026-05-13T06:00:00") == "2026-05-13 15:00:00 JST"
+
+    def test_none_returns_na(self):
+        """None を渡すと 'N/A' を返す。"""
+        assert to_jst_str(None) == "N/A"
+
+    def test_empty_string_returns_na(self):
+        """空文字列を渡すと 'N/A' を返す。"""
+        assert to_jst_str("") == "N/A"
+
+    def test_truncated_19char_string(self):
+        """[:19] でタイムゾーンが切り落とされた文字列（naive）も UTC として扱う。"""
+        assert to_jst_str("2026-05-13T06:00:00") == "2026-05-13 15:00:00 JST"
+
+    def test_invalid_string_returns_original(self):
+        """パース不能な文字列はそのまま返す（表示が壊れない）。"""
+        assert to_jst_str("not-a-datetime") == "not-a-datetime"

--- a/tests/test_datetime_utils.py
+++ b/tests/test_datetime_utils.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from kabusys.utils.datetime_utils import to_jst_str
 
 


### PR DESCRIPTION
## Summary

- `src/kabusys/utils/datetime_utils.py` に `to_jst_str()` ユーティリティを新規追加
  - UTC ISO 文字列 → `YYYY-MM-DD HH:MM:SS JST` 形式の JST 文字列に変換
  - `None` / 空文字列は `"N/A"` を返す、パース失敗時は元の文字列をそのまま返す（表示が壊れない設計）
- `tests/test_datetime_utils.py` に 9 ケースのユニットテスト追加（UTC offset、Z suffix、日付越え、naive datetime、None、空文字列、無効文字列）
- Streamlit 4 ページに `to_jst_str()` を適用
  - `3_Pre_Market.py` — `generated_at` 表示
  - `4_Execution_Startup.py` — `generated_at` 表示
  - `11_Process_Monitor.py` — `started_at` / `finished_at` 表示（`[:19]` スライスを置換）
  - `5_Intraday_Monitor.py` — risk_logs / trade_logs の `logged_at` 列

## Test plan

- [ ] `pytest tests/test_datetime_utils.py` — 9 tests PASS を確認
- [ ] `ruff check` / `ruff format` — エラーなしを確認
- [ ] Pre-Market ページの「生成:」表示が JST になっていることを確認
- [ ] Process Monitor の「開始」「終了」列が JST 形式で表示されることを確認
- [ ] Intraday Monitor の Risk Logs / Trade Logs の `logged_at` 列が JST 形式で表示されることを確認

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)