### PR TITLE
feat: portfolio_construction を環境別の実際の資産・余力から動的サイジングに改善 (#335)

### DIFF
--- a/scripts/run_portfolio_construction.py
+++ b/scripts/run_portfolio_construction.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import calendar
 import contextlib
 import logging
+import math
 import sqlite3
 import sys
 import uuid
@@ -55,7 +56,7 @@ from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_loggin
 _run_log = setup_logging(app_name="portfolio_construction", capture_stdio=True)
 logger = logging.getLogger(__name__)
 
-_MAX_UTILIZATION = 0.70  # Live モード専用: 余力の安全マージン。Paper では適用しない
+_MAX_UTILIZATION = 0.70  # Live/その他環境でのフォールバック時に適用。Paper では適用しない
 _JOB_NAME = "portfolio_construction_job"
 _APP_NAME = "portfolio_construction"
 
@@ -99,8 +100,15 @@ def _calc_live_portfolio_value(
             base_url=settings.kabu_api_base_url,
         )
         cash = client.get_available_cash()
-        available_cash = cash
-        logger.info("available_cash: カブステーション API 余力=%.0f 円", available_cash)
+        if isinstance(cash, (int, float)) and math.isfinite(cash) and cash >= 0:
+            available_cash = float(cash)
+            logger.info("available_cash: カブステーション API 余力=%.0f 円", available_cash)
+        else:
+            logger.warning(
+                "Kabu API 余力が不正値(%s)。pv×max_utilization=%.0f 円を使用",
+                cash,
+                available_cash,
+            )
     except Exception:
         logger.warning(
             "カブステーション余力 API 呼び出しに失敗。"
@@ -121,8 +129,9 @@ def _calc_paper_portfolio_value(
     paper_trading.db の約定履歴から現金残高・保有ポジション時価を計算する。
     DB が存在しない・読み取り失敗時は PAPER_TRADING_INITIAL_CASH にフォールバックする。
 
-    portfolio_value = 現金残高 + 保有ポジション時価
+    portfolio_value = 現金残高 + 保有ロングポジション時価
     available_cash  = 現金残高（マイナスの場合は 0 に補正）
+    注: ショートポジション（net_qty < 0）は市場価値に含めない（Paper ではショート非対応）。
     """
     initial_cash = settings.paper_trading_initial_cash
     sqlite_path = settings.paper_sqlite_path
@@ -204,10 +213,11 @@ def _calc_paper_portfolio_value(
     portfolio_value = max(net_cash + market_value, 0.0)
 
     logger.info(
-        "Paper portfolio_value 算出: 現金=%.0f 円, 時価=%.0f 円, 合計=%.0f 円",
+        "Paper portfolio_value 算出: 現金=%.0f 円, 時価=%.0f 円, 合計=%.0f 円, 利用可能現金=%.0f 円",
         net_cash,
         market_value,
         portfolio_value,
+        available_cash,
     )
     return portfolio_value, available_cash
 
@@ -249,6 +259,9 @@ def main() -> None:
             available_cash = portfolio_value * _MAX_UTILIZATION
             logger.info(
                 "portfolio_value: PORTFOLIO_VALUE=%.0f 円 (env=%s)", portfolio_value, settings.env
+            )
+            logger.info(
+                "available_cash: pv×max_utilization=%.0f 円 (env=%s)", available_cash, settings.env
             )
 
         inserted = 0

--- a/scripts/run_portfolio_construction.py
+++ b/scripts/run_portfolio_construction.py
@@ -6,14 +6,20 @@ signals テーブルから当日の BUY シグナルを読み込み、
 ポートフォリオ構築を行って signal_queue と portfolio_targets に書き込む。
 
 環境変数:
-    PORTFOLIO_VALUE: 総資産額（円）。デフォルト: 10,000,000
+    PORTFOLIO_VALUE: Live 時フォールバック用総資産前提値（円）。
+                     通常はカブステーション余力 API / DuckDB 実績値から自動取得されるため設定不要。
+                     デフォルト: 10,000,000
+    PAPER_TRADING_INITIAL_CASH: Paper 時フォールバック用初期資金（円）。
+                                通常は paper_trading.db の約定履歴から自動算出される。
+                                デフォルト: 10,000,000
 """
 
 from __future__ import annotations
 
 import calendar
+import contextlib
 import logging
-import os
+import sqlite3
 import sys
 import uuid
 from datetime import date, datetime, timezone
@@ -49,10 +55,161 @@ from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_loggin
 _run_log = setup_logging(app_name="portfolio_construction", capture_stdio=True)
 logger = logging.getLogger(__name__)
 
-_DEFAULT_PORTFOLIO_VALUE = 10_000_000
 _MAX_UTILIZATION = 0.70
 _JOB_NAME = "portfolio_construction_job"
 _APP_NAME = "portfolio_construction"
+
+
+def _calc_live_portfolio_value(
+    settings: Settings,
+    duckdb_conn: duckdb.DuckDBPyConnection,
+) -> tuple[float, float]:
+    """Live モード用 (portfolio_value, available_cash) を算出する。
+
+    portfolio_value: DuckDB portfolio_performance の直近 equity → PORTFOLIO_VALUE 環境変数
+    available_cash:  カブステーション /wallet/cash API → portfolio_value × max_utilization
+    """
+    fallback_pv = settings.portfolio_value
+
+    portfolio_value = fallback_pv
+    try:
+        row = duckdb_conn.execute(
+            "SELECT equity FROM portfolio_performance WHERE env = 'live' ORDER BY date DESC LIMIT 1"
+        ).fetchone()
+        if row and row[0] is not None:
+            portfolio_value = float(row[0])
+            logger.info("portfolio_value: DuckDB 実績値=%.0f 円 (env=live)", portfolio_value)
+        else:
+            logger.info(
+                "portfolio_performance に live データなし。PORTFOLIO_VALUE=%.0f 円を使用",
+                fallback_pv,
+            )
+    except Exception:
+        logger.warning(
+            "DuckDB portfolio_performance 参照に失敗。フォールバックを使用", exc_info=True
+        )
+
+    available_cash = portfolio_value * _MAX_UTILIZATION
+    try:
+        from kabusys.execution.kabu_client import KabuStationClient
+
+        client = KabuStationClient(
+            api_password=settings.kabu_api_password,
+            trade_password=settings.kabu_trade_password,
+            base_url=settings.kabu_api_base_url,
+        )
+        cash = client.get_available_cash()
+        available_cash = cash
+        logger.info("available_cash: カブステーション API 余力=%.0f 円", available_cash)
+    except Exception:
+        logger.warning(
+            "カブステーション余力 API 呼び出しに失敗。"
+            "portfolio_value × max_utilization=%.0f 円を使用",
+            available_cash,
+            exc_info=True,
+        )
+
+    return portfolio_value, available_cash
+
+
+def _calc_paper_portfolio_value(
+    settings: Settings,
+    duckdb_conn: duckdb.DuckDBPyConnection,
+) -> tuple[float, float]:
+    """Paper モード用 (portfolio_value, available_cash) を算出する。
+
+    paper_trading.db の約定履歴から現金残高・保有ポジション時価を計算する。
+    DB が存在しない・読み取り失敗時は PAPER_TRADING_INITIAL_CASH にフォールバックする。
+
+    portfolio_value = 現金残高 + 保有ポジション時価
+    available_cash  = 現金残高（マイナスの場合は 0 に補正）
+    """
+    initial_cash = settings.paper_trading_initial_cash
+    sqlite_path = settings.paper_sqlite_path
+
+    if not sqlite_path.exists():
+        logger.info(
+            "paper_trading.db が未存在。PAPER_TRADING_INITIAL_CASH=%.0f 円を使用", initial_cash
+        )
+        return initial_cash, initial_cash * _MAX_UTILIZATION
+
+    try:
+        with contextlib.closing(sqlite3.connect(str(sqlite_path))) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                "SELECT side, code, filled_qty, avg_fill_price FROM orders"
+                " WHERE filled_qty > 0 AND avg_fill_price IS NOT NULL"
+            ).fetchall()
+    except Exception:
+        logger.warning(
+            "paper_trading.db の読み込みに失敗。PAPER_TRADING_INITIAL_CASH=%.0f 円を使用",
+            initial_cash,
+            exc_info=True,
+        )
+        return initial_cash, initial_cash * _MAX_UTILIZATION
+
+    data: dict[str, list[float]] = {}
+    for row in rows:
+        side = (row["side"] or "").lower()
+        if side not in ("buy", "sell"):
+            continue
+        code = row["code"]
+        filled_qty = int(row["filled_qty"])
+        avg_price = float(row["avg_fill_price"])
+        if code not in data:
+            data[code] = [0.0, 0.0, 0.0, 0.0]
+        if side == "buy":
+            data[code][0] += filled_qty
+            data[code][1] += filled_qty * avg_price
+        else:
+            data[code][2] += filled_qty
+            data[code][3] += filled_qty * avg_price
+
+    net_cash = initial_cash
+    positions: dict[str, int] = {}
+    for code, (buy_qty, buy_cost, sell_qty, sell_proceeds) in data.items():
+        net_cash -= buy_cost
+        net_cash += sell_proceeds
+        net_qty = int(buy_qty) - int(sell_qty)
+        if net_qty > 0:
+            positions[code] = net_qty
+
+    market_value = 0.0
+    if positions:
+        codes = list(positions.keys())
+        code_params = ",".join(["?"] * len(codes))
+        try:
+            price_rows = duckdb_conn.execute(
+                f"""
+                SELECT p.code, p.close
+                FROM prices_daily p
+                INNER JOIN (
+                    SELECT code, MAX(date) AS max_date
+                    FROM prices_daily
+                    WHERE code IN ({code_params})
+                    GROUP BY code
+                ) latest ON p.code = latest.code AND p.date = latest.max_date
+                """,
+                codes,
+            ).fetchall()
+            for pcode, price in price_rows:
+                if price is not None and pcode in positions:
+                    market_value += positions[pcode] * float(price)
+        except Exception:
+            logger.warning(
+                "ポジション時価計算に失敗。現金のみで portfolio_value を算出します", exc_info=True
+            )
+
+    available_cash = max(net_cash, 0.0)
+    portfolio_value = max(net_cash + market_value, 0.0)
+
+    logger.info(
+        "Paper portfolio_value 算出: 現金=%.0f 円, 時価=%.0f 円, 合計=%.0f 円",
+        net_cash,
+        market_value,
+        portfolio_value,
+    )
+    return portfolio_value, available_cash
 
 
 def _get_today_return(conn: duckdb.DuckDBPyConnection, target_date: date, env: str) -> float | None:
@@ -82,17 +239,18 @@ def main() -> None:
     try:
         settings = Settings()
         conn = duckdb.connect(str(settings.duckdb_path))
-        portfolio_value_str = os.environ.get("PORTFOLIO_VALUE", str(_DEFAULT_PORTFOLIO_VALUE))
-        try:
-            portfolio_value = float(portfolio_value_str)
-        except ValueError:
-            logger.warning(
-                "PORTFOLIO_VALUE が不正な値です (%s)。デフォルト値を使用します: %s",
-                portfolio_value_str,
-                _DEFAULT_PORTFOLIO_VALUE,
+
+        if settings.is_live:
+            portfolio_value, available_cash = _calc_live_portfolio_value(settings, conn)
+        elif settings.is_paper or settings.is_dev:
+            portfolio_value, available_cash = _calc_paper_portfolio_value(settings, conn)
+        else:
+            portfolio_value = settings.portfolio_value
+            available_cash = portfolio_value * _MAX_UTILIZATION
+            logger.info(
+                "portfolio_value: PORTFOLIO_VALUE=%.0f 円 (env=%s)", portfolio_value, settings.env
             )
-            portfolio_value = float(_DEFAULT_PORTFOLIO_VALUE)
-        available_cash = portfolio_value * _MAX_UTILIZATION
+
         inserted = 0
 
         cur = conn.execute(

--- a/scripts/run_portfolio_construction.py
+++ b/scripts/run_portfolio_construction.py
@@ -55,7 +55,7 @@ from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_loggin
 _run_log = setup_logging(app_name="portfolio_construction", capture_stdio=True)
 logger = logging.getLogger(__name__)
 
-_MAX_UTILIZATION = 0.70
+_MAX_UTILIZATION = 0.70  # Live モード専用: 余力の安全マージン。Paper では適用しない
 _JOB_NAME = "portfolio_construction_job"
 _APP_NAME = "portfolio_construction"
 
@@ -131,7 +131,7 @@ def _calc_paper_portfolio_value(
         logger.info(
             "paper_trading.db が未存在。PAPER_TRADING_INITIAL_CASH=%.0f 円を使用", initial_cash
         )
-        return initial_cash, initial_cash * _MAX_UTILIZATION
+        return initial_cash, initial_cash
 
     try:
         with contextlib.closing(sqlite3.connect(str(sqlite_path))) as conn:
@@ -146,7 +146,7 @@ def _calc_paper_portfolio_value(
             initial_cash,
             exc_info=True,
         )
-        return initial_cash, initial_cash * _MAX_UTILIZATION
+        return initial_cash, initial_cash
 
     data: dict[str, list[float]] = {}
     for row in rows:

--- a/scripts/run_portfolio_construction.py
+++ b/scripts/run_portfolio_construction.py
@@ -78,8 +78,16 @@ def _calc_live_portfolio_value(
             "SELECT equity FROM portfolio_performance WHERE env = 'live' ORDER BY date DESC LIMIT 1"
         ).fetchone()
         if row and row[0] is not None:
-            portfolio_value = float(row[0])
-            logger.info("portfolio_value: DuckDB 実績値=%.0f 円 (env=live)", portfolio_value)
+            equity = float(row[0])
+            if math.isfinite(equity) and equity > 0:
+                portfolio_value = equity
+                logger.info("portfolio_value: DuckDB 実績値=%.0f 円 (env=live)", portfolio_value)
+            else:
+                logger.warning(
+                    "DuckDB equity が不正値(%.0f)。PORTFOLIO_VALUE=%.0f 円を使用",
+                    equity,
+                    fallback_pv,
+                )
         else:
             logger.info(
                 "portfolio_performance に live データなし。PORTFOLIO_VALUE=%.0f 円を使用",

--- a/src/kabusys/config.py
+++ b/src/kabusys/config.py
@@ -247,6 +247,25 @@ class Settings:
         return Path(os.environ.get("SQLITE_PATH", "data/monitoring.db")).expanduser()
 
     @property
+    def portfolio_value(self) -> float:
+        """portfolio_construction フォールバック用総資産前提値（PORTFOLIO_VALUE、デフォルト: 10,000,000）。
+
+        Live 時: カブステーション余力 API / DuckDB portfolio_performance から自動取得できない場合のみ参照。
+        Paper 時: paper_trading.db から自動計算できない場合のみ参照。
+        Backtest 時: simulator.portfolio_value を使用するため参照されない。
+        """
+        raw = os.environ.get("PORTFOLIO_VALUE", "10000000")
+        try:
+            val = float(raw)
+        except ValueError as exc:
+            raise ValueError(
+                f"PORTFOLIO_VALUE の値が不正です: '{raw}'. 正の数値で設定してください。"
+            ) from exc
+        if val <= 0:
+            raise ValueError(f"PORTFOLIO_VALUE は正の値で設定してください（現在値: {val}）")
+        return val
+
+    @property
     def paper_trading_initial_cash(self) -> float:
         """ペーパートレード用初期資金（PAPER_TRADING_INITIAL_CASH、デフォルト: 10,000,000）。"""
         raw = os.environ.get("PAPER_TRADING_INITIAL_CASH", "10000000")

--- a/tests/test_scripts_batch.py
+++ b/tests/test_scripts_batch.py
@@ -439,6 +439,36 @@ def test_settings_portfolio_value_non_numeric(monkeypatch):
         Settings().portfolio_value
 
 
+# ---------- Settings.paper_trading_initial_cash ----------
+
+
+def test_settings_paper_trading_initial_cash_negative(monkeypatch):
+    """PAPER_TRADING_INITIAL_CASH が負値のとき ValueError を送出する。"""
+    from kabusys.config import Settings
+
+    monkeypatch.setenv("PAPER_TRADING_INITIAL_CASH", "-1")
+    with pytest.raises(ValueError, match="正の値"):
+        Settings().paper_trading_initial_cash
+
+
+def test_settings_paper_trading_initial_cash_zero(monkeypatch):
+    """PAPER_TRADING_INITIAL_CASH が 0 のとき ValueError を送出する。"""
+    from kabusys.config import Settings
+
+    monkeypatch.setenv("PAPER_TRADING_INITIAL_CASH", "0")
+    with pytest.raises(ValueError, match="正の値"):
+        Settings().paper_trading_initial_cash
+
+
+def test_settings_paper_trading_initial_cash_non_numeric(monkeypatch):
+    """PAPER_TRADING_INITIAL_CASH が数値でないとき ValueError を送出する。"""
+    from kabusys.config import Settings
+
+    monkeypatch.setenv("PAPER_TRADING_INITIAL_CASH", "abc")
+    with pytest.raises(ValueError, match="不正"):
+        Settings().paper_trading_initial_cash
+
+
 # ---------- run_tdnet_collection ----------
 
 

--- a/tests/test_scripts_batch.py
+++ b/tests/test_scripts_batch.py
@@ -105,7 +105,17 @@ def test_run_strategy_signal_calls_generate_signals():
 # ---------- run_portfolio_construction ----------
 
 
-def test_portfolio_construction_writes_signal_queue():
+def _mock_paper_settings(mock_settings: MagicMock, tmp_path: Path) -> None:
+    """portfolio_construction テスト用の Paper モード settings を設定する。"""
+    mock_settings.return_value.duckdb_path = Path("/fake.duckdb")
+    mock_settings.return_value.is_live = False
+    mock_settings.return_value.is_paper = True
+    mock_settings.return_value.is_dev = False
+    mock_settings.return_value.paper_trading_initial_cash = 10_000_000.0
+    mock_settings.return_value.paper_sqlite_path = tmp_path / "nonexistent.db"
+
+
+def test_portfolio_construction_writes_signal_queue(tmp_path: Path):
     import run_portfolio_construction
 
     mock_conn = MagicMock()
@@ -143,7 +153,7 @@ def test_portfolio_construction_writes_signal_queue():
         patch("run_portfolio_construction.Settings") as mock_settings,
         patch("run_portfolio_construction.duckdb.connect", return_value=mock_conn),
     ):
-        mock_settings.return_value.duckdb_path = Path("/fake.duckdb")
+        _mock_paper_settings(mock_settings, tmp_path)
         run_portfolio_construction.main()
 
     # signal_queue への INSERT が呼ばれたことを確認
@@ -155,7 +165,7 @@ def test_portfolio_construction_writes_signal_queue():
     assert len(insert_calls) >= 1
 
 
-def test_portfolio_construction_no_signals_exits_0():
+def test_portfolio_construction_no_signals_exits_0(tmp_path: Path):
     """シグナルが 0 件のとき正常終了する（signal_queue は空のまま）。"""
     import run_portfolio_construction
 
@@ -169,7 +179,7 @@ def test_portfolio_construction_no_signals_exits_0():
         patch("run_portfolio_construction.Settings") as mock_settings,
         patch("run_portfolio_construction.duckdb.connect", return_value=mock_conn),
     ):
-        mock_settings.return_value.duckdb_path = Path("/fake.duckdb")
+        _mock_paper_settings(mock_settings, tmp_path)
         run_portfolio_construction.main()  # SystemExit が起きないこと
 
 

--- a/tests/test_scripts_batch.py
+++ b/tests/test_scripts_batch.py
@@ -365,6 +365,28 @@ def test_calc_live_portfolio_value_both_fail():
     assert ac == pytest.approx(10_000_000.0 * 0.70)
 
 
+def test_calc_live_portfolio_value_no_duckdb_row_api_success():
+    """DuckDB に live 行なし + Kabu API 成功 → portfolio_value=ENV値, available_cash=API値。"""
+    import run_portfolio_construction
+
+    settings = _make_live_settings()
+    db_cursor = MagicMock()
+    db_cursor.fetchone.return_value = None  # live 行なし
+    mock_conn = MagicMock()
+    mock_conn.execute.return_value = db_cursor
+
+    mock_kabu_module = MagicMock()
+    mock_client = MagicMock()
+    mock_client.get_available_cash.return_value = 7_000_000.0
+    mock_kabu_module.KabuStationClient.return_value = mock_client
+
+    with patch.dict("sys.modules", {"kabusys.execution.kabu_client": mock_kabu_module}):
+        pv, ac = run_portfolio_construction._calc_live_portfolio_value(settings, mock_conn)
+
+    assert pv == pytest.approx(10_000_000.0)  # ENV フォールバック
+    assert ac == pytest.approx(7_000_000.0)  # API 値
+
+
 def test_calc_live_portfolio_value_api_returns_invalid():
     """Kabu API が不正値（負値）を返したとき pv×max_utilization にフォールバックする。"""
     import run_portfolio_construction

--- a/tests/test_scripts_batch.py
+++ b/tests/test_scripts_batch.py
@@ -183,6 +183,193 @@ def test_portfolio_construction_no_signals_exits_0(tmp_path: Path):
         run_portfolio_construction.main()  # SystemExit が起きないこと
 
 
+# ---------- _calc_paper_portfolio_value ----------
+
+
+def test_calc_paper_portfolio_value_db_not_exists(tmp_path: Path):
+    """paper_trading.db が未存在のとき (initial_cash, initial_cash) を返す（_MAX_UTILIZATION 非適用）。"""
+    import sqlite3
+
+    import run_portfolio_construction
+
+    settings = MagicMock()
+    settings.paper_trading_initial_cash = 5_000_000.0
+    settings.paper_sqlite_path = tmp_path / "nonexistent.db"
+    mock_conn = MagicMock()
+
+    pv, ac = run_portfolio_construction._calc_paper_portfolio_value(settings, mock_conn)
+
+    assert pv == pytest.approx(5_000_000.0)
+    assert ac == pytest.approx(5_000_000.0)
+
+
+def test_calc_paper_portfolio_value_with_positions(tmp_path: Path):
+    """買いポジションあり: portfolio_value = 現金残高 + 時価。"""
+    import sqlite3
+
+    import run_portfolio_construction
+
+    db_path = tmp_path / "paper_trading.db"
+    with sqlite3.connect(str(db_path)) as db:
+        db.execute(
+            "CREATE TABLE orders"
+            " (side TEXT, code TEXT, filled_qty INTEGER, avg_fill_price REAL)"
+        )
+        db.execute("INSERT INTO orders VALUES ('buy', '7203', 100, 2000.0)")
+
+    settings = MagicMock()
+    settings.paper_trading_initial_cash = 1_000_000.0
+    settings.paper_sqlite_path = db_path
+
+    price_cursor = MagicMock()
+    price_cursor.fetchall.return_value = [("7203", 2500.0)]
+    mock_conn = MagicMock()
+    mock_conn.execute.return_value = price_cursor
+
+    pv, ac = run_portfolio_construction._calc_paper_portfolio_value(settings, mock_conn)
+
+    # net_cash = 1,000,000 - 100*2000 = 800,000
+    # market_value = 100 * 2500 = 250,000
+    assert pv == pytest.approx(1_050_000.0)
+    assert ac == pytest.approx(800_000.0)
+
+
+def test_calc_paper_portfolio_value_negative_cash_clipped(tmp_path: Path):
+    """net_cash が負のとき available_cash は 0 に補正される。"""
+    import sqlite3
+
+    import run_portfolio_construction
+
+    db_path = tmp_path / "paper_trading.db"
+    with sqlite3.connect(str(db_path)) as db:
+        db.execute(
+            "CREATE TABLE orders"
+            " (side TEXT, code TEXT, filled_qty INTEGER, avg_fill_price REAL)"
+        )
+        # 1,000株買い (cost=2,000,000 > initial_cash=1,000,000)
+        db.execute("INSERT INTO orders VALUES ('buy', '7203', 1000, 2000.0)")
+
+    settings = MagicMock()
+    settings.paper_trading_initial_cash = 1_000_000.0
+    settings.paper_sqlite_path = db_path
+
+    price_cursor = MagicMock()
+    price_cursor.fetchall.return_value = [("7203", 2000.0)]
+    mock_conn = MagicMock()
+    mock_conn.execute.return_value = price_cursor
+
+    pv, ac = run_portfolio_construction._calc_paper_portfolio_value(settings, mock_conn)
+
+    # net_cash = 1,000,000 - 2,000,000 = -1,000,000 → available_cash=0
+    assert ac == pytest.approx(0.0)
+    # portfolio_value = max(-1,000,000 + 2,000,000, 0) = 1,000,000
+    assert pv == pytest.approx(1_000_000.0)
+
+
+def test_calc_paper_portfolio_value_price_fetch_fails(tmp_path: Path):
+    """DuckDB 価格取得失敗時に market_value=0 でフォールバック。"""
+    import sqlite3
+
+    import run_portfolio_construction
+
+    db_path = tmp_path / "paper_trading.db"
+    with sqlite3.connect(str(db_path)) as db:
+        db.execute(
+            "CREATE TABLE orders"
+            " (side TEXT, code TEXT, filled_qty INTEGER, avg_fill_price REAL)"
+        )
+        db.execute("INSERT INTO orders VALUES ('buy', '7203', 100, 2000.0)")
+
+    settings = MagicMock()
+    settings.paper_trading_initial_cash = 1_000_000.0
+    settings.paper_sqlite_path = db_path
+
+    mock_conn = MagicMock()
+    mock_conn.execute.side_effect = Exception("DuckDB connection error")
+
+    pv, ac = run_portfolio_construction._calc_paper_portfolio_value(settings, mock_conn)
+
+    # net_cash = 1,000,000 - 200,000 = 800,000; market_value = 0 (failed)
+    assert pv == pytest.approx(800_000.0)
+    assert ac == pytest.approx(800_000.0)
+
+
+# ---------- _calc_live_portfolio_value ----------
+
+
+def _make_live_settings() -> MagicMock:
+    s = MagicMock()
+    s.portfolio_value = 10_000_000.0
+    s.kabu_api_password = "pass"
+    s.kabu_trade_password = None
+    s.kabu_api_base_url = "http://localhost:18080/kabusapi"
+    return s
+
+
+def test_calc_live_portfolio_value_api_and_duckdb_success():
+    """Kabu API 成功 → available_cash = API 値。portfolio_value = DuckDB 値。"""
+    import run_portfolio_construction
+
+    settings = _make_live_settings()
+    db_cursor = MagicMock()
+    db_cursor.fetchone.return_value = (12_000_000.0,)
+    mock_conn = MagicMock()
+    mock_conn.execute.return_value = db_cursor
+
+    mock_kabu_module = MagicMock()
+    mock_client = MagicMock()
+    mock_client.get_available_cash.return_value = 8_000_000.0
+    mock_kabu_module.KabuStationClient.return_value = mock_client
+
+    with patch.dict("sys.modules", {"kabusys.execution.kabu_client": mock_kabu_module}):
+        pv, ac = run_portfolio_construction._calc_live_portfolio_value(settings, mock_conn)
+
+    assert pv == pytest.approx(12_000_000.0)
+    assert ac == pytest.approx(8_000_000.0)
+
+
+def test_calc_live_portfolio_value_api_fails_duckdb_success():
+    """Kabu API 失敗 + DuckDB 成功 → available_cash = pv × 0.7。"""
+    import run_portfolio_construction
+
+    settings = _make_live_settings()
+    db_cursor = MagicMock()
+    db_cursor.fetchone.return_value = (12_000_000.0,)
+    mock_conn = MagicMock()
+    mock_conn.execute.return_value = db_cursor
+
+    mock_kabu_module = MagicMock()
+    mock_client = MagicMock()
+    mock_client.get_available_cash.side_effect = RuntimeError("API error")
+    mock_kabu_module.KabuStationClient.return_value = mock_client
+
+    with patch.dict("sys.modules", {"kabusys.execution.kabu_client": mock_kabu_module}):
+        pv, ac = run_portfolio_construction._calc_live_portfolio_value(settings, mock_conn)
+
+    assert pv == pytest.approx(12_000_000.0)
+    assert ac == pytest.approx(12_000_000.0 * 0.70)
+
+
+def test_calc_live_portfolio_value_both_fail():
+    """Kabu API 失敗 + DuckDB 失敗 → portfolio_value = ENV 値, available_cash = pv × 0.7。"""
+    import run_portfolio_construction
+
+    settings = _make_live_settings()
+    mock_conn = MagicMock()
+    mock_conn.execute.side_effect = Exception("DuckDB error")
+
+    mock_kabu_module = MagicMock()
+    mock_client = MagicMock()
+    mock_client.get_available_cash.side_effect = RuntimeError("API error")
+    mock_kabu_module.KabuStationClient.return_value = mock_client
+
+    with patch.dict("sys.modules", {"kabusys.execution.kabu_client": mock_kabu_module}):
+        pv, ac = run_portfolio_construction._calc_live_portfolio_value(settings, mock_conn)
+
+    assert pv == pytest.approx(10_000_000.0)
+    assert ac == pytest.approx(10_000_000.0 * 0.70)
+
+
 # ---------- run_tdnet_collection ----------
 
 

--- a/tests/test_scripts_batch.py
+++ b/tests/test_scripts_batch.py
@@ -210,8 +210,7 @@ def test_calc_paper_portfolio_value_with_positions(tmp_path: Path):
     db_path = tmp_path / "paper_trading.db"
     with sqlite3.connect(str(db_path)) as db:
         db.execute(
-            "CREATE TABLE orders"
-            " (side TEXT, code TEXT, filled_qty INTEGER, avg_fill_price REAL)"
+            "CREATE TABLE orders (side TEXT, code TEXT, filled_qty INTEGER, avg_fill_price REAL)"
         )
         db.execute("INSERT INTO orders VALUES ('buy', '7203', 100, 2000.0)")
 
@@ -241,8 +240,7 @@ def test_calc_paper_portfolio_value_negative_cash_clipped(tmp_path: Path):
     db_path = tmp_path / "paper_trading.db"
     with sqlite3.connect(str(db_path)) as db:
         db.execute(
-            "CREATE TABLE orders"
-            " (side TEXT, code TEXT, filled_qty INTEGER, avg_fill_price REAL)"
+            "CREATE TABLE orders (side TEXT, code TEXT, filled_qty INTEGER, avg_fill_price REAL)"
         )
         # 1,000株買い (cost=2,000,000 > initial_cash=1,000,000)
         db.execute("INSERT INTO orders VALUES ('buy', '7203', 1000, 2000.0)")
@@ -273,8 +271,7 @@ def test_calc_paper_portfolio_value_price_fetch_fails(tmp_path: Path):
     db_path = tmp_path / "paper_trading.db"
     with sqlite3.connect(str(db_path)) as db:
         db.execute(
-            "CREATE TABLE orders"
-            " (side TEXT, code TEXT, filled_qty INTEGER, avg_fill_price REAL)"
+            "CREATE TABLE orders (side TEXT, code TEXT, filled_qty INTEGER, avg_fill_price REAL)"
         )
         db.execute("INSERT INTO orders VALUES ('buy', '7203', 100, 2000.0)")
 

--- a/tests/test_scripts_batch.py
+++ b/tests/test_scripts_batch.py
@@ -188,8 +188,6 @@ def test_portfolio_construction_no_signals_exits_0(tmp_path: Path):
 
 def test_calc_paper_portfolio_value_db_not_exists(tmp_path: Path):
     """paper_trading.db が未存在のとき (initial_cash, initial_cash) を返す（_MAX_UTILIZATION 非適用）。"""
-    import sqlite3
-
     import run_portfolio_construction
 
     settings = MagicMock()

--- a/tests/test_scripts_batch.py
+++ b/tests/test_scripts_batch.py
@@ -365,6 +365,58 @@ def test_calc_live_portfolio_value_both_fail():
     assert ac == pytest.approx(10_000_000.0 * 0.70)
 
 
+def test_calc_live_portfolio_value_api_returns_invalid():
+    """Kabu API が不正値（負値）を返したとき pv×max_utilization にフォールバックする。"""
+    import run_portfolio_construction
+
+    settings = _make_live_settings()
+    db_cursor = MagicMock()
+    db_cursor.fetchone.return_value = (10_000_000.0,)
+    mock_conn = MagicMock()
+    mock_conn.execute.return_value = db_cursor
+
+    mock_kabu_module = MagicMock()
+    mock_client = MagicMock()
+    mock_client.get_available_cash.return_value = -1.0  # 不正値
+    mock_kabu_module.KabuStationClient.return_value = mock_client
+
+    with patch.dict("sys.modules", {"kabusys.execution.kabu_client": mock_kabu_module}):
+        pv, ac = run_portfolio_construction._calc_live_portfolio_value(settings, mock_conn)
+
+    assert pv == pytest.approx(10_000_000.0)
+    assert ac == pytest.approx(10_000_000.0 * 0.70)
+
+
+# ---------- Settings.portfolio_value ----------
+
+
+def test_settings_portfolio_value_negative(monkeypatch):
+    """PORTFOLIO_VALUE が負値のとき ValueError を送出する。"""
+    from kabusys.config import Settings
+
+    monkeypatch.setenv("PORTFOLIO_VALUE", "-1")
+    with pytest.raises(ValueError, match="正の値"):
+        Settings().portfolio_value
+
+
+def test_settings_portfolio_value_zero(monkeypatch):
+    """PORTFOLIO_VALUE が 0 のとき ValueError を送出する。"""
+    from kabusys.config import Settings
+
+    monkeypatch.setenv("PORTFOLIO_VALUE", "0")
+    with pytest.raises(ValueError, match="正の値"):
+        Settings().portfolio_value
+
+
+def test_settings_portfolio_value_non_numeric(monkeypatch):
+    """PORTFOLIO_VALUE が数値でないとき ValueError を送出する。"""
+    from kabusys.config import Settings
+
+    monkeypatch.setenv("PORTFOLIO_VALUE", "abc")
+    with pytest.raises(ValueError, match="不正"):
+        Settings().portfolio_value
+
+
 # ---------- run_tdnet_collection ----------
 
 


### PR DESCRIPTION
## 概要

Issue #335 の実装。

`run_portfolio_construction.py` が静的な `PORTFOLIO_VALUE` 環境変数に依存していた問題を修正し、環境別に実際の資産・余力を動的に取得してポジションサイジングを行うよう改善。

## 変更内容

### `scripts/run_portfolio_construction.py`

**Live モード（`_calc_live_portfolio_value`）:**
- `portfolio_value`: DuckDB `portfolio_performance.equity`（直近 live エントリ）→ `PORTFOLIO_VALUE` 環境変数
- `available_cash`: カブステーション `/wallet/cash` API → `portfolio_value × max_utilization`
- API 失敗・DuckDB データなしはそれぞれ独立してフォールバック

**Paper モード（`_calc_paper_portfolio_value`）:**
- `paper_trading.db` の約定履歴から現金残高を計算（`_restore_paper_state` と同ロジック）
- 保有ポジションの時価を DuckDB `prices_daily` から取得して加算
- DB 未存在・読み取り失敗時は `PAPER_TRADING_INITIAL_CASH` 環境変数にフォールバック

**Backtest:** 変更なし（`simulator.portfolio_value` で動的管理済み）

### `src/kabusys/config.py`

- `Settings.portfolio_value` プロパティを追加（`PORTFOLIO_VALUE` 環境変数、デフォルト 10,000,000）

### `tests/test_scripts_batch.py`

- `Settings` モックに `is_live` / `is_paper` / `is_dev` を明示設定するヘルパー `_mock_paper_settings` を追加
- `tmp_path` フィクスチャを使用して `paper_sqlite_path` を非存在パスに設定

## テスト

```
1918 passed in 59.84s
```

## フォールバック連鎖（Live）

```
available_cash の取得:
  1. カブステーション /wallet/cash API（21:00 時点で起動中を期待）
  2. portfolio_value × max_utilization（API 失敗時）

portfolio_value の取得:
  1. DuckDB portfolio_performance.equity（env='live' の直近値）
  2. PORTFOLIO_VALUE 環境変数（DuckDB データなし・失敗時）
```

## フォールバック連鎖（Paper）

```
portfolio_value / available_cash の取得:
  1. paper_trading.db の約定履歴（現金残高 + ポジション時価）
  2. PAPER_TRADING_INITIAL_CASH 環境変数（DB 未存在・失敗時）
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)