### PR TITLE
feat: MA200 バイナリフィルター・出来高ブレイクアウトフィルターをシグナル生成に追加 (#346)

### DIFF
--- a/config/strategy_config.yaml
+++ b/config/strategy_config.yaml
@@ -26,7 +26,7 @@ strategy:
   # ギャップダウン閾値（この比率以下の寄り安は BUY 抑制）
   gap_down_threshold: -0.03
   # RSI(14) 過熱判定閾値（この値超の銘柄は BUY 抑制。50 < x <= 100）
-  rsi_overbought_threshold: 70.0
+  rsi_overbought_threshold: 65.0
 
 value_score:
   # バリュースコア計算の重み（合計 1.0）

--- a/src/kabusys/backtest/engine.py
+++ b/src/kabusys/backtest/engine.py
@@ -414,6 +414,10 @@ def run_backtest(
                            負の値を指定すること（例: -0.12）。
         topix_size_multiplier_bear: ベア判定時の size_multiplier（None のとき strategy_config.yaml から読み込む）。
                            0 < x <= 1 の範囲で指定すること。
+        use_ma200_filter:  True のとき株価が 200 日移動平均線を下回る銘柄の BUY を抑制する。
+                           False（デフォルト）で無効。generate_signals() の同名引数に転送。
+        volume_breakout_threshold: 指定した場合、volume_ratio が閾値未満の銘柄の BUY を抑制する。
+                           None（デフォルト）で無効。generate_signals() の同名引数に転送。
 
     Returns:
         BacktestResult（history, trades, metrics および scope_mode/excluded_codes 等のスコープメタデータ）。

--- a/src/kabusys/backtest/engine.py
+++ b/src/kabusys/backtest/engine.py
@@ -377,6 +377,8 @@ def run_backtest(
     threshold: float | None = None,
     topix_drawdown_threshold: float | None = None,
     topix_size_multiplier_bear: float | None = None,
+    use_ma200_filter: bool = False,
+    volume_breakout_threshold: float | None = None,
 ) -> BacktestResult:
     """バックテストを実行し結果を返す。
 
@@ -546,6 +548,8 @@ def run_backtest(
                 bt_conn,
                 target_date=trading_day,
                 threshold=threshold,
+                use_ma200_filter=use_ma200_filter,
+                volume_breakout_threshold=volume_breakout_threshold,
                 event_dates=event_dates or {},
                 scope=backtest_scope,
                 min_holding_days=min_holding_days,

--- a/src/kabusys/backtest/run.py
+++ b/src/kabusys/backtest/run.py
@@ -165,6 +165,18 @@ def main() -> None:
         default=None,
         help="size_multiplier applied when TOPIX bear guard triggers (0 < x <= 1). Overrides strategy_config.yaml when specified.",
     )
+    parser.add_argument(
+        "--ma200-filter",
+        action="store_true",
+        default=False,
+        help="When set, suppress BUY signals for stocks trading below their 200-day MA (ma200_dev < 0).",
+    )
+    parser.add_argument(
+        "--volume-breakout-threshold",
+        type=float,
+        default=None,
+        help="Suppress BUY signals when volume_ratio is below this multiplier (e.g. 1.5 means volume must be >= 1.5x 20-day average).",
+    )
     parser.add_argument("--db", required=True, help="DuckDB file path")
     parser.add_argument(
         "--output-format",
@@ -234,6 +246,8 @@ def main() -> None:
             threshold=args.threshold,
             topix_drawdown_threshold=args.topix_drawdown_threshold,
             topix_size_multiplier_bear=args.topix_size_multiplier_bear,
+            use_ma200_filter=args.ma200_filter,
+            volume_breakout_threshold=args.volume_breakout_threshold,
         )
     finally:
         conn.close()

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -78,7 +78,7 @@ _TOPIX_DRAWDOWN_THRESHOLD: float = -0.15  # 200MA 乖離率がこの値未満で
 _TOPIX_SIZE_MULTIPLIER_BEAR: float = 0.5  # 地合い悪化時の size_multiplier
 _TOPIX_MIN_DATA_COUNT: int = 100  # 200MA を信頼できる最低データ数（初期運用でのデータ蓄積期間を考慮し 200 でなく 100 に設定）
 
-_RSI_OVERBOUGHT_THRESHOLD: float = 70.0  # RSI(14) > この値の銘柄は BUY 抑制（過熱判定）
+_RSI_OVERBOUGHT_THRESHOLD: float = 65.0  # RSI(14) > この値の銘柄は BUY 抑制（過熱判定）
 
 # features テーブルから SELECT する列（2箇所で共用）
 _FEATURES_SELECT_COLS: tuple[str, ...] = (
@@ -1133,6 +1133,13 @@ def generate_signals(
                            None の場合は strategy_config.yaml から読み込む。
         topix_size_multiplier_bear: ベア判定時の BUY size_multiplier（0 < x <= 1）。
                            None の場合は strategy_config.yaml から読み込む。
+        use_ma200_filter:  True のとき株価が 200 日移動平均線を下回る銘柄（ma200_dev < 0）
+                           の BUY を抑制する。ma200_dev が None の場合は安全側で BUY 許可。
+                           False（デフォルト）では無効。
+        volume_breakout_threshold: 指定した場合、volume_ratio（20日平均出来高比）が
+                           この値を下回る銘柄の BUY を抑制する（例: 1.5 = 1.5倍未満を除外）。
+                           volume_ratio が None の場合は安全側で BUY 許可。
+                           None（デフォルト）で無効。
         regime_provider:   レジームラベルを返すプロバイダー。明示的に渡した場合は
                            ENABLE_AI_SENTIMENT の設定値より優先される。省略時は
                            ENABLE_AI_SENTIMENT フラグに基づいて自動生成する。

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -1103,6 +1103,8 @@ def generate_signals(
     trailing_stop_atr: float | None = None,
     topix_drawdown_threshold: float | None = None,
     topix_size_multiplier_bear: float | None = None,
+    use_ma200_filter: bool = False,
+    volume_breakout_threshold: float | None = None,
     *,
     regime_provider: RegimeProvider | None = None,
     sqlite_conn: sqlite3.Connection | None = None,
@@ -1326,7 +1328,15 @@ def generate_signals(
                 target_date,
             )
             boosted_count += 1
-        scored.append({"code": code, "score": final_score, "rsi_14": feat.get("rsi_14")})
+        scored.append(
+            {
+                "code": code,
+                "score": final_score,
+                "rsi_14": feat.get("rsi_14"),
+                "ma200_dev": feat.get("ma200_dev"),
+                "volume_ratio": feat.get("volume_ratio"),
+            }
+        )
 
     if not regime_is_bear and not breadth_stop and boosted_count:
         logger.info(
@@ -1351,6 +1361,8 @@ def generate_signals(
         )
         gap_suppressed = 0
         rsi_suppressed = 0
+        ma200_suppressed = 0
+        volume_suppressed = 0
         sector_suppressed = 0
         reentry_suppressed = 0
         earnings_suppressed = 0
@@ -1368,6 +1380,31 @@ def generate_signals(
                 )
                 rsi_suppressed += 1
                 continue
+            # 200MA バイナリフィルタ（use_ma200_filter=True のとき MA200 下の銘柄を抑制）
+            if use_ma200_filter:
+                ma200_dev_val = r.get("ma200_dev")
+                if ma200_dev_val is not None and ma200_dev_val < 0:
+                    logger.debug(
+                        "ma200 filter: %s ma200_dev=%.4f — BUY を抑制 date=%s",
+                        r["code"],
+                        ma200_dev_val,
+                        target_date,
+                    )
+                    ma200_suppressed += 1
+                    continue
+            # 出来高ブレイクアウトフィルタ（threshold 指定時に volume_ratio が閾値未満の銘柄を抑制）
+            if volume_breakout_threshold is not None:
+                volume_ratio_val = r.get("volume_ratio")
+                if volume_ratio_val is not None and volume_ratio_val < volume_breakout_threshold:
+                    logger.debug(
+                        "volume breakout filter: %s volume_ratio=%.2f < threshold=%.2f — BUY を抑制 date=%s",
+                        r["code"],
+                        volume_ratio_val,
+                        volume_breakout_threshold,
+                        target_date,
+                    )
+                    volume_suppressed += 1
+                    continue
             gap = gap_ratios.get(r["code"])
             if gap is not None and (
                 gap > _gap_up + _GAP_THRESHOLD_EPSILON or gap <= _gap_down + _GAP_THRESHOLD_EPSILON
@@ -1417,6 +1454,18 @@ def generate_signals(
                 "generate_signals: rsi filter — %d 銘柄を RSI 過熱(%s超)で抑制 date=%s",
                 rsi_suppressed,
                 _rsi_threshold,
+                target_date,
+            )
+        if ma200_suppressed:
+            logger.info(
+                "generate_signals: ma200 filter — %d 銘柄を MA200 下で抑制 date=%s",
+                ma200_suppressed,
+                target_date,
+            )
+        if volume_suppressed:
+            logger.info(
+                "generate_signals: volume breakout filter — %d 銘柄を出来高不足で抑制 date=%s",
+                volume_suppressed,
                 target_date,
             )
         if gap_suppressed:

--- a/tests/test_backtest_engine_params.py
+++ b/tests/test_backtest_engine_params.py
@@ -75,6 +75,21 @@ def test_run_backtest_accepts_topix_params():
     )
 
 
+def test_run_backtest_accepts_factor_filter_params():
+    """run_backtest() が use_ma200_filter / volume_breakout_threshold を受け取れること。"""
+    import inspect
+
+    from kabusys.backtest.engine import run_backtest
+
+    sig = inspect.signature(run_backtest)
+    assert "use_ma200_filter" in sig.parameters, (
+        "run_backtest() に use_ma200_filter パラメータが存在しない"
+    )
+    assert "volume_breakout_threshold" in sig.parameters, (
+        "run_backtest() に volume_breakout_threshold パラメータが存在しない"
+    )
+
+
 def test_run_py_cli_has_threshold_arg():
     """kabusys.backtest.run の argparse に --threshold が定義されていること。"""
     import argparse
@@ -129,4 +144,33 @@ def test_run_py_cli_has_topix_args():
     )
     assert "topix_size_multiplier_bear" in actions, (
         f"--topix-size-multiplier-bear が argparse に定義されていない: {actions}"
+    )
+
+
+def test_run_py_cli_has_factor_filter_args():
+    """kabusys.backtest.run の argparse に --ma200-filter / --volume-breakout-threshold が定義されていること。"""
+    import argparse
+    import importlib
+    from unittest.mock import patch
+
+    captured: list[argparse.ArgumentParser] = []
+
+    def capturing_parse(self, args=None, namespace=None):
+        captured.append(self)
+        raise SystemExit(0)
+
+    with patch.object(argparse.ArgumentParser, "parse_args", capturing_parse):
+        try:
+            import kabusys.backtest.run as run_module
+
+            importlib.reload(run_module)
+            run_module.main()
+        except SystemExit:
+            pass
+
+    assert captured
+    actions = {a.dest for a in captured[0]._actions}
+    assert "ma200_filter" in actions, f"--ma200-filter が argparse に定義されていない: {actions}"
+    assert "volume_breakout_threshold" in actions, (
+        f"--volume-breakout-threshold が argparse に定義されていない: {actions}"
     )

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -1029,14 +1029,14 @@ class TestRsiFilterInGenerateSignals:
         assert "1001" in buy_codes
 
     def test_rsi_at_threshold_allows_buy(self, conn):
-        """RSI がちょうど閾値（70.0）の場合は BUY を許可すること（> のため境界値は許可）。"""
+        """RSI がちょうど閾値（65.0）の場合は BUY を許可すること（> のため境界値は許可）。"""
         import sqlite3
 
         from kabusys.strategy.signal_generator import generate_signals
 
         _insert_regime(conn, TARGET_DATE, "bull")
         _insert_breadth(conn, TARGET_DATE, breadth_stop=False)
-        self._insert_feature_with_rsi(conn, "1001", TARGET_DATE, rsi=70.0)
+        self._insert_feature_with_rsi(conn, "1001", TARGET_DATE, rsi=65.0)
         conn.execute(
             "INSERT INTO prices_daily (date, code, open, high, low, close, volume) "
             "VALUES (?, '1001', 1000, 1010, 990, 1000, 100000)",
@@ -1054,4 +1054,181 @@ class TestRsiFilterInGenerateSignals:
                 "SELECT code FROM signals WHERE date=? AND side='buy'", [TARGET_DATE]
             ).fetchall()
         ]
-        assert "1001" in buy_codes, "RSI=70.0（閾値ちょうど）は BUY 許可（> 判定のため）"
+        assert "1001" in buy_codes, "RSI=65.0（閾値ちょうど）は BUY 許可（> 判定のため）"
+
+
+# ---------------------------------------------------------------------------
+# 200MA バイナリフィルター / 出来高ブレイクアウトフィルター テスト (Issue #346)
+# ---------------------------------------------------------------------------
+
+
+def _insert_feature_with_values(
+    conn,
+    code: str,
+    d: date,
+    *,
+    momentum_20: float = 3.0,
+    momentum_60: float = 3.0,
+    volatility_20: float = -3.0,
+    volume_ratio: float = 3.0,
+    per: float = 5.0,
+    ma200_dev: float = 3.0,
+) -> None:
+    conn.execute(
+        "INSERT INTO features "
+        "(date, code, momentum_20, momentum_60, volatility_20, volume_ratio, per, ma200_dev) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        [d, code, momentum_20, momentum_60, volatility_20, volume_ratio, per, ma200_dev],
+    )
+
+
+class TestMa200Filter:
+    """use_ma200_filter=True のとき MA200 下の銘柄の BUY を抑制する。"""
+
+    def test_below_ma200_suppressed(self, conn):
+        """use_ma200_filter=True → ma200_dev < 0 の銘柄の BUY を抑制する。"""
+        from kabusys.strategy.signal_generator import generate_signals
+
+        _insert_regime(conn, TARGET_DATE, "bull")
+        _insert_breadth(conn, TARGET_DATE, breadth_stop=False)
+        _insert_feature_with_values(conn, "8001", TARGET_DATE, ma200_dev=-0.05)
+
+        generate_signals(conn, TARGET_DATE, use_ma200_filter=True)
+
+        buy_codes = [
+            r[0]
+            for r in conn.execute(
+                "SELECT code FROM signals WHERE date = ? AND side = 'buy'", [TARGET_DATE]
+            ).fetchall()
+        ]
+        assert "8001" not in buy_codes
+
+    def test_above_ma200_allowed(self, conn):
+        """use_ma200_filter=True → ma200_dev >= 0 の銘柄の BUY を許可する。"""
+        from kabusys.strategy.signal_generator import generate_signals
+
+        _insert_regime(conn, TARGET_DATE, "bull")
+        _insert_breadth(conn, TARGET_DATE, breadth_stop=False)
+        _insert_feature_with_values(conn, "8002", TARGET_DATE, ma200_dev=0.05)
+
+        generate_signals(conn, TARGET_DATE, use_ma200_filter=True)
+
+        buy_codes = [
+            r[0]
+            for r in conn.execute(
+                "SELECT code FROM signals WHERE date = ? AND side = 'buy'", [TARGET_DATE]
+            ).fetchall()
+        ]
+        assert "8002" in buy_codes
+
+    def test_filter_disabled_by_default(self, conn):
+        """use_ma200_filter=False（デフォルト）→ ma200_dev < 0 でも BUY を許可する。"""
+        from kabusys.strategy.signal_generator import generate_signals
+
+        _insert_regime(conn, TARGET_DATE, "bull")
+        _insert_breadth(conn, TARGET_DATE, breadth_stop=False)
+        _insert_feature_with_values(conn, "8003", TARGET_DATE, ma200_dev=-0.05)
+
+        generate_signals(conn, TARGET_DATE)
+
+        buy_codes = [
+            r[0]
+            for r in conn.execute(
+                "SELECT code FROM signals WHERE date = ? AND side = 'buy'", [TARGET_DATE]
+            ).fetchall()
+        ]
+        assert "8003" in buy_codes
+
+    def test_ma200_dev_zero_allowed(self, conn):
+        """ma200_dev == 0.0 は MA200 と同値 → BUY を許可する（>= 0 判定）。"""
+        from kabusys.strategy.signal_generator import generate_signals
+
+        _insert_regime(conn, TARGET_DATE, "bull")
+        _insert_breadth(conn, TARGET_DATE, breadth_stop=False)
+        _insert_feature_with_values(conn, "8004", TARGET_DATE, ma200_dev=0.0)
+
+        generate_signals(conn, TARGET_DATE, use_ma200_filter=True)
+
+        buy_codes = [
+            r[0]
+            for r in conn.execute(
+                "SELECT code FROM signals WHERE date = ? AND side = 'buy'", [TARGET_DATE]
+            ).fetchall()
+        ]
+        assert "8004" in buy_codes
+
+
+class TestVolumeBreakoutFilter:
+    """volume_breakout_threshold が指定されると出来高比率が低い銘柄の BUY を抑制する。"""
+
+    def test_low_volume_suppressed(self, conn):
+        """volume_breakout_threshold=1.5 → volume_ratio=1.2 の銘柄の BUY を抑制する。"""
+        from kabusys.strategy.signal_generator import generate_signals
+
+        _insert_regime(conn, TARGET_DATE, "bull")
+        _insert_breadth(conn, TARGET_DATE, breadth_stop=False)
+        _insert_feature_with_values(conn, "9001", TARGET_DATE, volume_ratio=1.2)
+
+        generate_signals(conn, TARGET_DATE, volume_breakout_threshold=1.5)
+
+        buy_codes = [
+            r[0]
+            for r in conn.execute(
+                "SELECT code FROM signals WHERE date = ? AND side = 'buy'", [TARGET_DATE]
+            ).fetchall()
+        ]
+        assert "9001" not in buy_codes
+
+    def test_high_volume_allowed(self, conn):
+        """volume_breakout_threshold=1.5 → volume_ratio=2.0 の銘柄の BUY を許可する。"""
+        from kabusys.strategy.signal_generator import generate_signals
+
+        _insert_regime(conn, TARGET_DATE, "bull")
+        _insert_breadth(conn, TARGET_DATE, breadth_stop=False)
+        _insert_feature_with_values(conn, "9002", TARGET_DATE, volume_ratio=2.0)
+
+        generate_signals(conn, TARGET_DATE, volume_breakout_threshold=1.5)
+
+        buy_codes = [
+            r[0]
+            for r in conn.execute(
+                "SELECT code FROM signals WHERE date = ? AND side = 'buy'", [TARGET_DATE]
+            ).fetchall()
+        ]
+        assert "9002" in buy_codes
+
+    def test_threshold_none_disabled(self, conn):
+        """volume_breakout_threshold=None（デフォルト）→ volume_ratio=1.0 でも BUY 許可。"""
+        from kabusys.strategy.signal_generator import generate_signals
+
+        _insert_regime(conn, TARGET_DATE, "bull")
+        _insert_breadth(conn, TARGET_DATE, breadth_stop=False)
+        _insert_feature_with_values(conn, "9003", TARGET_DATE, volume_ratio=1.0)
+
+        generate_signals(conn, TARGET_DATE)
+
+        buy_codes = [
+            r[0]
+            for r in conn.execute(
+                "SELECT code FROM signals WHERE date = ? AND side = 'buy'", [TARGET_DATE]
+            ).fetchall()
+        ]
+        assert "9003" in buy_codes
+
+    def test_volume_exactly_at_threshold_allowed(self, conn):
+        """volume_ratio がちょうど閾値の場合は BUY を許可する（>= 判定）。"""
+        from kabusys.strategy.signal_generator import generate_signals
+
+        _insert_regime(conn, TARGET_DATE, "bull")
+        _insert_breadth(conn, TARGET_DATE, breadth_stop=False)
+        _insert_feature_with_values(conn, "9004", TARGET_DATE, volume_ratio=1.5)
+
+        generate_signals(conn, TARGET_DATE, volume_breakout_threshold=1.5)
+
+        buy_codes = [
+            r[0]
+            for r in conn.execute(
+                "SELECT code FROM signals WHERE date = ? AND side = 'buy'", [TARGET_DATE]
+            ).fetchall()
+        ]
+        assert "9004" in buy_codes

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -910,10 +910,10 @@ class TestCalcRsi:
 class TestRsiOverboughtConfig:
     """rsi_overbought_threshold の config 読み込みテスト。"""
 
-    def test_default_is_70(self):
+    def test_default_is_65(self):
         from kabusys.strategy.signal_generator import _STRATEGY_CONFIG_DEFAULTS
 
-        assert _STRATEGY_CONFIG_DEFAULTS["rsi_overbought_threshold"] == 70.0
+        assert _STRATEGY_CONFIG_DEFAULTS["rsi_overbought_threshold"] == 65.0
 
     def test_valid_value_accepted(self, tmp_path, monkeypatch):
         yaml_text = "strategy:\n  rsi_overbought_threshold: 75.0\n"
@@ -921,10 +921,10 @@ class TestRsiOverboughtConfig:
         assert cfg["rsi_overbought_threshold"] == 75.0
 
     def test_value_50_rejected(self, tmp_path, monkeypatch):
-        """50 以下は無効（50 < x <= 100 の範囲外）。"""
+        """50 以下は無効（50 < x <= 100 の範囲外）→ デフォルト 65.0 にフォールバック。"""
         yaml_text = "strategy:\n  rsi_overbought_threshold: 50.0\n"
         cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
-        assert cfg["rsi_overbought_threshold"] == 70.0  # default
+        assert cfg["rsi_overbought_threshold"] == 65.0  # default
 
     def test_value_100_accepted(self, tmp_path, monkeypatch):
         """100 は有効（フィルタ実質オフ）。"""


### PR DESCRIPTION
## Summary

- `generate_signals()` に `use_ma200_filter` / `volume_breakout_threshold` パラメータを追加し、BUY エントリー品質を向上させるフィルターを実装
- RSI 過熱閾値を `strategy_config.yaml` で 70 → 65 に修正（バックテスト分析結果に基づく）
- TDD（RED → GREEN）で実装、全 1986 テスト pass 確認済み

## 変更詳細

### MA200 バイナリフィルター (`use_ma200_filter: bool = False`)

株価が200日移動平均線を**下回る**銘柄（`ma200_dev < 0`）の BUY を抑制する。
`ma200_dev` は既存の `features` テーブルに存在するため追加 DB クエリは不要。

```python
generate_signals(conn, target_date, use_ma200_filter=True)
# または CLI で
# python -m kabusys.backtest.run ... --ma200-filter
```

### 出来高ブレイクアウトフィルター (`volume_breakout_threshold: float | None = None`)

`volume_ratio`（20日平均出来高比）が閾値を下回る銘柄の BUY を抑制する。

```python
generate_signals(conn, target_date, volume_breakout_threshold=1.5)
# または CLI で
# python -m kabusys.backtest.run ... --volume-breakout-threshold 1.5
```

### フィルターの位置（BUY ループ）

```
RSI 過熱フィルター → 200MA フィルター（新規） → 出来高フィルター（新規） → ギャップフィルター → ...
```

## 背景

バックテスト分析で `10m_equal_4slots`（equal/4slots/threshold=0.58）が最良設定と判明。
MDD をさらに低減するため、トレンドフォローと出来高確認によるエントリー品質向上を実装。

## Test plan

- [x] `TestMa200Filter` 4件（MA200 下抑制・上許可・デフォルト無効・境界値 0.0）
- [x] `TestVolumeBreakoutFilter` 4件（低出来高抑制・高出来高許可・None無効・閾値ちょうど許可）
- [x] `test_run_backtest_accepts_factor_filter_params` — engine パラメータ受け入れ確認
- [x] `test_run_py_cli_has_factor_filter_args` — CLI 引数定義確認
- [x] 全1986テスト pass

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)