### PR TITLE
feat: position_reconciliation_report の自動実行化 (#325)

### DIFF
--- a/scripts/run_position_reconciliation_report.py
+++ b/scripts/run_position_reconciliation_report.py
@@ -1,0 +1,108 @@
+"""scripts/run_position_reconciliation_report.py
+
+Position Reconciliation Report の生成ランナー（Task Scheduler 用）。
+
+毎朝 08:05 に自動実行し、ブローカーとローカル DB のポジション差分を検出・保存した上で
+LINE 通知を送信する。DISCREPANCY 検出時は緊急アラートとして通知する。
+手動実行も可能（引数なし）。
+
+Task Scheduler 登録:
+    KabuSys_PositionReconciliationReport  08:05  -> scripts/run_position_reconciliation_report.py
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+from kabusys.config import Settings
+from kabusys.execution.broker_factory import BrokerClientFactory
+from kabusys.execution.order_repository import OrderRepository
+from kabusys.operations.line_reports import format_position_reconciliation_message
+from kabusys.operations.notifier import build_notifier
+from kabusys.operations.position_reconciliation_report import (
+    build_report,
+    collect_position_snapshot,
+    format_cli_summary,
+    save_report,
+)
+from kabusys.operations.process_registry import register_process, update_process
+from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
+
+_run_log = setup_logging(app_name="position_reconciliation_report", capture_stdio=True)
+logger = logging.getLogger(__name__)
+
+_JOB_NAME = "position_reconciliation_report_job"
+_APP_NAME = "position_reconciliation_report"
+
+
+def main() -> None:
+    started_at = datetime.now(timezone.utc)
+    log_run_start(_APP_NAME)
+    run_id: int | None = None
+    try:
+        run_id = register_process(_JOB_NAME, log_file=str(_run_log) if _run_log else None)
+    except Exception:
+        logger.warning("process_registry 登録に失敗しました", exc_info=True)
+
+    _failed = False
+    settings = Settings()
+    today = date.today()
+    sqlite_conn = None
+    broker = None
+    try:
+        sqlite_uri = Path(settings.sqlite_path).resolve().as_uri() + "?mode=ro"
+        sqlite_conn = sqlite3.connect(sqlite_uri, uri=True)
+        broker = BrokerClientFactory.create(settings)
+        repo = OrderRepository(sqlite_conn)
+
+        entries = collect_position_snapshot(broker, repo)
+        report = build_report(entries, report_date=today)
+
+        saved_path = save_report(report)
+        logger.info("レポート保存: %s", saved_path)
+        print(format_cli_summary(report))
+
+        # LINE 通知（失敗しても処理継続）
+        try:
+            notifier = build_notifier(settings)
+            msg = format_position_reconciliation_message(
+                status=report.status,
+                total_count=report.total_count,
+                mismatch_count=report.mismatch_count,
+                positions=report.positions,
+                report_date=today.isoformat(),
+            )
+            notifier.send(msg)
+        except Exception:
+            logger.warning(
+                "Position Reconciliation LINE 通知に失敗しました（処理続行）", exc_info=True
+            )
+
+    except Exception:
+        logger.exception("position_reconciliation_report バッチが失敗しました")
+        _failed = True
+    finally:
+        if sqlite_conn is not None:
+            sqlite_conn.close()
+        if broker is not None and hasattr(broker, "close"):
+            try:
+                broker.close()
+            except Exception:
+                logger.warning("broker.close() で例外が発生しました", exc_info=True)
+        if run_id is not None:
+            try:
+                update_process(run_id, status="failed" if _failed else "success")
+            except Exception:
+                logger.warning("process_registry 更新に失敗しました", exc_info=True)
+        log_run_end(_APP_NAME, status="failed" if _failed else "success", started_at=started_at)
+    if _failed:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_position_reconciliation_report.py
+++ b/scripts/run_position_reconciliation_report.py
@@ -55,7 +55,7 @@ def main() -> None:
     sqlite_conn = None
     broker = None
     try:
-        sqlite_uri = Path(settings.sqlite_path).resolve().as_uri() + "?mode=ro"
+        sqlite_uri = f"file:{Path(settings.sqlite_path).resolve().as_posix()}?mode=ro"
         sqlite_conn = sqlite3.connect(sqlite_uri, uri=True)
         broker = BrokerClientFactory.create(settings)
         repo = OrderRepository(sqlite_conn)
@@ -64,7 +64,13 @@ def main() -> None:
         report = build_report(entries, report_date=today)
 
         saved_path = save_report(report)
-        logger.info("レポート保存: %s", saved_path)
+        logger.info(
+            "レポート保存: %s  ステータス=%s  差分=%d/%d",
+            saved_path,
+            report.status,
+            report.mismatch_count,
+            report.total_count,
+        )
         print(format_cli_summary(report))
 
         # LINE 通知（失敗しても処理継続）
@@ -75,7 +81,7 @@ def main() -> None:
                 total_count=report.total_count,
                 mismatch_count=report.mismatch_count,
                 positions=report.positions,
-                report_date=today.isoformat(),
+                report_date=report.report_date,
             )
             notifier.send(msg)
         except Exception:

--- a/scripts/setup_task_scheduler.ps1
+++ b/scripts/setup_task_scheduler.ps1
@@ -99,8 +99,9 @@ Register-KabuSysTask -TaskName "KabuSys_StrategySignal"        -Script "run_stra
 Register-KabuSysTask -TaskName "KabuSys_PortfolioConstruction" -Script "run_portfolio_construction.py" -TriggerTime "21:00"
 Register-KabuSysTask -TaskName "KabuSys_NightBatchReport"      -Script "run_night_batch_report.py"     -TriggerTime "21:15"
 Register-KabuSysTask -TaskName "KabuSys_PreMarketReport"       -Script "run_pre_market_report.py"      -TriggerTime "08:00"
-Register-KabuSysTask -TaskName "KabuSys_SignalQueueReport"     -Script "run_signal_queue_report.py"    -TriggerTime "08:02"
-Register-KabuSysTask -TaskName "KabuSys_ExecutionStart"        -Script "start_system.py" -Arguments "--component execution"  -TriggerTime "08:30"
+Register-KabuSysTask -TaskName "KabuSys_SignalQueueReport"              -Script "run_signal_queue_report.py"             -TriggerTime "08:02"
+Register-KabuSysTask -TaskName "KabuSys_PositionReconciliationReport"   -Script "run_position_reconciliation_report.py"  -TriggerTime "08:05"
+Register-KabuSysTask -TaskName "KabuSys_ExecutionStart"                 -Script "start_system.py" -Arguments "--component execution"  -TriggerTime "08:30"
 Register-KabuSysTask -TaskName "KabuSys_MonitoringStart"       -Script "start_system.py" -Arguments "--component monitoring" -TriggerTime "09:00"
 
 # ---------------------------------------------------------------------------

--- a/src/kabusys/operations/line_reports.py
+++ b/src/kabusys/operations/line_reports.py
@@ -25,6 +25,7 @@ def format_position_reconciliation_message(
     mismatch_count: int,
     positions: list[dict],
     report_date: str,
+    max_mismatches: int = 10,
 ) -> str:
     """Position Reconciliation Report 完了時の LINE 通知メッセージを生成する。
 
@@ -43,15 +44,21 @@ def format_position_reconciliation_message(
     ]
 
     if status == "DISCREPANCY":
-        mismatches = [p for p in positions if p.get("status") == "MISMATCH"]
+        mismatches = sorted(
+            [p for p in positions if p.get("status") == "MISMATCH"],
+            key=lambda p: p["code"],
+        )
         if mismatches:
+            shown = mismatches[:max_mismatches]
             lines.append("差分銘柄:")
-            for p in mismatches:
-                diff = p["broker_qty"] - p["local_qty"]
+            for p in shown:
+                diff = p.get("diff", p["broker_qty"] - p["local_qty"])
                 diff_str = f"+{diff}" if diff > 0 else str(diff)
                 lines.append(
                     f"  {p['code']} ブローカー:{p['broker_qty']} / ローカル:{p['local_qty']} (差分:{diff_str})"
                 )
+            if len(mismatches) > max_mismatches:
+                lines.append(f"  … 他 {len(mismatches) - max_mismatches} 件")
 
     return "\n".join(lines)
 

--- a/src/kabusys/operations/line_reports.py
+++ b/src/kabusys/operations/line_reports.py
@@ -18,6 +18,44 @@ def _fmt_yen(value: float | None) -> str:
     return f"{value:,.0f} 円"
 
 
+def format_position_reconciliation_message(
+    *,
+    status: str,
+    total_count: int,
+    mismatch_count: int,
+    positions: list[dict],
+    report_date: str,
+) -> str:
+    """Position Reconciliation Report 完了時の LINE 通知メッセージを生成する。
+
+    status は "CLEAN" / "DISCREPANCY" のいずれか。
+    DISCREPANCY 時は差分銘柄の詳細を含め、緊急アラートとして送信する。
+    """
+    if status == "DISCREPANCY":
+        header = f"【⚠️ KabuSys ポジション差分検出】{report_date}"
+    else:
+        header = f"【KabuSys Reconciliation】{report_date}"
+
+    lines = [
+        header,
+        f"ステータス: {status}",
+        f"差分あり: {mismatch_count} 件 / 全体: {total_count} 件",
+    ]
+
+    if status == "DISCREPANCY":
+        mismatches = [p for p in positions if p.get("status") == "MISMATCH"]
+        if mismatches:
+            lines.append("差分銘柄:")
+            for p in mismatches:
+                diff = p["broker_qty"] - p["local_qty"]
+                diff_str = f"+{diff}" if diff > 0 else str(diff)
+                lines.append(
+                    f"  {p['code']} ブローカー:{p['broker_qty']} / ローカル:{p['local_qty']} (差分:{diff_str})"
+                )
+
+    return "\n".join(lines)
+
+
 def format_signal_queue_message(
     *,
     status: str,

--- a/tests/test_line_reports.py
+++ b/tests/test_line_reports.py
@@ -228,6 +228,24 @@ class TestFormatPositionReconciliationMessage:
         assert "7203" not in msg
         assert "6758" not in msg
 
+    def test_positive_diff_shows_plus_sign(self):
+        msg = format_position_reconciliation_message(
+            status="DISCREPANCY",
+            total_count=1,
+            mismatch_count=1,
+            positions=[
+                {
+                    "code": "7203",
+                    "broker_qty": 100,
+                    "local_qty": 0,
+                    "diff": 100,
+                    "status": "MISMATCH",
+                }
+            ],
+            report_date="2026-05-13",
+        )
+        assert "+100" in msg
+
     def test_returns_string(self):
         msg = format_position_reconciliation_message(
             status="CLEAN",

--- a/tests/test_line_reports.py
+++ b/tests/test_line_reports.py
@@ -9,6 +9,7 @@ from kabusys.operations.line_reports import (
     format_evening_message,
     format_monthly_message,
     format_morning_message,
+    format_position_reconciliation_message,
     format_pre_market_message,
     format_signal_queue_message,
     format_weekly_message,
@@ -160,6 +161,80 @@ class TestFormatMonthlyMessage:
             summary=summary,
             from_date="2026-04-01",
             to_date="2026-04-30",
+        )
+        assert isinstance(msg, str)
+        assert len(msg) > 0
+
+
+class TestFormatPositionReconciliationMessage:
+    _CLEAN_POSITIONS = [
+        {"code": "7203", "broker_qty": 100, "local_qty": 100, "diff": 0, "status": "MATCH"},
+        {"code": "6758", "broker_qty": 200, "local_qty": 200, "diff": 0, "status": "MATCH"},
+    ]
+    _MISMATCH_POSITIONS = [
+        {"code": "7203", "broker_qty": 100, "local_qty": 0, "diff": 100, "status": "MISMATCH"},
+        {"code": "6758", "broker_qty": 0, "local_qty": 200, "diff": -200, "status": "MISMATCH"},
+        {"code": "9984", "broker_qty": 50, "local_qty": 50, "diff": 0, "status": "MATCH"},
+    ]
+
+    def test_clean_status(self):
+        msg = format_position_reconciliation_message(
+            status="CLEAN",
+            total_count=2,
+            mismatch_count=0,
+            positions=self._CLEAN_POSITIONS,
+            report_date="2026-05-13",
+        )
+        assert "2026-05-13" in msg
+        assert "CLEAN" in msg
+        assert "2" in msg
+        assert "0" in msg
+
+    def test_discrepancy_status_has_alert(self):
+        msg = format_position_reconciliation_message(
+            status="DISCREPANCY",
+            total_count=3,
+            mismatch_count=2,
+            positions=self._MISMATCH_POSITIONS,
+            report_date="2026-05-13",
+        )
+        assert "DISCREPANCY" in msg
+        assert "2" in msg
+        assert "7203" in msg
+        assert "6758" in msg
+        # MATCH の 9984 は含まれない
+        assert "9984" not in msg
+
+    def test_discrepancy_includes_diff_detail(self):
+        msg = format_position_reconciliation_message(
+            status="DISCREPANCY",
+            total_count=3,
+            mismatch_count=2,
+            positions=self._MISMATCH_POSITIONS,
+            report_date="2026-05-13",
+        )
+        assert "100" in msg  # broker_qty
+        assert "200" in msg  # local_qty
+
+    def test_clean_no_position_detail(self):
+        msg = format_position_reconciliation_message(
+            status="CLEAN",
+            total_count=2,
+            mismatch_count=0,
+            positions=self._CLEAN_POSITIONS,
+            report_date="2026-05-13",
+        )
+        # CLEAN 時は銘柄詳細を表示しない
+        assert "7203" not in msg
+        assert "6758" not in msg
+
+    def test_returns_string(self):
+        msg = format_position_reconciliation_message(
+            status="CLEAN",
+            total_count=0,
+            mismatch_count=0,
+            positions=[],
+            report_date="2026-05-13",
         )
         assert isinstance(msg, str)
         assert len(msg) > 0


### PR DESCRIPTION
## Summary

- `scripts/run_position_reconciliation_report.py` を新規作成（Task Scheduler 用ランナー）
  - `register_process` / `update_process` で Process Monitor に記録
  - `BrokerClientFactory.create()` でブローカー接続（`paper_trading` 時は `MockBrokerClient` を使用）
  - `broker.close()` を `finally` で安全にクローズ
  - LINE で通知（失敗しても処理を継続）
- `src/kabusys/operations/line_reports.py` に `format_position_reconciliation_message()` を追加
  - **CLEAN**: 通常通知（差分なし確認済み）
  - **DISCREPANCY**: `⚠️ 緊急アラート` ＋ 差分銘柄の詳細一覧（MATCH 銘柄は除外）
- `scripts/setup_task_scheduler.ps1` に `KabuSys_PositionReconciliationReport`（08:05）を追加
  - `KabuSys_SignalQueueReport`（08:02）の後・`KabuSys_ExecutionStart`（08:30）の前
- `tests/test_line_reports.py` に `TestFormatPositionReconciliationMessage`（5 テスト）を追加

## Test plan

- [ ] `pytest tests/test_line_reports.py` — 35 tests PASS を確認
- [ ] `ruff check / ruff format` — エラーなしを確認
- [ ] Task Scheduler 再登録後、`Get-ScheduledTask -TaskName 'KabuSys_PositionReconciliationReport'` で確認
- [ ] 手動実行 `python scripts/run_position_reconciliation_report.py` が正常終了することを確認
- [ ] Process Monitor で `position_reconciliation_report_job` が記録されることを確認
- [ ] CLEAN 時: 差分なし通知が届くことを確認
- [ ] DISCREPANCY 時: ⚠️ アラートと差分銘柄一覧が届くことを確認

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)