### PR TITLE
fix: バックテストで topix_daily コピー漏れと threshold/topix_* パラメータ欠落を修正

### DIFF
--- a/src/kabusys/backtest/engine.py
+++ b/src/kabusys/backtest/engine.py
@@ -437,9 +437,13 @@ def run_backtest(
     if threshold is not None and not (0 < threshold < 1):
         raise ValueError(f"threshold は (0, 1) の範囲で指定してください: {threshold}")
     if topix_drawdown_threshold is not None and topix_drawdown_threshold >= 0:
-        raise ValueError(f"topix_drawdown_threshold は負の値を指定してください: {topix_drawdown_threshold}")
+        raise ValueError(
+            f"topix_drawdown_threshold は負の値を指定してください: {topix_drawdown_threshold}"
+        )
     if topix_size_multiplier_bear is not None and not (0 < topix_size_multiplier_bear <= 1):
-        raise ValueError(f"topix_size_multiplier_bear は (0, 1] の範囲で指定してください: {topix_size_multiplier_bear}")
+        raise ValueError(
+            f"topix_size_multiplier_bear は (0, 1] の範囲で指定してください: {topix_size_multiplier_bear}"
+        )
 
     # try ブロック外でも参照できるようデフォルト初期化
     _scope_mode: Literal["default_universe", "manual_codes"] = (

--- a/src/kabusys/backtest/engine.py
+++ b/src/kabusys/backtest/engine.py
@@ -92,7 +92,7 @@ def _build_backtest_conn(
     data_start = start_date - timedelta(days=300)
 
     # 日付範囲でフィルタするテーブル
-    _core_tables: tuple[str, ...] = ("prices_daily", "features", "market_regime")
+    _core_tables: tuple[str, ...] = ("prices_daily", "features", "market_regime", "topix_daily")
     _ai_tables: tuple[str, ...] = ("ai_scores",) if ai_enabled else ()
     date_filtered_tables = _core_tables + _ai_tables
     for table in date_filtered_tables:
@@ -367,6 +367,9 @@ def run_backtest(
     min_holding_days: int = 5,
     max_holding_days: int = 60,
     trailing_stop_atr: float = 2.0,
+    threshold: float | None = None,
+    topix_drawdown_threshold: float | None = None,
+    topix_size_multiplier_bear: float | None = None,
 ) -> BacktestResult:
     """バックテストを実行し結果を返す。
 
@@ -397,6 +400,11 @@ def run_backtest(
         trailing_stop_atr: トレーリングストップの ATR 乗数（デフォルト 2.0）。
                            close < peak_close - trailing_stop_atr × ATR_20d のとき SELL 発動。
                            正の値を指定すること。
+        threshold:         BUY シグナル生成の final_score 閾値（None のとき strategy_config.yaml から読み込む）。
+        topix_drawdown_threshold: TOPIX 200MA 乖離率のベア判定閾値（None のとき strategy_config.yaml から読み込む）。
+                           負の値を指定すること（例: -0.12）。
+        topix_size_multiplier_bear: ベア判定時の size_multiplier（None のとき strategy_config.yaml から読み込む）。
+                           0 < x <= 1 の範囲で指定すること。
 
     Returns:
         BacktestResult（history, trades, metrics および scope_mode/excluded_codes 等のスコープメタデータ）。
@@ -520,11 +528,14 @@ def run_backtest(
             generate_signals(
                 bt_conn,
                 target_date=trading_day,
+                threshold=threshold,
                 event_dates=event_dates or {},
                 scope=backtest_scope,
                 min_holding_days=min_holding_days,
                 max_holding_days=max_holding_days,
                 trailing_stop_atr=trailing_stop_atr,
+                topix_drawdown_threshold=topix_drawdown_threshold,
+                topix_size_multiplier_bear=topix_size_multiplier_bear,
             )
 
             # Step 5: ポートフォリオ構築（Phase 5 モジュール使用）

--- a/src/kabusys/backtest/engine.py
+++ b/src/kabusys/backtest/engine.py
@@ -434,6 +434,12 @@ def run_backtest(
         raise ValueError(f"max_holding_days は 1 以上を指定してください: {max_holding_days}")
     if trailing_stop_atr <= 0:
         raise ValueError(f"trailing_stop_atr は正の値を指定してください: {trailing_stop_atr}")
+    if threshold is not None and not (0 < threshold < 1):
+        raise ValueError(f"threshold は (0, 1) の範囲で指定してください: {threshold}")
+    if topix_drawdown_threshold is not None and topix_drawdown_threshold >= 0:
+        raise ValueError(f"topix_drawdown_threshold は負の値を指定してください: {topix_drawdown_threshold}")
+    if topix_size_multiplier_bear is not None and not (0 < topix_size_multiplier_bear <= 1):
+        raise ValueError(f"topix_size_multiplier_bear は (0, 1] の範囲で指定してください: {topix_size_multiplier_bear}")
 
     # try ブロック外でも参照できるようデフォルト初期化
     _scope_mode: Literal["default_universe", "manual_codes"] = (

--- a/src/kabusys/backtest/engine.py
+++ b/src/kabusys/backtest/engine.py
@@ -109,7 +109,14 @@ def _build_backtest_conn(
             placeholders = ", ".join(["?" for _ in cols])
             bt_conn.executemany(f"INSERT INTO {table} ({col_list}) VALUES ({placeholders})", rows)
         except Exception as exc:
-            logger.warning("_build_backtest_conn: %s のコピーをスキップ: %s", table, exc)
+            if table == "topix_daily":
+                logger.warning(
+                    "_build_backtest_conn: topix_daily が見つかりません — ベアガードは無効化されます"
+                    " (size_multiplier=1.0): %s",
+                    exc,
+                )
+            else:
+                logger.warning("_build_backtest_conn: %s のコピーをスキップ: %s", table, exc)
 
     # market_calendar は全件コピー
     try:

--- a/src/kabusys/backtest/run.py
+++ b/src/kabusys/backtest/run.py
@@ -147,6 +147,24 @@ def main() -> None:
         default=2.0,
         help="ATR multiplier for trailing stop. Position is sold when close < peak − N×ATR. [default: %(default)s]",
     )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=None,
+        help="BUY signal score threshold. Overrides strategy_config.yaml when specified.",
+    )
+    parser.add_argument(
+        "--topix-drawdown-threshold",
+        type=float,
+        default=None,
+        help="TOPIX 200MA deviation threshold for bear guard (negative value, e.g. -0.12). Overrides strategy_config.yaml when specified.",
+    )
+    parser.add_argument(
+        "--topix-size-multiplier-bear",
+        type=float,
+        default=None,
+        help="size_multiplier applied when TOPIX bear guard triggers (0 < x <= 1). Overrides strategy_config.yaml when specified.",
+    )
     parser.add_argument("--db", required=True, help="DuckDB file path")
     parser.add_argument(
         "--output-format",
@@ -213,6 +231,9 @@ def main() -> None:
             min_holding_days=args.min_holding_days,
             max_holding_days=args.max_holding_days,
             trailing_stop_atr=args.trailing_stop_atr,
+            threshold=args.threshold,
+            topix_drawdown_threshold=args.topix_drawdown_threshold,
+            topix_size_multiplier_bear=args.topix_size_multiplier_bear,
         )
     finally:
         conn.close()

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -1126,6 +1126,11 @@ def generate_signals(
                            1 以上を指定すること。
         trailing_stop_atr: ATR 乗数。peak_close − N×ATR を下回ったら trailing_stop SELL。
                            正の値を指定すること（None の場合は config から読み込む）。
+        topix_drawdown_threshold: TOPIX 200MA 乖離率のベア判定閾値（負の値、例: -0.12）。
+                           この値未満のとき size_multiplier_bear を適用する。
+                           None の場合は strategy_config.yaml から読み込む。
+        topix_size_multiplier_bear: ベア判定時の BUY size_multiplier（0 < x <= 1）。
+                           None の場合は strategy_config.yaml から読み込む。
         regime_provider:   レジームラベルを返すプロバイダー。明示的に渡した場合は
                            ENABLE_AI_SENTIMENT の設定値より優先される。省略時は
                            ENABLE_AI_SENTIMENT フラグに基づいて自動生成する。

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -1101,6 +1101,8 @@ def generate_signals(
     min_holding_days: int | None = None,
     max_holding_days: int | None = None,
     trailing_stop_atr: float | None = None,
+    topix_drawdown_threshold: float | None = None,
+    topix_size_multiplier_bear: float | None = None,
     *,
     regime_provider: RegimeProvider | None = None,
     sqlite_conn: sqlite3.Connection | None = None,
@@ -1189,8 +1191,16 @@ def generate_signals(
     topix_multiplier = _get_topix_size_multiplier(
         conn,
         target_date,
-        drawdown_threshold=_cfg["topix_drawdown_threshold"],
-        size_multiplier_bear=_cfg["topix_size_multiplier_bear"],
+        drawdown_threshold=(
+            topix_drawdown_threshold
+            if topix_drawdown_threshold is not None
+            else _cfg["topix_drawdown_threshold"]
+        ),
+        size_multiplier_bear=(
+            topix_size_multiplier_bear
+            if topix_size_multiplier_bear is not None
+            else _cfg["topix_size_multiplier_bear"]
+        ),
     )
     size_multiplier = min(size_multiplier, topix_multiplier)
 

--- a/tests/test_backtest_engine_params.py
+++ b/tests/test_backtest_engine_params.py
@@ -90,6 +90,7 @@ def test_run_py_cli_has_threshold_arg():
     with patch.object(argparse.ArgumentParser, "parse_args", capturing_parse):
         try:
             import kabusys.backtest.run as run_module
+
             importlib.reload(run_module)
             run_module.main()
         except SystemExit:
@@ -115,6 +116,7 @@ def test_run_py_cli_has_topix_args():
     with patch.object(argparse.ArgumentParser, "parse_args", capturing_parse):
         try:
             import kabusys.backtest.run as run_module
+
             importlib.reload(run_module)
             run_module.main()
         except SystemExit:

--- a/tests/test_backtest_engine_params.py
+++ b/tests/test_backtest_engine_params.py
@@ -1,0 +1,128 @@
+"""tests/test_backtest_engine_params.py
+
+Issue #344: topix_daily が in-memory DB にコピーされない / threshold・topix_* が
+run_backtest() に渡せないバグの回帰テスト。
+"""
+
+from datetime import date, timedelta
+
+import pytest
+
+
+@pytest.fixture
+def source_conn():
+    """topix_daily が揃ったソース DB。"""
+    from kabusys.data.schema import init_schema
+
+    conn = init_schema(":memory:")
+
+    conn.executemany(
+        "INSERT INTO market_calendar (date, is_trading_day) VALUES (?, ?)",
+        [(date(2025, 1, 6) + timedelta(days=i), True) for i in range(5)],
+    )
+
+    for i in range(220):
+        d = date(2024, 6, 10) + timedelta(days=i)
+        conn.execute(
+            "INSERT INTO topix_daily (date, open, high, low, close) VALUES (?, ?, ?, ?, ?)",
+            [d, 2500.0, 2510.0, 2490.0, 2500.0],
+        )
+
+    yield conn
+    conn.close()
+
+
+def test_build_backtest_conn_copies_topix_daily(source_conn):
+    """_build_backtest_conn() が topix_daily を in-memory DB にコピーすること。"""
+    from kabusys.backtest.engine import _build_backtest_conn
+
+    bt_conn = _build_backtest_conn(
+        source_conn,
+        start_date=date(2025, 1, 6),
+        end_date=date(2025, 1, 10),
+        ai_enabled=False,
+    )
+    try:
+        row = bt_conn.execute("SELECT COUNT(*) FROM topix_daily").fetchone()
+        assert row is not None
+        assert row[0] > 0, "topix_daily が in-memory DB にコピーされていない"
+    finally:
+        bt_conn.close()
+
+
+def test_run_backtest_accepts_threshold_param():
+    """run_backtest() が threshold パラメータを受け取れること。"""
+    import inspect
+    from kabusys.backtest.engine import run_backtest
+
+    sig = inspect.signature(run_backtest)
+    assert "threshold" in sig.parameters, "run_backtest() に threshold パラメータが存在しない"
+
+
+def test_run_backtest_accepts_topix_params():
+    """run_backtest() が topix_drawdown_threshold / topix_size_multiplier_bear を受け取れること。"""
+    import inspect
+    from kabusys.backtest.engine import run_backtest
+
+    sig = inspect.signature(run_backtest)
+    assert "topix_drawdown_threshold" in sig.parameters, (
+        "run_backtest() に topix_drawdown_threshold パラメータが存在しない"
+    )
+    assert "topix_size_multiplier_bear" in sig.parameters, (
+        "run_backtest() に topix_size_multiplier_bear パラメータが存在しない"
+    )
+
+
+def test_run_py_cli_has_threshold_arg():
+    """kabusys.backtest.run の argparse に --threshold が定義されていること。"""
+    import argparse
+    import importlib
+    from unittest.mock import patch
+
+    captured: list[argparse.ArgumentParser] = []
+
+    def capturing_parse(self, args=None, namespace=None):
+        captured.append(self)
+        raise SystemExit(0)
+
+    with patch.object(argparse.ArgumentParser, "parse_args", capturing_parse):
+        try:
+            import kabusys.backtest.run as run_module
+            importlib.reload(run_module)
+            run_module.main()
+        except SystemExit:
+            pass
+
+    assert captured, "ArgumentParser が生成されなかった"
+    actions = {a.dest for a in captured[0]._actions}
+    assert "threshold" in actions, f"--threshold が argparse に定義されていない: {actions}"
+
+
+def test_run_py_cli_has_topix_args():
+    """kabusys.backtest.run の argparse に --topix-drawdown-threshold / --topix-size-multiplier-bear が定義されていること。"""
+    import argparse
+    import importlib
+    from unittest.mock import patch
+
+    captured: list[argparse.ArgumentParser] = []
+
+    def capturing_parse(self, args=None, namespace=None):
+        captured.append(self)
+        raise SystemExit(0)
+
+    with patch.object(argparse.ArgumentParser, "parse_args", capturing_parse):
+        try:
+            import kabusys.backtest.run as run_module
+            importlib.reload(run_module)
+            run_module.main()
+        except SystemExit:
+            pass
+
+    assert captured
+    actions = {a.dest for a in captured[0]._actions}
+    assert "topix_drawdown_threshold" in actions, (
+        f"--topix-drawdown-threshold が argparse に定義されていない: {actions}"
+    )
+    assert "topix_size_multiplier_bear" in actions, (
+        f"--topix-size-multiplier-bear が argparse に定義されていない: {actions}"
+    )

--- a/tests/test_backtest_engine_params.py
+++ b/tests/test_backtest_engine_params.py
@@ -53,6 +53,7 @@ def test_build_backtest_conn_copies_topix_daily(source_conn):
 def test_run_backtest_accepts_threshold_param():
     """run_backtest() が threshold パラメータを受け取れること。"""
     import inspect
+
     from kabusys.backtest.engine import run_backtest
 
     sig = inspect.signature(run_backtest)
@@ -62,6 +63,7 @@ def test_run_backtest_accepts_threshold_param():
 def test_run_backtest_accepts_topix_params():
     """run_backtest() が topix_drawdown_threshold / topix_size_multiplier_bear を受け取れること。"""
     import inspect
+
     from kabusys.backtest.engine import run_backtest
 
     sig = inspect.signature(run_backtest)


### PR DESCRIPTION
## Summary

Closes #344

バックテストスイープで `threshold` / `topix_size_multiplier_bear` / `topix_drawdown_threshold` を変えても結果が同一になるバグを修正。

- **engine.py**: `_build_backtest_conn()` の `_core_tables` に `topix_daily` を追加。これがなかったため `_get_topix_size_multiplier()` が常に例外を捕捉して `1.0` を返し、TOPIX ベアガードが完全に無効だった
- **engine.py**: `run_backtest()` に `threshold` / `topix_drawdown_threshold` / `topix_size_multiplier_bear` パラメータを追加し `generate_signals()` に渡す
- **signal_generator.py**: `generate_signals()` に同3パラメータを追加。引数が `None` のときは従来どおり `strategy_config.yaml` からフォールバック
- **run.py**: `--threshold` / `--topix-drawdown-threshold` / `--topix-size-multiplier-bear` CLI 引数を追加し `run_backtest()` に渡す

## Test plan

- [ ] `tests/test_backtest_engine_params.py` の新規5件がすべてパスすること
- [ ] 既存 1965 件のテストにリグレッションがないこと（1970 passed 確認済み）
- [ ] `run_backtest_improvement_10m.py` を再実行したとき `10m_base` / `10m_tighter_entry` / `10m_bear_guard` で結果が異なることを確認する

## Root cause

`_build_backtest_conn()` が in-memory DB にコピーするテーブル一覧に `topix_daily` が含まれていなかった。`_get_topix_size_multiplier()` はテーブル不在時に例外を捕捉して `1.0` を返す設計のため、ベアガードが silently 無効になっていた。`threshold` などは YAML 経由で動作するが CLI から直接制御できなかった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
