### PR TITLE
feat: signal_queue_report の自動実行化 (#324)

### DIFF
--- a/scripts/run_signal_queue_report.py
+++ b/scripts/run_signal_queue_report.py
@@ -1,0 +1,95 @@
+"""scripts/run_signal_queue_report.py
+
+Signal Queue Report の生成ランナー（Task Scheduler 用）。
+
+毎朝 08:02 に自動実行し、当日の pending シグナルをレポート・保存した上で LINE 通知を送信する。
+手動実行も可能（引数なし）。
+
+Task Scheduler 登録:
+    KabuSys_SignalQueueReport  08:02  -> scripts/run_signal_queue_report.py
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import duckdb
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+from kabusys.config import Settings
+from kabusys.operations.line_reports import format_signal_queue_message
+from kabusys.operations.notifier import build_notifier
+from kabusys.operations.process_registry import register_process, update_process
+from kabusys.operations.signal_queue_report import (
+    build_report,
+    collect_signals,
+    format_cli_summary,
+    save_report,
+)
+from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
+
+_run_log = setup_logging(app_name="signal_queue_report", capture_stdio=True)
+logger = logging.getLogger(__name__)
+
+_JOB_NAME = "signal_queue_report_job"
+_APP_NAME = "signal_queue_report"
+
+
+def main() -> None:
+    started_at = datetime.now(timezone.utc)
+    log_run_start(_APP_NAME)
+    run_id: int | None = None
+    try:
+        run_id = register_process(_JOB_NAME, log_file=str(_run_log) if _run_log else None)
+    except Exception:
+        logger.warning("process_registry 登録に失敗しました", exc_info=True)
+
+    _failed = False
+    settings = Settings()
+    today = date.today()
+    conn = None
+    try:
+        conn = duckdb.connect(str(settings.duckdb_path), read_only=True)
+
+        signals = collect_signals(conn, today)
+        report = build_report(signals, report_date=today)
+
+        saved_path = save_report(report)
+        logger.info("レポート保存: %s", saved_path)
+        print(format_cli_summary(report))
+
+        # LINE 通知（失敗しても処理継続）
+        try:
+            notifier = build_notifier(settings)
+            msg = format_signal_queue_message(
+                status=report.status,
+                buy_count=report.buy_count,
+                sell_count=report.sell_count,
+                signals=report.signals,
+                report_date=today.isoformat(),
+            )
+            notifier.send(msg)
+        except Exception:
+            logger.warning("Signal Queue LINE 通知に失敗しました（処理続行）", exc_info=True)
+
+    except Exception:
+        logger.exception("signal_queue_report バッチが失敗しました")
+        _failed = True
+    finally:
+        if conn is not None:
+            conn.close()
+        if run_id is not None:
+            try:
+                update_process(run_id, status="failed" if _failed else "success")
+            except Exception:
+                logger.warning("process_registry 更新に失敗しました", exc_info=True)
+        log_run_end(_APP_NAME, status="failed" if _failed else "success", started_at=started_at)
+    if _failed:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup_task_scheduler.ps1
+++ b/scripts/setup_task_scheduler.ps1
@@ -99,6 +99,7 @@ Register-KabuSysTask -TaskName "KabuSys_StrategySignal"        -Script "run_stra
 Register-KabuSysTask -TaskName "KabuSys_PortfolioConstruction" -Script "run_portfolio_construction.py" -TriggerTime "21:00"
 Register-KabuSysTask -TaskName "KabuSys_NightBatchReport"      -Script "run_night_batch_report.py"     -TriggerTime "21:15"
 Register-KabuSysTask -TaskName "KabuSys_PreMarketReport"       -Script "run_pre_market_report.py"      -TriggerTime "08:00"
+Register-KabuSysTask -TaskName "KabuSys_SignalQueueReport"     -Script "run_signal_queue_report.py"    -TriggerTime "08:02"
 Register-KabuSysTask -TaskName "KabuSys_ExecutionStart"        -Script "start_system.py" -Arguments "--component execution"  -TriggerTime "08:30"
 Register-KabuSysTask -TaskName "KabuSys_MonitoringStart"       -Script "start_system.py" -Arguments "--component monitoring" -TriggerTime "09:00"
 

--- a/src/kabusys/operations/line_reports.py
+++ b/src/kabusys/operations/line_reports.py
@@ -39,13 +39,15 @@ def format_signal_queue_message(
     ]
     if signals:
         shown = signals[:max_signals]
-        lines.append("銘柄一覧:")
+        truncated = len(signals) > max_signals
+        header = f"銘柄一覧（上位 {max_signals} 件）:" if truncated else "銘柄一覧:"
+        lines.append(header)
         for s in shown:
             side = s["side"].upper()
             size = s.get("target_size")
             size_str = f" {size}株" if size is not None else ""
             lines.append(f"  {s['code']} {side}{size_str}")
-        if len(signals) > max_signals:
+        if truncated:
             lines.append(f"  … 他 {len(signals) - max_signals} 件")
     return "\n".join(lines)
 

--- a/src/kabusys/operations/line_reports.py
+++ b/src/kabusys/operations/line_reports.py
@@ -18,6 +18,38 @@ def _fmt_yen(value: float | None) -> str:
     return f"{value:,.0f} 円"
 
 
+def format_signal_queue_message(
+    *,
+    status: str,
+    buy_count: int,
+    sell_count: int,
+    signals: list[dict],
+    report_date: str,
+    max_signals: int = 10,
+) -> str:
+    """Signal Queue Report 完了時の LINE 通知メッセージを生成する。
+
+    status は "READY" / "EMPTY" のいずれか。
+    銘柄一覧は max_signals 件まで表示し、超過分は「他 N 件」と省略する。
+    """
+    lines = [
+        f"【KabuSys Signal Queue】{report_date}",
+        f"ステータス: {status}",
+        f"BUY: {buy_count} 件 / SELL: {sell_count} 件",
+    ]
+    if signals:
+        shown = signals[:max_signals]
+        lines.append("銘柄一覧:")
+        for s in shown:
+            side = s["side"].upper()
+            size = s.get("target_size")
+            size_str = f" {size}株" if size is not None else ""
+            lines.append(f"  {s['code']} {side}{size_str}")
+        if len(signals) > max_signals:
+            lines.append(f"  … 他 {len(signals) - max_signals} 件")
+    return "\n".join(lines)
+
+
 def format_pre_market_message(
     *,
     status: str,

--- a/tests/test_line_reports.py
+++ b/tests/test_line_reports.py
@@ -10,6 +10,7 @@ from kabusys.operations.line_reports import (
     format_monthly_message,
     format_morning_message,
     format_pre_market_message,
+    format_signal_queue_message,
     format_weekly_message,
 )
 
@@ -159,6 +160,86 @@ class TestFormatMonthlyMessage:
             summary=summary,
             from_date="2026-04-01",
             to_date="2026-04-30",
+        )
+        assert isinstance(msg, str)
+        assert len(msg) > 0
+
+
+class TestFormatSignalQueueMessage:
+    _SIGNALS = [
+        {"code": "7203", "side": "buy", "target_size": 100},
+        {"code": "6758", "side": "sell", "target_size": 200},
+        {"code": "9984", "side": "buy", "target_size": None},
+    ]
+
+    def test_ready_with_signals(self):
+        msg = format_signal_queue_message(
+            status="READY",
+            buy_count=2,
+            sell_count=1,
+            signals=self._SIGNALS,
+            report_date="2026-05-13",
+        )
+        assert "2026-05-13" in msg
+        assert "READY" in msg
+        assert "2" in msg
+        assert "1" in msg
+        assert "7203" in msg
+        assert "BUY" in msg
+        assert "6758" in msg
+        assert "SELL" in msg
+
+    def test_empty_status(self):
+        msg = format_signal_queue_message(
+            status="EMPTY",
+            buy_count=0,
+            sell_count=0,
+            signals=[],
+            report_date="2026-05-13",
+        )
+        assert "EMPTY" in msg
+        assert "0" in msg
+
+    def test_target_size_shown(self):
+        msg = format_signal_queue_message(
+            status="READY",
+            buy_count=1,
+            sell_count=0,
+            signals=[{"code": "7203", "side": "buy", "target_size": 100}],
+            report_date="2026-05-13",
+        )
+        assert "100" in msg
+
+    def test_none_target_size_no_crash(self):
+        msg = format_signal_queue_message(
+            status="READY",
+            buy_count=1,
+            sell_count=0,
+            signals=[{"code": "9984", "side": "buy", "target_size": None}],
+            report_date="2026-05-13",
+        )
+        assert "9984" in msg
+        assert isinstance(msg, str)
+
+    def test_max_signals_truncation(self):
+        many = [{"code": str(1000 + i), "side": "buy", "target_size": 100} for i in range(15)]
+        msg = format_signal_queue_message(
+            status="READY",
+            buy_count=15,
+            sell_count=0,
+            signals=many,
+            report_date="2026-05-13",
+        )
+        assert "他" in msg
+        assert "5" in msg
+
+    def test_returns_string(self):
+        msg = format_signal_queue_message(
+            status="EMPTY",
+            buy_count=0,
+            sell_count=0,
+            signals=[],
+            report_date="2026-05-13",
         )
         assert isinstance(msg, str)
         assert len(msg) > 0

--- a/tests/test_line_reports.py
+++ b/tests/test_line_reports.py
@@ -233,6 +233,36 @@ class TestFormatSignalQueueMessage:
         assert "他" in msg
         assert "5" in msg
 
+    def test_exact_max_signals_no_truncation(self):
+        exactly_ten = [
+            {"code": str(1000 + i), "side": "buy", "target_size": 100} for i in range(10)
+        ]
+        msg = format_signal_queue_message(
+            status="READY",
+            buy_count=10,
+            sell_count=0,
+            signals=exactly_ten,
+            report_date="2026-05-13",
+        )
+        assert "他" not in msg
+        assert "上位" not in msg
+
+    def test_side_uppercased(self):
+        msg = format_signal_queue_message(
+            status="READY",
+            buy_count=1,
+            sell_count=1,
+            signals=[
+                {"code": "7203", "side": "buy", "target_size": 100},
+                {"code": "6758", "side": "sell", "target_size": 50},
+            ],
+            report_date="2026-05-13",
+        )
+        assert "BUY" in msg
+        assert "SELL" in msg
+        assert "buy" not in msg
+        assert "sell" not in msg
+
     def test_returns_string(self):
         msg = format_signal_queue_message(
             status="EMPTY",


### PR DESCRIPTION
## Summary

- `scripts/run_signal_queue_report.py` を新規作成（Task Scheduler 用ランナー）
  - `register_process` / `update_process` で Process Monitor に記録
  - LINE で当日シグナルを通知（失敗しても処理を継続）
  - `run_pre_market_report.py` / `run_night_batch_report.py` と同パターンで実装
- `src/kabusys/operations/line_reports.py` に `format_signal_queue_message()` を追加
  - 通知内容: ステータス（READY/EMPTY）・BUY/SELL 件数・銘柄一覧（上位 10 件、超過は「他 N 件」省略）
- `scripts/setup_task_scheduler.ps1` に `KabuSys_SignalQueueReport`（08:02）を追加
  - `KabuSys_PreMarketReport`（08:00）の直後・`KabuSys_ExecutionStart`（08:30）の前に配置
- `tests/test_line_reports.py` に `TestFormatSignalQueueMessage` クラス（6 テスト）を追加

## Test plan

- [ ] `pytest tests/test_line_reports.py` — 28 tests PASS を確認
- [ ] `ruff check / ruff format` — エラーなしを確認
- [ ] Task Scheduler 再登録後、`Get-ScheduledTask -TaskName 'KabuSys_SignalQueueReport'` で登録確認
- [ ] 手動実行 `python scripts/run_signal_queue_report.py` が正常終了することを確認
- [ ] Process Monitor で `signal_queue_report_job` が記録されることを確認
- [ ] LINE 通知で BUY/SELL 件数・銘柄一覧が届くことを確認

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)