### PR TITLE
feat: pre_market_report の自動実行化 (#323)

### DIFF
--- a/scripts/run_pre_market_report.py
+++ b/scripts/run_pre_market_report.py
@@ -35,6 +35,7 @@ _JOB_NAME = "pre_market_report_job"
 _APP_NAME = "pre_market_report"
 _BASE = Path(__file__).resolve().parent.parent
 _STOP_FLAG = _BASE / "data" / "stop_requested.flag"
+# Pre-Market チェックで「08:30 の ExecutionStart タスクが Ready 状態か」を確認するために使用
 _TASK_NAME = "KabuSys_ExecutionStart"
 
 

--- a/scripts/run_pre_market_report.py
+++ b/scripts/run_pre_market_report.py
@@ -1,0 +1,112 @@
+"""scripts/run_pre_market_report.py
+
+Pre-Market Report の生成ランナー（Task Scheduler 用）。
+
+毎朝 08:00 に自動実行し、レポートを生成・保存した上で LINE 通知を送信する。
+手動実行も可能（引数なし）。
+
+Task Scheduler 登録:
+    KabuSys_PreMarketReport  08:00  -> scripts/run_pre_market_report.py
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import duckdb
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+from kabusys.config import Settings
+from kabusys.operations.line_reports import format_pre_market_message
+from kabusys.operations.notifier import build_notifier
+from kabusys.operations.pre_market_collector import collect
+from kabusys.operations.pre_market_report import build_report, format_cli_summary, save_report
+from kabusys.operations.process_registry import register_process, update_process
+from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
+
+_run_log = setup_logging(app_name="pre_market_report", capture_stdio=True)
+logger = logging.getLogger(__name__)
+
+_JOB_NAME = "pre_market_report_job"
+_APP_NAME = "pre_market_report"
+_BASE = Path(__file__).resolve().parent.parent
+_STOP_FLAG = _BASE / "data" / "stop_requested.flag"
+_TASK_NAME = "KabuSys_ExecutionStart"
+
+
+def main() -> None:
+    started_at = datetime.now(timezone.utc)
+    log_run_start(_APP_NAME)
+    run_id: int | None = None
+    try:
+        run_id = register_process(_JOB_NAME, log_file=str(_run_log) if _run_log else None)
+    except Exception:
+        logger.warning("process_registry 登録に失敗しました", exc_info=True)
+
+    _failed = False
+    settings = Settings()
+    today = date.today()
+    duckdb_conn = None
+    sqlite_conn = None
+    try:
+        duckdb_conn = duckdb.connect(str(settings.duckdb_path), read_only=True)
+        sqlite_conn = sqlite3.connect(f"file:{settings.sqlite_path}?mode=ro", uri=True)
+
+        data = collect(
+            duckdb_conn=duckdb_conn,
+            sqlite_conn=sqlite_conn,
+            stop_flag_path=_STOP_FLAG,
+            task_name=_TASK_NAME,
+            today=today,
+        )
+
+        report = build_report(
+            report_date=today,
+            data_freshness_ok=data.data_freshness_ok,
+            signal_queue_pending=data.signal_queue_pending,
+            position_count=data.position_count,
+            stop_flag_exists=data.stop_flag_exists,
+            task_scheduler_ready=data.task_scheduler_ready,
+        )
+
+        saved_path = save_report(report)
+        logger.info("レポート保存: %s", saved_path)
+        print(format_cli_summary(report))
+
+        # LINE 通知（失敗しても処理継続）
+        try:
+            notifier = build_notifier(settings)
+            msg = format_pre_market_message(
+                status=report.status,
+                warnings_count=len(report.warnings),
+                pending_count=report.signal_queue_pending,
+                report_date=today.isoformat(),
+            )
+            notifier.send(msg)
+        except Exception:
+            logger.warning("Pre-Market LINE 通知に失敗しました（処理続行）", exc_info=True)
+
+    except Exception:
+        logger.exception("pre_market_report バッチが失敗しました")
+        _failed = True
+    finally:
+        if sqlite_conn is not None:
+            sqlite_conn.close()
+        if duckdb_conn is not None:
+            duckdb_conn.close()
+        if run_id is not None:
+            try:
+                update_process(run_id, status="failed" if _failed else "success")
+            except Exception:
+                logger.warning("process_registry 更新に失敗しました", exc_info=True)
+        log_run_end(_APP_NAME, status="failed" if _failed else "success", started_at=started_at)
+    if _failed:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup_task_scheduler.ps1
+++ b/scripts/setup_task_scheduler.ps1
@@ -98,6 +98,7 @@ Register-KabuSysTask -TaskName "KabuSys_FeatureGen"            -Script "run_feat
 Register-KabuSysTask -TaskName "KabuSys_StrategySignal"        -Script "run_strategy_signal.py"        -TriggerTime "20:00"
 Register-KabuSysTask -TaskName "KabuSys_PortfolioConstruction" -Script "run_portfolio_construction.py" -TriggerTime "21:00"
 Register-KabuSysTask -TaskName "KabuSys_NightBatchReport"      -Script "run_night_batch_report.py"     -TriggerTime "21:15"
+Register-KabuSysTask -TaskName "KabuSys_PreMarketReport"       -Script "run_pre_market_report.py"      -TriggerTime "08:00"
 Register-KabuSysTask -TaskName "KabuSys_ExecutionStart"        -Script "start_system.py" -Arguments "--component execution"  -TriggerTime "08:30"
 Register-KabuSysTask -TaskName "KabuSys_MonitoringStart"       -Script "start_system.py" -Arguments "--component monitoring" -TriggerTime "09:00"
 

--- a/src/kabusys/operations/line_reports.py
+++ b/src/kabusys/operations/line_reports.py
@@ -18,6 +18,23 @@ def _fmt_yen(value: float | None) -> str:
     return f"{value:,.0f} 円"
 
 
+def format_pre_market_message(
+    *,
+    status: str,
+    warnings_count: int,
+    pending_count: int,
+    report_date: str,
+) -> str:
+    """Pre-Market Report 完了時の LINE 通知メッセージを生成する。"""
+    lines = [
+        f"【KabuSys Pre-Market】{report_date}",
+        f"ステータス: {status}",
+        f"警告件数: {warnings_count} 件",
+        f"pending シグナル: {pending_count} 件",
+    ]
+    return "\n".join(lines)
+
+
 def format_morning_message(
     *,
     status: str,

--- a/src/kabusys/operations/line_reports.py
+++ b/src/kabusys/operations/line_reports.py
@@ -25,7 +25,10 @@ def format_pre_market_message(
     pending_count: int,
     report_date: str,
 ) -> str:
-    """Pre-Market Report 完了時の LINE 通知メッセージを生成する。"""
+    """Pre-Market Report 完了時の LINE 通知メッセージを生成する。
+
+    status は "READY" / "READY_WITH_WARNINGS" / "BLOCKED" のいずれか。
+    """
     lines = [
         f"【KabuSys Pre-Market】{report_date}",
         f"ステータス: {status}",

--- a/tests/test_line_reports.py
+++ b/tests/test_line_reports.py
@@ -9,6 +9,7 @@ from kabusys.operations.line_reports import (
     format_evening_message,
     format_monthly_message,
     format_morning_message,
+    format_pre_market_message,
     format_weekly_message,
 )
 
@@ -158,6 +159,51 @@ class TestFormatMonthlyMessage:
             summary=summary,
             from_date="2026-04-01",
             to_date="2026-04-30",
+        )
+        assert isinstance(msg, str)
+        assert len(msg) > 0
+
+
+class TestFormatPreMarketMessage:
+    def test_ready_status(self):
+        msg = format_pre_market_message(
+            status="READY",
+            warnings_count=0,
+            pending_count=5,
+            report_date="2026-05-13",
+        )
+        assert "2026-05-13" in msg
+        assert "READY" in msg
+        assert "5" in msg
+        assert "0" in msg
+
+    def test_blocked_status(self):
+        msg = format_pre_market_message(
+            status="BLOCKED",
+            warnings_count=2,
+            pending_count=0,
+            report_date="2026-05-13",
+        )
+        assert "BLOCKED" in msg
+        assert "2" in msg
+
+    def test_ready_with_warnings(self):
+        msg = format_pre_market_message(
+            status="READY_WITH_WARNINGS",
+            warnings_count=1,
+            pending_count=3,
+            report_date="2026-05-13",
+        )
+        assert "READY_WITH_WARNINGS" in msg
+        assert "1" in msg
+        assert "3" in msg
+
+    def test_returns_string(self):
+        msg = format_pre_market_message(
+            status="READY",
+            warnings_count=0,
+            pending_count=0,
+            report_date="2026-05-13",
         )
         assert isinstance(msg, str)
         assert len(msg) > 0


### PR DESCRIPTION
## Summary

- `scripts/run_pre_market_report.py` を新規作成（Task Scheduler 用ランナー）
  - `register_process` / `update_process` で Process Monitor に記録
  - LINE で通知（失敗しても処理を継続）
  - `run_night_batch_report.py` と同じパターンで実装
- `src/kabusys/operations/line_reports.py` に `format_pre_market_message()` を追加
  - 通知内容: ステータス（READY/READY_WITH_WARNINGS/BLOCKED）・警告件数・pending シグナル件数
- `scripts/setup_task_scheduler.ps1` に `KabuSys_PreMarketReport`（08:00）を追加
  - 既存の `KabuSys_ExecutionStart`（08:30）より前に実行
- `tests/test_line_reports.py` に `TestFormatPreMarketMessage` クラス（4 テスト）を追加

## Test plan

- [ ] `pytest tests/test_line_reports.py` — 22 tests PASS を確認
- [ ] `ruff check / ruff format` — エラーなしを確認
- [ ] Task Scheduler 再登録後、`Get-ScheduledTask -TaskName 'KabuSys_PreMarketReport'` で登録確認
- [ ] 手動実行で `python scripts/run_pre_market_report.py` が正常終了することを確認
- [ ] Process Monitor ページで `pre_market_report_job` が記録されることを確認
- [ ] LINE 通知が届くことを確認（`LINE_NOTIFY_ENABLED=true` 環境）

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)