### PR TITLE
feat: raw_prices → prices_daily 同期ステップを ETL に追加 (#337)

### DIFF
--- a/src/kabusys/data/pipeline.py
+++ b/src/kabusys/data/pipeline.py
@@ -68,6 +68,7 @@ class ETLResult:
         earnings_calendar_saved:     DBに保存を試みた決算カレンダーレコード数。
         dividends_fetched:           取得した配当レコード数。
         dividends_saved:             DBに保存した配当レコード数。
+        prices_daily_synced:         raw_prices -> prices_daily 同期で書き込んだレコード数。
         quality_issues:              品質チェックで検出された問題のリスト。
         errors:                      処理中に発生したエラーの概要メッセージのリスト。
     """
@@ -85,6 +86,7 @@ class ETLResult:
     dividends_saved: int = 0
     topix_fetched: int = 0
     topix_saved: int = 0
+    prices_daily_synced: int = 0
     quality_issues: list[quality.QualityIssue] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
 
@@ -331,6 +333,76 @@ def run_prices_etl(
     return len(records), saved
 
 
+def sync_raw_prices_to_prices_daily(
+    conn: duckdb.DuckDBPyConnection,
+    date_from: date,
+    date_to: date,
+) -> int:
+    """raw_prices から prices_daily へ指定日付範囲を同期する（冪等）。
+
+    フィルタ条件: OHLCV が NOT NULL かつ OHLCV > 0 かつ low <= high。
+    既存行は ON CONFLICT DO UPDATE で上書きする。
+
+    Args:
+        conn:      DuckDB 接続。
+        date_from: 同期開始日（含む）。
+        date_to:   同期終了日（含む）。
+
+    Returns:
+        prices_daily に書き込んだレコード数。
+    """
+    conn.execute("BEGIN")
+    try:
+        conn.execute(
+            """
+            INSERT INTO prices_daily (date, code, open, high, low, close, volume, turnover)
+            SELECT date, code, open, high, low, close, volume, turnover
+            FROM raw_prices
+            WHERE date >= ? AND date <= ?
+              AND open IS NOT NULL AND open > 0
+              AND high IS NOT NULL AND high > 0
+              AND low IS NOT NULL AND low > 0
+              AND close IS NOT NULL AND close > 0
+              AND volume IS NOT NULL
+              AND low <= high
+            ON CONFLICT (date, code) DO UPDATE SET
+                open = excluded.open,
+                high = excluded.high,
+                low = excluded.low,
+                close = excluded.close,
+                volume = excluded.volume,
+                turnover = excluded.turnover
+            """,
+            [date_from, date_to],
+        )
+        row = conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM raw_prices
+            WHERE date >= ? AND date <= ?
+              AND open IS NOT NULL AND open > 0
+              AND high IS NOT NULL AND high > 0
+              AND low IS NOT NULL AND low > 0
+              AND close IS NOT NULL AND close > 0
+              AND volume IS NOT NULL
+              AND low <= high
+            """,
+            [date_from, date_to],
+        ).fetchone()
+        count = int(row[0]) if row else 0
+        conn.execute("COMMIT")
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
+    logger.info(
+        "sync_raw_prices_to_prices_daily: date_from=%s date_to=%s synced=%d",
+        date_from,
+        date_to,
+        count,
+    )
+    return count
+
+
 def run_financials_etl(
     conn: duckdb.DuckDBPyConnection,
     target_date: date,
@@ -572,6 +644,15 @@ def run_daily_etl(
         logger.exception("run_prices_etl 失敗")
         result.errors.append("run_prices_etl 失敗")
 
+    # 2b. raw_prices -> prices_daily 同期
+    try:
+        sync_date_from = trading_day - timedelta(days=backfill_days - 1)
+        synced = sync_raw_prices_to_prices_daily(conn, sync_date_from, trading_day)
+        result.prices_daily_synced = synced
+    except Exception:
+        logger.exception("sync_raw_prices_to_prices_daily 失敗")
+        result.errors.append("sync_raw_prices_to_prices_daily 失敗")
+
     # 3. 財務データETL
     try:
         fetched, saved = run_financials_etl(conn, trading_day, backfill_days=backfill_days)
@@ -634,6 +715,7 @@ def run_daily_etl(
     logger.info(
         "run_daily_etl 完了: date=%s "
         "prices fetched=%d saved=%d "
+        "prices_daily_synced=%d "
         "financials fetched=%d saved=%d "
         "dividends fetched=%d saved=%d "
         "calendar fetched=%d saved=%d "
@@ -642,6 +724,7 @@ def run_daily_etl(
         today,
         result.prices_fetched,
         result.prices_saved,
+        result.prices_daily_synced,
         result.financials_fetched,
         result.financials_saved,
         result.dividends_fetched,

--- a/src/kabusys/data/pipeline.py
+++ b/src/kabusys/data/pipeline.py
@@ -340,7 +340,11 @@ def sync_raw_prices_to_prices_daily(
 ) -> int:
     """raw_prices から prices_daily へ指定日付範囲を同期する（冪等）。
 
-    フィルタ条件: OHLCV が NOT NULL かつ OHLCV > 0 かつ low <= high。
+    フィルタ条件:
+      - open / high / low / close: NOT NULL かつ > 0
+      - volume: NOT NULL（出来高 0 は許容）
+      - low <= high
+
     既存行は ON CONFLICT DO UPDATE で上書きする。
 
     Args:
@@ -349,7 +353,8 @@ def sync_raw_prices_to_prices_daily(
         date_to:   同期終了日（含む）。
 
     Returns:
-        prices_daily に書き込んだレコード数。
+        同期対象となった (date, code) キーの件数。raw_prices は (date, code) 複合 PK
+        のため COUNT(*) は DISTINCT と等価。INSERT/UPDATE の区別はしない。
     """
     conn.execute("BEGIN")
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,18 @@ MINIMAL_DDL = [
         is_sq_day       BOOLEAN     NOT NULL DEFAULT false,
         holiday_name    VARCHAR
     )""",
+    """CREATE TABLE IF NOT EXISTS prices_daily (
+        date        DATE          NOT NULL,
+        code        VARCHAR       NOT NULL,
+        open        DECIMAL(18,4) NOT NULL,
+        high        DECIMAL(18,4) NOT NULL,
+        low         DECIMAL(18,4) NOT NULL,
+        close       DECIMAL(18,4) NOT NULL,
+        volume      BIGINT        NOT NULL,
+        turnover    DECIMAL(18,2),
+        PRIMARY KEY (date, code),
+        CHECK (low <= high)
+    )""",
 ]
 
 

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -692,3 +692,25 @@ class TestSyncRawPricesToPricesDaily:
         """raw_prices が空のとき 0 を返すこと。"""
         count = sync_raw_prices_to_prices_daily(mem_db, date(2024, 1, 10), date(2024, 1, 10))
         assert count == 0
+
+    def test_volume_zero_is_accepted(self, mem_db):
+        """volume=0 のレコードは同期されること（出来高 0 は許容する設計）。"""
+        _insert_raw_price(mem_db, "2024-01-10", volume=0)
+        count = sync_raw_prices_to_prices_daily(mem_db, date(2024, 1, 10), date(2024, 1, 10))
+        assert count == 1
+
+    def test_turnover_null_is_accepted(self, mem_db):
+        """turnover が NULL のレコードは同期されること（prices_daily DDL で NULL 可）。"""
+        _insert_raw_price(mem_db, "2024-01-10", turnover=None)
+        count = sync_raw_prices_to_prices_daily(mem_db, date(2024, 1, 10), date(2024, 1, 10))
+        assert count == 1
+        row = mem_db.execute(
+            "SELECT turnover FROM prices_daily WHERE date='2024-01-10' AND code='7203'"
+        ).fetchone()
+        assert row[0] is None
+
+    def test_low_equals_high_is_accepted(self, mem_db):
+        """low == high の境界値は同期されること（CHECK (low <= high) を満たす）。"""
+        _insert_raw_price(mem_db, "2024-01-10", low=2800.0, high=2800.0)
+        count = sync_raw_prices_to_prices_daily(mem_db, date(2024, 1, 10), date(2024, 1, 10))
+        assert count == 1

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -595,3 +595,100 @@ class TestRunTopixEtl:
             [(date(2024, 1, 10),), (date(2024, 1, 11),)],
         )
         assert get_last_topix_date(mem_db_topix) == date(2024, 1, 11)
+
+
+# ---------------------------------------------------------------------------
+# sync_raw_prices_to_prices_daily
+# ---------------------------------------------------------------------------
+
+
+from kabusys.data.pipeline import sync_raw_prices_to_prices_daily  # noqa: E402
+
+
+def _insert_raw_price(
+    conn,
+    date_str: str,
+    code: str = "7203",
+    open_: float | None = 2800.0,
+    high: float | None = 2850.0,
+    low: float | None = 2780.0,
+    close: float | None = 2830.0,
+    volume: int | None = 1000000,
+    turnover: float | None = 2830000000.0,
+) -> None:
+    conn.execute(
+        "INSERT INTO raw_prices (date, code, open, high, low, close, volume, turnover) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
+        "ON CONFLICT (date, code) DO UPDATE SET "
+        "open=excluded.open, high=excluded.high, low=excluded.low, "
+        "close=excluded.close, volume=excluded.volume, turnover=excluded.turnover",
+        [date_str, code, open_, high, low, close, volume, turnover],
+    )
+
+
+class TestSyncRawPricesToPricesDaily:
+    def test_basic_sync(self, mem_db):
+        """有効なレコードが prices_daily に書き込まれること。"""
+        _insert_raw_price(mem_db, "2024-01-10")
+        count = sync_raw_prices_to_prices_daily(mem_db, date(2024, 1, 10), date(2024, 1, 10))
+        assert count == 1
+        row = mem_db.execute(
+            "SELECT close FROM prices_daily WHERE date='2024-01-10' AND code='7203'"
+        ).fetchone()
+        assert row is not None
+        assert float(row[0]) == 2830.0
+
+    def test_idempotent(self, mem_db):
+        """同一レコードを2回同期しても prices_daily の件数は変わらないこと。"""
+        _insert_raw_price(mem_db, "2024-01-10")
+        sync_raw_prices_to_prices_daily(mem_db, date(2024, 1, 10), date(2024, 1, 10))
+        count2 = sync_raw_prices_to_prices_daily(mem_db, date(2024, 1, 10), date(2024, 1, 10))
+        assert count2 == 1
+        rows = mem_db.execute("SELECT COUNT(*) FROM prices_daily").fetchone()[0]
+        assert rows == 1
+
+    def test_update_on_conflict(self, mem_db):
+        """raw_prices の値が変わったとき prices_daily も上書きされること。"""
+        _insert_raw_price(mem_db, "2024-01-10", close=2830.0)
+        sync_raw_prices_to_prices_daily(mem_db, date(2024, 1, 10), date(2024, 1, 10))
+        _insert_raw_price(mem_db, "2024-01-10", close=2900.0)
+        sync_raw_prices_to_prices_daily(mem_db, date(2024, 1, 10), date(2024, 1, 10))
+        close = mem_db.execute(
+            "SELECT close FROM prices_daily WHERE date='2024-01-10' AND code='7203'"
+        ).fetchone()[0]
+        assert float(close) == 2900.0
+
+    def test_filters_null_ohlcv(self, mem_db):
+        """OHLCV に NULL があるレコードは同期されないこと。"""
+        _insert_raw_price(mem_db, "2024-01-10", close=None)
+        count = sync_raw_prices_to_prices_daily(mem_db, date(2024, 1, 10), date(2024, 1, 10))
+        assert count == 0
+        rows = mem_db.execute("SELECT COUNT(*) FROM prices_daily").fetchone()[0]
+        assert rows == 0
+
+    def test_filters_zero_open(self, mem_db):
+        """open が 0 のレコードは同期されないこと。"""
+        _insert_raw_price(mem_db, "2024-01-10", open_=0.0)
+        count = sync_raw_prices_to_prices_daily(mem_db, date(2024, 1, 10), date(2024, 1, 10))
+        assert count == 0
+
+    def test_filters_low_gt_high(self, mem_db):
+        """low > high の不正レコードは同期されないこと。"""
+        _insert_raw_price(mem_db, "2024-01-10", low=2900.0, high=2800.0)
+        count = sync_raw_prices_to_prices_daily(mem_db, date(2024, 1, 10), date(2024, 1, 10))
+        assert count == 0
+
+    def test_date_range_filter(self, mem_db):
+        """指定した日付範囲外のレコードは同期されないこと。"""
+        _insert_raw_price(mem_db, "2024-01-09")
+        _insert_raw_price(mem_db, "2024-01-10", code="8001")
+        _insert_raw_price(mem_db, "2024-01-11")
+        count = sync_raw_prices_to_prices_daily(mem_db, date(2024, 1, 10), date(2024, 1, 10))
+        assert count == 1
+        row = mem_db.execute("SELECT code FROM prices_daily").fetchone()
+        assert row[0] == "8001"
+
+    def test_empty_raw_prices(self, mem_db):
+        """raw_prices が空のとき 0 を返すこと。"""
+        count = sync_raw_prices_to_prices_daily(mem_db, date(2024, 1, 10), date(2024, 1, 10))
+        assert count == 0


### PR DESCRIPTION
## 概要

Issue #337: `run_daily_etl` が `raw_prices` に書き込んだ後、`prices_daily` へ同期しないため `night_batch_report` が prices_daily=0 でブロックされていた問題を修正する。

## 変更内容

### `src/kabusys/data/pipeline.py`
- `sync_raw_prices_to_prices_daily(conn, date_from, date_to) -> int` 関数を追加
  - フィルタ条件: OHLCV が NOT NULL かつ > 0 かつ `low <= high`
  - `ON CONFLICT DO UPDATE` で冪等動作を保証
  - `BEGIN` / `ROLLBACK` トランザクションで保護
- `run_daily_etl()` にステップ 2b として同期呼び出しを挿入（`run_prices_etl` 直後）
- 完了ログに `prices_daily_synced=%d` を追加
- `ETLResult.prices_daily_synced` フィールドは前コミットで追加済み

### `tests/conftest.py`
- `MINIMAL_DDL` に `prices_daily` テーブル定義を追加（テスト共通フィクスチャ）

### `tests/test_data_pipeline.py`
- `TestSyncRawPricesToPricesDaily` クラスを追加（8テスト）
  - 基本同期、冪等性、ON CONFLICT 更新
  - NULL OHLCV フィルタ、zero open フィルタ、low > high フィルタ
  - 日付範囲フィルタ、空テーブル

## テスト結果

```
43 passed in 1.29s
```

## 根本原因

`save_daily_quotes()` は `raw_prices` のみに書き込む。`prices_daily` への `INSERT` は `bootstrap/loaders.py` にしか存在せず、daily ETL では呼ばれていなかった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)