### PR TITLE
feat: max_positions を strategy_config.yaml で設定可能にする (#333)

### DIFF
--- a/config/strategy_config.yaml
+++ b/config/strategy_config.yaml
@@ -49,3 +49,7 @@ regime:
   topix_drawdown_threshold: -0.15
   # 地合い悪化時の size_multiplier（0 < x ≤ 1）
   topix_size_multiplier_bear: 0.5
+
+portfolio:
+  # 最大保有銘柄数（select_candidates() に渡される上限値、1 以上の整数）
+  max_positions: 10

--- a/scripts/run_portfolio_construction.py
+++ b/scripts/run_portfolio_construction.py
@@ -104,7 +104,7 @@ def main() -> None:
 
         portfolio_cfg = load_portfolio_config()
         max_positions = portfolio_cfg["max_positions"]
-        logger.info("max_positions: %d", max_positions)
+        logger.info("最大保有銘柄数: %d", max_positions)
 
         if not buy_signals:
             logger.info("本日の BUY シグナルが 0 件です。signal_queue を更新しません。")

--- a/scripts/run_portfolio_construction.py
+++ b/scripts/run_portfolio_construction.py
@@ -38,7 +38,11 @@ from kabusys.operations.performance_collector import (
 )
 from kabusys.operations.performance_report import build_report
 from kabusys.operations.process_registry import register_process, update_process
-from kabusys.portfolio.portfolio_builder import calc_score_weights, select_candidates
+from kabusys.portfolio.portfolio_builder import (
+    calc_score_weights,
+    load_portfolio_config,
+    select_candidates,
+)
 from kabusys.portfolio.position_sizing import calc_position_sizes
 from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
 
@@ -98,11 +102,15 @@ def main() -> None:
         rows = cur.fetchall()
         buy_signals = [dict(zip([d[0] for d in cur.description], row)) for row in rows]
 
+        portfolio_cfg = load_portfolio_config()
+        max_positions = portfolio_cfg["max_positions"]
+        logger.info("max_positions: %d", max_positions)
+
         if not buy_signals:
             logger.info("本日の BUY シグナルが 0 件です。signal_queue を更新しません。")
             _updated_rows["signal_queue"] = 0
         else:
-            candidates = select_candidates(buy_signals)
+            candidates = select_candidates(buy_signals, max_positions=max_positions)
             if not candidates:
                 logger.info("銘柄選定結果が 0 件です。signal_queue を更新しません。")
                 _updated_rows["signal_queue"] = 0

--- a/src/kabusys/portfolio/portfolio_builder.py
+++ b/src/kabusys/portfolio/portfolio_builder.py
@@ -7,8 +7,38 @@ DB 参照なし — メモリ内計算のみ。
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+_PORTFOLIO_CONFIG_PATH = Path(__file__).resolve().parents[3] / "config" / "strategy_config.yaml"
+_DEFAULT_MAX_POSITIONS = 10
+
+
+def load_portfolio_config() -> dict:
+    """config/strategy_config.yaml の portfolio セクションから設定を読み込む。
+
+    ファイル不在・読み込み失敗・不正値はデフォルト値にフォールバック。
+    """
+    import yaml
+
+    result: dict = {"max_positions": _DEFAULT_MAX_POSITIONS}
+    if not _PORTFOLIO_CONFIG_PATH.exists():
+        return result
+    try:
+        with open(_PORTFOLIO_CONFIG_PATH, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except Exception:
+        return result
+    if not isinstance(data, dict):
+        return result
+    p = data.get("portfolio")
+    if not isinstance(p, dict):
+        return result
+    v = p.get("max_positions")
+    if v is not None and not isinstance(v, bool) and isinstance(v, (int, float)) and int(v) >= 1:
+        result["max_positions"] = int(v)
+    return result
 
 
 def select_candidates(

--- a/src/kabusys/portfolio/portfolio_builder.py
+++ b/src/kabusys/portfolio/portfolio_builder.py
@@ -15,14 +15,14 @@ _PORTFOLIO_CONFIG_PATH = Path(__file__).resolve().parents[3] / "config" / "strat
 _DEFAULT_MAX_POSITIONS = 10
 
 
-def load_portfolio_config() -> dict:
+def load_portfolio_config() -> dict[str, int]:
     """config/strategy_config.yaml の portfolio セクションから設定を読み込む。
 
     ファイル不在・読み込み失敗・不正値はデフォルト値にフォールバック。
     """
     import yaml
 
-    result: dict = {"max_positions": _DEFAULT_MAX_POSITIONS}
+    result: dict[str, int] = {"max_positions": _DEFAULT_MAX_POSITIONS}
     if not _PORTFOLIO_CONFIG_PATH.exists():
         logger.warning(
             "strategy_config.yaml が見つからないため、max_positions はデフォルト %d を使用します",
@@ -40,12 +40,19 @@ def load_portfolio_config() -> dict:
         )
         return result
     if not isinstance(data, dict):
+        logger.debug(
+            "strategy_config.yaml のルートが dict でないため、max_positions はデフォルト値を使用します"
+        )
         return result
     p = data.get("portfolio")
     if not isinstance(p, dict):
+        logger.debug(
+            "portfolio セクションが存在しないか dict でないため、max_positions はデフォルト値を使用します"
+        )
         return result
     v = p.get("max_positions")
     if v is None:
+        logger.debug("portfolio.max_positions が未設定のため、デフォルト値を使用します")
         return result
     if (
         isinstance(v, bool)

--- a/src/kabusys/portfolio/portfolio_builder.py
+++ b/src/kabusys/portfolio/portfolio_builder.py
@@ -24,11 +24,20 @@ def load_portfolio_config() -> dict:
 
     result: dict = {"max_positions": _DEFAULT_MAX_POSITIONS}
     if not _PORTFOLIO_CONFIG_PATH.exists():
+        logger.warning(
+            "strategy_config.yaml が見つからないため、max_positions はデフォルト %d を使用します",
+            _DEFAULT_MAX_POSITIONS,
+        )
         return result
     try:
         with open(_PORTFOLIO_CONFIG_PATH, encoding="utf-8") as f:
             data = yaml.safe_load(f)
     except Exception:
+        logger.warning(
+            "strategy_config.yaml の読み込みに失敗したため、max_positions はデフォルト %d を使用します",
+            _DEFAULT_MAX_POSITIONS,
+            exc_info=True,
+        )
         return result
     if not isinstance(data, dict):
         return result
@@ -36,8 +45,21 @@ def load_portfolio_config() -> dict:
     if not isinstance(p, dict):
         return result
     v = p.get("max_positions")
-    if v is not None and not isinstance(v, bool) and isinstance(v, (int, float)) and int(v) >= 1:
-        result["max_positions"] = int(v)
+    if v is None:
+        return result
+    if (
+        isinstance(v, bool)
+        or not isinstance(v, (int, float))
+        or (isinstance(v, float) and not v.is_integer())
+        or int(v) < 1
+    ):
+        logger.warning(
+            "portfolio.max_positions=%r は無効な値のため、デフォルト %d を使用します",
+            v,
+            _DEFAULT_MAX_POSITIONS,
+        )
+        return result
+    result["max_positions"] = int(v)
     return result
 
 

--- a/src/kabusys/validate_config.py
+++ b/src/kabusys/validate_config.py
@@ -409,6 +409,10 @@ def _check_strategy_config_content(data: object) -> None:
                     _error(
                         f"strategy_config.yaml: portfolio.max_positions は整数で設定してください（現在値: {mp!r}）。"
                     )
+                elif isinstance(mp, float) and not mp.is_integer():
+                    _error(
+                        f"strategy_config.yaml: portfolio.max_positions は整数で設定してください（現在値: {mp}）。"
+                    )
                 elif int(mp) < 1:
                     _error(
                         f"strategy_config.yaml: portfolio.max_positions は 1 以上で設定してください（現在値: {mp}）。"

--- a/src/kabusys/validate_config.py
+++ b/src/kabusys/validate_config.py
@@ -397,6 +397,25 @@ def _check_strategy_config_content(data: object) -> None:
             " time_exit が最低保有日数より先に発火するため、min_holding_days は実質的に無効になります。"
         )
 
+    # portfolio.max_positions
+    port = data.get("portfolio") if isinstance(data, dict) else None
+    if port is not None:
+        if not isinstance(port, dict):
+            _error("strategy_config.yaml: 'portfolio' セクションが dict ではありません。")
+        else:
+            mp = port.get("max_positions")
+            if mp is not None:
+                if isinstance(mp, bool) or not isinstance(mp, (int, float)):
+                    _error(
+                        f"strategy_config.yaml: portfolio.max_positions は整数で設定してください（現在値: {mp!r}）。"
+                    )
+                elif int(mp) < 1:
+                    _error(
+                        f"strategy_config.yaml: portfolio.max_positions は 1 以上で設定してください（現在値: {mp}）。"
+                    )
+                else:
+                    _info(f"strategy_config.yaml: portfolio.max_positions = {int(mp)}")
+
 
 def _check_config_yaml_files() -> None:
     """config/*.yaml の存在・構文確認。risk_config.yaml および strategy_config.yaml はセマンティック検証も行う。"""

--- a/tests/test_portfolio_builder_config.py
+++ b/tests/test_portfolio_builder_config.py
@@ -128,3 +128,13 @@ class TestLoadPortfolioConfig:
         monkeypatch.setattr(portfolio_builder, "_PORTFOLIO_CONFIG_PATH", cfg_file)
         result = portfolio_builder.load_portfolio_config()
         assert result["max_positions"] == 10
+
+    def test_falls_back_when_yaml_root_is_not_dict(self, tmp_path, monkeypatch):
+        """YAML ルートが dict でない場合（例: リスト）はデフォルト 10 にフォールバックする。"""
+        from kabusys.portfolio import portfolio_builder
+
+        cfg_file = tmp_path / "strategy_config.yaml"
+        cfg_file.write_text("- item1\n- item2\n", encoding="utf-8")
+        monkeypatch.setattr(portfolio_builder, "_PORTFOLIO_CONFIG_PATH", cfg_file)
+        result = portfolio_builder.load_portfolio_config()
+        assert result["max_positions"] == 10

--- a/tests/test_portfolio_builder_config.py
+++ b/tests/test_portfolio_builder_config.py
@@ -2,10 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
-import pytest
-
 
 class TestLoadPortfolioConfig:
     def test_returns_default_when_no_file(self, tmp_path, monkeypatch):

--- a/tests/test_portfolio_builder_config.py
+++ b/tests/test_portfolio_builder_config.py
@@ -1,0 +1,86 @@
+"""tests/test_portfolio_builder_config.py — load_portfolio_config() のテスト"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+class TestLoadPortfolioConfig:
+    def test_returns_default_when_no_file(self, tmp_path, monkeypatch):
+        """strategy_config.yaml が存在しない場合はデフォルト値を返す。"""
+        from kabusys.portfolio import portfolio_builder
+
+        monkeypatch.setattr(portfolio_builder, "_PORTFOLIO_CONFIG_PATH", tmp_path / "no_such.yaml")
+        result = portfolio_builder.load_portfolio_config()
+        assert result["max_positions"] == 10
+
+    def test_reads_max_positions_from_yaml(self, tmp_path, monkeypatch):
+        """portfolio.max_positions を yaml から読み込む。"""
+        import yaml
+
+        from kabusys.portfolio import portfolio_builder
+
+        cfg_file = tmp_path / "strategy_config.yaml"
+        cfg_file.write_text(yaml.dump({"portfolio": {"max_positions": 15}}), encoding="utf-8")
+        monkeypatch.setattr(portfolio_builder, "_PORTFOLIO_CONFIG_PATH", cfg_file)
+        result = portfolio_builder.load_portfolio_config()
+        assert result["max_positions"] == 15
+
+    def test_falls_back_on_invalid_type(self, tmp_path, monkeypatch):
+        """max_positions が文字列の場合はデフォルト 10 にフォールバックする。"""
+        import yaml
+
+        from kabusys.portfolio import portfolio_builder
+
+        cfg_file = tmp_path / "strategy_config.yaml"
+        cfg_file.write_text(yaml.dump({"portfolio": {"max_positions": "ten"}}), encoding="utf-8")
+        monkeypatch.setattr(portfolio_builder, "_PORTFOLIO_CONFIG_PATH", cfg_file)
+        result = portfolio_builder.load_portfolio_config()
+        assert result["max_positions"] == 10
+
+    def test_falls_back_when_max_positions_below_minimum(self, tmp_path, monkeypatch):
+        """max_positions が 1 未満（0 以下）の場合はデフォルト 10 にフォールバックする。"""
+        import yaml
+
+        from kabusys.portfolio import portfolio_builder
+
+        cfg_file = tmp_path / "strategy_config.yaml"
+        cfg_file.write_text(yaml.dump({"portfolio": {"max_positions": 0}}), encoding="utf-8")
+        monkeypatch.setattr(portfolio_builder, "_PORTFOLIO_CONFIG_PATH", cfg_file)
+        result = portfolio_builder.load_portfolio_config()
+        assert result["max_positions"] == 10
+
+    def test_falls_back_when_portfolio_section_missing(self, tmp_path, monkeypatch):
+        """portfolio セクションが存在しない場合はデフォルト 10 を返す。"""
+        import yaml
+
+        from kabusys.portfolio import portfolio_builder
+
+        cfg_file = tmp_path / "strategy_config.yaml"
+        cfg_file.write_text(yaml.dump({"strategy": {"threshold": 0.6}}), encoding="utf-8")
+        monkeypatch.setattr(portfolio_builder, "_PORTFOLIO_CONFIG_PATH", cfg_file)
+        result = portfolio_builder.load_portfolio_config()
+        assert result["max_positions"] == 10
+
+    def test_max_positions_one_is_valid(self, tmp_path, monkeypatch):
+        """max_positions = 1 は有効な最小値として受け入れられる。"""
+        import yaml
+
+        from kabusys.portfolio import portfolio_builder
+
+        cfg_file = tmp_path / "strategy_config.yaml"
+        cfg_file.write_text(yaml.dump({"portfolio": {"max_positions": 1}}), encoding="utf-8")
+        monkeypatch.setattr(portfolio_builder, "_PORTFOLIO_CONFIG_PATH", cfg_file)
+        result = portfolio_builder.load_portfolio_config()
+        assert result["max_positions"] == 1
+
+    def test_returns_dict(self, tmp_path, monkeypatch):
+        """戻り値は dict である。"""
+        from kabusys.portfolio import portfolio_builder
+
+        monkeypatch.setattr(portfolio_builder, "_PORTFOLIO_CONFIG_PATH", tmp_path / "no_such.yaml")
+        result = portfolio_builder.load_portfolio_config()
+        assert isinstance(result, dict)
+        assert "max_positions" in result

--- a/tests/test_portfolio_builder_config.py
+++ b/tests/test_portfolio_builder_config.py
@@ -80,3 +80,51 @@ class TestLoadPortfolioConfig:
         result = portfolio_builder.load_portfolio_config()
         assert isinstance(result, dict)
         assert "max_positions" in result
+
+    def test_integer_valued_float_is_accepted(self, tmp_path, monkeypatch):
+        """max_positions = 10.0（整数値の float）は有効として受け入れる。"""
+        import yaml
+
+        from kabusys.portfolio import portfolio_builder
+
+        cfg_file = tmp_path / "strategy_config.yaml"
+        cfg_file.write_text(yaml.dump({"portfolio": {"max_positions": 10.0}}), encoding="utf-8")
+        monkeypatch.setattr(portfolio_builder, "_PORTFOLIO_CONFIG_PATH", cfg_file)
+        result = portfolio_builder.load_portfolio_config()
+        assert result["max_positions"] == 10
+
+    def test_non_integer_float_falls_back(self, tmp_path, monkeypatch):
+        """max_positions = 10.5（非整数 float）はデフォルト 10 にフォールバックする。"""
+        import yaml
+
+        from kabusys.portfolio import portfolio_builder
+
+        cfg_file = tmp_path / "strategy_config.yaml"
+        cfg_file.write_text(yaml.dump({"portfolio": {"max_positions": 10.5}}), encoding="utf-8")
+        monkeypatch.setattr(portfolio_builder, "_PORTFOLIO_CONFIG_PATH", cfg_file)
+        result = portfolio_builder.load_portfolio_config()
+        assert result["max_positions"] == 10
+
+    def test_falls_back_when_portfolio_is_list(self, tmp_path, monkeypatch):
+        """portfolio セクションが list の場合はデフォルト 10 にフォールバックする。"""
+        import yaml
+
+        from kabusys.portfolio import portfolio_builder
+
+        cfg_file = tmp_path / "strategy_config.yaml"
+        cfg_file.write_text(yaml.dump({"portfolio": [10]}), encoding="utf-8")
+        monkeypatch.setattr(portfolio_builder, "_PORTFOLIO_CONFIG_PATH", cfg_file)
+        result = portfolio_builder.load_portfolio_config()
+        assert result["max_positions"] == 10
+
+    def test_falls_back_when_max_positions_is_bool(self, tmp_path, monkeypatch):
+        """max_positions が bool の場合はデフォルト 10 にフォールバックする。"""
+        import yaml
+
+        from kabusys.portfolio import portfolio_builder
+
+        cfg_file = tmp_path / "strategy_config.yaml"
+        cfg_file.write_text(yaml.dump({"portfolio": {"max_positions": True}}), encoding="utf-8")
+        monkeypatch.setattr(portfolio_builder, "_PORTFOLIO_CONFIG_PATH", cfg_file)
+        result = portfolio_builder.load_portfolio_config()
+        assert result["max_positions"] == 10


### PR DESCRIPTION
## Summary

- `config/strategy_config.yaml` に `portfolio.max_positions` キーを追加（デフォルト: 10）
- `portfolio_builder.py` に `_PORTFOLIO_CONFIG_PATH` と `load_portfolio_config()` を追加
  - ファイル不在・不正値・型エラー時はデフォルト値 10 にフォールバック
- `run_portfolio_construction.py` で `load_portfolio_config()` を呼び出し `select_candidates()` に `max_positions` を渡す
- `validate_config.py` に `portfolio.max_positions` のセマンティック検証を追加（1 以上の整数）

## Test plan

- [x] `tests/test_portfolio_builder_config.py` — 7 テストケース（RED → GREEN確認済み）
  - デフォルト返却（ファイルなし）
  - YAML から値読み込み
  - 型不正時フォールバック
  - 値 0 以下でフォールバック
  - portfolio セクション欠如でフォールバック
  - 最小値 1 が有効
  - 戻り値が dict
- [x] 全テスト 1913 件パス（リグレッションなし）

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)