### PR TITLE
feat: BUY フィルタに RSI(14) 過熱判定を追加して急騰直後の購入を抑制する (#338)

### DIFF
--- a/config/strategy_config.yaml
+++ b/config/strategy_config.yaml
@@ -25,6 +25,8 @@ strategy:
   gap_up_threshold: 0.05
   # ギャップダウン閾値（この比率以下の寄り安は BUY 抑制）
   gap_down_threshold: -0.03
+  # RSI(14) 過熱判定閾値（この値超の銘柄は BUY 抑制。50 < x <= 100）
+  rsi_overbought_threshold: 70.0
 
 value_score:
   # バリュースコア計算の重み（合計 1.0）

--- a/src/kabusys/data/schema.py
+++ b/src/kabusys/data/schema.py
@@ -205,6 +205,7 @@ CREATE TABLE IF NOT EXISTS features (
     topix_rel_20    DOUBLE,
     topix_rel_60    DOUBLE,
     quality_score   DOUBLE,
+    rsi_14          DOUBLE,
     created_at      TIMESTAMP   NOT NULL DEFAULT current_timestamp,
     PRIMARY KEY (date, code)
 )
@@ -490,6 +491,8 @@ _MIGRATIONS: list[str] = [
     "ALTER TABLE features ADD COLUMN IF NOT EXISTS topix_rel_20 DOUBLE",
     "ALTER TABLE features ADD COLUMN IF NOT EXISTS topix_rel_60 DOUBLE",
     "ALTER TABLE features ADD COLUMN IF NOT EXISTS quality_score DOUBLE",
+    # Issue #338: features に RSI(14) を追加
+    "ALTER TABLE features ADD COLUMN IF NOT EXISTS rsi_14 DOUBLE",
 ]
 
 # ---------------------------------------------------------------------------

--- a/src/kabusys/research/factor_research.py
+++ b/src/kabusys/research/factor_research.py
@@ -535,6 +535,7 @@ def calc_rsi(
         )
         SELECT code,
             CASE
+                WHEN avg_gain = 0 AND avg_loss = 0 THEN NULL
                 WHEN avg_loss = 0 THEN 100.0
                 ELSE 100.0 - 100.0 / (1.0 + avg_gain / avg_loss)
             END AS rsi_14

--- a/src/kabusys/research/factor_research.py
+++ b/src/kabusys/research/factor_research.py
@@ -466,3 +466,84 @@ def calc_quality(
     result = [dict(zip(cols, r)) for r in rows]
     logger.debug("calc_quality: %d 銘柄 date=%s", len(result), target_date)
     return result
+
+
+# ---------------------------------------------------------------------------
+# RSI ファクター
+# ---------------------------------------------------------------------------
+
+_RSI_PERIOD = 14  # Wilder's RSI 期間
+_RSI_SCAN_DAYS = (_RSI_PERIOD + 1) * 3  # データスキャン範囲（カレンダー日）
+
+
+def calc_rsi(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date,
+) -> list[dict[str, Any]]:
+    """RSI(14) を計算する。
+
+    Wilder の平滑移動平均（初期値は単純平均）で計算する。
+    target_date 以前の最新 14+1 件の終値を使用するため、ルックアヘッドバイアスはない。
+    データ件数が 15 件未満の銘柄は rsi_14=None を返す。
+
+    Args:
+        conn:        DuckDB 接続。prices_daily テーブルを参照する。
+        target_date: 計算基準日。
+
+    Returns:
+        [{"code": str, "rsi_14": float | None}, ...] のリスト。
+    """
+    scan_from = target_date - timedelta(days=_RSI_SCAN_DAYS)
+    rows = conn.execute(
+        """
+        WITH price_window AS (
+            SELECT code, date,
+                CAST(close AS DOUBLE) AS close,
+                ROW_NUMBER() OVER (PARTITION BY code ORDER BY date DESC) AS rn
+            FROM prices_daily
+            WHERE date <= ? AND date >= ?
+              AND close IS NOT NULL
+        ),
+        recent AS (
+            SELECT code, date, close
+            FROM price_window
+            WHERE rn <= ?
+        ),
+        changes AS (
+            SELECT code, date,
+                close - LAG(close) OVER (PARTITION BY code ORDER BY date) AS chg
+            FROM recent
+        ),
+        gains_losses AS (
+            SELECT code,
+                GREATEST(chg, 0)  AS gain,
+                GREATEST(-chg, 0) AS loss
+            FROM changes
+            WHERE chg IS NOT NULL
+        ),
+        counts AS (
+            SELECT code, COUNT(*) AS n FROM gains_losses GROUP BY code
+        ),
+        avg_gl AS (
+            SELECT g.code,
+                AVG(g.gain) AS avg_gain,
+                AVG(g.loss) AS avg_loss
+            FROM gains_losses g
+            INNER JOIN counts c ON g.code = c.code
+            WHERE c.n >= ?
+            GROUP BY g.code
+        )
+        SELECT code,
+            CASE
+                WHEN avg_loss = 0 THEN 100.0
+                ELSE 100.0 - 100.0 / (1.0 + avg_gain / avg_loss)
+            END AS rsi_14
+        FROM avg_gl
+        ORDER BY code
+        """,
+        [target_date, scan_from, _RSI_PERIOD + 1, _RSI_PERIOD],
+    ).fetchall()
+
+    result = [{"code": code, "rsi_14": rsi} for code, rsi in rows]
+    logger.debug("calc_rsi: %d 銘柄 date=%s", len(result), target_date)
+    return result

--- a/src/kabusys/research/factor_research.py
+++ b/src/kabusys/research/factor_research.py
@@ -472,7 +472,7 @@ def calc_quality(
 # RSI ファクター
 # ---------------------------------------------------------------------------
 
-_RSI_PERIOD = 14  # Wilder's RSI 期間
+_RSI_PERIOD = 14  # RSI 期間
 _RSI_SCAN_DAYS = (_RSI_PERIOD + 1) * 3  # データスキャン範囲（カレンダー日）
 
 
@@ -480,11 +480,10 @@ def calc_rsi(
     conn: duckdb.DuckDBPyConnection,
     target_date: date,
 ) -> list[dict[str, Any]]:
-    """RSI(14) を計算する。
+    """RSI(14) を計算する（簡易 14 期間単純平均、Wilder の近似）。
 
-    Wilder の平滑移動平均（初期値は単純平均）で計算する。
     target_date 以前の最新 14+1 件の終値を使用するため、ルックアヘッドバイアスはない。
-    データ件数が 15 件未満の銘柄は rsi_14=None を返す。
+    データ件数が 15 件未満の銘柄は結果に含めない（features 側の辞書マージで rsi_14=None になる）。
 
     Args:
         conn:        DuckDB 接続。prices_daily テーブルを参照する。
@@ -492,6 +491,7 @@ def calc_rsi(
 
     Returns:
         [{"code": str, "rsi_14": float | None}, ...] のリスト。
+        rsi_14=None は avg_gain=avg_loss=0（横ばい価格）のケースで、BUY 許可の安全側として扱う。
     """
     scan_from = target_date - timedelta(days=_RSI_SCAN_DAYS)
     rows = conn.execute(

--- a/src/kabusys/strategy/feature_engineering.py
+++ b/src/kabusys/strategy/feature_engineering.py
@@ -28,6 +28,7 @@ from kabusys.data.stats import zscore_normalize
 from kabusys.research.factor_research import (
     calc_momentum,
     calc_quality,
+    calc_rsi,
     calc_topix_relative,
     calc_value,
     calc_volatility,
@@ -112,12 +113,14 @@ def build_features(
     val_list = calc_value(conn, target_date)
     topix_rel_list = calc_topix_relative(conn, target_date)
     quality_list = calc_quality(conn, target_date)
+    rsi_list = calc_rsi(conn, target_date)
 
     mom_map: dict[str, dict] = {r["code"]: r for r in mom_list}
     vol_map: dict[str, dict] = {r["code"]: r for r in vol_list}
     val_map: dict[str, dict] = {r["code"]: r for r in val_list}
     topix_map: dict[str, dict] = {r["code"]: r for r in topix_rel_list}
     quality_map: dict[str, dict] = {r["code"]: r for r in quality_list}
+    rsi_map: dict[str, dict] = {r["code"]: r for r in rsi_list}
 
     # 2. current close prices（ユニバースフィルタ用）
     # target_date 以前の最新価格を参照（休場日・当日欠損に対応）
@@ -145,6 +148,7 @@ def build_features(
         f = val_map.get(code, {})
         t = topix_map.get(code, {})
         q = quality_map.get(code, {})
+        r = rsi_map.get(code, {})
         merged.append(
             {
                 "code": code,
@@ -155,13 +159,14 @@ def build_features(
                 "atr_pct": v.get("atr_pct"),
                 "volume_ratio": v.get("volume_ratio"),
                 "per": f.get("per"),
-                "pbr": f.get("pbr"),  # 追加
-                "div_yield": f.get("div_yield"),  # 追加
+                "pbr": f.get("pbr"),
+                "div_yield": f.get("div_yield"),
                 "topix_rel_20": t.get("topix_rel_20"),
                 "topix_rel_60": t.get("topix_rel_60"),
                 "op_margin": q.get("op_margin"),
                 "rev_growth_yoy": q.get("rev_growth_yoy"),
                 "profit_growth_yoy": q.get("profit_growth_yoy"),
+                "rsi_14": r.get("rsi_14"),
             }
         )
 
@@ -198,12 +203,13 @@ def build_features(
             r.get("atr_pct"),
             r.get("volume_ratio"),
             r.get("per"),
-            r.get("pbr"),  # 追加
-            r.get("div_yield"),  # 追加
+            r.get("pbr"),
+            r.get("div_yield"),
             r.get("ma200_dev"),
             r.get("topix_rel_20"),
             r.get("topix_rel_60"),
             r.get("quality_score"),
+            r.get("rsi_14"),
         )
         for r in normalized
     ]
@@ -216,8 +222,8 @@ def build_features(
                 INSERT INTO features
                     (date, code, momentum_20, momentum_60, volatility_20, volume_ratio,
                      per, pbr, div_yield, ma200_dev,
-                     topix_rel_20, topix_rel_60, quality_score, created_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, current_timestamp)
+                     topix_rel_20, topix_rel_60, quality_score, rsi_14, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, current_timestamp)
                 """,
                 params,
             )

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -78,6 +78,8 @@ _TOPIX_DRAWDOWN_THRESHOLD: float = -0.15  # 200MA 乖離率がこの値未満で
 _TOPIX_SIZE_MULTIPLIER_BEAR: float = 0.5  # 地合い悪化時の size_multiplier
 _TOPIX_MIN_DATA_COUNT: int = 100  # 200MA を信頼できる最低データ数（初期運用でのデータ蓄積期間を考慮し 200 でなく 100 に設定）
 
+_RSI_OVERBOUGHT_THRESHOLD: float = 70.0  # RSI(14) > この値の銘柄は BUY 抑制（過熱判定）
+
 
 # ---------------------------------------------------------------------------
 # 設定ファイル読み込み
@@ -97,6 +99,7 @@ _STRATEGY_CONFIG_DEFAULTS: dict = {
     "sector_quartile": _SECTOR_QUARTILE,
     "topix_drawdown_threshold": _TOPIX_DRAWDOWN_THRESHOLD,
     "topix_size_multiplier_bear": _TOPIX_SIZE_MULTIPLIER_BEAR,
+    "rsi_overbought_threshold": _RSI_OVERBOUGHT_THRESHOLD,
 }
 
 _STRATEGY_CONFIG_PATH = Path(__file__).resolve().parents[3] / "config" / "strategy_config.yaml"
@@ -127,6 +130,7 @@ def _load_strategy_config() -> dict:
             "sector_quartile": float,
             "topix_drawdown_threshold": float,
             "topix_size_multiplier_bear": float,
+            "rsi_overbought_threshold": float,
         }
     """
     global _strategy_config_cache, _strategy_config_mtime
@@ -271,6 +275,17 @@ def _load_strategy_config() -> dict:
             and 0.0 < float(v) <= 1.0
         ):
             result["topix_size_multiplier_bear"] = float(v)
+
+    # rsi_overbought_threshold: strategy セクション配下（50 < x <= 100）
+    v = s.get("rsi_overbought_threshold") if isinstance(s, dict) else None
+    if (
+        v is not None
+        and isinstance(v, (int, float))
+        and not isinstance(v, bool)
+        and math.isfinite(float(v))
+        and 50.0 < float(v) <= 100.0
+    ):
+        result["rsi_overbought_threshold"] = float(v)
 
     _strategy_config_cache = result
     _strategy_config_mtime = current_mtime
@@ -1177,7 +1192,7 @@ def generate_signals(
             placeholders = ", ".join(["?" for _ in _scope_codes])
             feat_rows = conn.execute(
                 f"""
-                SELECT code, momentum_20, momentum_60, volatility_20, volume_ratio, per, pbr, div_yield, ma200_dev
+                SELECT code, momentum_20, momentum_60, volatility_20, volume_ratio, per, pbr, div_yield, ma200_dev, rsi_14
                 FROM features
                 WHERE date = ? AND code IN ({placeholders})
                 """,
@@ -1189,7 +1204,7 @@ def generate_signals(
     else:
         feat_rows = conn.execute(
             """
-            SELECT code, momentum_20, momentum_60, volatility_20, volume_ratio, per, pbr, div_yield, ma200_dev
+            SELECT code, momentum_20, momentum_60, volatility_20, volume_ratio, per, pbr, div_yield, ma200_dev, rsi_14
             FROM features
             WHERE date = ?
             """,
@@ -1205,6 +1220,7 @@ def generate_signals(
         "pbr",
         "div_yield",
         "ma200_dev",
+        "rsi_14",
     ]
     features = [dict(zip(feat_cols, r)) for r in feat_rows]
 
@@ -1300,7 +1316,7 @@ def generate_signals(
                 target_date,
             )
             boosted_count += 1
-        scored.append({"code": code, "score": final_score})
+        scored.append({"code": code, "score": final_score, "rsi_14": feat.get("rsi_14")})
 
     if not regime_is_bear and not breadth_stop and boosted_count:
         logger.info(
@@ -1316,6 +1332,7 @@ def generate_signals(
     # 6. BUY シグナル生成（Bear レジームまたは breadth_stop では抑制）
     _gap_up = _cfg["gap_up_threshold"]
     _gap_down = _cfg["gap_down_threshold"]
+    _rsi_threshold = _cfg["rsi_overbought_threshold"]
     buy_signals: list[dict] = []
     if not regime_is_bear and not breadth_stop:
         # 3c. ギャップ比率を一括取得（BUY 生成が必要な場合のみ実行）
@@ -1323,11 +1340,23 @@ def generate_signals(
             conn, [r["code"] for r in scored if r["score"] >= threshold], target_date
         )
         gap_suppressed = 0
+        rsi_suppressed = 0
         sector_suppressed = 0
         reentry_suppressed = 0
         earnings_suppressed = 0
         for rank, r in enumerate(scored, 1):
             if r["score"] < threshold:
+                continue
+            # RSI 過熱フィルタ（rsi_14 が None の場合は安全側で許可）
+            rsi = r.get("rsi_14")
+            if rsi is not None and rsi > _rsi_threshold:
+                logger.debug(
+                    "rsi filter: %s rsi=%.1f — BUY を抑制 date=%s",
+                    r["code"],
+                    rsi,
+                    target_date,
+                )
+                rsi_suppressed += 1
                 continue
             gap = gap_ratios.get(r["code"])
             if gap is not None and (
@@ -1373,6 +1402,13 @@ def generate_signals(
                 earnings_suppressed += 1
                 continue
             buy_signals.append({"code": r["code"], "score": r["score"], "rank": rank})
+        if rsi_suppressed:
+            logger.info(
+                "generate_signals: rsi filter — %d 銘柄を RSI 過熱(%s超)で抑制 date=%s",
+                rsi_suppressed,
+                _rsi_threshold,
+                target_date,
+            )
         if gap_suppressed:
             logger.info(
                 "generate_signals: gap filter — %d 銘柄を抑制 date=%s",

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -80,6 +80,20 @@ _TOPIX_MIN_DATA_COUNT: int = 100  # 200MA を信頼できる最低データ数�
 
 _RSI_OVERBOUGHT_THRESHOLD: float = 70.0  # RSI(14) > この値の銘柄は BUY 抑制（過熱判定）
 
+# features テーブルから SELECT する列（2箇所で共用）
+_FEATURES_SELECT_COLS: tuple[str, ...] = (
+    "code",
+    "momentum_20",
+    "momentum_60",
+    "volatility_20",
+    "volume_ratio",
+    "per",
+    "pbr",
+    "div_yield",
+    "ma200_dev",
+    "rsi_14",
+)
+
 
 # ---------------------------------------------------------------------------
 # 設定ファイル読み込み
@@ -1186,16 +1200,13 @@ def generate_signals(
         # codes が指定されている場合（空リストを含む）
         _scope_codes = frozenset(scope.codes) if scope.codes else frozenset()
 
+    _select_cols = ", ".join(_FEATURES_SELECT_COLS)
     if _scope_codes is not None:
         if _scope_codes:
             # codes が空でない場合
             placeholders = ", ".join(["?" for _ in _scope_codes])
             feat_rows = conn.execute(
-                f"""
-                SELECT code, momentum_20, momentum_60, volatility_20, volume_ratio, per, pbr, div_yield, ma200_dev, rsi_14
-                FROM features
-                WHERE date = ? AND code IN ({placeholders})
-                """,
+                f"SELECT {_select_cols} FROM features WHERE date = ? AND code IN ({placeholders})",
                 [target_date, *_scope_codes],
             ).fetchall()
         else:
@@ -1203,26 +1214,10 @@ def generate_signals(
             feat_rows = []
     else:
         feat_rows = conn.execute(
-            """
-            SELECT code, momentum_20, momentum_60, volatility_20, volume_ratio, per, pbr, div_yield, ma200_dev, rsi_14
-            FROM features
-            WHERE date = ?
-            """,
+            f"SELECT {_select_cols} FROM features WHERE date = ?",
             [target_date],
         ).fetchall()
-    feat_cols = [
-        "code",
-        "momentum_20",
-        "momentum_60",
-        "volatility_20",
-        "volume_ratio",
-        "per",
-        "pbr",
-        "div_yield",
-        "ma200_dev",
-        "rsi_14",
-    ]
-    features = [dict(zip(feat_cols, r)) for r in feat_rows]
+    features = [dict(zip(_FEATURES_SELECT_COLS, r)) for r in feat_rows]
 
     if not features:
         logger.warning(

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -141,3 +141,30 @@ class TestBuildFeaturesWithNewColumns:
         build_features(conn, TARGET)
         count = conn.execute("SELECT COUNT(*) FROM features WHERE date=?", [TARGET]).fetchone()[0]
         assert count == 1  # 日付単位で置換されるため重複なし
+
+    def test_rsi_14_populated_with_sufficient_data(self, conn):
+        """15件以上の価格データがある場合、rsi_14 が計算されること。"""
+        _insert_prices(conn, "1001", START, 430)
+        _insert_financials(conn, "1001")
+        build_features(conn, TARGET)
+        row = conn.execute(
+            "SELECT rsi_14 FROM features WHERE date=? AND code=?",
+            [TARGET, "1001"],
+        ).fetchone()
+        assert row is not None
+        assert row[0] is not None
+        assert 0.0 <= float(row[0]) <= 100.0
+
+    def test_rsi_14_null_with_insufficient_data(self, conn):
+        """価格データが 14 件以下の場合、rsi_14 が NULL になること。"""
+        # 10 件のみ挿入（RSI 計算に必要な 15 件未満）
+        _insert_prices(conn, "1001", TARGET - timedelta(days=10), 10, base=600.0)
+        _insert_financials(conn, "1001")
+        build_features(conn, TARGET)
+        row = conn.execute(
+            "SELECT rsi_14 FROM features WHERE date=? AND code=?",
+            [TARGET, "1001"],
+        ).fetchone()
+        # データ不足で銘柄がフィルタされるか rsi_14=None のいずれか
+        if row is not None:
+            assert row[0] is None

--- a/tests/test_generate_signals_config.py
+++ b/tests/test_generate_signals_config.py
@@ -16,7 +16,7 @@ def _make_db():
         CREATE TABLE features (
             date DATE, code VARCHAR, momentum_20 DOUBLE, momentum_60 DOUBLE,
             volatility_20 DOUBLE, volume_ratio DOUBLE, per DOUBLE, pbr DOUBLE,
-            div_yield DOUBLE, ma200_dev DOUBLE
+            div_yield DOUBLE, ma200_dev DOUBLE, rsi_14 DOUBLE
         )
     """)
     conn.execute("""
@@ -95,7 +95,7 @@ class TestGenerateSignalsConfigWeights:
         target = date(2025, 1, 6)
         # Insert one stock with high momentum
         conn.execute(
-            "INSERT INTO features VALUES (?, '1001', 3.0, 3.0, 0.0, 0.0, NULL, NULL, NULL, 0.0)",
+            "INSERT INTO features VALUES (?, '1001', 3.0, 3.0, 0.0, 0.0, NULL, NULL, NULL, 0.0, NULL)",
             [target],
         )
 
@@ -143,7 +143,7 @@ class TestGenerateSignalsConfigWeights:
         target = date(2025, 1, 6)
         # volatility_20 = -3.0 → low volatility (good) → _sigmoid(-(-3.0)) ≈ 0.95 > 0.50
         conn.execute(
-            "INSERT INTO features VALUES (?, '1001', 0.0, 0.0, -3.0, 0.0, NULL, NULL, NULL, 0.0)",
+            "INSERT INTO features VALUES (?, '1001', 0.0, 0.0, -3.0, 0.0, NULL, NULL, NULL, 0.0, NULL)",
             [target],
         )
 
@@ -205,7 +205,7 @@ class TestGenerateSignalsConfigThreshold:
         target = date(2025, 1, 6)
         # Insert stock with moderate score that would pass 0.60 but not 0.99
         conn.execute(
-            "INSERT INTO features VALUES (?, '1001', 0.5, 0.5, 0.0, 0.0, NULL, NULL, NULL, 0.0)",
+            "INSERT INTO features VALUES (?, '1001', 0.5, 0.5, 0.0, 0.0, NULL, NULL, NULL, 0.0, NULL)",
             [target],
         )
 
@@ -253,7 +253,7 @@ class TestGenerateSignalsConfigThreshold:
         conn = _make_db()
         target = date(2025, 1, 6)
         conn.execute(
-            "INSERT INTO features VALUES (?, '1001', 3.0, 3.0, 0.0, 0.0, NULL, NULL, NULL, 0.0)",
+            "INSERT INTO features VALUES (?, '1001', 3.0, 3.0, 0.0, 0.0, NULL, NULL, NULL, 0.0, NULL)",
             [target],
         )
 

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -808,3 +808,222 @@ class TestCalcSectorStrengthsQuartile:
         self._setup_4sectors(conn)
         top, _, _ = _calc_sector_strengths(conn, date(2026, 1, 21), sector_quartile=0.50)
         assert len(top) == 2  # ceil(4 * 0.50) = 2
+
+
+# ---------------------------------------------------------------------------
+# RSI 過熱フィルタ テスト (Issue #338)
+# ---------------------------------------------------------------------------
+
+from kabusys.research.factor_research import calc_rsi  # noqa: E402
+
+
+class TestCalcRsi:
+    """calc_rsi の単体テスト。"""
+
+    def test_returns_rsi_with_sufficient_data(self, conn):
+        """15件以上の価格データで RSI が計算されること。"""
+        base = date(2024, 1, 1)
+        rows = [
+            (
+                base + timedelta(days=i),
+                "1001",
+                1000.0 + i,
+                1010.0 + i,
+                990.0 + i,
+                1000.0 + i,
+                100000,
+            )
+            for i in range(20)
+        ]
+        conn.executemany(
+            "INSERT INTO prices_daily (date, code, open, high, low, close, volume) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+        result = calc_rsi(conn, base + timedelta(days=19))
+        assert len(result) == 1
+        rsi = result[0]["rsi_14"]
+        assert rsi is not None
+        assert 0.0 <= rsi <= 100.0
+
+    def test_returns_empty_with_insufficient_data(self, conn):
+        """14件以下の価格データでは結果が空または rsi_14=None になること。"""
+        base = date(2024, 1, 1)
+        rows = [
+            (base + timedelta(days=i), "1001", 1000.0, 1010.0, 990.0, 1000.0, 100000)
+            for i in range(10)
+        ]
+        conn.executemany(
+            "INSERT INTO prices_daily (date, code, open, high, low, close, volume) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+        result = calc_rsi(conn, base + timedelta(days=9))
+        # データ不足なら空リストか rsi_14=None
+        assert all(r["rsi_14"] is None for r in result) or len(result) == 0
+
+    def test_rsi_100_when_all_gains(self, conn):
+        """終値が毎日上昇する場合、RSI は 100 に近づくこと。"""
+        base = date(2024, 1, 1)
+        rows = [
+            (
+                base + timedelta(days=i),
+                "1001",
+                1000.0 + i * 10,
+                1010.0 + i * 10,
+                990.0 + i * 10,
+                1000.0 + i * 10,
+                100000,
+            )
+            for i in range(20)
+        ]
+        conn.executemany(
+            "INSERT INTO prices_daily (date, code, open, high, low, close, volume) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+        result = calc_rsi(conn, base + timedelta(days=19))
+        assert len(result) == 1
+        assert result[0]["rsi_14"] == 100.0
+
+    def test_rsi_0_when_all_losses(self, conn):
+        """終値が毎日下降する場合、RSI は 0 に近づくこと。"""
+        base = date(2024, 1, 1)
+        rows = [
+            (
+                base + timedelta(days=i),
+                "1001",
+                1000.0 - i * 10,
+                1010.0 - i * 10,
+                990.0 - i * 10,
+                max(100.0, 1000.0 - i * 10),
+                100000,
+            )
+            for i in range(20)
+        ]
+        conn.executemany(
+            "INSERT INTO prices_daily (date, code, open, high, low, close, volume) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+        result = calc_rsi(conn, base + timedelta(days=19))
+        assert len(result) == 1
+        assert result[0]["rsi_14"] == 0.0
+
+
+class TestRsiOverboughtConfig:
+    """rsi_overbought_threshold の config 読み込みテスト。"""
+
+    def test_default_is_70(self):
+        from kabusys.strategy.signal_generator import _STRATEGY_CONFIG_DEFAULTS
+
+        assert _STRATEGY_CONFIG_DEFAULTS["rsi_overbought_threshold"] == 70.0
+
+    def test_valid_value_accepted(self, tmp_path, monkeypatch):
+        yaml_text = "strategy:\n  rsi_overbought_threshold: 75.0\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["rsi_overbought_threshold"] == 75.0
+
+    def test_value_50_rejected(self, tmp_path, monkeypatch):
+        """50 以下は無効（50 < x <= 100 の範囲外）。"""
+        yaml_text = "strategy:\n  rsi_overbought_threshold: 50.0\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["rsi_overbought_threshold"] == 70.0  # default
+
+    def test_value_100_accepted(self, tmp_path, monkeypatch):
+        """100 は有効（フィルタ実質オフ）。"""
+        yaml_text = "strategy:\n  rsi_overbought_threshold: 100.0\n"
+        cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
+        assert cfg["rsi_overbought_threshold"] == 100.0
+
+
+class TestRsiFilterInGenerateSignals:
+    """generate_signals の RSI 過熱フィルタ動作テスト。"""
+
+    def _insert_feature_with_rsi(self, conn, code: str, d: date, rsi: float | None) -> None:
+        conn.execute(
+            "INSERT INTO features "
+            "(date, code, momentum_20, momentum_60, volatility_20, volume_ratio, per, ma200_dev, rsi_14) "
+            "VALUES (?, ?, 3.0, 3.0, -3.0, 3.0, 5.0, 3.0, ?)",
+            [d, code, rsi],
+        )
+
+    def test_rsi_over_threshold_suppresses_buy(self, conn):
+        """RSI > 70 の銘柄が BUY 対象から除外されること。"""
+        import sqlite3
+
+        from kabusys.strategy.signal_generator import generate_signals
+
+        _insert_regime(conn, TARGET_DATE, "bull")
+        _insert_breadth(conn, TARGET_DATE, breadth_stop=False)
+        self._insert_feature_with_rsi(conn, "1001", TARGET_DATE, rsi=75.0)
+        conn.execute(
+            "INSERT INTO prices_daily (date, code, open, high, low, close, volume) "
+            "VALUES (?, '1001', 1000, 1010, 990, 1000, 100000)",
+            [TARGET_DATE],
+        )
+        sqlite_conn = sqlite3.connect(":memory:")
+        from kabusys.execution.order_repository import init_orders_db, init_position_entries_db
+
+        init_orders_db(sqlite_conn)
+        init_position_entries_db(sqlite_conn)
+        generate_signals(conn, TARGET_DATE, sqlite_conn=sqlite_conn)
+        buy_codes = [
+            r[0]
+            for r in conn.execute(
+                "SELECT code FROM signals WHERE date=? AND side='buy'", [TARGET_DATE]
+            ).fetchall()
+        ]
+        assert "1001" not in buy_codes
+
+    def test_rsi_below_threshold_allows_buy(self, conn):
+        """RSI <= 70 の銘柄は BUY 対象になること。"""
+        import sqlite3
+
+        from kabusys.strategy.signal_generator import generate_signals
+
+        _insert_regime(conn, TARGET_DATE, "bull")
+        _insert_breadth(conn, TARGET_DATE, breadth_stop=False)
+        self._insert_feature_with_rsi(conn, "1001", TARGET_DATE, rsi=65.0)
+        conn.execute(
+            "INSERT INTO prices_daily (date, code, open, high, low, close, volume) "
+            "VALUES (?, '1001', 1000, 1010, 990, 1000, 100000)",
+            [TARGET_DATE],
+        )
+        sqlite_conn = sqlite3.connect(":memory:")
+        from kabusys.execution.order_repository import init_orders_db, init_position_entries_db
+
+        init_orders_db(sqlite_conn)
+        init_position_entries_db(sqlite_conn)
+        generate_signals(conn, TARGET_DATE, sqlite_conn=sqlite_conn)
+        buy_codes = [
+            r[0]
+            for r in conn.execute(
+                "SELECT code FROM signals WHERE date=? AND side='buy'", [TARGET_DATE]
+            ).fetchall()
+        ]
+        assert "1001" in buy_codes
+
+    def test_rsi_none_allows_buy(self, conn):
+        """RSI が NULL（データ不足）の場合は安全側で BUY を許可すること。"""
+        import sqlite3
+
+        from kabusys.strategy.signal_generator import generate_signals
+
+        _insert_regime(conn, TARGET_DATE, "bull")
+        _insert_breadth(conn, TARGET_DATE, breadth_stop=False)
+        self._insert_feature_with_rsi(conn, "1001", TARGET_DATE, rsi=None)
+        conn.execute(
+            "INSERT INTO prices_daily (date, code, open, high, low, close, volume) "
+            "VALUES (?, '1001', 1000, 1010, 990, 1000, 100000)",
+            [TARGET_DATE],
+        )
+        sqlite_conn = sqlite3.connect(":memory:")
+        from kabusys.execution.order_repository import init_orders_db, init_position_entries_db
+
+        init_orders_db(sqlite_conn)
+        init_position_entries_db(sqlite_conn)
+        generate_signals(conn, TARGET_DATE, sqlite_conn=sqlite_conn)
+        buy_codes = [
+            r[0]
+            for r in conn.execute(
+                "SELECT code FROM signals WHERE date=? AND side='buy'", [TARGET_DATE]
+            ).fetchall()
+        ]
+        assert "1001" in buy_codes

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -1027,3 +1027,31 @@ class TestRsiFilterInGenerateSignals:
             ).fetchall()
         ]
         assert "1001" in buy_codes
+
+    def test_rsi_at_threshold_allows_buy(self, conn):
+        """RSI がちょうど閾値（70.0）の場合は BUY を許可すること（> のため境界値は許可）。"""
+        import sqlite3
+
+        from kabusys.strategy.signal_generator import generate_signals
+
+        _insert_regime(conn, TARGET_DATE, "bull")
+        _insert_breadth(conn, TARGET_DATE, breadth_stop=False)
+        self._insert_feature_with_rsi(conn, "1001", TARGET_DATE, rsi=70.0)
+        conn.execute(
+            "INSERT INTO prices_daily (date, code, open, high, low, close, volume) "
+            "VALUES (?, '1001', 1000, 1010, 990, 1000, 100000)",
+            [TARGET_DATE],
+        )
+        sqlite_conn = sqlite3.connect(":memory:")
+        from kabusys.execution.order_repository import init_orders_db, init_position_entries_db
+
+        init_orders_db(sqlite_conn)
+        init_position_entries_db(sqlite_conn)
+        generate_signals(conn, TARGET_DATE, sqlite_conn=sqlite_conn)
+        buy_codes = [
+            r[0]
+            for r in conn.execute(
+                "SELECT code FROM signals WHERE date=? AND side='buy'", [TARGET_DATE]
+            ).fetchall()
+        ]
+        assert "1001" in buy_codes, "RSI=70.0（閾値ちょうど）は BUY 許可（> 判定のため）"


### PR DESCRIPTION
## 概要

Issue #338: 急騰直後の過熱銘柄への BUY シグナル抑制。

予算 1,000,000 円での成績悪化の根本原因は、`offensive_sector_boost` が強く上がっている銘柄を拾いやすい一方、RSI 系の上限制御がなかった点にある。RSI(14) > 70 の銘柄を BUY 対象から除外することで急落リスクを低減する。

## 変更内容

### `src/kabusys/data/schema.py`
- `features` テーブルに `rsi_14 DOUBLE` 列を追加
- `_MIGRATIONS` に既存 DB へのマイグレーション `ALTER TABLE features ADD COLUMN IF NOT EXISTS rsi_14 DOUBLE` を追加

### `src/kabusys/research/factor_research.py`
- `calc_rsi(conn, target_date)` 関数を追加
  - DuckDB ウィンドウ関数で RSI(14) を計算（SQL ベース、ルックアヘッドバイアスなし）
  - データ件数 < 15 の銘柄は結果から除外（NULL 安全）

### `src/kabusys/strategy/feature_engineering.py`
- `calc_rsi` をインポートし `build_features()` で呼び出し
- `features` テーブルへの INSERT に `rsi_14` を追加

### `src/kabusys/strategy/signal_generator.py`
- 定数 `_RSI_OVERBOUGHT_THRESHOLD = 70.0` を追加
- `_STRATEGY_CONFIG_DEFAULTS` に `rsi_overbought_threshold` を追加
- `_load_strategy_config()` に `rsi_overbought_threshold`（50 < x <= 100）の検証を追加
- `features` SELECT に `rsi_14` を追加
- BUY ループに RSI 過熱フィルタを追加（`rsi_14 is None` は安全側で許可）
- フィルタ適用件数のログを追加

### `config/strategy_config.yaml`
- `strategy.rsi_overbought_threshold: 70.0` を追加（調整可能）

### テスト（計 +13 件）
- `TestCalcRsi`: RSI 計算の基本動作（データ十分・不足・全上昇・全下落）
- `TestRsiOverboughtConfig`: config 読み込み（デフォルト・有効値・無効値）
- `TestRsiFilterInGenerateSignals`: RSI>70 で BUY 抑制・RSI≤70 で BUY 許可・NULL で許可
- `TestBuildFeaturesWithNewColumns`: rsi_14 が features に保存されること

## テスト結果

```
55 passed in 11.83s
```

## 設計メモ

- RSI が NULL（価格データ不足）の場合は**安全側（BUY 許可）**で処理
- 閾値は `strategy_config.yaml` で変更可能（例: より厳しくするなら 65.0 に下げる）
- RSI の算出は簡易 14 期間単純平均（Wilder 指数平滑の近似）— フィルタ目的には十分な精度

🤖 Generated with [Claude Code](https://claude.com/claude-code)