### PR TITLE
feat: バックテスト用特徴量バックフィルスクリプトを追加 (#342)

### DIFF
--- a/documents/WebManual/C_Backtest.md
+++ b/documents/WebManual/C_Backtest.md
@@ -11,7 +11,36 @@ KabuSys のバックテストは、実運用と同じ `generate_signals()` ロ�
 
 ---
 
-## C-B-2. 基本実行
+## C-B-2. 事前準備 — 特徴量のバックフィル
+
+バックテストは `features` テーブルにデータが存在することを前提とします。
+初めてバックテストを実行する際、または対象期間を拡張した場合は、先に `backfill_features.py` で特徴量を生成してください。
+
+```powershell
+# ステップ 1: 価格・財務データを取得（初回または差分更新）
+python -m kabusys.data.bootstrap
+
+# ステップ 2: 特徴量を期間一括生成
+python scripts/backfill_features.py --start 2022-01-01 --end 2024-12-31
+
+# ステップ 3: バックテスト実行
+python -m kabusys.backtest.run --start 2022-01-01 --end 2024-12-31 --db data/kabusys.duckdb
+```
+
+### backfill_features.py のオプション
+
+| オプション | 説明 |
+|---|---|
+| `--start` / `--end` | 対象期間（必須） |
+| `--db` | DuckDB ファイルパス（省略時は設定ファイルのデフォルト） |
+| `--force` | 既存データを上書きする（省略時は既存データがある日をスキップ） |
+| `--dry-run` | 対象日付の一覧を表示するのみ（DB への書き込みなし） |
+
+> **ヒント:** 価格データが存在しない日は自動的にスキップされます。スキップ数が多い場合は先に `bootstrap` を実行してください。
+
+---
+
+## C-B-4. 基本実行
 
 ```powershell
 python -m kabusys.backtest.run `
@@ -22,7 +51,7 @@ python -m kabusys.backtest.run `
 
 ---
 
-## C-B-3. 主なオプション
+## C-B-5. 主なオプション
 
 | オプション | デフォルト | 説明 |
 |---|---|---|
@@ -50,7 +79,7 @@ python -m kabusys.backtest.run `
 
 ---
 
-## C-B-4. 対象銘柄を絞る（Targeted Backtest）
+## C-B-6. 対象銘柄を絞る（Targeted Backtest）
 
 特定銘柄のみで検証する場合は `--scope-mode manual_codes` を使います。
 
@@ -65,7 +94,7 @@ python -m kabusys.backtest.run `
 
 ---
 
-## C-B-5. strategy_config.yaml でチューニングできるパラメータ
+## C-B-7. strategy_config.yaml でチューニングできるパラメータ
 
 バックテストは実運用と同じ `strategy_config.yaml` を読み込みます。以下のパラメータを変更すると、バックテスト結果に反映されます。
 
@@ -92,7 +121,7 @@ strategy:
 
 ---
 
-## C-B-6. 詳細リファレンス
+## C-B-8. 詳細リファレンス
 
 技術仕様・モジュール構成・インメモリ DB の詳細は設計ドキュメントを参照してください。
 

--- a/scripts/backfill_features.py
+++ b/scripts/backfill_features.py
@@ -1,0 +1,207 @@
+# scripts/backfill_features.py
+"""バックテスト用特徴量バックフィル。
+
+指定期間の全営業日分の特徴量を一括生成し features テーブルへ格納する。
+バックテスト実行前の事前準備として使用する。
+
+使い方:
+    python scripts/backfill_features.py --start 2022-01-01 --end 2024-12-31
+    python scripts/backfill_features.py --start 2022-01-01 --end 2024-12-31 --force
+    python scripts/backfill_features.py --start 2022-01-01 --end 2024-12-31 --dry-run
+
+ワークフロー:
+    1. python -m kabusys.data.bootstrap          # 価格・財務データ取得
+    2. python scripts/backfill_features.py       # 特徴量を期間一括生成（本スクリプト）
+    3. python -m kabusys.backtest.run ...        # バックテスト実行
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import date
+from pathlib import Path
+
+import duckdb
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+from kabusys.config import Settings
+from kabusys.data.calendar_management import get_trading_days
+from kabusys.strategy.feature_engineering import build_features
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+# RSI(14) に必要なルックバック日数（カレンダー日）
+# factor_research._RSI_SCAN_DAYS と同値: (14+1) * 3 = 45
+_RSI_LOOKBACK_DAYS = 45
+
+
+def _check_rsi_lookback(conn: duckdb.DuckDBPyConnection, start: date) -> None:
+    """start 以前に RSI 計算に必要な価格データが存在するか確認し、不足時は警告を出す。
+
+    RSI(14) は target_date から遡って最低 14 件の日次変化量が必要。
+    prices_daily の最古日が start - _RSI_LOOKBACK_DAYS より新しい場合、
+    開始直後の数営業日は rsi_14 = NULL となりバックテスト精度が下がる。
+    """
+    from datetime import timedelta
+
+    required_from = start - timedelta(days=_RSI_LOOKBACK_DAYS)
+    row = conn.execute("SELECT MIN(date) FROM prices_daily WHERE date < ?", [start]).fetchone()
+    oldest = row[0] if row else None
+
+    if oldest is None:
+        logger.warning(
+            "prices_daily に --start (%s) 以前のデータが存在しません。"
+            "開始直後の約 14 営業日は rsi_14 = NULL になります。"
+            "先に `python -m kabusys.data.bootstrap` で過去データを取得してください。",
+            start,
+        )
+    elif oldest > required_from:
+        logger.warning(
+            "prices_daily の最古データ (%s) が RSI ルックバック要求日 (%s) より新しいです。"
+            "--start 付近の最初の約 14 営業日は rsi_14 = NULL になる可能性があります。"
+            "より古いデータを bootstrap で取得するか、--start を %s 以降に設定してください。",
+            oldest,
+            required_from,
+            oldest + timedelta(days=_RSI_LOOKBACK_DAYS),
+        )
+    else:
+        logger.debug("RSI ルックバック確認OK: 最古価格=%s, 要求=%s", oldest, required_from)
+
+
+def _dates_with_features(conn: duckdb.DuckDBPyConnection, start: date, end: date) -> set[date]:
+    rows = conn.execute(
+        "SELECT DISTINCT date FROM features WHERE date >= ? AND date <= ?",
+        [start, end],
+    ).fetchall()
+    return {r[0] for r in rows}
+
+
+def _has_prices(conn: duckdb.DuckDBPyConnection, target_date: date) -> bool:
+    count = conn.execute(
+        "SELECT COUNT(*) FROM prices_daily WHERE date = ?", [target_date]
+    ).fetchone()[0]
+    return count > 0
+
+
+def backfill(
+    conn: duckdb.DuckDBPyConnection,
+    start: date,
+    end: date,
+    force: bool = False,
+    dry_run: bool = False,
+) -> tuple[int, int, int]:
+    """指定期間の特徴量を生成する。
+
+    Returns:
+        (processed, skipped, no_price_data) のタプル。
+    """
+    _check_rsi_lookback(conn, start)
+
+    trading_days = get_trading_days(conn, start, end)
+    if not trading_days:
+        logger.warning("指定期間に営業日が見つかりません: %s ~ %s", start, end)
+        return 0, 0, 0
+
+    existing = _dates_with_features(conn, start, end) if not force else set()
+
+    processed = skipped = no_price = 0
+
+    for i, target_date in enumerate(trading_days, 1):
+        prefix = f"[{i}/{len(trading_days)}] {target_date}"
+
+        if target_date in existing:
+            logger.info("%s — スキップ（既存データあり。上書きは --force を指定）", prefix)
+            skipped += 1
+            continue
+
+        if not _has_prices(conn, target_date):
+            logger.warning("%s — スキップ（prices_daily にデータなし）", prefix)
+            no_price += 1
+            continue
+
+        if dry_run:
+            logger.info("%s — [dry-run] 生成対象", prefix)
+            processed += 1
+            continue
+
+        n = build_features(conn, target_date)
+        logger.info("%s — 完了 (%d 銘柄)", prefix, n)
+        processed += 1
+
+    return processed, skipped, no_price
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="バックテスト用特徴量バックフィル",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--start", required=True, help="開始日 YYYY-MM-DD")
+    parser.add_argument("--end", required=True, help="終了日 YYYY-MM-DD")
+    parser.add_argument(
+        "--db", default=None, help="DuckDB ファイルパス（省略時は設定ファイルのパス）"
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="既存データを上書きする（省略時はスキップ）",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="対象日付の一覧を表示するのみ（DB への書き込みなし）",
+    )
+    args = parser.parse_args()
+
+    try:
+        start_date = date.fromisoformat(args.start)
+        end_date = date.fromisoformat(args.end)
+    except ValueError as exc:
+        logger.error("日付フォーマットが不正です: %s", exc)
+        sys.exit(1)
+
+    if start_date > end_date:
+        logger.error("--start は --end より前の日付を指定してください")
+        sys.exit(1)
+
+    db_path = args.db or str(Settings().duckdb_path)
+
+    if args.dry_run:
+        logger.info("[dry-run] DB への書き込みは行いません")
+
+    conn = duckdb.connect(db_path)
+    try:
+        processed, skipped, no_price = backfill(
+            conn,
+            start=start_date,
+            end=end_date,
+            force=args.force,
+            dry_run=args.dry_run,
+        )
+    except Exception:
+        logger.exception("backfill_features が失敗しました")
+        sys.exit(1)
+    finally:
+        conn.close()
+
+    label = "[dry-run] " if args.dry_run else ""
+    logger.info(
+        "%s完了 — 処理: %d 日 / スキップ: %d 日 / 価格データなし: %d 日",
+        label,
+        processed,
+        skipped,
+        no_price,
+    )
+
+    if no_price > 0:
+        logger.warning(
+            "価格データなしでスキップされた日があります。"
+            "先に `python -m kabusys.data.bootstrap` を実行してください。"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/backfill_features.py
+++ b/scripts/backfill_features.py
@@ -79,11 +79,13 @@ def _dates_with_features(conn: duckdb.DuckDBPyConnection, start: date, end: date
     return {r[0] for r in rows}
 
 
-def _has_prices(conn: duckdb.DuckDBPyConnection, target_date: date) -> bool:
-    count = conn.execute(
-        "SELECT COUNT(*) FROM prices_daily WHERE date = ?", [target_date]
-    ).fetchone()[0]
-    return count > 0
+def _dates_with_prices(conn: duckdb.DuckDBPyConnection, start: date, end: date) -> set[date]:
+    """期間内で prices_daily にデータが存在する日付を一括取得する。"""
+    rows = conn.execute(
+        "SELECT DISTINCT date FROM prices_daily WHERE date >= ? AND date <= ?",
+        [start, end],
+    ).fetchall()
+    return {r[0] for r in rows}
 
 
 def backfill(
@@ -94,6 +96,9 @@ def backfill(
     dry_run: bool = False,
 ) -> tuple[int, int, int]:
     """指定期間の特徴量を生成する。
+
+    force=True のとき build_features() は内部で DELETE FROM features WHERE date=? を
+    実行してから INSERT するため、既存行との重複・衝突は発生しない（冪等）。
 
     Returns:
         (processed, skipped, no_price_data) のタプル。
@@ -106,6 +111,7 @@ def backfill(
         return 0, 0, 0
 
     existing = _dates_with_features(conn, start, end) if not force else set()
+    price_dates = _dates_with_prices(conn, start, end)
 
     processed = skipped = no_price = 0
 
@@ -113,11 +119,11 @@ def backfill(
         prefix = f"[{i}/{len(trading_days)}] {target_date}"
 
         if target_date in existing:
-            logger.info("%s — スキップ（既存データあり。上書きは --force を指定）", prefix)
+            logger.debug("%s — スキップ（既存データあり。上書きは --force を指定）", prefix)
             skipped += 1
             continue
 
-        if not _has_prices(conn, target_date):
+        if target_date not in price_dates:
             logger.warning("%s — スキップ（prices_daily にデータなし）", prefix)
             no_price += 1
             continue
@@ -128,7 +134,7 @@ def backfill(
             continue
 
         n = build_features(conn, target_date)
-        logger.info("%s — 完了 (%d 銘柄)", prefix, n)
+        logger.debug("%s — 完了 (%d 銘柄)", prefix, n)
         processed += 1
 
     return processed, skipped, no_price

--- a/tests/test_backfill_features.py
+++ b/tests/test_backfill_features.py
@@ -1,0 +1,201 @@
+"""tests/test_backfill_features.py — backfill_features.backfill() のテスト。"""
+
+from __future__ import annotations
+
+import importlib.util
+from datetime import date, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kabusys.data.schema import init_schema
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "backfill_features.py"
+_spec = importlib.util.spec_from_file_location("backfill_features", _SCRIPT)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+backfill = _mod.backfill
+_check_rsi_lookback = _mod._check_rsi_lookback
+_RSI_LOOKBACK_DAYS = _mod._RSI_LOOKBACK_DAYS
+
+
+# ---------------------------------------------------------------------------
+# フィクスチャ
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def conn():
+    c = init_schema(":memory:")
+    yield c
+    c.close()
+
+
+def _insert_prices(conn, target_date: date) -> None:
+    conn.execute(
+        "INSERT INTO prices_daily (date, code, open, high, low, close, volume, turnover) "
+        "VALUES (?, '1001', 1000, 1050, 990, 1020, 10000, 500_000_000) ON CONFLICT DO NOTHING",
+        [target_date],
+    )
+
+
+def _insert_features(conn, target_date: date) -> None:
+    conn.execute(
+        "INSERT INTO features (date, code, created_at) VALUES (?, '1001', current_timestamp) "
+        "ON CONFLICT DO NOTHING",
+        [target_date],
+    )
+
+
+def _insert_trading_day(conn, target_date: date) -> None:
+    conn.execute(
+        "INSERT INTO market_calendar (date, is_trading_day) VALUES (?, TRUE) ON CONFLICT DO NOTHING",
+        [target_date],
+    )
+
+
+# ---------------------------------------------------------------------------
+# テストケース
+# ---------------------------------------------------------------------------
+
+_D1 = date(2024, 1, 4)  # 木曜日（営業日として扱われる）
+_D2 = date(2024, 1, 5)  # 金曜日
+
+
+class TestBackfill:
+    def test_processes_date_with_price_data(self, conn):
+        """prices_daily にデータがある営業日は build_features が呼ばれる。"""
+        _insert_trading_day(conn, _D1)
+        _insert_prices(conn, _D1)
+
+        with patch.object(_mod, "build_features", return_value=10) as mock_bf:
+            processed, skipped, no_price = backfill(conn, _D1, _D1)
+
+        assert processed == 1
+        assert skipped == 0
+        assert no_price == 0
+        mock_bf.assert_called_once()
+
+    def test_skips_existing_features_without_force(self, conn):
+        """既存データがある日は --force なしでスキップされる。"""
+        _insert_trading_day(conn, _D1)
+        _insert_prices(conn, _D1)
+        _insert_features(conn, _D1)
+
+        with patch.object(_mod, "build_features") as mock_bf:
+            processed, skipped, no_price = backfill(conn, _D1, _D1, force=False)
+
+        assert processed == 0
+        assert skipped == 1
+        assert no_price == 0
+        mock_bf.assert_not_called()
+
+    def test_force_overwrites_existing_features(self, conn):
+        """--force 指定時は既存データがある日も build_features が呼ばれる。"""
+        _insert_trading_day(conn, _D1)
+        _insert_prices(conn, _D1)
+        _insert_features(conn, _D1)
+
+        with patch.object(_mod, "build_features", return_value=5) as mock_bf:
+            processed, skipped, no_price = backfill(conn, _D1, _D1, force=True)
+
+        assert processed == 1
+        assert skipped == 0
+        mock_bf.assert_called_once()
+
+    def test_skips_date_without_price_data(self, conn):
+        """prices_daily にデータがない日は no_price カウントに記録されスキップされる。"""
+        _insert_trading_day(conn, _D1)
+        # prices_daily へのデータ投入なし
+
+        with patch.object(_mod, "build_features") as mock_bf:
+            processed, skipped, no_price = backfill(conn, _D1, _D1)
+
+        assert processed == 0
+        assert skipped == 0
+        assert no_price == 1
+        mock_bf.assert_not_called()
+
+    def test_dry_run_does_not_call_build_features(self, conn):
+        """--dry-run では build_features が呼ばれず processed のみカウントされる。"""
+        _insert_trading_day(conn, _D1)
+        _insert_prices(conn, _D1)
+
+        with patch.object(_mod, "build_features") as mock_bf:
+            processed, skipped, no_price = backfill(conn, _D1, _D1, dry_run=True)
+
+        assert processed == 1
+        assert skipped == 0
+        mock_bf.assert_not_called()
+
+    def test_multiple_days_mixed(self, conn):
+        """複数日：処理・スキップ・価格なしが混在するケース。"""
+        for d in [_D1, _D2]:
+            _insert_trading_day(conn, d)
+
+        _insert_prices(conn, _D1)  # _D1: 処理対象
+        _insert_features(conn, _D2)  # _D2: 既存あり → skipped
+
+        with patch.object(_mod, "build_features", return_value=3):
+            processed, skipped, no_price = backfill(conn, _D1, _D2, force=False)
+
+        assert processed == 1  # _D1
+        assert skipped == 1  # _D2（既存あり）
+        assert no_price == 0
+
+    def test_empty_range_returns_zeros(self, conn):
+        """営業日が存在しない期間はすべて 0 を返す。"""
+        sat = date(2024, 1, 6)
+        sun = date(2024, 1, 7)
+        conn.execute(
+            "INSERT INTO market_calendar (date, is_trading_day) VALUES (?, FALSE), (?, FALSE)",
+            [sat, sun],
+        )
+
+        with patch.object(_mod, "build_features") as mock_bf:
+            processed, skipped, no_price = backfill(conn, sat, sun)
+
+        assert processed == 0
+        assert skipped == 0
+        assert no_price == 0
+        mock_bf.assert_not_called()
+
+
+class TestCheckRsiLookback:
+    def test_no_prior_prices_emits_warning(self, conn, caplog):
+        """prices_daily に start 以前のデータが全くない場合は WARNING を出す。"""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            _check_rsi_lookback(conn, _D1)
+        assert any("以前のデータが存在しません" in r.message for r in caplog.records)
+
+    def test_sufficient_prior_prices_no_warning(self, conn, caplog):
+        """start より十分前に価格データがあれば WARNING を出さない。"""
+        import logging
+
+        old_date = _D1 - timedelta(days=_RSI_LOOKBACK_DAYS + 10)
+        conn.execute(
+            "INSERT INTO prices_daily (date, code, open, high, low, close, volume, turnover) "
+            "VALUES (?, '1001', 1000, 1000, 1000, 1000, 1000, 1000) ON CONFLICT DO NOTHING",
+            [old_date],
+        )
+        with caplog.at_level(logging.WARNING):
+            _check_rsi_lookback(conn, _D1)
+        assert not any(r.levelno == logging.WARNING for r in caplog.records)
+
+    def test_insufficient_prior_prices_emits_warning(self, conn, caplog):
+        """start より古いデータがあるが RSI ルックバック日数に満たない場合は WARNING を出す。"""
+        import logging
+
+        # _RSI_LOOKBACK_DAYS - 5 日前のデータしかない（要求より新しい）
+        insufficient_date = _D1 - timedelta(days=_RSI_LOOKBACK_DAYS - 5)
+        conn.execute(
+            "INSERT INTO prices_daily (date, code, open, high, low, close, volume, turnover) "
+            "VALUES (?, '1001', 1000, 1000, 1000, 1000, 1000, 1000) ON CONFLICT DO NOTHING",
+            [insufficient_date],
+        )
+        with caplog.at_level(logging.WARNING):
+            _check_rsi_lookback(conn, _D1)
+        assert any("最古データ" in r.message for r in caplog.records)

--- a/tests/test_backfill_features.py
+++ b/tests/test_backfill_features.py
@@ -134,8 +134,8 @@ class TestBackfill:
         for d in [_D1, _D2]:
             _insert_trading_day(conn, d)
 
-        _insert_prices(conn, _D1)  # _D1: 処理対象
-        _insert_features(conn, _D2)  # _D2: 既存あり → skipped
+        _insert_prices(conn, _D1)  # _D1: 処理対象（既存なし・価格あり）
+        _insert_features(conn, _D2)  # _D2: 既存あり・価格なし → skipped（既存チェックが先）
 
         with patch.object(_mod, "build_features", return_value=3):
             processed, skipped, no_price = backfill(conn, _D1, _D2, force=False)
@@ -143,6 +143,40 @@ class TestBackfill:
         assert processed == 1  # _D1
         assert skipped == 1  # _D2（既存あり）
         assert no_price == 0
+
+    def test_force_actually_overwrites_in_db(self, conn):
+        """--force 時に build_features が DELETE+INSERT を行い重複なく上書きされること。
+
+        build_features() 内部は DELETE FROM features WHERE date=? + INSERT のため冪等。
+        モックではなく実テーブルで検証する。
+        """
+        from datetime import timedelta
+
+        from kabusys.data.schema import init_schema as _init  # noqa: F401
+
+        # 十分な価格データを投入（RSI の計算に必要な 15 件分）
+        _insert_trading_day(conn, _D1)
+        for i in range(20):
+            d = _D1 - timedelta(days=i)
+            conn.execute(
+                "INSERT INTO prices_daily (date, code, open, high, low, close, volume, turnover) "
+                "VALUES (?, '1001', ?, ?, ?, ?, 10000, 500_000_000) ON CONFLICT DO NOTHING",
+                [d, 1000 + i, 1050 + i, 990 + i, 1020 + i],
+            )
+
+        # 事前に features を 1 行挿入
+        _insert_features(conn, _D1)
+        before = conn.execute("SELECT COUNT(*) FROM features WHERE date = ?", [_D1]).fetchone()[0]
+        assert before == 1
+
+        # --force で上書き実行
+        processed, skipped, no_price = backfill(conn, _D1, _D1, force=True)
+
+        after = conn.execute("SELECT COUNT(*) FROM features WHERE date = ?", [_D1]).fetchone()[0]
+        assert processed == 1
+        assert skipped == 0
+        # 重複せず、build_features が生成した行数になっていること（1 以上）
+        assert after >= 1
 
     def test_empty_range_returns_zeros(self, conn):
         """営業日が存在しない期間はすべて 0 を返す。"""


### PR DESCRIPTION
## 概要

Closes #342

バックテスト実行前の事前準備として、指定期間の全営業日分の特徴量（RSI 含む）を一括生成する `scripts/backfill_features.py` を追加する。

## 背景

`kabusys.data.bootstrap` で価格・財務データを取得しても `features` テーブルは空のままのため、バックテストが全銘柄を除外してしまう問題があった。

## ワークフロー（完成後）

```powershell
# 1. 価格・財務データ取得
python -m kabusys.data.bootstrap

# 2. 特徴量を期間一括生成（本 PR で追加）
python scripts/backfill_features.py --start 2022-01-01 --end 2024-12-31

# 3. バックテスト実行
python -m kabusys.backtest.run --start 2022-01-01 --end 2024-12-31 --db data/kabusys.duckdb
```

## 変更内容

### `scripts/backfill_features.py`（新規）
- `--start` / `--end` で期間指定（必須）
- `--force` で既存データを上書き（省略時はスキップ → 中断・再実行可能）
- `--dry-run` で対象日付の確認のみ（書き込みなし）
- `get_trading_days()` で営業日のみを処理対象に絞り込み
- `prices_daily` にデータがない日は自動スキップ＋警告
- **RSI ルックバック不足の事前警告**: `--start` 以前 45 日分の価格データが不足している場合に WARNING を出力（最初の約 14 営業日で `rsi_14=NULL` になる旨と対処法を案内）

### `tests/test_backfill_features.py`（新規）
- 10 ケース（処理・スキップ・force・dry-run・no_price・RSI ルックバックチェック）

### `documents/WebManual/C_Backtest.md`（更新）
- C-B-2「事前準備 — 特徴量のバックフィル」セクションを新設

## テスト計画

- [x] `tests/test_backfill_features.py` — 10 ケース全通過
- [x] `--force` なしで既存データをスキップする動作
- [x] `--dry-run` で書き込みなし
- [x] RSI ルックバック不足時の WARNING 出力（3 パターン）