### PR TITLE
docs: 朝レポート自動実行化に伴うドキュメント修正 (#326)

### DIFF
--- a/documents/08_Operations/TradingRunbook.md
+++ b/documents/08_Operations/TradingRunbook.md
@@ -13,7 +13,7 @@
 08:02  signal_queue_report（自動）
 08:05  position_reconciliation_report（自動）
 08:30  Execution 起動（自動）
-09:00  Monitoring 起動・前場監視（自動）
+09:00  Monitoring 起動（自動）・前場監視
 11:30  昼休み確認
 12:30  後場監視
 15:00  Market Close 確認

--- a/documents/08_Operations/TradingRunbook.md
+++ b/documents/08_Operations/TradingRunbook.md
@@ -9,9 +9,11 @@
 
 ```text
 07:50  PC / kabuステーション起動確認
-08:00  Pre-Market Checklist
-08:30  Execution 起動
-09:00  Monitoring 起動・前場監視
+08:00  pre_market_report（自動）
+08:02  signal_queue_report（自動）
+08:05  position_reconciliation_report（自動）
+08:30  Execution 起動（自動）
+09:00  Monitoring 起動・前場監視（自動）
 11:30  昼休み確認
 12:30  後場監視
 15:00  Market Close 確認
@@ -27,7 +29,15 @@
 
 ---
 
-## 2. Pre-Market（08:00）
+## 2. Pre-Market（08:00〜08:05）
+
+3 本のレポートが Task Scheduler により自動実行される。LINE 通知（有効時）で結果を確認する。
+
+| 時刻 | ジョブ | 出力先 |
+|------|--------|--------|
+| 08:00 | `KabuSys_PreMarketReport` | `artifacts/pre_market/{date}/report.md` |
+| 08:02 | `KabuSys_SignalQueueReport` | `artifacts/signal_queue/{date}/report.md` |
+| 08:05 | `KabuSys_PositionReconciliationReport` | `artifacts/position_reconciliation/{date}/report.json` |
 
 確認項目:
 
@@ -39,23 +49,19 @@
 - Task Scheduler の `KabuSys_*` が `Ready`
 - DB と口座のポジション差分が許容範囲
 
-主要コマンド:
-
-```cmd
-python -m kabusys.run_pre_market_report --save
-python -m kabusys.run_signal_queue_report
-python -m kabusys.run_position_reconciliation_report
-```
-
 判定:
 
 - `READY`: 執行開始可
 - `READY_WITH_WARNINGS`: 警告確認の上で開始判断
 - `BLOCKED`: 自動執行を開始しない
 
-出力先:
+手動再実行（再確認・デバッグ時）:
 
-- `artifacts/pre_market/{date}/report.md`
+```cmd
+python scripts/run_pre_market_report.py
+python scripts/run_signal_queue_report.py
+python scripts/run_position_reconciliation_report.py
+```
 
 **signal_queue に不要な pending がある場合:**
 

--- a/documents/10_Runtime/RuntimeJobSchedule.md
+++ b/documents/10_Runtime/RuntimeJobSchedule.md
@@ -18,10 +18,12 @@ KabuSys は、夜間バッチで翌営業日のシグナルと発注キューを
 21:00  portfolio_construction
 21:15  night_batch_report（自動生成）
 21:30  night batch status confirmation（オペレーター確認）
-08:00  pre_market_report
-08:30  execution start
-09:00  monitoring start
-15:00  market_close_report
+08:00  pre_market_report（自動）
+08:02  signal_queue_report（自動）
+08:05  position_reconciliation_report（自動）
+08:30  execution start（自動）
+09:00  monitoring start（自動）
+15:00  market_close_report（手動）
 ```
 
 > **スケジュール設計の根拠**: J-Quants の日足株価データ（`daily_quotes`）は東証引け（15:30）直後ではなく 16:30〜17:00 頃に公開される。15:30 に data_update を実行すると当日データを取得できず feature_gen が 0 件になる。17:30 に遅延することでデータ確実取得後に実行できる。
@@ -153,19 +155,23 @@ Get-ScheduledTask -TaskName "KabuSys_*" | Get-ScheduledTaskInfo | Select-Object 
 
 ---
 
-## 4. Pre-Market（08:00）
+## 4. Pre-Market（08:00〜08:05）
 
-```cmd
-python -m kabusys.run_pre_market_report --save
-```
+3 本のレポートが Task Scheduler により自動実行される。
 
-判定:
+| 時刻 | タスク名 | スクリプト | 出力先 |
+|------|----------|------------|--------|
+| 08:00 | `KabuSys_PreMarketReport` | `scripts/run_pre_market_report.py` | `artifacts/pre_market/{date}/report.md` |
+| 08:02 | `KabuSys_SignalQueueReport` | `scripts/run_signal_queue_report.py` | `artifacts/signal_queue/{date}/report.md` |
+| 08:05 | `KabuSys_PositionReconciliationReport` | `scripts/run_position_reconciliation_report.py` | `artifacts/position_reconciliation/{date}/report.json` |
+
+判定（pre_market_report）:
 
 - `READY`
 - `READY_WITH_WARNINGS`
 - `BLOCKED`
 
-確認対象:
+確認対象（pre_market_report）:
 
 - stop flag
 - Task Scheduler readiness
@@ -173,9 +179,13 @@ python -m kabusys.run_pre_market_report --save
 - ポジション差分
 - データ鮮度
 
-出力先:
+手動再実行（デバッグ時）:
 
-- `artifacts/pre_market/{date}/report.md`
+```cmd
+python scripts/run_pre_market_report.py
+python scripts/run_signal_queue_report.py
+python scripts/run_position_reconciliation_report.py
+```
 
 ---
 
@@ -237,6 +247,9 @@ python -m kabusys.run_performance_report --type daily --save
 | 20:00 | `KabuSys_StrategySignal` | `scripts\run_strategy_signal.py` |
 | 21:00 | `KabuSys_PortfolioConstruction` | `scripts\run_portfolio_construction.py` |
 | 21:15 | `KabuSys_NightBatchReport` | `scripts\run_night_batch_report.py` |
+| 08:00 | `KabuSys_PreMarketReport` | `scripts\run_pre_market_report.py` |
+| 08:02 | `KabuSys_SignalQueueReport` | `scripts\run_signal_queue_report.py` |
+| 08:05 | `KabuSys_PositionReconciliationReport` | `scripts\run_position_reconciliation_report.py` |
 | 08:30 | `KabuSys_ExecutionStart` | `scripts\start_system.py --component execution` |
 | 09:00 | `KabuSys_MonitoringStart` | `scripts\start_system.py --component monitoring` |
 

--- a/documents/WebManual/A_OperationsCycle.md
+++ b/documents/WebManual/A_OperationsCycle.md
@@ -25,7 +25,9 @@ KabuSys は、**市場が閉まっている時間に翌営業日の売買準備�
 
 ```text
 07:50  PC・kabuステーション起動確認
-08:00  Pre-Market Checklist（手動確認）
+08:00  pre_market_report（自動）
+08:02  signal_queue_report（自動）
+08:05  position_reconciliation_report（自動）
 08:30  Execution 起動（自動）
 09:00  Monitoring 起動（自動） / 前場開始
 09:00-11:30  前場監視
@@ -60,23 +62,33 @@ KabuSys は、**市場が閉まっている時間に翌営業日の売買準備�
 
 システムはこの時点では、まだ売買を始めません。
 
-### 3.2 Pre-Market Checklist（08:00）
+### 3.2 Pre-Market Checklist（08:00〜08:05）
 
-市場開始前に、ユーザーが手動で運用チェックを行います。
+市場開始前のレポート 3 本が Task Scheduler により自動実行されます。
 
-確認方法:
+| 時刻 | ジョブ | 出力先 |
+|------|--------|--------|
+| 08:00 | `pre_market_report` | `artifacts/pre_market/{date}/report.md` |
+| 08:02 | `signal_queue_report` | `artifacts/signal_queue/{date}/report.md` |
+| 08:05 | `position_reconciliation_report` | `artifacts/position_reconciliation/{date}/report.json` |
 
-08:00 前後にオペレーターが以下のコマンドを手動実行し、`artifacts/pre_market/{date}/report.md` にレポートを生成します。ステータスが `READY` であれば運用開始可能です。`BLOCKED` の場合は原因を確認して対処してください。
+LINE 通知が有効な場合、各レポートの結果がスマートフォンへ自動送信されます。結果は Streamlit の **Pre-Market** / **Signal Queue** ページでも確認できます。
+
+ステータスが `READY` であれば運用開始可能です。`BLOCKED` の場合は原因を確認して対処してください。
+
+手動で再実行したい場合（再確認・デバッグ時）:
 
 ```powershell
-python -m kabusys.run_pre_market_report --save
+python scripts/run_pre_market_report.py
+python scripts/run_signal_queue_report.py
+python scripts/run_position_reconciliation_report.py
 ```
 
 確認項目:
 
 - 前日分データが正常に取り込まれている
 - 本日の `Signal Queue` に `pending` シグナルが存在する
-- DB 上のポジションと証券口座のポジションが一致している
+- DB 上のポジションと証券口座のポジションが一致している（`position_reconciliation_report` で確認）
 - `data/stop_requested.flag` が存在しない
 - Task Scheduler の KabuSys タスクが `Ready` 状態である
 

--- a/documents/WebManual/A_Overview.md
+++ b/documents/WebManual/A_Overview.md
@@ -85,8 +85,8 @@ Addon 機能:（任意・後から追加可能。未設定でも Core は動作�
 08:00  pre_market_report（自動）
 08:02  signal_queue_report（自動）
 08:05  position_reconciliation_report（自動）
-08:30  execution start
-09:00  monitoring start
+08:30  execution start（自動）
+09:00  monitoring start（自動）
 15:00  market_close_report（手動）
 
 # AI Addon（ENABLE_AI_SENTIMENT=true のときのみ）

--- a/documents/WebManual/A_Overview.md
+++ b/documents/WebManual/A_Overview.md
@@ -82,7 +82,9 @@ Addon 機能:（任意・後から追加可能。未設定でも Core は動作�
 20:00  strategy_signal
 21:00  portfolio_construction
 21:15  night_batch_report（自動）
-08:00  pre_market_report（手動）
+08:00  pre_market_report（自動）
+08:02  signal_queue_report（自動）
+08:05  position_reconciliation_report（自動）
 08:30  execution start
 09:00  monitoring start
 15:00  market_close_report（手動）

--- a/documents/WebManual/B_CoreSetup.md
+++ b/documents/WebManual/B_CoreSetup.md
@@ -214,8 +214,11 @@ powershell -File scripts\remove_task_scheduler.ps1
 | 20:00 | 売買シグナル生成 | `scripts/run_strategy_signal.py` |
 | 21:00 | ポートフォリオ構築 | `scripts/run_portfolio_construction.py` |
 | 21:15 | 夜間バッチ結果レポート | `scripts/run_night_batch_report.py` |
-| 08:30 | Execution Engine 起動 | `python -m kabusys.run_execution` |
-| 09:00 | Monitoring 起動 | `python -m kabusys.run_monitoring` |
+| 08:00 | Pre-Market レポート | `scripts/run_pre_market_report.py` |
+| 08:02 | Signal Queue レポート | `scripts/run_signal_queue_report.py` |
+| 08:05 | Position Reconciliation レポート | `scripts/run_position_reconciliation_report.py` |
+| 08:30 | Execution Engine 起動 | `scripts/start_system.py --component execution` |
+| 09:00 | Monitoring 起動 | `scripts/start_system.py --component monitoring` |
 
 > ℹ️ **スケジュール設計の根拠**: J-Quants の日足データは東証引け（15:30）直後ではなく 16:30〜17:00 頃に公開されます。17:30 に data_update を実行することで当日データを確実に取得してから feature_gen（18:30）を起動できます。
 
@@ -233,7 +236,7 @@ powershell -File scripts\remove_task_scheduler.ps1
 
 > 詳細は `documents/10_Runtime/RuntimeJobSchedule.md` を参照してください。
 
-> **補足:** `pre_market_report`（08:00）および `market_close_report`（15:00）は Task Scheduler の自動ジョブではなく、オペレーターが手動で実行するコマンドです（`python -m kabusys.run_pre_market_report`、`python -m kabusys.run_market_close_report`）。詳細は [D_LiveOperation.md](./D_LiveOperation.md) を参照してください。
+> **補足:** `pre_market_report`（08:00）・`signal_queue_report`（08:02）・`position_reconciliation_report`（08:05）は Task Scheduler の Core 標準ジョブとして自動実行されます。`market_close_report`（15:00）はオペレーターが手動で実行するコマンドです（`python -m kabusys.run_market_close_report`）。詳細は [D_LiveOperation.md](./D_LiveOperation.md) を参照してください。
 
 ---
 

--- a/documents/WebManual/C_PaperTrading.md
+++ b/documents/WebManual/C_PaperTrading.md
@@ -174,12 +174,24 @@ python -m kabusys.run_signal_queue_report --date 2026-05-13
 ペーパートレードは本番と同じ `TradingRunbook.md` の運用フローに従います。
 以下は、ペーパートレード固有の差分のみを説明します。
 
-### 朝の確認（08:00）
+### 朝の確認（08:00〜08:05）
 
-本番と同様に Pre-Market Report で確認します。
+本番と同様に、3 本のレポートが Task Scheduler により自動実行されます。
+
+| 時刻 | ジョブ | ペーパートレードでの主な確認内容 |
+|------|--------|----------------------------------|
+| 08:00 | `pre_market_report` | READY/BLOCKED 判定・停止フラグ確認 |
+| 08:02 | `signal_queue_report` | `pending` シグナルの銘柄・売買方向・数量の確認 |
+| 08:05 | `position_reconciliation_report` | DB ポジションとブローカー（Mock）の整合確認 |
+
+> ℹ️ `signal_queue_report` は発注予定内容（銘柄・売買方向・数量）を一覧化します。ペーパートレードでも発注内容を事前確認するために活用してください。Pure Mock モードではブローカー接続が不要なため、`position_reconciliation_report` は常に CLEAN と判定されます。
+
+手動で再実行したい場合（再確認・デバッグ時）:
 
 ```powershell
-python -m kabusys.run_pre_market_report --save
+python scripts/run_pre_market_report.py
+python scripts/run_signal_queue_report.py
+python scripts/run_position_reconciliation_report.py
 ```
 
 | 確認項目 | ペーパートレードでの確認内容 |

--- a/documents/WebManual/C_PaperTrading.md
+++ b/documents/WebManual/C_PaperTrading.md
@@ -184,7 +184,7 @@ python -m kabusys.run_signal_queue_report --date 2026-05-13
 | 08:02 | `signal_queue_report` | `pending` シグナルの銘柄・売買方向・数量の確認 |
 | 08:05 | `position_reconciliation_report` | DB ポジションとブローカー（Mock）の整合確認 |
 
-> ℹ️ `signal_queue_report` は発注予定内容（銘柄・売買方向・数量）を一覧化します。ペーパートレードでも発注内容を事前確認するために活用してください。Pure Mock モードではブローカー接続が不要なため、`position_reconciliation_report` は常に CLEAN と判定されます。
+> ℹ️ `signal_queue_report` は発注予定内容（銘柄・売買方向・数量）を一覧化します。ペーパートレードでも発注内容を事前確認するために活用してください。Pure Mock モードではブローカー接続が不要なため、`position_reconciliation_report` は常に `CLEAN` と判定されます。
 
 手動で再実行したい場合（再確認・デバッグ時）:
 

--- a/documents/WebManual/D_LiveOperation.md
+++ b/documents/WebManual/D_LiveOperation.md
@@ -23,9 +23,11 @@
 ## D-2. 1日の流れ
 
 ```text
-08:00  Pre-Market
-08:30  Execution 起動
-09:00  Monitoring 起動
+08:00  pre_market_report（自動）
+08:02  signal_queue_report（自動）
+08:05  position_reconciliation_report（自動）
+08:30  Execution 起動（自動）
+09:00  Monitoring 起動（自動）
 09:00-15:00  ザラ場監視
 15:00  Market Close
 17:30-21:15  夜間バッチ（21:15 にレポート自動生成）
@@ -34,27 +36,33 @@
 
 ---
 
-## D-3. 朝の確認（08:00）
+## D-3. 朝の確認（08:00〜08:05）
 
-主要コマンド:
+3 本のレポートが Task Scheduler により自動実行されます。
 
-```cmd
-python -m kabusys.run_pre_market_report --save
-python -m kabusys.run_signal_queue_report
-python -m kabusys.run_position_reconciliation_report
-```
+| 時刻 | ジョブ | 出力先 |
+|------|--------|--------|
+| 08:00 | `KabuSys_PreMarketReport` | `artifacts/pre_market/{date}/report.md` |
+| 08:02 | `KabuSys_SignalQueueReport` | `artifacts/signal_queue/{date}/report.md` |
+| 08:05 | `KabuSys_PositionReconciliationReport` | `artifacts/position_reconciliation/{date}/report.json` |
+
+LINE 通知が有効な場合、各レポート完了後に結果が自動送信されます。
 
 判定:
 
-- `READY`
-- `READY_WITH_WARNINGS`
-- `BLOCKED`
+- `READY`: 執行開始可
+- `READY_WITH_WARNINGS`: 警告確認の上で開始判断
+- `BLOCKED`: Execution を開始しない
 
-`BLOCKED` の場合は Execution を開始しない。
+`BLOCKED` の場合は原因を解消してから Execution を起動してください。
 
-出力先:
+手動で再実行したい場合（再確認・デバッグ時）:
 
-- `artifacts/pre_market/{date}/report.md`
+```cmd
+python scripts/run_pre_market_report.py
+python scripts/run_signal_queue_report.py
+python scripts/run_position_reconciliation_report.py
+```
 
 ---
 


### PR DESCRIPTION
## Summary

Issue #323〜#325 で `pre_market_report` / `signal_queue_report` / `position_reconciliation_report` が Task Scheduler 自動実行に変わったことを受け、関連 7 ファイルのドキュメントを更新する。

- **A_Overview.md**: `pre_market_report（手動）` → `（自動）` に変更。`signal_queue_report`（08:02）・`position_reconciliation_report`（08:05）の行を追加
- **A_OperationsCycle.md**: タイムラインに 08:02/08:05 を追記。3.2 節を「手動コマンド実行」から「自動実行 + 手動再実行可能」の記述に改訂
- **B_CoreSetup.md**: Task Scheduler Core ジョブ一覧に朝の 3 ジョブを追加。補足注記の「手動」→「自動」に修正
- **C_PaperTrading.md**: C-4 節を自動実行前提に更新。`signal_queue_report` の活用説明（発注内容の事前確認）を追記
- **D_LiveOperation.md**: D-2 タイムライン・D-3 節を自動実行前提に改訂。テーブル形式で 3 ジョブの時刻・出力先を整理
- **RuntimeJobSchedule.md**: 全体像テキスト・Section 4・Section 7 Core ジョブテーブルに 3 ジョブを追加
- **TradingRunbook.md**: タイムライン・Section 2 を自動実行前提に改訂

## 依存関係

- #323 `pre_market_report` 自動実行化（マージ済み）
- #324 `signal_queue_report` 自動実行化（マージ済み）
- #325 `position_reconciliation_report` 自動実行化（マージ済み）

## Test plan

- [ ] 各ドキュメントのタイムライン記述に 08:00/08:02/08:05 が正しく反映されている
- [ ] 「手動実行」前提の記述が「自動実行」前提に変更されている
- [ ] 手動再実行コマンドが `scripts/run_*.py` 形式で記載されている
- [ ] `signal_queue_report` の活用説明が C_PaperTrading.md に追記されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)