### PR TITLE
feat: 10m MDD対策（ポートフォリオドローダウンストップ）& 1m ファクターアブレーション分析

### DIFF
--- a/backtest/backtest_improvement_plan/backtest_improvement_plan.md
+++ b/backtest/backtest_improvement_plan/backtest_improvement_plan.md
@@ -1,0 +1,386 @@
+# バックテスト改善計画
+
+作成日: 2026-05-16  
+対象スクリプト: `work/run_backtest_rsi65_trim_slots7_cash_compare.py`
+
+---
+
+## 1. 現状の問題点サマリー
+
+### 100万円の根本問題：単元株制約
+
+現行の `risk_based` 配分では 1 ポジションあたりの予算が小さすぎる。
+
+```
+1ポジション予算 = cash × risk_pct / stop_loss_pct
+               = 1,000,000 × 0.005 / 0.09 = 55,556 円
+```
+
+- 55,556 円 ÷ 100 株 = **上限株価 555 円**
+- 全シグナルのうち実際に執行できたのは **28 / 492 件（約 6%）**
+- 特定銘柄（63660）が利益の **67%** を占める過集中状態
+- 統計的に意味のある評価が不可能
+
+### 1000万円の問題
+
+| 問題 | 数値 | 影響 |
+|---|---|---|
+| Profit Factor ギリギリ | 1.037 | 少しの悪化でマイナス転落 |
+| 短期保有（≤5日）損失 | **-1,470,750 円** | 30 トレードで全利益を食う |
+| 4月の下落 | **-581,823 円** | トランプ関税ショック |
+| 11月の下落 | **-479,076 円** | ベア相場対応不足 |
+| 手数料が利益と同水準 | 227,437 円 vs 利益 211,860 円 | 短期売買が多すぎる |
+
+---
+
+## 2. 検証パターン
+
+### 2-A. 100万円向けパターン（4本）
+
+**目的**: `allocation_method=equal` に切り替え、ポジション予算を拡大して単元株制約を緩和する。
+
+| シナリオ名 | allocation_method | max_positions | max_position_pct | 1ポジション予算 | アクセス可能上限 |
+|---|---|---|---|---|---|
+| `1m_base` | risk_based | 7 | 10% | ~55,556 円 | ~500 円/株（現行） |
+| `1m_equal_6slots` | **equal** | **6** | **15%** | **150,000 円** | ~1,500 円/株 |
+| `1m_equal_5slots` | **equal** | **5** | **18%** | **180,000 円** | ~1,800 円/株 |
+| `1m_equal_4slots` | **equal** | **4** | **22%** | **220,000 円** | ~2,200 円/株 |
+
+> **注**: equal allocation では `1ポジション予算 = cash × max_utilization / max_positions`  
+> 例: 1,000,000 × 0.75 / 5 = **150,000 円**（`1m_equal_6slots` の場合）
+
+#### 共通の strategy_config 設定（100万円向け）
+
+```yaml
+strategy:
+  threshold: 0.58
+  rsi_overbought_threshold: 65.0
+  gap_up_threshold: 0.07
+  gap_down_threshold: -0.05
+  stop_loss_rate: -0.08
+  min_holding_days: 5
+  max_holding_days: 60
+  trailing_stop_atr_mult: 2.0
+  reentry_cooldown_days: 5
+sector:
+  boost: 0.05
+  quartile: 0.30
+regime:
+  topix_drawdown_threshold: -0.15
+  topix_size_multiplier_bear: 0.50
+```
+
+#### 各シナリオの backtest パラメータ
+
+```python
+# 1m_base（現行・比較ベースライン）
+{
+    "cash": 1_000_000,
+    "allocation_method": "risk_based",
+    "max_positions": 7,
+    "max_position_pct": 0.10,
+    "max_utilization": 0.70,
+    "risk_pct": 0.005,
+    "stop_loss_pct": 0.09,
+}
+
+# 1m_equal_6slots
+{
+    "cash": 1_000_000,
+    "allocation_method": "equal",
+    "max_positions": 6,
+    "max_position_pct": 0.15,
+    "max_utilization": 0.75,
+    "risk_pct": 0.005,     # equal では参照されないが保持
+    "stop_loss_pct": 0.09,
+}
+
+# 1m_equal_5slots
+{
+    "cash": 1_000_000,
+    "allocation_method": "equal",
+    "max_positions": 5,
+    "max_position_pct": 0.18,
+    "max_utilization": 0.75,
+    "risk_pct": 0.005,
+    "stop_loss_pct": 0.09,
+}
+
+# 1m_equal_4slots
+{
+    "cash": 1_000_000,
+    "allocation_method": "equal",
+    "max_positions": 4,
+    "max_position_pct": 0.22,
+    "max_utilization": 0.80,
+    "risk_pct": 0.005,
+    "stop_loss_pct": 0.09,
+}
+```
+
+---
+
+### 2-B. 1000万円向けパターン（4本）
+
+**目的**: 短期損失の抑制、ベア局面フィルタ強化、Winner をより長く保有して Payoff 改善。
+
+| シナリオ名 | threshold | bear_mult | trailing_atr | 主な狙い |
+|---|---|---|---|---|
+| `10m_base` | 0.58 | 0.50 | 2.0 | 現行比較ベースライン |
+| `10m_tighter_entry` | **0.62** | 0.50 | 2.0 | シグナル精度向上・不要エントリー削減 |
+| `10m_bear_guard` | **0.62** | **0.30** | 2.0 | 4月・11月の下落局面でポジション抑制 |
+| `10m_hold_longer` | **0.62** | **0.30** | **2.5** | Payoff 改善（Winner をより長く保有） |
+
+#### 各シナリオの変更点詳細
+
+```python
+# 10m_base（現行・比較ベースライン）
+strategy:
+  threshold: 0.58
+  trailing_stop_atr_mult: 2.0
+regime:
+  topix_drawdown_threshold: -0.15
+  topix_size_multiplier_bear: 0.50
+
+# 10m_tighter_entry
+# → threshold のみ変更。1 点の変化の効果を単独で測定する
+strategy:
+  threshold: 0.62        # ← 変更
+
+# 10m_bear_guard
+# → threshold 引き上げ + ベア判定の早期化・ポジション抑制
+strategy:
+  threshold: 0.62
+regime:
+  topix_drawdown_threshold: -0.12   # ← 変更（-15%→-12%: 早めにベア判定）
+  topix_size_multiplier_bear: 0.30  # ← 変更（0.5→0.3: ベア時は 70%削減）
+
+# 10m_hold_longer
+# → bear_guard に加えてトレーリングストップを緩め Winner を引っ張る
+strategy:
+  threshold: 0.62
+  trailing_stop_atr_mult: 2.5       # ← 変更（2.0→2.5）
+regime:
+  topix_drawdown_threshold: -0.12
+  topix_size_multiplier_bear: 0.30
+```
+
+#### 共通の backtest パラメータ（1000万円向け）
+
+```python
+{
+    "cash": 10_000_000,
+    "allocation_method": "risk_based",
+    "max_positions": 7,
+    "max_position_pct": 0.10,
+    "max_utilization": 0.70,
+    "risk_pct": 0.005,
+    "stop_loss_pct": 0.09,
+}
+```
+
+---
+
+## 3. スクリプト修正内容
+
+対象: `work/run_backtest_rsi65_trim_slots7_cash_compare.py`
+
+### 修正 1：`SCENARIOS` リストを展開
+
+`SCENARIOS` を 100万円 4 本 + 1000万円 4 本の 8 本に差し替える。
+
+```python
+SCENARIOS = [
+    # --- 100万円：allocation_method 比較 ---
+    {"name": "1m_base",         "cash": 1_000_000,  "allocation_method": "risk_based", "max_positions": 7, "max_position_pct": 0.10, "max_utilization": 0.70},
+    {"name": "1m_equal_6slots", "cash": 1_000_000,  "allocation_method": "equal",      "max_positions": 6, "max_position_pct": 0.15, "max_utilization": 0.75},
+    {"name": "1m_equal_5slots", "cash": 1_000_000,  "allocation_method": "equal",      "max_positions": 5, "max_position_pct": 0.18, "max_utilization": 0.75},
+    {"name": "1m_equal_4slots", "cash": 1_000_000,  "allocation_method": "equal",      "max_positions": 4, "max_position_pct": 0.22, "max_utilization": 0.80},
+    # --- 1000万円：threshold / bear / hold チューニング ---
+    {"name": "10m_base",           "cash": 10_000_000, "allocation_method": "risk_based", "threshold": 0.58, "topix_size_multiplier_bear": 0.50, "topix_drawdown_threshold": -0.15, "trailing_stop_atr_mult": 2.0},
+    {"name": "10m_tighter_entry",  "cash": 10_000_000, "allocation_method": "risk_based", "threshold": 0.62, "topix_size_multiplier_bear": 0.50, "topix_drawdown_threshold": -0.15, "trailing_stop_atr_mult": 2.0},
+    {"name": "10m_bear_guard",     "cash": 10_000_000, "allocation_method": "risk_based", "threshold": 0.62, "topix_size_multiplier_bear": 0.30, "topix_drawdown_threshold": -0.12, "trailing_stop_atr_mult": 2.0},
+    {"name": "10m_hold_longer",    "cash": 10_000_000, "allocation_method": "risk_based", "threshold": 0.62, "topix_size_multiplier_bear": 0.30, "topix_drawdown_threshold": -0.12, "trailing_stop_atr_mult": 2.5},
+]
+```
+
+---
+
+### 修正 2：`_build_strategy_config()` をシナリオ対応に変更
+
+現在は固定値で上書きしている。シナリオごとに `threshold` / `trailing_stop_atr_mult` / `regime` を切り替えられるよう引数を追加する。
+
+```python
+def _build_strategy_config(base: dict, scenario: dict) -> dict:
+    strategy_config = deepcopy(base)
+    strategy_section = strategy_config.setdefault("strategy", {})
+    sector_section   = strategy_config.setdefault("sector", {})
+    regime_section   = strategy_config.setdefault("regime", {})
+    portfolio_section = strategy_config.setdefault("portfolio", {})
+
+    # 固定値
+    strategy_section["rsi_overbought_threshold"] = 65.0
+    strategy_section["gap_up_threshold"]         = 0.07
+    strategy_section["gap_down_threshold"]       = -0.05
+    strategy_section["stop_loss_rate"]           = -0.08
+    strategy_section["min_holding_days"]         = 5
+    strategy_section["max_holding_days"]         = 60
+    strategy_section["reentry_cooldown_days"]    = 5
+    sector_section["boost"]    = 0.05
+    sector_section["quartile"] = 0.30
+
+    # シナリオで上書き可能な値
+    strategy_section["threshold"]              = scenario.get("threshold", 0.58)
+    strategy_section["trailing_stop_atr_mult"] = scenario.get("trailing_stop_atr_mult", 2.0)
+    regime_section["topix_size_multiplier_bear"]  = scenario.get("topix_size_multiplier_bear", 0.50)
+    regime_section["topix_drawdown_threshold"]    = scenario.get("topix_drawdown_threshold", -0.15)
+
+    portfolio_section["max_positions"] = scenario.get("max_positions", 7)
+    return strategy_config
+```
+
+---
+
+### 修正 3：`_build_backtest_params()` に `allocation_method` / `max_positions` / `max_position_pct` / `max_utilization` を追加
+
+```python
+def _build_backtest_params(scenario: dict) -> dict[str, object]:
+    return {
+        "start":             "2025-01-01",
+        "end":               "2025-12-31",
+        "cash":              scenario["cash"],
+        "allocation_method": scenario.get("allocation_method", "risk_based"),
+        "max_positions":     scenario.get("max_positions", 7),
+        "max_position_pct":  scenario.get("max_position_pct", 0.10),
+        "max_utilization":   scenario.get("max_utilization", 0.70),
+        "risk_pct":          scenario.get("risk_pct", 0.005),
+        "stop_loss_pct":     scenario.get("stop_loss_pct", 0.09),
+        "min_holding_days":  5,
+        "max_holding_days":  60,
+        "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
+    }
+```
+
+---
+
+### 修正 4：`_build_command()` に `--allocation-method` を追加
+
+```python
+def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -> list[str]:
+    return [
+        sys.executable, "-m", "kabusys.backtest.run",
+        "--db",                str(db_path),
+        "--start",             str(params["start"]),
+        "--end",               str(params["end"]),
+        "--cash",              str(params["cash"]),
+        "--allocation-method", str(params["allocation_method"]),   # ← 追加
+        "--max-position-pct",  str(params["max_position_pct"]),
+        "--max-utilization",   str(params["max_utilization"]),
+        "--max-positions",     str(params["max_positions"]),
+        "--risk-pct",          str(params["risk_pct"]),
+        "--stop-loss-pct",     str(params["stop_loss_pct"]),
+        "--min-holding-days",  str(params["min_holding_days"]),
+        "--max-holding-days",  str(params["max_holding_days"]),
+        "--trailing-stop-atr", str(params["trailing_stop_atr"]),
+        "--output-format",     "all",
+        "--output-dir",        str(output_dir),
+    ]
+```
+
+---
+
+### 修正 5：`fieldnames` と `record` に `allocation_method` を追加
+
+```python
+fieldnames = [
+    "name", "run_id", "created_at",
+    "cash", "allocation_method",          # ← allocation_method 追加
+    "threshold",                           # ← 追加（シナリオ差異を記録）
+    "topix_size_multiplier_bear",          # ← 追加
+    "trailing_stop_atr",                   # ← 追加
+    "rsi_overbought_threshold",
+    "max_positions", "max_position_pct", "max_utilization",
+    "risk_pct", "stop_loss_pct",
+    "cagr", "sharpe", "max_drawdown",
+    "win_rate", "payoff_ratio", "profit_factor",
+    "avg_holding_days", "total_trades",
+    "trades_csv",
+]
+```
+
+```python
+record = {
+    "name":                       scenario_slug,
+    "run_id":                     run_id,
+    "created_at":                 metrics["created_at"],
+    "cash":                       params["cash"],
+    "allocation_method":          params["allocation_method"],
+    "threshold":                  scenario.get("threshold", 0.58),
+    "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+    "trailing_stop_atr":          scenario.get("trailing_stop_atr_mult", 2.0),
+    "rsi_overbought_threshold":   65.0,
+    "max_positions":              params["max_positions"],
+    "max_position_pct":           params["max_position_pct"],
+    "max_utilization":            params["max_utilization"],
+    "risk_pct":                   params["risk_pct"],
+    "stop_loss_pct":              params["stop_loss_pct"],
+    **metrics,
+    "trades_csv":                 str(scenario_dir / "trades.csv"),
+}
+```
+
+---
+
+### 修正 6：`main()` 内のループ呼び出しを更新
+
+`_build_strategy_config` と `_build_backtest_params` の呼び出し箇所を修正する。
+
+```python
+# Before
+strategy_config = _build_strategy_config(context["strategy_config"])
+...
+params = _build_backtest_params(int(scenario["cash"]))
+
+# After
+strategy_config = _build_strategy_config(context["strategy_config"], scenario)  # ← 引数追加
+...
+params = _build_backtest_params(scenario)  # ← scenario 全体を渡す
+```
+
+> `_build_strategy_config` の呼び出しを `for scenario in SCENARIOS:` ループ**内**に移動すること（現在はループ外で一度だけ呼んでいる）。
+
+---
+
+## 4. 期待される改善効果
+
+### 100万円
+
+| シナリオ | トレード数予測 | PF 目標 | 備考 |
+|---|---|---|---|
+| `1m_base`（現行） | ~28 | <1.0 | 対照群 |
+| `1m_equal_6slots` | **~150 以上** | 未知 | 1,500 円以下の銘柄にアクセス可能 |
+| `1m_equal_5slots` | **~200 以上** | 未知 | 1,800 円以下にアクセス可能 |
+| `1m_equal_4slots` | **~250 以上** | 未知 | 2,200 円以下にアクセス可能 |
+
+### 1000万円
+
+| シナリオ | 変更点 | 期待効果 |
+|---|---|---|
+| `10m_base`（現行） | なし | 対照群（PF 1.037） |
+| `10m_tighter_entry` | threshold 0.58→0.62 | 勝率向上、PF 改善 |
+| `10m_bear_guard` | + bear_mult 0.5→0.3 | 4月・11月損失削減 |
+| `10m_hold_longer` | + trailing_atr 2.0→2.5 | Payoff 改善 |
+
+---
+
+## 5. 追加指標の候補（次フェーズ）
+
+上記スウィープで PF > 1.1 程度が安定して出たら、以下の指標追加も検討する。
+
+| 指標 | 計算式 | 狙い | 実装難易度 |
+|---|---|---|---|
+| `high52w_proximity` | `(close - MAX(high) 252日) / MAX(high) 252日` | ブレイクアウト銘柄の識別 | 低 |
+| `mom_accel` | `mom_1m(今日) - mom_1m(20日前)` | モメンタム加速中の銘柄を選別 | 低 |
+| `beta_60` | 60日間の TOPIX 共分散 / TOPIX 分散 | ベア相場での高ベータ銘柄除外 | 中 |
+| `ma5_dev` | `(close - MA5) / MA5` | 短期過熱エントリーの回避 | 低 |
+| `roe_yoy` | `ROE(当期) - ROE(前期)` | 改善中 ROE の識別 | 中 |

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_10m.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_10m.py
@@ -1,19 +1,3 @@
-"""1m ファクターアブレーション分析スクリプト
-
-各ファクターを1つずつ weight=0 にして 2023/2024/2025 を検証し、
-どのファクターが 2023/2024 の損失を引き起こしているかを特定する。
-
-残りの重みは generate_signals() 内で自動正規化されるため合計が 1.0 でなくても動作する。
-
-シナリオ（計6件）× 3年（2023/2024/2025）= 18ラン:
-  base          : 現行重み（momentum=0.40, value=0.20, vol=0.15, liq=0.15, news=0.10）
-  no_momentum   : momentum weight = 0
-  no_value      : value weight = 0
-  no_volatility : volatility weight = 0
-  no_liquidity  : liquidity weight = 0
-  no_news       : news weight = 0
-"""
-
 from __future__ import annotations
 
 import csv
@@ -45,43 +29,67 @@ STRATEGY_CONFIG_PATH = REPO_ROOT / "config" / "strategy_config.yaml"
 RISK_CONFIG_PATH = REPO_ROOT / "config" / "risk_config.yaml"
 RUN_ID_PATTERN = re.compile(r"run_id:\s*([0-9a-fA-F-]+)|run_id=([0-9a-fA-F-]+)")
 SUBPROCESS_ENCODING = locale.getpreferredencoding(False) or "cp932"
-ARTIFACTS_ROOT = REPO_ROOT / "artifacts" / "backtest_improvement_1m_ablation"
+ARTIFACTS_ROOT = REPO_ROOT / "artifacts" / "backtest_improvement_10m"
 
-# 1m_equal_4slots の固定ベースパラメータ（v2 最良設定）
-_BASE = {
-    "cash": 1_000_000,
-    "allocation_method": "equal",
-    "max_positions": 4,
-    "max_position_pct": 0.22,
-    "max_utilization": 0.80,
-    "risk_pct": 0.005,
-    "stop_loss_pct": 0.09,
-    "threshold": 0.58,
-    "topix_size_multiplier_bear": 0.50,
-    "topix_drawdown_threshold": -0.15,
-    "trailing_stop_atr_mult": 2.0,
-    "max_holding_days": 60,
-}
-
-# 現行の重み（ベースライン）
-_WEIGHTS_BASE = {
-    "momentum": 0.40,
-    "value": 0.20,
-    "volatility": 0.15,
-    "liquidity": 0.15,
-    "news": 0.10,
-}
 
 SCENARIOS = [
-    {**_BASE, "name": "base", "weights": _WEIGHTS_BASE},
-    {**_BASE, "name": "no_momentum", "weights": {**_WEIGHTS_BASE, "momentum": 0.0}},
-    {**_BASE, "name": "no_value", "weights": {**_WEIGHTS_BASE, "value": 0.0}},
-    {**_BASE, "name": "no_volatility", "weights": {**_WEIGHTS_BASE, "volatility": 0.0}},
-    {**_BASE, "name": "no_liquidity", "weights": {**_WEIGHTS_BASE, "liquidity": 0.0}},
-    {**_BASE, "name": "no_news", "weights": {**_WEIGHTS_BASE, "news": 0.0}},
+    {
+        "name": "10m_base",
+        "cash": 10_000_000,
+        "allocation_method": "risk_based",
+        "max_positions": 7,
+        "max_position_pct": 0.10,
+        "max_utilization": 0.70,
+        "risk_pct": 0.005,
+        "stop_loss_pct": 0.09,
+        "threshold": 0.58,
+        "topix_size_multiplier_bear": 0.50,
+        "topix_drawdown_threshold": -0.15,
+        "trailing_stop_atr_mult": 2.0,
+    },
+    {
+        "name": "10m_tighter_entry",
+        "cash": 10_000_000,
+        "allocation_method": "risk_based",
+        "max_positions": 7,
+        "max_position_pct": 0.10,
+        "max_utilization": 0.70,
+        "risk_pct": 0.005,
+        "stop_loss_pct": 0.09,
+        "threshold": 0.62,
+        "topix_size_multiplier_bear": 0.50,
+        "topix_drawdown_threshold": -0.15,
+        "trailing_stop_atr_mult": 2.0,
+    },
+    {
+        "name": "10m_bear_guard",
+        "cash": 10_000_000,
+        "allocation_method": "risk_based",
+        "max_positions": 7,
+        "max_position_pct": 0.10,
+        "max_utilization": 0.70,
+        "risk_pct": 0.005,
+        "stop_loss_pct": 0.09,
+        "threshold": 0.62,
+        "topix_size_multiplier_bear": 0.30,
+        "topix_drawdown_threshold": -0.12,
+        "trailing_stop_atr_mult": 2.0,
+    },
+    {
+        "name": "10m_hold_longer",
+        "cash": 10_000_000,
+        "allocation_method": "risk_based",
+        "max_positions": 7,
+        "max_position_pct": 0.10,
+        "max_utilization": 0.70,
+        "risk_pct": 0.005,
+        "stop_loss_pct": 0.09,
+        "threshold": 0.62,
+        "topix_size_multiplier_bear": 0.30,
+        "topix_drawdown_threshold": -0.12,
+        "trailing_stop_atr_mult": 2.5,
+    },
 ]
-
-YEARS = [2023, 2024, 2025]
 
 
 def _load_env(path: Path) -> dict[str, str]:
@@ -113,10 +121,16 @@ def _build_base_context() -> dict[str, object]:
     env = _load_env(ENV_PATH)
     strategy_config = _load_yaml(STRATEGY_CONFIG_PATH)
     risk_config = _load_yaml(RISK_CONFIG_PATH)
+
     db_path = Path(env.get("DUCKDB_PATH", "data/kabusys.duckdb"))
     if not db_path.is_absolute():
         db_path = REPO_ROOT / db_path
-    return {"db_path": db_path, "strategy_config": strategy_config, "risk_config": risk_config}
+
+    return {
+        "db_path": db_path,
+        "strategy_config": strategy_config,
+        "risk_config": risk_config,
+    }
 
 
 def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
@@ -126,16 +140,13 @@ def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
     regime_section = strategy_config.setdefault("regime", {})
     portfolio_section = strategy_config.setdefault("portfolio", {})
 
-    # ファクター重み（シナリオごとに上書き）
-    strategy_section["weights"] = scenario["weights"]
-
     strategy_section["threshold"] = scenario.get("threshold", 0.58)
     strategy_section["gap_up_threshold"] = 0.07
     strategy_section["gap_down_threshold"] = -0.05
     strategy_section["rsi_overbought_threshold"] = 65.0
     strategy_section["stop_loss_rate"] = -0.08
     strategy_section["min_holding_days"] = 5
-    strategy_section["max_holding_days"] = scenario.get("max_holding_days", 60)
+    strategy_section["max_holding_days"] = 60
     strategy_section["trailing_stop_atr_mult"] = scenario.get("trailing_stop_atr_mult", 2.0)
     strategy_section["reentry_cooldown_days"] = 5
 
@@ -145,31 +156,31 @@ def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
     regime_section["topix_drawdown_threshold"] = scenario.get("topix_drawdown_threshold", -0.15)
     regime_section["topix_size_multiplier_bear"] = scenario.get("topix_size_multiplier_bear", 0.50)
 
-    portfolio_section["max_positions"] = scenario.get("max_positions", 4)
+    portfolio_section["max_positions"] = scenario.get("max_positions", 7)
     return strategy_config
 
 
 def _build_risk_config(base: dict, scenario: dict[str, object]) -> dict:
     risk_config = deepcopy(base)
     risk_section = risk_config.setdefault("risk", {})
-    risk_section["max_position_pct"] = scenario.get("max_position_pct", 0.22)
-    risk_section["max_utilization"] = scenario.get("max_utilization", 0.80)
+    risk_section["max_position_pct"] = scenario.get("max_position_pct", 0.10)
+    risk_section["max_utilization"] = scenario.get("max_utilization", 0.70)
     return risk_config
 
 
-def _build_backtest_params(scenario: dict[str, object], year: int) -> dict[str, object]:
+def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
     return {
-        "start": f"{year}-01-01",
-        "end": f"{year}-12-31",
+        "start": "2025-01-01",
+        "end": "2025-12-31",
         "cash": scenario["cash"],
-        "allocation_method": scenario.get("allocation_method", "equal"),
-        "max_positions": scenario.get("max_positions", 4),
-        "max_position_pct": scenario.get("max_position_pct", 0.22),
-        "max_utilization": scenario.get("max_utilization", 0.80),
+        "allocation_method": scenario.get("allocation_method", "risk_based"),
+        "max_positions": scenario.get("max_positions", 7),
+        "max_position_pct": scenario.get("max_position_pct", 0.10),
+        "max_utilization": scenario.get("max_utilization", 0.70),
         "risk_pct": scenario.get("risk_pct", 0.005),
         "stop_loss_pct": scenario.get("stop_loss_pct", 0.09),
         "min_holding_days": 5,
-        "max_holding_days": scenario.get("max_holding_days", 60),
+        "max_holding_days": 60,
         "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
         "threshold": scenario.get("threshold", 0.58),
         "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
@@ -231,9 +242,18 @@ def _extract_run_id(output: str) -> str:
 def _fetch_metrics(conn: duckdb.DuckDBPyConnection, run_id: str) -> dict[str, object]:
     row = conn.execute(
         """
-        SELECT created_at, cagr, sharpe, max_drawdown, win_rate,
-               payoff_ratio, profit_factor, avg_holding_days, total_trades
-        FROM backtest_runs WHERE run_id = ?
+        SELECT
+            created_at,
+            cagr,
+            sharpe,
+            max_drawdown,
+            win_rate,
+            payoff_ratio,
+            profit_factor,
+            avg_holding_days,
+            total_trades
+        FROM backtest_runs
+        WHERE run_id = ?
         """,
         [run_id],
     ).fetchone()
@@ -255,8 +275,18 @@ def _fetch_metrics(conn: duckdb.DuckDBPyConnection, run_id: str) -> dict[str, ob
 def _export_trades_csv(conn: duckdb.DuckDBPyConnection, run_id: str, out_path: Path) -> None:
     rows = conn.execute(
         """
-        SELECT trade_seq, date, code, side, shares, price, commission, realized_pnl
-        FROM backtest_trades WHERE run_id = ? ORDER BY trade_seq
+        SELECT
+            trade_seq,
+            date,
+            code,
+            side,
+            shares,
+            price,
+            commission,
+            realized_pnl
+        FROM backtest_trades
+        WHERE run_id = ?
+        ORDER BY trade_seq
         """,
         [run_id],
     ).fetchall()
@@ -297,7 +327,8 @@ def main() -> None:
     log_csv_path = output_dir / "results.csv"
 
     (output_dir / "scenarios.json").write_text(
-        json.dumps(SCENARIOS, ensure_ascii=False, indent=2), encoding="utf-8"
+        json.dumps(SCENARIOS, ensure_ascii=False, indent=2),
+        encoding="utf-8",
     )
 
     original_strategy_text = STRATEGY_CONFIG_PATH.read_text(encoding="utf-8")
@@ -305,23 +336,20 @@ def main() -> None:
 
     fieldnames = [
         "name",
-        "year",
-        "w_momentum",
-        "w_value",
-        "w_volatility",
-        "w_liquidity",
-        "w_news",
         "run_id",
         "created_at",
         "cash",
         "allocation_method",
         "threshold",
-        "stop_loss_pct",
+        "topix_size_multiplier_bear",
+        "topix_drawdown_threshold",
         "trailing_stop_atr",
-        "max_holding_days",
+        "rsi_overbought_threshold",
         "max_positions",
         "max_position_pct",
         "max_utilization",
+        "risk_pct",
+        "stop_loss_pct",
         "cagr",
         "sharpe",
         "max_drawdown",
@@ -334,7 +362,7 @@ def main() -> None:
     ]
 
     print(f"output_dir={output_dir}")
-    print("scenario\tyear\tcagr\tsharpe\tmax_dd\twin_rate\tpf\ttrades")
+    print("scenario\trun_id\tthreshold\tbear_mult\ttrail_atr\tcagr\tsharpe\tmax_dd\tpf\ttrades")
 
     with (
         log_jsonl_path.open("w", encoding="utf-8") as jsonl_file,
@@ -345,93 +373,100 @@ def main() -> None:
 
         try:
             for scenario in SCENARIOS:
-                for year in YEARS:
-                    strategy_config = _build_strategy_config(context["strategy_config"], scenario)
-                    risk_config = _build_risk_config(context["risk_config"], scenario)
-                    _save_yaml(STRATEGY_CONFIG_PATH, strategy_config)
-                    _save_yaml(RISK_CONFIG_PATH, risk_config)
+                strategy_config = _build_strategy_config(context["strategy_config"], scenario)
+                risk_config = _build_risk_config(context["risk_config"], scenario)
+                _save_yaml(STRATEGY_CONFIG_PATH, strategy_config)
+                _save_yaml(RISK_CONFIG_PATH, risk_config)
 
-                    scenario_name = str(scenario["name"])
-                    run_slug = f"{scenario_name}_{year}"
-                    scenario_dir = output_dir / run_slug
-                    scenario_dir.mkdir(parents=True, exist_ok=True)
+                scenario_slug = str(scenario["name"])
+                scenario_dir = output_dir / scenario_slug
+                scenario_dir.mkdir(parents=True, exist_ok=True)
 
-                    params = _build_backtest_params(scenario, year)
-                    (scenario_dir / "effective_backtest_params.json").write_text(
-                        json.dumps(params, ensure_ascii=False, indent=2), encoding="utf-8"
+                params = _build_backtest_params(scenario)
+                (scenario_dir / "strategy_config.yaml").write_text(
+                    yaml.dump(
+                        strategy_config,
+                        allow_unicode=True,
+                        default_flow_style=False,
+                        sort_keys=False,
+                    ),
+                    encoding="utf-8",
+                )
+                (scenario_dir / "risk_config.yaml").write_text(
+                    yaml.dump(
+                        risk_config, allow_unicode=True, default_flow_style=False, sort_keys=False
+                    ),
+                    encoding="utf-8",
+                )
+                (scenario_dir / "effective_backtest_params.json").write_text(
+                    json.dumps(params, ensure_ascii=False, indent=2),
+                    encoding="utf-8",
+                )
+
+                report_base_dir = scenario_dir / "report"
+                cmd = _build_command(db_path, params, report_base_dir)
+                print(f"\n=== running: {scenario_slug} ===")
+                print("command:", subprocess.list2cmdline(cmd))
+
+                completed = subprocess.run(
+                    cmd,
+                    cwd=str(REPO_ROOT),
+                    capture_output=True,
+                    text=True,
+                    encoding=SUBPROCESS_ENCODING,
+                    errors="replace",
+                )
+
+                (scenario_dir / "stdout.log").write_text(completed.stdout or "", encoding="utf-8")
+                (scenario_dir / "stderr.log").write_text(completed.stderr or "", encoding="utf-8")
+
+                if completed.returncode != 0:
+                    raise RuntimeError(
+                        f"scenario={scenario_slug} failed with exit code {completed.returncode}"
                     )
 
-                    report_base_dir = scenario_dir / "report"
-                    cmd = _build_command(db_path, params, report_base_dir)
-                    print(f"\n=== running: {run_slug} ===")
+                run_id = _extract_run_id(f"{completed.stdout}\n{completed.stderr}")
+                conn = duckdb.connect(str(db_path), read_only=True)
+                try:
+                    metrics = _fetch_metrics(conn, run_id)
+                    trades_csv_path = scenario_dir / "trades.csv"
+                    _export_trades_csv(conn, run_id, trades_csv_path)
+                finally:
+                    conn.close()
 
-                    completed = subprocess.run(
-                        cmd,
-                        cwd=str(REPO_ROOT),
-                        capture_output=True,
-                        text=True,
-                        encoding=SUBPROCESS_ENCODING,
-                        errors="replace",
-                    )
+                record = {
+                    "name": scenario_slug,
+                    "run_id": run_id,
+                    "created_at": metrics["created_at"],
+                    "cash": params["cash"],
+                    "allocation_method": params["allocation_method"],
+                    "threshold": scenario.get("threshold", 0.58),
+                    "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+                    "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
+                    "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
+                    "rsi_overbought_threshold": 65.0,
+                    "max_positions": params["max_positions"],
+                    "max_position_pct": params["max_position_pct"],
+                    "max_utilization": params["max_utilization"],
+                    "risk_pct": params["risk_pct"],
+                    "stop_loss_pct": params["stop_loss_pct"],
+                    **metrics,
+                    "trades_csv": str(scenario_dir / "trades.csv"),
+                }
 
-                    (scenario_dir / "stdout.log").write_text(
-                        completed.stdout or "", encoding="utf-8"
-                    )
-                    (scenario_dir / "stderr.log").write_text(
-                        completed.stderr or "", encoding="utf-8"
-                    )
+                jsonl_file.write(json.dumps(record, ensure_ascii=False) + "\n")
+                jsonl_file.flush()
+                writer.writerow(record)
+                csv_file.flush()
 
-                    if completed.returncode != 0:
-                        raise RuntimeError(
-                            f"scenario={run_slug} failed with exit code {completed.returncode}"
-                        )
-
-                    run_id = _extract_run_id(f"{completed.stdout}\n{completed.stderr}")
-                    conn = duckdb.connect(str(db_path), read_only=True)
-                    try:
-                        metrics = _fetch_metrics(conn, run_id)
-                        _export_trades_csv(conn, run_id, scenario_dir / "trades.csv")
-                    finally:
-                        conn.close()
-
-                    weights = scenario["weights"]
-                    record = {
-                        "name": scenario_name,
-                        "year": year,
-                        "w_momentum": weights["momentum"],
-                        "w_value": weights["value"],
-                        "w_volatility": weights["volatility"],
-                        "w_liquidity": weights["liquidity"],
-                        "w_news": weights["news"],
-                        "run_id": run_id,
-                        "created_at": metrics["created_at"],
-                        "cash": params["cash"],
-                        "allocation_method": params["allocation_method"],
-                        "threshold": params["threshold"],
-                        "stop_loss_pct": params["stop_loss_pct"],
-                        "trailing_stop_atr": params["trailing_stop_atr"],
-                        "max_holding_days": params["max_holding_days"],
-                        "max_positions": params["max_positions"],
-                        "max_position_pct": params["max_position_pct"],
-                        "max_utilization": params["max_utilization"],
-                        **metrics,
-                        "trades_csv": str(scenario_dir / "trades.csv"),
-                    }
-
-                    jsonl_file.write(json.dumps(record, ensure_ascii=False) + "\n")
-                    jsonl_file.flush()
-                    writer.writerow(record)
-                    csv_file.flush()
-
-                    print(
-                        f"{run_slug}\t{year}\t"
-                        f"{_format_metric(metrics['cagr'])}\t"
-                        f"{_format_metric(metrics['sharpe'])}\t"
-                        f"{_format_metric(metrics['max_drawdown'])}\t"
-                        f"{_format_metric(metrics['win_rate'])}\t"
-                        f"{_format_metric(metrics['profit_factor'])}\t"
-                        f"{metrics['total_trades']}"
-                    )
+                print(
+                    f"{scenario_slug}\t{run_id}\t{scenario.get('threshold', 0.58)}\t"
+                    f"{scenario.get('topix_size_multiplier_bear', 0.50)}\t"
+                    f"{scenario.get('trailing_stop_atr_mult', 2.0)}\t"
+                    f"{_format_metric(metrics['cagr'])}\t{_format_metric(metrics['sharpe'])}\t"
+                    f"{_format_metric(metrics['max_drawdown'])}\t{_format_metric(metrics['profit_factor'])}\t"
+                    f"{metrics['total_trades']}"
+                )
         finally:
             STRATEGY_CONFIG_PATH.write_text(original_strategy_text, encoding="utf-8")
             RISK_CONFIG_PATH.write_text(original_risk_text, encoding="utf-8")

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_10m_factors.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_10m_factors.py
@@ -1,17 +1,9 @@
-"""1m ファクターアブレーション分析スクリプト
+"""10m ファクターフィルター比較スクリプト
 
-各ファクターを1つずつ weight=0 にして 2023/2024/2025 を検証し、
-どのファクターが 2023/2024 の損失を引き起こしているかを特定する。
-
-残りの重みは generate_signals() 内で自動正規化されるため合計が 1.0 でなくても動作する。
-
-シナリオ（計6件）× 3年（2023/2024/2025）= 18ラン:
-  base          : 現行重み（momentum=0.40, value=0.20, vol=0.15, liq=0.15, news=0.10）
-  no_momentum   : momentum weight = 0
-  no_value      : value weight = 0
-  no_volatility : volatility weight = 0
-  no_liquidity  : liquidity weight = 0
-  no_news       : news weight = 0
+10m_equal_4slots（2025年最良設定）をベースに、以下のファクターフィルターを追加検証する。
+  1. 200MA バイナリフィルター    : MA200 上にある銘柄のみ BUY (use_ma200_filter=True)
+  2. 出来高ブレイクアウトフィルター: volume_ratio >= 閾値の銘柄のみ BUY (volume_breakout_threshold)
+  3. 両フィルター同時適用
 """
 
 from __future__ import annotations
@@ -45,43 +37,50 @@ STRATEGY_CONFIG_PATH = REPO_ROOT / "config" / "strategy_config.yaml"
 RISK_CONFIG_PATH = REPO_ROOT / "config" / "risk_config.yaml"
 RUN_ID_PATTERN = re.compile(r"run_id:\s*([0-9a-fA-F-]+)|run_id=([0-9a-fA-F-]+)")
 SUBPROCESS_ENCODING = locale.getpreferredencoding(False) or "cp932"
-ARTIFACTS_ROOT = REPO_ROOT / "artifacts" / "backtest_improvement_1m_ablation"
+ARTIFACTS_ROOT = REPO_ROOT / "artifacts" / "backtest_improvement_10m_factors"
 
-# 1m_equal_4slots の固定ベースパラメータ（v2 最良設定）
+# 10m_equal_4slots の固定パラメータ（最良設定）
 _BASE = {
-    "cash": 1_000_000,
+    "cash": 10_000_000,
     "allocation_method": "equal",
     "max_positions": 4,
     "max_position_pct": 0.22,
     "max_utilization": 0.80,
     "risk_pct": 0.005,
-    "stop_loss_pct": 0.09,
+    "stop_loss_pct": 0.07,
     "threshold": 0.58,
     "topix_size_multiplier_bear": 0.50,
     "topix_drawdown_threshold": -0.15,
     "trailing_stop_atr_mult": 2.0,
     "max_holding_days": 60,
-}
-
-# 現行の重み（ベースライン）
-_WEIGHTS_BASE = {
-    "momentum": 0.40,
-    "value": 0.20,
-    "volatility": 0.15,
-    "liquidity": 0.15,
-    "news": 0.10,
+    "use_ma200_filter": False,
+    "volume_breakout_threshold": None,
 }
 
 SCENARIOS = [
-    {**_BASE, "name": "base", "weights": _WEIGHTS_BASE},
-    {**_BASE, "name": "no_momentum", "weights": {**_WEIGHTS_BASE, "momentum": 0.0}},
-    {**_BASE, "name": "no_value", "weights": {**_WEIGHTS_BASE, "value": 0.0}},
-    {**_BASE, "name": "no_volatility", "weights": {**_WEIGHTS_BASE, "volatility": 0.0}},
-    {**_BASE, "name": "no_liquidity", "weights": {**_WEIGHTS_BASE, "liquidity": 0.0}},
-    {**_BASE, "name": "no_news", "weights": {**_WEIGHTS_BASE, "news": 0.0}},
+    # ── ベースライン ──────────────────────────────────────────────────────────
+    {**_BASE, "name": "10m_eq4_base"},
+    # ── 200MA フィルター：MA200 上の銘柄のみ BUY ───────────────────────────
+    {**_BASE, "name": "10m_eq4_ma200", "use_ma200_filter": True},
+    # ── 出来高ブレイクアウト 1.5x：20日平均の 1.5 倍超の銘柄のみ BUY ────────
+    {**_BASE, "name": "10m_eq4_vol15", "volume_breakout_threshold": 1.5},
+    # ── 出来高ブレイクアウト 2.0x：より厳格なブレイクアウト条件 ───────────────
+    {**_BASE, "name": "10m_eq4_vol20", "volume_breakout_threshold": 2.0},
+    # ── 両フィルター同時：MA200 上 + 出来高 1.5x ──────────────────────────
+    {
+        **_BASE,
+        "name": "10m_eq4_ma200_vol15",
+        "use_ma200_filter": True,
+        "volume_breakout_threshold": 1.5,
+    },
+    # ── 両フィルター同時（厳格）：MA200 上 + 出来高 2.0x ─────────────────
+    {
+        **_BASE,
+        "name": "10m_eq4_ma200_vol20",
+        "use_ma200_filter": True,
+        "volume_breakout_threshold": 2.0,
+    },
 ]
-
-YEARS = [2023, 2024, 2025]
 
 
 def _load_env(path: Path) -> dict[str, str]:
@@ -113,10 +112,16 @@ def _build_base_context() -> dict[str, object]:
     env = _load_env(ENV_PATH)
     strategy_config = _load_yaml(STRATEGY_CONFIG_PATH)
     risk_config = _load_yaml(RISK_CONFIG_PATH)
+
     db_path = Path(env.get("DUCKDB_PATH", "data/kabusys.duckdb"))
     if not db_path.is_absolute():
         db_path = REPO_ROOT / db_path
-    return {"db_path": db_path, "strategy_config": strategy_config, "risk_config": risk_config}
+
+    return {
+        "db_path": db_path,
+        "strategy_config": strategy_config,
+        "risk_config": risk_config,
+    }
 
 
 def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
@@ -125,9 +130,6 @@ def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
     sector_section = strategy_config.setdefault("sector", {})
     regime_section = strategy_config.setdefault("regime", {})
     portfolio_section = strategy_config.setdefault("portfolio", {})
-
-    # ファクター重み（シナリオごとに上書き）
-    strategy_section["weights"] = scenario["weights"]
 
     strategy_section["threshold"] = scenario.get("threshold", 0.58)
     strategy_section["gap_up_threshold"] = 0.07
@@ -157,28 +159,30 @@ def _build_risk_config(base: dict, scenario: dict[str, object]) -> dict:
     return risk_config
 
 
-def _build_backtest_params(scenario: dict[str, object], year: int) -> dict[str, object]:
+def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
     return {
-        "start": f"{year}-01-01",
-        "end": f"{year}-12-31",
+        "start": "2025-01-01",
+        "end": "2025-12-31",
         "cash": scenario["cash"],
         "allocation_method": scenario.get("allocation_method", "equal"),
         "max_positions": scenario.get("max_positions", 4),
         "max_position_pct": scenario.get("max_position_pct", 0.22),
         "max_utilization": scenario.get("max_utilization", 0.80),
         "risk_pct": scenario.get("risk_pct", 0.005),
-        "stop_loss_pct": scenario.get("stop_loss_pct", 0.09),
+        "stop_loss_pct": scenario.get("stop_loss_pct", 0.07),
         "min_holding_days": 5,
         "max_holding_days": scenario.get("max_holding_days", 60),
         "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
         "threshold": scenario.get("threshold", 0.58),
         "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
         "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+        "use_ma200_filter": scenario.get("use_ma200_filter", False),
+        "volume_breakout_threshold": scenario.get("volume_breakout_threshold"),
     }
 
 
 def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -> list[str]:
-    return [
+    cmd = [
         sys.executable,
         "-m",
         "kabusys.backtest.run",
@@ -219,6 +223,11 @@ def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -
         "--output-dir",
         str(output_dir),
     ]
+    if params.get("use_ma200_filter"):
+        cmd.append("--ma200-filter")
+    if params.get("volume_breakout_threshold") is not None:
+        cmd.extend(["--volume-breakout-threshold", str(params["volume_breakout_threshold"])])
+    return cmd
 
 
 def _extract_run_id(output: str) -> str:
@@ -305,12 +314,6 @@ def main() -> None:
 
     fieldnames = [
         "name",
-        "year",
-        "w_momentum",
-        "w_value",
-        "w_volatility",
-        "w_liquidity",
-        "w_news",
         "run_id",
         "created_at",
         "cash",
@@ -322,6 +325,8 @@ def main() -> None:
         "max_positions",
         "max_position_pct",
         "max_utilization",
+        "use_ma200_filter",
+        "volume_breakout_threshold",
         "cagr",
         "sharpe",
         "max_drawdown",
@@ -334,7 +339,7 @@ def main() -> None:
     ]
 
     print(f"output_dir={output_dir}")
-    print("scenario\tyear\tcagr\tsharpe\tmax_dd\twin_rate\tpf\ttrades")
+    print("scenario\tcagr\tsharpe\tmax_dd\twin_rate\tpf\ttrades\tma200\tvol_thr")
 
     with (
         log_jsonl_path.open("w", encoding="utf-8") as jsonl_file,
@@ -345,93 +350,85 @@ def main() -> None:
 
         try:
             for scenario in SCENARIOS:
-                for year in YEARS:
-                    strategy_config = _build_strategy_config(context["strategy_config"], scenario)
-                    risk_config = _build_risk_config(context["risk_config"], scenario)
-                    _save_yaml(STRATEGY_CONFIG_PATH, strategy_config)
-                    _save_yaml(RISK_CONFIG_PATH, risk_config)
+                strategy_config = _build_strategy_config(context["strategy_config"], scenario)
+                risk_config = _build_risk_config(context["risk_config"], scenario)
+                _save_yaml(STRATEGY_CONFIG_PATH, strategy_config)
+                _save_yaml(RISK_CONFIG_PATH, risk_config)
 
-                    scenario_name = str(scenario["name"])
-                    run_slug = f"{scenario_name}_{year}"
-                    scenario_dir = output_dir / run_slug
-                    scenario_dir.mkdir(parents=True, exist_ok=True)
+                scenario_slug = str(scenario["name"])
+                scenario_dir = output_dir / scenario_slug
+                scenario_dir.mkdir(parents=True, exist_ok=True)
 
-                    params = _build_backtest_params(scenario, year)
-                    (scenario_dir / "effective_backtest_params.json").write_text(
-                        json.dumps(params, ensure_ascii=False, indent=2), encoding="utf-8"
+                params = _build_backtest_params(scenario)
+                (scenario_dir / "effective_backtest_params.json").write_text(
+                    json.dumps(params, ensure_ascii=False, indent=2), encoding="utf-8"
+                )
+
+                report_base_dir = scenario_dir / "report"
+                cmd = _build_command(db_path, params, report_base_dir)
+                print(f"\n=== running: {scenario_slug} ===")
+                print("command:", subprocess.list2cmdline(cmd))
+
+                completed = subprocess.run(
+                    cmd,
+                    cwd=str(REPO_ROOT),
+                    capture_output=True,
+                    text=True,
+                    encoding=SUBPROCESS_ENCODING,
+                    errors="replace",
+                )
+
+                (scenario_dir / "stdout.log").write_text(completed.stdout or "", encoding="utf-8")
+                (scenario_dir / "stderr.log").write_text(completed.stderr or "", encoding="utf-8")
+
+                if completed.returncode != 0:
+                    raise RuntimeError(
+                        f"scenario={scenario_slug} failed with exit code {completed.returncode}"
                     )
 
-                    report_base_dir = scenario_dir / "report"
-                    cmd = _build_command(db_path, params, report_base_dir)
-                    print(f"\n=== running: {run_slug} ===")
+                run_id = _extract_run_id(f"{completed.stdout}\n{completed.stderr}")
+                conn = duckdb.connect(str(db_path), read_only=True)
+                try:
+                    metrics = _fetch_metrics(conn, run_id)
+                    _export_trades_csv(conn, run_id, scenario_dir / "trades.csv")
+                finally:
+                    conn.close()
 
-                    completed = subprocess.run(
-                        cmd,
-                        cwd=str(REPO_ROOT),
-                        capture_output=True,
-                        text=True,
-                        encoding=SUBPROCESS_ENCODING,
-                        errors="replace",
-                    )
+                record = {
+                    "name": scenario_slug,
+                    "run_id": run_id,
+                    "created_at": metrics["created_at"],
+                    "cash": params["cash"],
+                    "allocation_method": params["allocation_method"],
+                    "threshold": scenario.get("threshold", 0.58),
+                    "stop_loss_pct": params["stop_loss_pct"],
+                    "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
+                    "max_holding_days": params["max_holding_days"],
+                    "max_positions": params["max_positions"],
+                    "max_position_pct": params["max_position_pct"],
+                    "max_utilization": params["max_utilization"],
+                    "use_ma200_filter": params["use_ma200_filter"],
+                    "volume_breakout_threshold": params["volume_breakout_threshold"],
+                    **metrics,
+                    "trades_csv": str(scenario_dir / "trades.csv"),
+                }
 
-                    (scenario_dir / "stdout.log").write_text(
-                        completed.stdout or "", encoding="utf-8"
-                    )
-                    (scenario_dir / "stderr.log").write_text(
-                        completed.stderr or "", encoding="utf-8"
-                    )
+                jsonl_file.write(json.dumps(record, ensure_ascii=False) + "\n")
+                jsonl_file.flush()
+                writer.writerow(record)
+                csv_file.flush()
 
-                    if completed.returncode != 0:
-                        raise RuntimeError(
-                            f"scenario={run_slug} failed with exit code {completed.returncode}"
-                        )
-
-                    run_id = _extract_run_id(f"{completed.stdout}\n{completed.stderr}")
-                    conn = duckdb.connect(str(db_path), read_only=True)
-                    try:
-                        metrics = _fetch_metrics(conn, run_id)
-                        _export_trades_csv(conn, run_id, scenario_dir / "trades.csv")
-                    finally:
-                        conn.close()
-
-                    weights = scenario["weights"]
-                    record = {
-                        "name": scenario_name,
-                        "year": year,
-                        "w_momentum": weights["momentum"],
-                        "w_value": weights["value"],
-                        "w_volatility": weights["volatility"],
-                        "w_liquidity": weights["liquidity"],
-                        "w_news": weights["news"],
-                        "run_id": run_id,
-                        "created_at": metrics["created_at"],
-                        "cash": params["cash"],
-                        "allocation_method": params["allocation_method"],
-                        "threshold": params["threshold"],
-                        "stop_loss_pct": params["stop_loss_pct"],
-                        "trailing_stop_atr": params["trailing_stop_atr"],
-                        "max_holding_days": params["max_holding_days"],
-                        "max_positions": params["max_positions"],
-                        "max_position_pct": params["max_position_pct"],
-                        "max_utilization": params["max_utilization"],
-                        **metrics,
-                        "trades_csv": str(scenario_dir / "trades.csv"),
-                    }
-
-                    jsonl_file.write(json.dumps(record, ensure_ascii=False) + "\n")
-                    jsonl_file.flush()
-                    writer.writerow(record)
-                    csv_file.flush()
-
-                    print(
-                        f"{run_slug}\t{year}\t"
-                        f"{_format_metric(metrics['cagr'])}\t"
-                        f"{_format_metric(metrics['sharpe'])}\t"
-                        f"{_format_metric(metrics['max_drawdown'])}\t"
-                        f"{_format_metric(metrics['win_rate'])}\t"
-                        f"{_format_metric(metrics['profit_factor'])}\t"
-                        f"{metrics['total_trades']}"
-                    )
+                print(
+                    f"{scenario_slug}\t"
+                    f"{_format_metric(metrics['cagr'])}\t"
+                    f"{_format_metric(metrics['sharpe'])}\t"
+                    f"{_format_metric(metrics['max_drawdown'])}\t"
+                    f"{_format_metric(metrics['win_rate'])}\t"
+                    f"{_format_metric(metrics['profit_factor'])}\t"
+                    f"{metrics['total_trades']}\t"
+                    f"{params['use_ma200_filter']}\t"
+                    f"{params['volume_breakout_threshold']}"
+                )
         finally:
             STRATEGY_CONFIG_PATH.write_text(original_strategy_text, encoding="utf-8")
             RISK_CONFIG_PATH.write_text(original_risk_text, encoding="utf-8")

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_10m_mdd.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_10m_mdd.py
@@ -1,0 +1,416 @@
+"""10m MDD対策 検証スクリプト
+
+2024年のMaxDD 41%（8月ブラックマンデー）対策として、
+TOPIXベアガード強化とポートフォリオドローダウンストップの
+2段構えを検証する。
+
+シナリオ（計6件）× 3年（2023/2024/2025）= 18ラン:
+  base          : 変更なし（OOS2ベースラインの再現）
+  bear_stronger : TOPIXガード強化のみ（-0.10 / 0.25）
+  dd_stop15     : ポートフォリオストップのみ（15%）
+  dd_stop12     : ポートフォリオストップのみ（12%）
+  combined15    : TOPIX強化 + ポートフォリオストップ15%
+  combined12    : TOPIX強化 + ポートフォリオストップ12%
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import locale
+import re
+import shutil
+import subprocess
+import sys
+from copy import deepcopy
+from datetime import datetime
+from pathlib import Path
+
+import duckdb
+import yaml
+
+
+def _find_repo_root() -> Path:
+    current = Path(__file__).resolve().parent
+    for candidate in [current, *current.parents]:
+        if (candidate / "config" / "strategy_config.yaml").exists():
+            return candidate
+    raise FileNotFoundError("Could not locate repo root containing config/strategy_config.yaml")
+
+
+REPO_ROOT = _find_repo_root()
+ENV_PATH = REPO_ROOT / ".env"
+STRATEGY_CONFIG_PATH = REPO_ROOT / "config" / "strategy_config.yaml"
+RISK_CONFIG_PATH = REPO_ROOT / "config" / "risk_config.yaml"
+RUN_ID_PATTERN = re.compile(r"run_id:\s*([0-9a-fA-F-]+)|run_id=([0-9a-fA-F-]+)")
+SUBPROCESS_ENCODING = locale.getpreferredencoding(False) or "cp932"
+ARTIFACTS_ROOT = REPO_ROOT / "artifacts" / "backtest_improvement_10m_mdd"
+
+# 10m_equal_4slots の固定パラメータ（OOS2 ベースライン設定）
+_BASE = {
+    "cash": 10_000_000,
+    "allocation_method": "equal",
+    "max_positions": 4,
+    "max_position_pct": 0.22,
+    "max_utilization": 0.80,
+    "risk_pct": 0.005,
+    "stop_loss_pct": 0.07,
+    "threshold": 0.58,
+    "topix_size_multiplier_bear": 0.50,
+    "topix_drawdown_threshold": -0.15,
+    "trailing_stop_atr_mult": 2.0,
+    "max_holding_days": 60,
+    "portfolio_drawdown_stop_pct": None,
+}
+
+SCENARIOS = [
+    # ── ベースライン（OOS2 との内部一貫性確認）─────────────────────────────
+    {**_BASE, "name": "base"},
+    # ── TOPIXガード強化のみ ──────────────────────────────────────────────
+    {
+        **_BASE,
+        "name": "bear_stronger",
+        "topix_drawdown_threshold": -0.10,
+        "topix_size_multiplier_bear": 0.25,
+    },
+    # ── ポートフォリオストップのみ（15%）────────────────────────────────────
+    {**_BASE, "name": "dd_stop15", "portfolio_drawdown_stop_pct": 0.15},
+    # ── ポートフォリオストップのみ（12%）────────────────────────────────────
+    {**_BASE, "name": "dd_stop12", "portfolio_drawdown_stop_pct": 0.12},
+    # ── TOPIX強化 + ポートフォリオストップ15% ───────────────────────────────
+    {
+        **_BASE,
+        "name": "combined15",
+        "topix_drawdown_threshold": -0.10,
+        "topix_size_multiplier_bear": 0.25,
+        "portfolio_drawdown_stop_pct": 0.15,
+    },
+    # ── TOPIX強化 + ポートフォリオストップ12% ───────────────────────────────
+    {
+        **_BASE,
+        "name": "combined12",
+        "topix_drawdown_threshold": -0.10,
+        "topix_size_multiplier_bear": 0.25,
+        "portfolio_drawdown_stop_pct": 0.12,
+    },
+]
+
+YEARS = [2023, 2024, 2025]
+
+
+def _load_env(path: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    if not path.exists():
+        return result
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        result[key.strip()] = value.strip()
+    return result
+
+
+def _load_yaml(path: Path) -> dict:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return data if isinstance(data, dict) else {}
+
+
+def _save_yaml(path: Path, data: dict) -> None:
+    path.write_text(
+        yaml.dump(data, allow_unicode=True, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def _build_base_context() -> dict[str, object]:
+    env = _load_env(ENV_PATH)
+    strategy_config = _load_yaml(STRATEGY_CONFIG_PATH)
+    risk_config = _load_yaml(RISK_CONFIG_PATH)
+    db_path = Path(env.get("DUCKDB_PATH", "data/kabusys.duckdb"))
+    if not db_path.is_absolute():
+        db_path = REPO_ROOT / db_path
+    return {"db_path": db_path, "strategy_config": strategy_config, "risk_config": risk_config}
+
+
+def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
+    strategy_config = deepcopy(base)
+    strategy_section = strategy_config.setdefault("strategy", {})
+    sector_section = strategy_config.setdefault("sector", {})
+    regime_section = strategy_config.setdefault("regime", {})
+    portfolio_section = strategy_config.setdefault("portfolio", {})
+
+    strategy_section["threshold"] = scenario.get("threshold", 0.58)
+    strategy_section["gap_up_threshold"] = 0.07
+    strategy_section["gap_down_threshold"] = -0.05
+    strategy_section["rsi_overbought_threshold"] = 65.0
+    strategy_section["stop_loss_rate"] = -0.08
+    strategy_section["min_holding_days"] = 5
+    strategy_section["max_holding_days"] = scenario.get("max_holding_days", 60)
+    strategy_section["trailing_stop_atr_mult"] = scenario.get("trailing_stop_atr_mult", 2.0)
+    strategy_section["reentry_cooldown_days"] = 5
+
+    sector_section["boost"] = 0.05
+    sector_section["quartile"] = 0.30
+
+    regime_section["topix_drawdown_threshold"] = scenario.get("topix_drawdown_threshold", -0.15)
+    regime_section["topix_size_multiplier_bear"] = scenario.get("topix_size_multiplier_bear", 0.50)
+
+    portfolio_section["max_positions"] = scenario.get("max_positions", 4)
+    return strategy_config
+
+
+def _build_risk_config(base: dict, scenario: dict[str, object]) -> dict:
+    risk_config = deepcopy(base)
+    risk_section = risk_config.setdefault("risk", {})
+    risk_section["max_position_pct"] = scenario.get("max_position_pct", 0.22)
+    risk_section["max_utilization"] = scenario.get("max_utilization", 0.80)
+    return risk_config
+
+
+def _build_backtest_params(scenario: dict[str, object], year: int) -> dict[str, object]:
+    return {
+        "start": f"{year}-01-01",
+        "end": f"{year}-12-31",
+        "cash": scenario["cash"],
+        "allocation_method": scenario.get("allocation_method", "equal"),
+        "max_positions": scenario.get("max_positions", 4),
+        "max_position_pct": scenario.get("max_position_pct", 0.22),
+        "max_utilization": scenario.get("max_utilization", 0.80),
+        "risk_pct": scenario.get("risk_pct", 0.005),
+        "stop_loss_pct": scenario.get("stop_loss_pct", 0.07),
+        "min_holding_days": 5,
+        "max_holding_days": scenario.get("max_holding_days", 60),
+        "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
+        "threshold": scenario.get("threshold", 0.58),
+        "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
+        "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+        "portfolio_drawdown_stop_pct": scenario.get("portfolio_drawdown_stop_pct"),
+    }
+
+
+def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -> list[str]:
+    cmd = [
+        sys.executable, "-m", "kabusys.backtest.run",
+        "--db", str(db_path),
+        "--start", str(params["start"]),
+        "--end", str(params["end"]),
+        "--cash", str(params["cash"]),
+        "--allocation-method", str(params["allocation_method"]),
+        "--max-position-pct", str(params["max_position_pct"]),
+        "--max-utilization", str(params["max_utilization"]),
+        "--max-positions", str(params["max_positions"]),
+        "--risk-pct", str(params["risk_pct"]),
+        "--stop-loss-pct", str(params["stop_loss_pct"]),
+        "--min-holding-days", str(params["min_holding_days"]),
+        "--max-holding-days", str(params["max_holding_days"]),
+        "--trailing-stop-atr", str(params["trailing_stop_atr"]),
+        "--threshold", str(params["threshold"]),
+        "--topix-drawdown-threshold", str(params["topix_drawdown_threshold"]),
+        "--topix-size-multiplier-bear", str(params["topix_size_multiplier_bear"]),
+        "--output-format", "all",
+        "--output-dir", str(output_dir),
+    ]
+    if params.get("portfolio_drawdown_stop_pct") is not None:
+        cmd.extend(["--portfolio-drawdown-stop", str(params["portfolio_drawdown_stop_pct"])])
+    return cmd
+
+
+def _extract_run_id(output: str) -> str:
+    match = RUN_ID_PATTERN.search(output)
+    if not match:
+        raise RuntimeError("run_id could not be found in backtest output.")
+    return match.group(1) or match.group(2)
+
+
+def _fetch_metrics(conn: duckdb.DuckDBPyConnection, run_id: str) -> dict[str, object]:
+    row = conn.execute(
+        """
+        SELECT created_at, cagr, sharpe, max_drawdown, win_rate,
+               payoff_ratio, profit_factor, avg_holding_days, total_trades
+        FROM backtest_runs WHERE run_id = ?
+        """,
+        [run_id],
+    ).fetchone()
+    if row is None:
+        raise RuntimeError(f"backtest_runs does not contain run_id={run_id}.")
+    return {
+        "created_at": str(row[0]),
+        "cagr": row[1],
+        "sharpe": row[2],
+        "max_drawdown": row[3],
+        "win_rate": row[4],
+        "payoff_ratio": row[5],
+        "profit_factor": row[6],
+        "avg_holding_days": row[7],
+        "total_trades": row[8],
+    }
+
+
+def _export_trades_csv(conn: duckdb.DuckDBPyConnection, run_id: str, out_path: Path) -> None:
+    rows = conn.execute(
+        """
+        SELECT trade_seq, date, code, side, shares, price, commission, realized_pnl
+        FROM backtest_trades WHERE run_id = ? ORDER BY trade_seq
+        """,
+        [run_id],
+    ).fetchall()
+    with out_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            ["trade_seq", "date", "code", "side", "shares", "price", "commission", "realized_pnl"]
+        )
+        writer.writerows(rows)
+
+
+def _format_metric(value: object, digits: int = 6) -> str:
+    if value is None:
+        return "NA"
+    if isinstance(value, float):
+        return f"{value:.{digits}f}"
+    return str(value)
+
+
+def _make_output_dir() -> Path:
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_dir = ARTIFACTS_ROOT / stamp
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return output_dir
+
+
+def _make_db_snapshot(source_db_path: Path, output_dir: Path) -> Path:
+    snapshot_path = output_dir / "kabusys_snapshot.duckdb"
+    shutil.copy2(str(source_db_path), str(snapshot_path))
+    return snapshot_path
+
+
+def main() -> None:
+    context = _build_base_context()
+    output_dir = _make_output_dir()
+    db_path = _make_db_snapshot(context["db_path"], output_dir)
+    log_jsonl_path = output_dir / "results.jsonl"
+    log_csv_path = output_dir / "results.csv"
+
+    (output_dir / "scenarios.json").write_text(
+        json.dumps(SCENARIOS, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    original_strategy_text = STRATEGY_CONFIG_PATH.read_text(encoding="utf-8")
+    original_risk_text = RISK_CONFIG_PATH.read_text(encoding="utf-8")
+
+    fieldnames = [
+        "name", "year",
+        "topix_drawdown_threshold", "topix_size_multiplier_bear", "portfolio_drawdown_stop_pct",
+        "run_id", "created_at", "cash", "allocation_method",
+        "threshold", "stop_loss_pct", "trailing_stop_atr", "max_holding_days",
+        "max_positions", "max_position_pct", "max_utilization",
+        "cagr", "sharpe", "max_drawdown", "win_rate",
+        "payoff_ratio", "profit_factor", "avg_holding_days", "total_trades", "trades_csv",
+    ]
+
+    print(f"output_dir={output_dir}")
+    print("scenario\tyear\tbear_thr\tbear_mult\tdd_stop\tcagr\tsharpe\tmax_dd\ttrades")
+
+    with log_jsonl_path.open("w", encoding="utf-8") as jsonl_file, log_csv_path.open(
+        "w", newline="", encoding="utf-8"
+    ) as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+        writer.writeheader()
+
+        try:
+            for scenario in SCENARIOS:
+                for year in YEARS:
+                    strategy_config = _build_strategy_config(context["strategy_config"], scenario)
+                    risk_config = _build_risk_config(context["risk_config"], scenario)
+                    _save_yaml(STRATEGY_CONFIG_PATH, strategy_config)
+                    _save_yaml(RISK_CONFIG_PATH, risk_config)
+
+                    scenario_name = str(scenario["name"])
+                    run_slug = f"{scenario_name}_{year}"
+                    scenario_dir = output_dir / run_slug
+                    scenario_dir.mkdir(parents=True, exist_ok=True)
+
+                    params = _build_backtest_params(scenario, year)
+                    (scenario_dir / "effective_backtest_params.json").write_text(
+                        json.dumps(params, ensure_ascii=False, indent=2), encoding="utf-8"
+                    )
+
+                    report_base_dir = scenario_dir / "report"
+                    cmd = _build_command(db_path, params, report_base_dir)
+                    print(f"\n=== running: {run_slug} ===")
+
+                    completed = subprocess.run(
+                        cmd,
+                        cwd=str(REPO_ROOT),
+                        capture_output=True,
+                        text=True,
+                        encoding=SUBPROCESS_ENCODING,
+                        errors="replace",
+                    )
+
+                    (scenario_dir / "stdout.log").write_text(
+                        completed.stdout or "", encoding="utf-8"
+                    )
+                    (scenario_dir / "stderr.log").write_text(
+                        completed.stderr or "", encoding="utf-8"
+                    )
+
+                    if completed.returncode != 0:
+                        raise RuntimeError(
+                            f"scenario={run_slug} failed with exit code {completed.returncode}"
+                        )
+
+                    run_id = _extract_run_id(f"{completed.stdout}\n{completed.stderr}")
+                    conn = duckdb.connect(str(db_path), read_only=True)
+                    try:
+                        metrics = _fetch_metrics(conn, run_id)
+                        _export_trades_csv(conn, run_id, scenario_dir / "trades.csv")
+                    finally:
+                        conn.close()
+
+                    record = {
+                        "name": scenario_name,
+                        "year": year,
+                        "topix_drawdown_threshold": params["topix_drawdown_threshold"],
+                        "topix_size_multiplier_bear": params["topix_size_multiplier_bear"],
+                        "portfolio_drawdown_stop_pct": params["portfolio_drawdown_stop_pct"],
+                        "run_id": run_id,
+                        "created_at": metrics["created_at"],
+                        "cash": params["cash"],
+                        "allocation_method": params["allocation_method"],
+                        "threshold": params["threshold"],
+                        "stop_loss_pct": params["stop_loss_pct"],
+                        "trailing_stop_atr": params["trailing_stop_atr"],
+                        "max_holding_days": params["max_holding_days"],
+                        "max_positions": params["max_positions"],
+                        "max_position_pct": params["max_position_pct"],
+                        "max_utilization": params["max_utilization"],
+                        **metrics,
+                        "trades_csv": str(scenario_dir / "trades.csv"),
+                    }
+
+                    jsonl_file.write(json.dumps(record, ensure_ascii=False) + "\n")
+                    jsonl_file.flush()
+                    writer.writerow(record)
+                    csv_file.flush()
+
+                    print(
+                        f"{run_slug}\t{year}\t"
+                        f"{params['topix_drawdown_threshold']}\t"
+                        f"{params['topix_size_multiplier_bear']}\t"
+                        f"{params['portfolio_drawdown_stop_pct']}\t"
+                        f"{_format_metric(metrics['cagr'])}\t"
+                        f"{_format_metric(metrics['sharpe'])}\t"
+                        f"{_format_metric(metrics['max_drawdown'])}\t"
+                        f"{metrics['total_trades']}"
+                    )
+        finally:
+            STRATEGY_CONFIG_PATH.write_text(original_strategy_text, encoding="utf-8")
+            RISK_CONFIG_PATH.write_text(original_risk_text, encoding="utf-8")
+
+    print(f"\nresults_jsonl={log_jsonl_path}")
+    print(f"results_csv={log_csv_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_10m_mdd.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_10m_mdd.py
@@ -191,25 +191,45 @@ def _build_backtest_params(scenario: dict[str, object], year: int) -> dict[str, 
 
 def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -> list[str]:
     cmd = [
-        sys.executable, "-m", "kabusys.backtest.run",
-        "--db", str(db_path),
-        "--start", str(params["start"]),
-        "--end", str(params["end"]),
-        "--cash", str(params["cash"]),
-        "--allocation-method", str(params["allocation_method"]),
-        "--max-position-pct", str(params["max_position_pct"]),
-        "--max-utilization", str(params["max_utilization"]),
-        "--max-positions", str(params["max_positions"]),
-        "--risk-pct", str(params["risk_pct"]),
-        "--stop-loss-pct", str(params["stop_loss_pct"]),
-        "--min-holding-days", str(params["min_holding_days"]),
-        "--max-holding-days", str(params["max_holding_days"]),
-        "--trailing-stop-atr", str(params["trailing_stop_atr"]),
-        "--threshold", str(params["threshold"]),
-        "--topix-drawdown-threshold", str(params["topix_drawdown_threshold"]),
-        "--topix-size-multiplier-bear", str(params["topix_size_multiplier_bear"]),
-        "--output-format", "all",
-        "--output-dir", str(output_dir),
+        sys.executable,
+        "-m",
+        "kabusys.backtest.run",
+        "--db",
+        str(db_path),
+        "--start",
+        str(params["start"]),
+        "--end",
+        str(params["end"]),
+        "--cash",
+        str(params["cash"]),
+        "--allocation-method",
+        str(params["allocation_method"]),
+        "--max-position-pct",
+        str(params["max_position_pct"]),
+        "--max-utilization",
+        str(params["max_utilization"]),
+        "--max-positions",
+        str(params["max_positions"]),
+        "--risk-pct",
+        str(params["risk_pct"]),
+        "--stop-loss-pct",
+        str(params["stop_loss_pct"]),
+        "--min-holding-days",
+        str(params["min_holding_days"]),
+        "--max-holding-days",
+        str(params["max_holding_days"]),
+        "--trailing-stop-atr",
+        str(params["trailing_stop_atr"]),
+        "--threshold",
+        str(params["threshold"]),
+        "--topix-drawdown-threshold",
+        str(params["topix_drawdown_threshold"]),
+        "--topix-size-multiplier-bear",
+        str(params["topix_size_multiplier_bear"]),
+        "--output-format",
+        "all",
+        "--output-dir",
+        str(output_dir),
     ]
     if params.get("portfolio_drawdown_stop_pct") is not None:
         cmd.extend(["--portfolio-drawdown-stop", str(params["portfolio_drawdown_stop_pct"])])
@@ -299,21 +319,40 @@ def main() -> None:
     original_risk_text = RISK_CONFIG_PATH.read_text(encoding="utf-8")
 
     fieldnames = [
-        "name", "year",
-        "topix_drawdown_threshold", "topix_size_multiplier_bear", "portfolio_drawdown_stop_pct",
-        "run_id", "created_at", "cash", "allocation_method",
-        "threshold", "stop_loss_pct", "trailing_stop_atr", "max_holding_days",
-        "max_positions", "max_position_pct", "max_utilization",
-        "cagr", "sharpe", "max_drawdown", "win_rate",
-        "payoff_ratio", "profit_factor", "avg_holding_days", "total_trades", "trades_csv",
+        "name",
+        "year",
+        "topix_drawdown_threshold",
+        "topix_size_multiplier_bear",
+        "portfolio_drawdown_stop_pct",
+        "run_id",
+        "created_at",
+        "cash",
+        "allocation_method",
+        "threshold",
+        "stop_loss_pct",
+        "trailing_stop_atr",
+        "max_holding_days",
+        "max_positions",
+        "max_position_pct",
+        "max_utilization",
+        "cagr",
+        "sharpe",
+        "max_drawdown",
+        "win_rate",
+        "payoff_ratio",
+        "profit_factor",
+        "avg_holding_days",
+        "total_trades",
+        "trades_csv",
     ]
 
     print(f"output_dir={output_dir}")
     print("scenario\tyear\tbear_thr\tbear_mult\tdd_stop\tcagr\tsharpe\tmax_dd\ttrades")
 
-    with log_jsonl_path.open("w", encoding="utf-8") as jsonl_file, log_csv_path.open(
-        "w", newline="", encoding="utf-8"
-    ) as csv_file:
+    with (
+        log_jsonl_path.open("w", encoding="utf-8") as jsonl_file,
+        log_csv_path.open("w", newline="", encoding="utf-8") as csv_file,
+    ):
         writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
         writer.writeheader()
 

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_10m_oos.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_10m_oos.py
@@ -1,17 +1,7 @@
-"""1m ファクターアブレーション分析スクリプト
+"""10m アウトオブサンプル検証スクリプト
 
-各ファクターを1つずつ weight=0 にして 2023/2024/2025 を検証し、
-どのファクターが 2023/2024 の損失を引き起こしているかを特定する。
-
-残りの重みは generate_signals() 内で自動正規化されるため合計が 1.0 でなくても動作する。
-
-シナリオ（計6件）× 3年（2023/2024/2025）= 18ラン:
-  base          : 現行重み（momentum=0.40, value=0.20, vol=0.15, liq=0.15, news=0.10）
-  no_momentum   : momentum weight = 0
-  no_value      : value weight = 0
-  no_volatility : volatility weight = 0
-  no_liquidity  : liquidity weight = 0
-  no_news       : news weight = 0
+10m_equal_4slots（2025年最良設定）を 2023・2024・2025 の各年度で検証し、
+オーバーフィットでないかを確認する。
 """
 
 from __future__ import annotations
@@ -45,17 +35,17 @@ STRATEGY_CONFIG_PATH = REPO_ROOT / "config" / "strategy_config.yaml"
 RISK_CONFIG_PATH = REPO_ROOT / "config" / "risk_config.yaml"
 RUN_ID_PATTERN = re.compile(r"run_id:\s*([0-9a-fA-F-]+)|run_id=([0-9a-fA-F-]+)")
 SUBPROCESS_ENCODING = locale.getpreferredencoding(False) or "cp932"
-ARTIFACTS_ROOT = REPO_ROOT / "artifacts" / "backtest_improvement_1m_ablation"
+ARTIFACTS_ROOT = REPO_ROOT / "artifacts" / "backtest_improvement_10m_oos"
 
-# 1m_equal_4slots の固定ベースパラメータ（v2 最良設定）
-_BASE = {
-    "cash": 1_000_000,
+# 10m_equal_4slots の固定パラメータ
+BASE_PARAMS = {
+    "cash": 10_000_000,
     "allocation_method": "equal",
     "max_positions": 4,
     "max_position_pct": 0.22,
     "max_utilization": 0.80,
     "risk_pct": 0.005,
-    "stop_loss_pct": 0.09,
+    "stop_loss_pct": 0.07,
     "threshold": 0.58,
     "topix_size_multiplier_bear": 0.50,
     "topix_drawdown_threshold": -0.15,
@@ -63,25 +53,11 @@ _BASE = {
     "max_holding_days": 60,
 }
 
-# 現行の重み（ベースライン）
-_WEIGHTS_BASE = {
-    "momentum": 0.40,
-    "value": 0.20,
-    "volatility": 0.15,
-    "liquidity": 0.15,
-    "news": 0.10,
-}
-
 SCENARIOS = [
-    {**_BASE, "name": "base", "weights": _WEIGHTS_BASE},
-    {**_BASE, "name": "no_momentum", "weights": {**_WEIGHTS_BASE, "momentum": 0.0}},
-    {**_BASE, "name": "no_value", "weights": {**_WEIGHTS_BASE, "value": 0.0}},
-    {**_BASE, "name": "no_volatility", "weights": {**_WEIGHTS_BASE, "volatility": 0.0}},
-    {**_BASE, "name": "no_liquidity", "weights": {**_WEIGHTS_BASE, "liquidity": 0.0}},
-    {**_BASE, "name": "no_news", "weights": {**_WEIGHTS_BASE, "news": 0.0}},
+    {"name": "10m_eq4_2023", "year": 2023, **BASE_PARAMS},
+    {"name": "10m_eq4_2024", "year": 2024, **BASE_PARAMS},
+    {"name": "10m_eq4_2025", "year": 2025, **BASE_PARAMS},
 ]
-
-YEARS = [2023, 2024, 2025]
 
 
 def _load_env(path: Path) -> dict[str, str]:
@@ -113,10 +89,16 @@ def _build_base_context() -> dict[str, object]:
     env = _load_env(ENV_PATH)
     strategy_config = _load_yaml(STRATEGY_CONFIG_PATH)
     risk_config = _load_yaml(RISK_CONFIG_PATH)
+
     db_path = Path(env.get("DUCKDB_PATH", "data/kabusys.duckdb"))
     if not db_path.is_absolute():
         db_path = REPO_ROOT / db_path
-    return {"db_path": db_path, "strategy_config": strategy_config, "risk_config": risk_config}
+
+    return {
+        "db_path": db_path,
+        "strategy_config": strategy_config,
+        "risk_config": risk_config,
+    }
 
 
 def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
@@ -125,9 +107,6 @@ def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
     sector_section = strategy_config.setdefault("sector", {})
     regime_section = strategy_config.setdefault("regime", {})
     portfolio_section = strategy_config.setdefault("portfolio", {})
-
-    # ファクター重み（シナリオごとに上書き）
-    strategy_section["weights"] = scenario["weights"]
 
     strategy_section["threshold"] = scenario.get("threshold", 0.58)
     strategy_section["gap_up_threshold"] = 0.07
@@ -157,7 +136,8 @@ def _build_risk_config(base: dict, scenario: dict[str, object]) -> dict:
     return risk_config
 
 
-def _build_backtest_params(scenario: dict[str, object], year: int) -> dict[str, object]:
+def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
+    year = int(scenario.get("year", 2025))
     return {
         "start": f"{year}-01-01",
         "end": f"{year}-12-31",
@@ -167,7 +147,7 @@ def _build_backtest_params(scenario: dict[str, object], year: int) -> dict[str, 
         "max_position_pct": scenario.get("max_position_pct", 0.22),
         "max_utilization": scenario.get("max_utilization", 0.80),
         "risk_pct": scenario.get("risk_pct", 0.005),
-        "stop_loss_pct": scenario.get("stop_loss_pct", 0.09),
+        "stop_loss_pct": scenario.get("stop_loss_pct", 0.07),
         "min_holding_days": 5,
         "max_holding_days": scenario.get("max_holding_days", 60),
         "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
@@ -306,11 +286,6 @@ def main() -> None:
     fieldnames = [
         "name",
         "year",
-        "w_momentum",
-        "w_value",
-        "w_volatility",
-        "w_liquidity",
-        "w_news",
         "run_id",
         "created_at",
         "cash",
@@ -345,93 +320,82 @@ def main() -> None:
 
         try:
             for scenario in SCENARIOS:
-                for year in YEARS:
-                    strategy_config = _build_strategy_config(context["strategy_config"], scenario)
-                    risk_config = _build_risk_config(context["risk_config"], scenario)
-                    _save_yaml(STRATEGY_CONFIG_PATH, strategy_config)
-                    _save_yaml(RISK_CONFIG_PATH, risk_config)
+                strategy_config = _build_strategy_config(context["strategy_config"], scenario)
+                risk_config = _build_risk_config(context["risk_config"], scenario)
+                _save_yaml(STRATEGY_CONFIG_PATH, strategy_config)
+                _save_yaml(RISK_CONFIG_PATH, risk_config)
 
-                    scenario_name = str(scenario["name"])
-                    run_slug = f"{scenario_name}_{year}"
-                    scenario_dir = output_dir / run_slug
-                    scenario_dir.mkdir(parents=True, exist_ok=True)
+                scenario_slug = str(scenario["name"])
+                scenario_dir = output_dir / scenario_slug
+                scenario_dir.mkdir(parents=True, exist_ok=True)
 
-                    params = _build_backtest_params(scenario, year)
-                    (scenario_dir / "effective_backtest_params.json").write_text(
-                        json.dumps(params, ensure_ascii=False, indent=2), encoding="utf-8"
+                params = _build_backtest_params(scenario)
+                (scenario_dir / "effective_backtest_params.json").write_text(
+                    json.dumps(params, ensure_ascii=False, indent=2), encoding="utf-8"
+                )
+
+                report_base_dir = scenario_dir / "report"
+                cmd = _build_command(db_path, params, report_base_dir)
+                print(f"\n=== running: {scenario_slug} ({params['start']} ~ {params['end']}) ===")
+                print("command:", subprocess.list2cmdline(cmd))
+
+                completed = subprocess.run(
+                    cmd,
+                    cwd=str(REPO_ROOT),
+                    capture_output=True,
+                    text=True,
+                    encoding=SUBPROCESS_ENCODING,
+                    errors="replace",
+                )
+
+                (scenario_dir / "stdout.log").write_text(completed.stdout or "", encoding="utf-8")
+                (scenario_dir / "stderr.log").write_text(completed.stderr or "", encoding="utf-8")
+
+                if completed.returncode != 0:
+                    raise RuntimeError(
+                        f"scenario={scenario_slug} failed with exit code {completed.returncode}"
                     )
 
-                    report_base_dir = scenario_dir / "report"
-                    cmd = _build_command(db_path, params, report_base_dir)
-                    print(f"\n=== running: {run_slug} ===")
+                run_id = _extract_run_id(f"{completed.stdout}\n{completed.stderr}")
+                conn = duckdb.connect(str(db_path), read_only=True)
+                try:
+                    metrics = _fetch_metrics(conn, run_id)
+                    _export_trades_csv(conn, run_id, scenario_dir / "trades.csv")
+                finally:
+                    conn.close()
 
-                    completed = subprocess.run(
-                        cmd,
-                        cwd=str(REPO_ROOT),
-                        capture_output=True,
-                        text=True,
-                        encoding=SUBPROCESS_ENCODING,
-                        errors="replace",
-                    )
+                record = {
+                    "name": scenario_slug,
+                    "year": scenario.get("year"),
+                    "run_id": run_id,
+                    "created_at": metrics["created_at"],
+                    "cash": params["cash"],
+                    "allocation_method": params["allocation_method"],
+                    "threshold": scenario.get("threshold", 0.58),
+                    "stop_loss_pct": params["stop_loss_pct"],
+                    "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
+                    "max_holding_days": params["max_holding_days"],
+                    "max_positions": params["max_positions"],
+                    "max_position_pct": params["max_position_pct"],
+                    "max_utilization": params["max_utilization"],
+                    **metrics,
+                    "trades_csv": str(scenario_dir / "trades.csv"),
+                }
 
-                    (scenario_dir / "stdout.log").write_text(
-                        completed.stdout or "", encoding="utf-8"
-                    )
-                    (scenario_dir / "stderr.log").write_text(
-                        completed.stderr or "", encoding="utf-8"
-                    )
+                jsonl_file.write(json.dumps(record, ensure_ascii=False) + "\n")
+                jsonl_file.flush()
+                writer.writerow(record)
+                csv_file.flush()
 
-                    if completed.returncode != 0:
-                        raise RuntimeError(
-                            f"scenario={run_slug} failed with exit code {completed.returncode}"
-                        )
-
-                    run_id = _extract_run_id(f"{completed.stdout}\n{completed.stderr}")
-                    conn = duckdb.connect(str(db_path), read_only=True)
-                    try:
-                        metrics = _fetch_metrics(conn, run_id)
-                        _export_trades_csv(conn, run_id, scenario_dir / "trades.csv")
-                    finally:
-                        conn.close()
-
-                    weights = scenario["weights"]
-                    record = {
-                        "name": scenario_name,
-                        "year": year,
-                        "w_momentum": weights["momentum"],
-                        "w_value": weights["value"],
-                        "w_volatility": weights["volatility"],
-                        "w_liquidity": weights["liquidity"],
-                        "w_news": weights["news"],
-                        "run_id": run_id,
-                        "created_at": metrics["created_at"],
-                        "cash": params["cash"],
-                        "allocation_method": params["allocation_method"],
-                        "threshold": params["threshold"],
-                        "stop_loss_pct": params["stop_loss_pct"],
-                        "trailing_stop_atr": params["trailing_stop_atr"],
-                        "max_holding_days": params["max_holding_days"],
-                        "max_positions": params["max_positions"],
-                        "max_position_pct": params["max_position_pct"],
-                        "max_utilization": params["max_utilization"],
-                        **metrics,
-                        "trades_csv": str(scenario_dir / "trades.csv"),
-                    }
-
-                    jsonl_file.write(json.dumps(record, ensure_ascii=False) + "\n")
-                    jsonl_file.flush()
-                    writer.writerow(record)
-                    csv_file.flush()
-
-                    print(
-                        f"{run_slug}\t{year}\t"
-                        f"{_format_metric(metrics['cagr'])}\t"
-                        f"{_format_metric(metrics['sharpe'])}\t"
-                        f"{_format_metric(metrics['max_drawdown'])}\t"
-                        f"{_format_metric(metrics['win_rate'])}\t"
-                        f"{_format_metric(metrics['profit_factor'])}\t"
-                        f"{metrics['total_trades']}"
-                    )
+                print(
+                    f"{scenario_slug}\t{scenario.get('year')}\t"
+                    f"{_format_metric(metrics['cagr'])}\t"
+                    f"{_format_metric(metrics['sharpe'])}\t"
+                    f"{_format_metric(metrics['max_drawdown'])}\t"
+                    f"{_format_metric(metrics['win_rate'])}\t"
+                    f"{_format_metric(metrics['profit_factor'])}\t"
+                    f"{metrics['total_trades']}"
+                )
         finally:
             STRATEGY_CONFIG_PATH.write_text(original_strategy_text, encoding="utf-8")
             RISK_CONFIG_PATH.write_text(original_risk_text, encoding="utf-8")

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_10m_oos2.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_10m_oos2.py
@@ -1,17 +1,12 @@
-"""1m ファクターアブレーション分析スクリプト
+"""10m アウトオブサンプル検証 v2（MA200フィルター有無の比較）
 
-各ファクターを1つずつ weight=0 にして 2023/2024/2025 を検証し、
-どのファクターが 2023/2024 の損失を引き起こしているかを特定する。
+10m_equal_4slots の base と ma200 フィルター設定を
+2023・2024・2025 の各年度で検証し、MA200フィルターの
+オーバーフィット耐性改善効果を確認する。
 
-残りの重みは generate_signals() 内で自動正規化されるため合計が 1.0 でなくても動作する。
-
-シナリオ（計6件）× 3年（2023/2024/2025）= 18ラン:
-  base          : 現行重み（momentum=0.40, value=0.20, vol=0.15, liq=0.15, news=0.10）
-  no_momentum   : momentum weight = 0
-  no_value      : value weight = 0
-  no_volatility : volatility weight = 0
-  no_liquidity  : liquidity weight = 0
-  no_news       : news weight = 0
+シナリオ（計6件）:
+  base  × 3年: フィルターなし（前回 OOS との比較用）
+  ma200 × 3年: MA200フィルターあり
 """
 
 from __future__ import annotations
@@ -45,43 +40,35 @@ STRATEGY_CONFIG_PATH = REPO_ROOT / "config" / "strategy_config.yaml"
 RISK_CONFIG_PATH = REPO_ROOT / "config" / "risk_config.yaml"
 RUN_ID_PATTERN = re.compile(r"run_id:\s*([0-9a-fA-F-]+)|run_id=([0-9a-fA-F-]+)")
 SUBPROCESS_ENCODING = locale.getpreferredencoding(False) or "cp932"
-ARTIFACTS_ROOT = REPO_ROOT / "artifacts" / "backtest_improvement_1m_ablation"
+ARTIFACTS_ROOT = REPO_ROOT / "artifacts" / "backtest_improvement_10m_oos2"
 
-# 1m_equal_4slots の固定ベースパラメータ（v2 最良設定）
+# 10m_equal_4slots の固定パラメータ
 _BASE = {
-    "cash": 1_000_000,
+    "cash": 10_000_000,
     "allocation_method": "equal",
     "max_positions": 4,
     "max_position_pct": 0.22,
     "max_utilization": 0.80,
     "risk_pct": 0.005,
-    "stop_loss_pct": 0.09,
+    "stop_loss_pct": 0.07,
     "threshold": 0.58,
     "topix_size_multiplier_bear": 0.50,
     "topix_drawdown_threshold": -0.15,
     "trailing_stop_atr_mult": 2.0,
     "max_holding_days": 60,
-}
-
-# 現行の重み（ベースライン）
-_WEIGHTS_BASE = {
-    "momentum": 0.40,
-    "value": 0.20,
-    "volatility": 0.15,
-    "liquidity": 0.15,
-    "news": 0.10,
+    "use_ma200_filter": False,
 }
 
 SCENARIOS = [
-    {**_BASE, "name": "base", "weights": _WEIGHTS_BASE},
-    {**_BASE, "name": "no_momentum", "weights": {**_WEIGHTS_BASE, "momentum": 0.0}},
-    {**_BASE, "name": "no_value", "weights": {**_WEIGHTS_BASE, "value": 0.0}},
-    {**_BASE, "name": "no_volatility", "weights": {**_WEIGHTS_BASE, "volatility": 0.0}},
-    {**_BASE, "name": "no_liquidity", "weights": {**_WEIGHTS_BASE, "liquidity": 0.0}},
-    {**_BASE, "name": "no_news", "weights": {**_WEIGHTS_BASE, "news": 0.0}},
+    # ── フィルターなし × 3年 ─────────────────────────────────────────────
+    {**_BASE, "name": "10m_eq4_base_2023", "year": 2023},
+    {**_BASE, "name": "10m_eq4_base_2024", "year": 2024},
+    {**_BASE, "name": "10m_eq4_base_2025", "year": 2025},
+    # ── MA200フィルターあり × 3年 ─────────────────────────────────────────
+    {**_BASE, "name": "10m_eq4_ma200_2023", "year": 2023, "use_ma200_filter": True},
+    {**_BASE, "name": "10m_eq4_ma200_2024", "year": 2024, "use_ma200_filter": True},
+    {**_BASE, "name": "10m_eq4_ma200_2025", "year": 2025, "use_ma200_filter": True},
 ]
-
-YEARS = [2023, 2024, 2025]
 
 
 def _load_env(path: Path) -> dict[str, str]:
@@ -113,10 +100,16 @@ def _build_base_context() -> dict[str, object]:
     env = _load_env(ENV_PATH)
     strategy_config = _load_yaml(STRATEGY_CONFIG_PATH)
     risk_config = _load_yaml(RISK_CONFIG_PATH)
+
     db_path = Path(env.get("DUCKDB_PATH", "data/kabusys.duckdb"))
     if not db_path.is_absolute():
         db_path = REPO_ROOT / db_path
-    return {"db_path": db_path, "strategy_config": strategy_config, "risk_config": risk_config}
+
+    return {
+        "db_path": db_path,
+        "strategy_config": strategy_config,
+        "risk_config": risk_config,
+    }
 
 
 def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
@@ -125,9 +118,6 @@ def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
     sector_section = strategy_config.setdefault("sector", {})
     regime_section = strategy_config.setdefault("regime", {})
     portfolio_section = strategy_config.setdefault("portfolio", {})
-
-    # ファクター重み（シナリオごとに上書き）
-    strategy_section["weights"] = scenario["weights"]
 
     strategy_section["threshold"] = scenario.get("threshold", 0.58)
     strategy_section["gap_up_threshold"] = 0.07
@@ -157,7 +147,8 @@ def _build_risk_config(base: dict, scenario: dict[str, object]) -> dict:
     return risk_config
 
 
-def _build_backtest_params(scenario: dict[str, object], year: int) -> dict[str, object]:
+def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
+    year = int(scenario.get("year", 2025))
     return {
         "start": f"{year}-01-01",
         "end": f"{year}-12-31",
@@ -167,18 +158,19 @@ def _build_backtest_params(scenario: dict[str, object], year: int) -> dict[str, 
         "max_position_pct": scenario.get("max_position_pct", 0.22),
         "max_utilization": scenario.get("max_utilization", 0.80),
         "risk_pct": scenario.get("risk_pct", 0.005),
-        "stop_loss_pct": scenario.get("stop_loss_pct", 0.09),
+        "stop_loss_pct": scenario.get("stop_loss_pct", 0.07),
         "min_holding_days": 5,
         "max_holding_days": scenario.get("max_holding_days", 60),
         "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
         "threshold": scenario.get("threshold", 0.58),
         "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
         "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+        "use_ma200_filter": scenario.get("use_ma200_filter", False),
     }
 
 
 def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -> list[str]:
-    return [
+    cmd = [
         sys.executable,
         "-m",
         "kabusys.backtest.run",
@@ -219,6 +211,9 @@ def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -
         "--output-dir",
         str(output_dir),
     ]
+    if params.get("use_ma200_filter"):
+        cmd.append("--ma200-filter")
+    return cmd
 
 
 def _extract_run_id(output: str) -> str:
@@ -306,11 +301,7 @@ def main() -> None:
     fieldnames = [
         "name",
         "year",
-        "w_momentum",
-        "w_value",
-        "w_volatility",
-        "w_liquidity",
-        "w_news",
+        "use_ma200_filter",
         "run_id",
         "created_at",
         "cash",
@@ -334,7 +325,7 @@ def main() -> None:
     ]
 
     print(f"output_dir={output_dir}")
-    print("scenario\tyear\tcagr\tsharpe\tmax_dd\twin_rate\tpf\ttrades")
+    print("scenario\tyear\tma200\tcagr\tsharpe\tmax_dd\twin_rate\tpf\ttrades")
 
     with (
         log_jsonl_path.open("w", encoding="utf-8") as jsonl_file,
@@ -345,93 +336,84 @@ def main() -> None:
 
         try:
             for scenario in SCENARIOS:
-                for year in YEARS:
-                    strategy_config = _build_strategy_config(context["strategy_config"], scenario)
-                    risk_config = _build_risk_config(context["risk_config"], scenario)
-                    _save_yaml(STRATEGY_CONFIG_PATH, strategy_config)
-                    _save_yaml(RISK_CONFIG_PATH, risk_config)
+                strategy_config = _build_strategy_config(context["strategy_config"], scenario)
+                risk_config = _build_risk_config(context["risk_config"], scenario)
+                _save_yaml(STRATEGY_CONFIG_PATH, strategy_config)
+                _save_yaml(RISK_CONFIG_PATH, risk_config)
 
-                    scenario_name = str(scenario["name"])
-                    run_slug = f"{scenario_name}_{year}"
-                    scenario_dir = output_dir / run_slug
-                    scenario_dir.mkdir(parents=True, exist_ok=True)
+                scenario_slug = str(scenario["name"])
+                scenario_dir = output_dir / scenario_slug
+                scenario_dir.mkdir(parents=True, exist_ok=True)
 
-                    params = _build_backtest_params(scenario, year)
-                    (scenario_dir / "effective_backtest_params.json").write_text(
-                        json.dumps(params, ensure_ascii=False, indent=2), encoding="utf-8"
+                params = _build_backtest_params(scenario)
+                (scenario_dir / "effective_backtest_params.json").write_text(
+                    json.dumps(params, ensure_ascii=False, indent=2), encoding="utf-8"
+                )
+
+                report_base_dir = scenario_dir / "report"
+                cmd = _build_command(db_path, params, report_base_dir)
+                print(f"\n=== running: {scenario_slug} ({params['start']} ~ {params['end']}) ===")
+                print("command:", subprocess.list2cmdline(cmd))
+
+                completed = subprocess.run(
+                    cmd,
+                    cwd=str(REPO_ROOT),
+                    capture_output=True,
+                    text=True,
+                    encoding=SUBPROCESS_ENCODING,
+                    errors="replace",
+                )
+
+                (scenario_dir / "stdout.log").write_text(completed.stdout or "", encoding="utf-8")
+                (scenario_dir / "stderr.log").write_text(completed.stderr or "", encoding="utf-8")
+
+                if completed.returncode != 0:
+                    raise RuntimeError(
+                        f"scenario={scenario_slug} failed with exit code {completed.returncode}"
                     )
 
-                    report_base_dir = scenario_dir / "report"
-                    cmd = _build_command(db_path, params, report_base_dir)
-                    print(f"\n=== running: {run_slug} ===")
+                run_id = _extract_run_id(f"{completed.stdout}\n{completed.stderr}")
+                conn = duckdb.connect(str(db_path), read_only=True)
+                try:
+                    metrics = _fetch_metrics(conn, run_id)
+                    _export_trades_csv(conn, run_id, scenario_dir / "trades.csv")
+                finally:
+                    conn.close()
 
-                    completed = subprocess.run(
-                        cmd,
-                        cwd=str(REPO_ROOT),
-                        capture_output=True,
-                        text=True,
-                        encoding=SUBPROCESS_ENCODING,
-                        errors="replace",
-                    )
+                record = {
+                    "name": scenario_slug,
+                    "year": scenario.get("year"),
+                    "use_ma200_filter": params["use_ma200_filter"],
+                    "run_id": run_id,
+                    "created_at": metrics["created_at"],
+                    "cash": params["cash"],
+                    "allocation_method": params["allocation_method"],
+                    "threshold": scenario.get("threshold", 0.58),
+                    "stop_loss_pct": params["stop_loss_pct"],
+                    "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
+                    "max_holding_days": params["max_holding_days"],
+                    "max_positions": params["max_positions"],
+                    "max_position_pct": params["max_position_pct"],
+                    "max_utilization": params["max_utilization"],
+                    **metrics,
+                    "trades_csv": str(scenario_dir / "trades.csv"),
+                }
 
-                    (scenario_dir / "stdout.log").write_text(
-                        completed.stdout or "", encoding="utf-8"
-                    )
-                    (scenario_dir / "stderr.log").write_text(
-                        completed.stderr or "", encoding="utf-8"
-                    )
+                jsonl_file.write(json.dumps(record, ensure_ascii=False) + "\n")
+                jsonl_file.flush()
+                writer.writerow(record)
+                csv_file.flush()
 
-                    if completed.returncode != 0:
-                        raise RuntimeError(
-                            f"scenario={run_slug} failed with exit code {completed.returncode}"
-                        )
-
-                    run_id = _extract_run_id(f"{completed.stdout}\n{completed.stderr}")
-                    conn = duckdb.connect(str(db_path), read_only=True)
-                    try:
-                        metrics = _fetch_metrics(conn, run_id)
-                        _export_trades_csv(conn, run_id, scenario_dir / "trades.csv")
-                    finally:
-                        conn.close()
-
-                    weights = scenario["weights"]
-                    record = {
-                        "name": scenario_name,
-                        "year": year,
-                        "w_momentum": weights["momentum"],
-                        "w_value": weights["value"],
-                        "w_volatility": weights["volatility"],
-                        "w_liquidity": weights["liquidity"],
-                        "w_news": weights["news"],
-                        "run_id": run_id,
-                        "created_at": metrics["created_at"],
-                        "cash": params["cash"],
-                        "allocation_method": params["allocation_method"],
-                        "threshold": params["threshold"],
-                        "stop_loss_pct": params["stop_loss_pct"],
-                        "trailing_stop_atr": params["trailing_stop_atr"],
-                        "max_holding_days": params["max_holding_days"],
-                        "max_positions": params["max_positions"],
-                        "max_position_pct": params["max_position_pct"],
-                        "max_utilization": params["max_utilization"],
-                        **metrics,
-                        "trades_csv": str(scenario_dir / "trades.csv"),
-                    }
-
-                    jsonl_file.write(json.dumps(record, ensure_ascii=False) + "\n")
-                    jsonl_file.flush()
-                    writer.writerow(record)
-                    csv_file.flush()
-
-                    print(
-                        f"{run_slug}\t{year}\t"
-                        f"{_format_metric(metrics['cagr'])}\t"
-                        f"{_format_metric(metrics['sharpe'])}\t"
-                        f"{_format_metric(metrics['max_drawdown'])}\t"
-                        f"{_format_metric(metrics['win_rate'])}\t"
-                        f"{_format_metric(metrics['profit_factor'])}\t"
-                        f"{metrics['total_trades']}"
-                    )
+                print(
+                    f"{scenario_slug}\t{scenario.get('year')}\t"
+                    f"{params['use_ma200_filter']}\t"
+                    f"{_format_metric(metrics['cagr'])}\t"
+                    f"{_format_metric(metrics['sharpe'])}\t"
+                    f"{_format_metric(metrics['max_drawdown'])}\t"
+                    f"{_format_metric(metrics['win_rate'])}\t"
+                    f"{_format_metric(metrics['profit_factor'])}\t"
+                    f"{metrics['total_trades']}"
+                )
         finally:
             STRATEGY_CONFIG_PATH.write_text(original_strategy_text, encoding="utf-8")
             RISK_CONFIG_PATH.write_text(original_risk_text, encoding="utf-8")

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_10m_v2.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_10m_v2.py
@@ -1,0 +1,542 @@
+"""10m バックテスト改善スイート v2
+
+v1 で判明した課題（2025年通年マイナス）に対し、以下の方向性で探索する。
+  1. ストップ収縮   : stop_loss 9% → 6%, trail_atr 2.0 → 1.5, max_holding 60 → 30-40日
+  2. equal 配分     : 1m スイートで equal が好成績のため 10m でも検証
+  3. 閾値引き下げ   : threshold 0.58 → 0.55 で分散を増やす
+  4. スロット集中   : 4-5 スロットに絞り 1 銘柄あたりの重みを上げる
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import locale
+import re
+import shutil
+import subprocess
+import sys
+from copy import deepcopy
+from datetime import datetime
+from pathlib import Path
+
+import duckdb
+import yaml
+
+
+def _find_repo_root() -> Path:
+    current = Path(__file__).resolve().parent
+    for candidate in [current, *current.parents]:
+        if (candidate / "config" / "strategy_config.yaml").exists():
+            return candidate
+    raise FileNotFoundError("Could not locate repo root containing config/strategy_config.yaml")
+
+
+REPO_ROOT = _find_repo_root()
+ENV_PATH = REPO_ROOT / ".env"
+STRATEGY_CONFIG_PATH = REPO_ROOT / "config" / "strategy_config.yaml"
+RISK_CONFIG_PATH = REPO_ROOT / "config" / "risk_config.yaml"
+RUN_ID_PATTERN = re.compile(r"run_id:\s*([0-9a-fA-F-]+)|run_id=([0-9a-fA-F-]+)")
+SUBPROCESS_ENCODING = locale.getpreferredencoding(False) or "cp932"
+ARTIFACTS_ROOT = REPO_ROOT / "artifacts" / "backtest_improvement_10m_v2"
+
+
+SCENARIOS = [
+    # ── ベースライン（v1 との比較用） ──────────────────────────────────────────
+    {
+        "name": "10m_base",
+        "cash": 10_000_000,
+        "allocation_method": "risk_based",
+        "max_positions": 7,
+        "max_position_pct": 0.10,
+        "max_utilization": 0.70,
+        "risk_pct": 0.005,
+        "stop_loss_pct": 0.09,
+        "threshold": 0.58,
+        "topix_size_multiplier_bear": 0.50,
+        "topix_drawdown_threshold": -0.15,
+        "trailing_stop_atr_mult": 2.0,
+        "max_holding_days": 60,
+    },
+    # ── ストップ収縮：損切りを早めてドローダウン抑制 ─────────────────────────
+    {
+        "name": "10m_tighter_stop",
+        "cash": 10_000_000,
+        "allocation_method": "risk_based",
+        "max_positions": 7,
+        "max_position_pct": 0.10,
+        "max_utilization": 0.70,
+        "risk_pct": 0.005,
+        "stop_loss_pct": 0.06,
+        "threshold": 0.58,
+        "topix_size_multiplier_bear": 0.50,
+        "topix_drawdown_threshold": -0.15,
+        "trailing_stop_atr_mult": 1.5,
+        "max_holding_days": 40,
+    },
+    # ── 高速エグジット：短期回転で含み損を引きずらない ───────────────────────
+    {
+        "name": "10m_fast_exit",
+        "cash": 10_000_000,
+        "allocation_method": "risk_based",
+        "max_positions": 7,
+        "max_position_pct": 0.10,
+        "max_utilization": 0.70,
+        "risk_pct": 0.005,
+        "stop_loss_pct": 0.06,
+        "threshold": 0.58,
+        "topix_size_multiplier_bear": 0.50,
+        "topix_drawdown_threshold": -0.15,
+        "trailing_stop_atr_mult": 1.5,
+        "max_holding_days": 30,
+    },
+    # ── equal 配分 + 閾値引き下げ：分散と銘柄数のバランスを探る ─────────────
+    {
+        "name": "10m_equal_lower_thr",
+        "cash": 10_000_000,
+        "allocation_method": "equal",
+        "max_positions": 6,
+        "max_position_pct": 0.15,
+        "max_utilization": 0.75,
+        "risk_pct": 0.005,
+        "stop_loss_pct": 0.07,
+        "threshold": 0.55,
+        "topix_size_multiplier_bear": 0.50,
+        "topix_drawdown_threshold": -0.15,
+        "trailing_stop_atr_mult": 2.0,
+        "max_holding_days": 60,
+    },
+    # ── equal 集中 5slots：質重視で 1 銘柄あたりの重みを上げる ──────────────
+    {
+        "name": "10m_concentrate_5slots",
+        "cash": 10_000_000,
+        "allocation_method": "equal",
+        "max_positions": 5,
+        "max_position_pct": 0.18,
+        "max_utilization": 0.80,
+        "risk_pct": 0.005,
+        "stop_loss_pct": 0.07,
+        "threshold": 0.60,
+        "topix_size_multiplier_bear": 0.50,
+        "topix_drawdown_threshold": -0.15,
+        "trailing_stop_atr_mult": 1.5,
+        "max_holding_days": 40,
+    },
+    # ── equal 4slots：1m で最良だった設定を 10m に適用 ───────────────────────
+    {
+        "name": "10m_equal_4slots",
+        "cash": 10_000_000,
+        "allocation_method": "equal",
+        "max_positions": 4,
+        "max_position_pct": 0.22,
+        "max_utilization": 0.80,
+        "risk_pct": 0.005,
+        "stop_loss_pct": 0.07,
+        "threshold": 0.58,
+        "topix_size_multiplier_bear": 0.50,
+        "topix_drawdown_threshold": -0.15,
+        "trailing_stop_atr_mult": 2.0,
+        "max_holding_days": 60,
+    },
+]
+
+
+def _load_env(path: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    if not path.exists():
+        return result
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        result[key.strip()] = value.strip()
+    return result
+
+
+def _load_yaml(path: Path) -> dict:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return data if isinstance(data, dict) else {}
+
+
+def _save_yaml(path: Path, data: dict) -> None:
+    path.write_text(
+        yaml.dump(data, allow_unicode=True, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def _build_base_context() -> dict[str, object]:
+    env = _load_env(ENV_PATH)
+    strategy_config = _load_yaml(STRATEGY_CONFIG_PATH)
+    risk_config = _load_yaml(RISK_CONFIG_PATH)
+
+    db_path = Path(env.get("DUCKDB_PATH", "data/kabusys.duckdb"))
+    if not db_path.is_absolute():
+        db_path = REPO_ROOT / db_path
+
+    return {
+        "db_path": db_path,
+        "strategy_config": strategy_config,
+        "risk_config": risk_config,
+    }
+
+
+def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
+    strategy_config = deepcopy(base)
+    strategy_section = strategy_config.setdefault("strategy", {})
+    sector_section = strategy_config.setdefault("sector", {})
+    regime_section = strategy_config.setdefault("regime", {})
+    portfolio_section = strategy_config.setdefault("portfolio", {})
+
+    strategy_section["threshold"] = scenario.get("threshold", 0.58)
+    strategy_section["gap_up_threshold"] = 0.07
+    strategy_section["gap_down_threshold"] = -0.05
+    strategy_section["rsi_overbought_threshold"] = 65.0
+    strategy_section["stop_loss_rate"] = -0.08
+    strategy_section["min_holding_days"] = 5
+    strategy_section["max_holding_days"] = scenario.get("max_holding_days", 60)
+    strategy_section["trailing_stop_atr_mult"] = scenario.get("trailing_stop_atr_mult", 2.0)
+    strategy_section["reentry_cooldown_days"] = 5
+
+    sector_section["boost"] = 0.05
+    sector_section["quartile"] = 0.30
+
+    regime_section["topix_drawdown_threshold"] = scenario.get("topix_drawdown_threshold", -0.15)
+    regime_section["topix_size_multiplier_bear"] = scenario.get("topix_size_multiplier_bear", 0.50)
+
+    portfolio_section["max_positions"] = scenario.get("max_positions", 7)
+    return strategy_config
+
+
+def _build_risk_config(base: dict, scenario: dict[str, object]) -> dict:
+    risk_config = deepcopy(base)
+    risk_section = risk_config.setdefault("risk", {})
+    risk_section["max_position_pct"] = scenario.get("max_position_pct", 0.10)
+    risk_section["max_utilization"] = scenario.get("max_utilization", 0.70)
+    return risk_config
+
+
+def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
+    return {
+        "start": "2025-01-01",
+        "end": "2025-12-31",
+        "cash": scenario["cash"],
+        "allocation_method": scenario.get("allocation_method", "risk_based"),
+        "max_positions": scenario.get("max_positions", 7),
+        "max_position_pct": scenario.get("max_position_pct", 0.10),
+        "max_utilization": scenario.get("max_utilization", 0.70),
+        "risk_pct": scenario.get("risk_pct", 0.005),
+        "stop_loss_pct": scenario.get("stop_loss_pct", 0.09),
+        "min_holding_days": 5,
+        "max_holding_days": scenario.get("max_holding_days", 60),
+        "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
+        "threshold": scenario.get("threshold", 0.58),
+        "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
+        "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+    }
+
+
+def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -> list[str]:
+    return [
+        sys.executable,
+        "-m",
+        "kabusys.backtest.run",
+        "--db",
+        str(db_path),
+        "--start",
+        str(params["start"]),
+        "--end",
+        str(params["end"]),
+        "--cash",
+        str(params["cash"]),
+        "--allocation-method",
+        str(params["allocation_method"]),
+        "--max-position-pct",
+        str(params["max_position_pct"]),
+        "--max-utilization",
+        str(params["max_utilization"]),
+        "--max-positions",
+        str(params["max_positions"]),
+        "--risk-pct",
+        str(params["risk_pct"]),
+        "--stop-loss-pct",
+        str(params["stop_loss_pct"]),
+        "--min-holding-days",
+        str(params["min_holding_days"]),
+        "--max-holding-days",
+        str(params["max_holding_days"]),
+        "--trailing-stop-atr",
+        str(params["trailing_stop_atr"]),
+        "--threshold",
+        str(params["threshold"]),
+        "--topix-drawdown-threshold",
+        str(params["topix_drawdown_threshold"]),
+        "--topix-size-multiplier-bear",
+        str(params["topix_size_multiplier_bear"]),
+        "--output-format",
+        "all",
+        "--output-dir",
+        str(output_dir),
+    ]
+
+
+def _extract_run_id(output: str) -> str:
+    match = RUN_ID_PATTERN.search(output)
+    if not match:
+        raise RuntimeError("run_id could not be found in backtest output.")
+    return match.group(1) or match.group(2)
+
+
+def _fetch_metrics(conn: duckdb.DuckDBPyConnection, run_id: str) -> dict[str, object]:
+    row = conn.execute(
+        """
+        SELECT
+            created_at,
+            cagr,
+            sharpe,
+            max_drawdown,
+            win_rate,
+            payoff_ratio,
+            profit_factor,
+            avg_holding_days,
+            total_trades
+        FROM backtest_runs
+        WHERE run_id = ?
+        """,
+        [run_id],
+    ).fetchone()
+    if row is None:
+        raise RuntimeError(f"backtest_runs does not contain run_id={run_id}.")
+    return {
+        "created_at": str(row[0]),
+        "cagr": row[1],
+        "sharpe": row[2],
+        "max_drawdown": row[3],
+        "win_rate": row[4],
+        "payoff_ratio": row[5],
+        "profit_factor": row[6],
+        "avg_holding_days": row[7],
+        "total_trades": row[8],
+    }
+
+
+def _export_trades_csv(conn: duckdb.DuckDBPyConnection, run_id: str, out_path: Path) -> None:
+    rows = conn.execute(
+        """
+        SELECT
+            trade_seq,
+            date,
+            code,
+            side,
+            shares,
+            price,
+            commission,
+            realized_pnl
+        FROM backtest_trades
+        WHERE run_id = ?
+        ORDER BY trade_seq
+        """,
+        [run_id],
+    ).fetchall()
+    with out_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            ["trade_seq", "date", "code", "side", "shares", "price", "commission", "realized_pnl"]
+        )
+        writer.writerows(rows)
+
+
+def _format_metric(value: object, digits: int = 6) -> str:
+    if value is None:
+        return "NA"
+    if isinstance(value, float):
+        return f"{value:.{digits}f}"
+    return str(value)
+
+
+def _make_output_dir() -> Path:
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_dir = ARTIFACTS_ROOT / stamp
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return output_dir
+
+
+def _make_db_snapshot(source_db_path: Path, output_dir: Path) -> Path:
+    snapshot_path = output_dir / "kabusys_snapshot.duckdb"
+    shutil.copy2(str(source_db_path), str(snapshot_path))
+    return snapshot_path
+
+
+def main() -> None:
+    context = _build_base_context()
+    output_dir = _make_output_dir()
+    db_path = _make_db_snapshot(context["db_path"], output_dir)
+    log_jsonl_path = output_dir / "results.jsonl"
+    log_csv_path = output_dir / "results.csv"
+
+    (output_dir / "scenarios.json").write_text(
+        json.dumps(SCENARIOS, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    original_strategy_text = STRATEGY_CONFIG_PATH.read_text(encoding="utf-8")
+    original_risk_text = RISK_CONFIG_PATH.read_text(encoding="utf-8")
+
+    fieldnames = [
+        "name",
+        "run_id",
+        "created_at",
+        "cash",
+        "allocation_method",
+        "threshold",
+        "topix_size_multiplier_bear",
+        "topix_drawdown_threshold",
+        "trailing_stop_atr",
+        "rsi_overbought_threshold",
+        "max_positions",
+        "max_position_pct",
+        "max_utilization",
+        "risk_pct",
+        "stop_loss_pct",
+        "max_holding_days",
+        "cagr",
+        "sharpe",
+        "max_drawdown",
+        "win_rate",
+        "payoff_ratio",
+        "profit_factor",
+        "avg_holding_days",
+        "total_trades",
+        "trades_csv",
+    ]
+
+    print(f"output_dir={output_dir}")
+    print(
+        "scenario\trun_id\tthreshold\tstop%\ttrail_atr\tmax_hold\talloc\tslots"
+        "\tcagr\tsharpe\tmax_dd\tpf\ttrades"
+    )
+
+    with (
+        log_jsonl_path.open("w", encoding="utf-8") as jsonl_file,
+        log_csv_path.open("w", newline="", encoding="utf-8") as csv_file,
+    ):
+        writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+        writer.writeheader()
+
+        try:
+            for scenario in SCENARIOS:
+                strategy_config = _build_strategy_config(context["strategy_config"], scenario)
+                risk_config = _build_risk_config(context["risk_config"], scenario)
+                _save_yaml(STRATEGY_CONFIG_PATH, strategy_config)
+                _save_yaml(RISK_CONFIG_PATH, risk_config)
+
+                scenario_slug = str(scenario["name"])
+                scenario_dir = output_dir / scenario_slug
+                scenario_dir.mkdir(parents=True, exist_ok=True)
+
+                params = _build_backtest_params(scenario)
+                (scenario_dir / "strategy_config.yaml").write_text(
+                    yaml.dump(
+                        strategy_config,
+                        allow_unicode=True,
+                        default_flow_style=False,
+                        sort_keys=False,
+                    ),
+                    encoding="utf-8",
+                )
+                (scenario_dir / "risk_config.yaml").write_text(
+                    yaml.dump(
+                        risk_config,
+                        allow_unicode=True,
+                        default_flow_style=False,
+                        sort_keys=False,
+                    ),
+                    encoding="utf-8",
+                )
+                (scenario_dir / "effective_backtest_params.json").write_text(
+                    json.dumps(params, ensure_ascii=False, indent=2),
+                    encoding="utf-8",
+                )
+
+                report_base_dir = scenario_dir / "report"
+                cmd = _build_command(db_path, params, report_base_dir)
+                print(f"\n=== running: {scenario_slug} ===")
+                print("command:", subprocess.list2cmdline(cmd))
+
+                completed = subprocess.run(
+                    cmd,
+                    cwd=str(REPO_ROOT),
+                    capture_output=True,
+                    text=True,
+                    encoding=SUBPROCESS_ENCODING,
+                    errors="replace",
+                )
+
+                (scenario_dir / "stdout.log").write_text(completed.stdout or "", encoding="utf-8")
+                (scenario_dir / "stderr.log").write_text(completed.stderr or "", encoding="utf-8")
+
+                if completed.returncode != 0:
+                    raise RuntimeError(
+                        f"scenario={scenario_slug} failed with exit code {completed.returncode}"
+                    )
+
+                run_id = _extract_run_id(f"{completed.stdout}\n{completed.stderr}")
+                conn = duckdb.connect(str(db_path), read_only=True)
+                try:
+                    metrics = _fetch_metrics(conn, run_id)
+                    trades_csv_path = scenario_dir / "trades.csv"
+                    _export_trades_csv(conn, run_id, trades_csv_path)
+                finally:
+                    conn.close()
+
+                record = {
+                    "name": scenario_slug,
+                    "run_id": run_id,
+                    "created_at": metrics["created_at"],
+                    "cash": params["cash"],
+                    "allocation_method": params["allocation_method"],
+                    "threshold": scenario.get("threshold", 0.58),
+                    "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+                    "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
+                    "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
+                    "rsi_overbought_threshold": 65.0,
+                    "max_positions": params["max_positions"],
+                    "max_position_pct": params["max_position_pct"],
+                    "max_utilization": params["max_utilization"],
+                    "risk_pct": params["risk_pct"],
+                    "stop_loss_pct": params["stop_loss_pct"],
+                    "max_holding_days": params["max_holding_days"],
+                    **metrics,
+                    "trades_csv": str(scenario_dir / "trades.csv"),
+                }
+
+                jsonl_file.write(json.dumps(record, ensure_ascii=False) + "\n")
+                jsonl_file.flush()
+                writer.writerow(record)
+                csv_file.flush()
+
+                print(
+                    f"{scenario_slug}\t{run_id}\t"
+                    f"{scenario.get('threshold', 0.58)}\t"
+                    f"{scenario.get('stop_loss_pct', 0.09)}\t"
+                    f"{scenario.get('trailing_stop_atr_mult', 2.0)}\t"
+                    f"{scenario.get('max_holding_days', 60)}\t"
+                    f"{scenario.get('allocation_method', 'risk_based')}\t"
+                    f"{scenario.get('max_positions', 7)}\t"
+                    f"{_format_metric(metrics['cagr'])}\t"
+                    f"{_format_metric(metrics['sharpe'])}\t"
+                    f"{_format_metric(metrics['max_drawdown'])}\t"
+                    f"{_format_metric(metrics['profit_factor'])}\t"
+                    f"{metrics['total_trades']}"
+                )
+        finally:
+            STRATEGY_CONFIG_PATH.write_text(original_strategy_text, encoding="utf-8")
+            RISK_CONFIG_PATH.write_text(original_risk_text, encoding="utf-8")
+
+    print(f"\nresults_jsonl={log_jsonl_path}")
+    print(f"results_csv={log_csv_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_1m.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_1m.py
@@ -1,0 +1,459 @@
+from __future__ import annotations
+
+import csv
+import json
+import locale
+import re
+import shutil
+import subprocess
+import sys
+from copy import deepcopy
+from datetime import datetime
+from pathlib import Path
+
+import duckdb
+import yaml
+
+
+def _find_repo_root() -> Path:
+    current = Path(__file__).resolve().parent
+    for candidate in [current, *current.parents]:
+        if (candidate / "config" / "strategy_config.yaml").exists():
+            return candidate
+    raise FileNotFoundError("Could not locate repo root containing config/strategy_config.yaml")
+
+
+REPO_ROOT = _find_repo_root()
+ENV_PATH = REPO_ROOT / ".env"
+STRATEGY_CONFIG_PATH = REPO_ROOT / "config" / "strategy_config.yaml"
+RISK_CONFIG_PATH = REPO_ROOT / "config" / "risk_config.yaml"
+RUN_ID_PATTERN = re.compile(r"run_id:\s*([0-9a-fA-F-]+)|run_id=([0-9a-fA-F-]+)")
+SUBPROCESS_ENCODING = locale.getpreferredencoding(False) or "cp932"
+ARTIFACTS_ROOT = REPO_ROOT / "artifacts" / "backtest_improvement_1m"
+
+
+SCENARIOS = [
+    {
+        "name": "1m_base",
+        "cash": 1_000_000,
+        "allocation_method": "risk_based",
+        "max_positions": 7,
+        "max_position_pct": 0.10,
+        "max_utilization": 0.70,
+        "risk_pct": 0.005,
+        "stop_loss_pct": 0.09,
+    },
+    {
+        "name": "1m_equal_6slots",
+        "cash": 1_000_000,
+        "allocation_method": "equal",
+        "max_positions": 6,
+        "max_position_pct": 0.15,
+        "max_utilization": 0.75,
+        "risk_pct": 0.005,
+        "stop_loss_pct": 0.09,
+    },
+    {
+        "name": "1m_equal_5slots",
+        "cash": 1_000_000,
+        "allocation_method": "equal",
+        "max_positions": 5,
+        "max_position_pct": 0.18,
+        "max_utilization": 0.75,
+        "risk_pct": 0.005,
+        "stop_loss_pct": 0.09,
+    },
+    {
+        "name": "1m_equal_4slots",
+        "cash": 1_000_000,
+        "allocation_method": "equal",
+        "max_positions": 4,
+        "max_position_pct": 0.22,
+        "max_utilization": 0.80,
+        "risk_pct": 0.005,
+        "stop_loss_pct": 0.09,
+    },
+]
+
+
+def _load_env(path: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    if not path.exists():
+        return result
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        result[key.strip()] = value.strip()
+    return result
+
+
+def _load_yaml(path: Path) -> dict:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return data if isinstance(data, dict) else {}
+
+
+def _save_yaml(path: Path, data: dict) -> None:
+    path.write_text(
+        yaml.dump(data, allow_unicode=True, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def _build_base_context() -> dict[str, object]:
+    env = _load_env(ENV_PATH)
+    strategy_config = _load_yaml(STRATEGY_CONFIG_PATH)
+    risk_config = _load_yaml(RISK_CONFIG_PATH)
+
+    db_path = Path(env.get("DUCKDB_PATH", "data/kabusys.duckdb"))
+    if not db_path.is_absolute():
+        db_path = REPO_ROOT / db_path
+
+    return {
+        "db_path": db_path,
+        "strategy_config": strategy_config,
+        "risk_config": risk_config,
+    }
+
+
+def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
+    strategy_config = deepcopy(base)
+    strategy_section = strategy_config.setdefault("strategy", {})
+    sector_section = strategy_config.setdefault("sector", {})
+    regime_section = strategy_config.setdefault("regime", {})
+    portfolio_section = strategy_config.setdefault("portfolio", {})
+
+    strategy_section["threshold"] = 0.58
+    strategy_section["gap_up_threshold"] = 0.07
+    strategy_section["gap_down_threshold"] = -0.05
+    strategy_section["rsi_overbought_threshold"] = 65.0
+    strategy_section["stop_loss_rate"] = -0.08
+    strategy_section["min_holding_days"] = 5
+    strategy_section["max_holding_days"] = 60
+    strategy_section["trailing_stop_atr_mult"] = 2.0
+    strategy_section["reentry_cooldown_days"] = 5
+
+    sector_section["boost"] = 0.05
+    sector_section["quartile"] = 0.30
+
+    regime_section["topix_drawdown_threshold"] = -0.15
+    regime_section["topix_size_multiplier_bear"] = 0.50
+
+    portfolio_section["max_positions"] = scenario.get("max_positions", 7)
+    return strategy_config
+
+
+def _build_risk_config(base: dict, scenario: dict[str, object]) -> dict:
+    risk_config = deepcopy(base)
+    risk_section = risk_config.setdefault("risk", {})
+    risk_section["max_position_pct"] = scenario.get("max_position_pct", 0.10)
+    risk_section["max_utilization"] = scenario.get("max_utilization", 0.70)
+    return risk_config
+
+
+def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
+    return {
+        "start": "2025-01-01",
+        "end": "2025-12-31",
+        "cash": scenario["cash"],
+        "allocation_method": scenario.get("allocation_method", "risk_based"),
+        "max_positions": scenario.get("max_positions", 7),
+        "max_position_pct": scenario.get("max_position_pct", 0.10),
+        "max_utilization": scenario.get("max_utilization", 0.70),
+        "risk_pct": scenario.get("risk_pct", 0.005),
+        "stop_loss_pct": scenario.get("stop_loss_pct", 0.09),
+        "min_holding_days": 5,
+        "max_holding_days": 60,
+        "trailing_stop_atr": 2.0,
+        "threshold": scenario.get("threshold", 0.58),
+        "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
+        "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+    }
+
+
+def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -> list[str]:
+    return [
+        sys.executable,
+        "-m",
+        "kabusys.backtest.run",
+        "--db",
+        str(db_path),
+        "--start",
+        str(params["start"]),
+        "--end",
+        str(params["end"]),
+        "--cash",
+        str(params["cash"]),
+        "--allocation-method",
+        str(params["allocation_method"]),
+        "--max-position-pct",
+        str(params["max_position_pct"]),
+        "--max-utilization",
+        str(params["max_utilization"]),
+        "--max-positions",
+        str(params["max_positions"]),
+        "--risk-pct",
+        str(params["risk_pct"]),
+        "--stop-loss-pct",
+        str(params["stop_loss_pct"]),
+        "--min-holding-days",
+        str(params["min_holding_days"]),
+        "--max-holding-days",
+        str(params["max_holding_days"]),
+        "--trailing-stop-atr",
+        str(params["trailing_stop_atr"]),
+        "--threshold",
+        str(params["threshold"]),
+        "--topix-drawdown-threshold",
+        str(params["topix_drawdown_threshold"]),
+        "--topix-size-multiplier-bear",
+        str(params["topix_size_multiplier_bear"]),
+        "--output-format",
+        "all",
+        "--output-dir",
+        str(output_dir),
+    ]
+
+
+def _extract_run_id(output: str) -> str:
+    match = RUN_ID_PATTERN.search(output)
+    if not match:
+        raise RuntimeError("run_id could not be found in backtest output.")
+    return match.group(1) or match.group(2)
+
+
+def _fetch_metrics(conn: duckdb.DuckDBPyConnection, run_id: str) -> dict[str, object]:
+    row = conn.execute(
+        """
+        SELECT
+            created_at,
+            cagr,
+            sharpe,
+            max_drawdown,
+            win_rate,
+            payoff_ratio,
+            profit_factor,
+            avg_holding_days,
+            total_trades
+        FROM backtest_runs
+        WHERE run_id = ?
+        """,
+        [run_id],
+    ).fetchone()
+    if row is None:
+        raise RuntimeError(f"backtest_runs does not contain run_id={run_id}.")
+    return {
+        "created_at": str(row[0]),
+        "cagr": row[1],
+        "sharpe": row[2],
+        "max_drawdown": row[3],
+        "win_rate": row[4],
+        "payoff_ratio": row[5],
+        "profit_factor": row[6],
+        "avg_holding_days": row[7],
+        "total_trades": row[8],
+    }
+
+
+def _export_trades_csv(conn: duckdb.DuckDBPyConnection, run_id: str, out_path: Path) -> None:
+    rows = conn.execute(
+        """
+        SELECT
+            trade_seq,
+            date,
+            code,
+            side,
+            shares,
+            price,
+            commission,
+            realized_pnl
+        FROM backtest_trades
+        WHERE run_id = ?
+        ORDER BY trade_seq
+        """,
+        [run_id],
+    ).fetchall()
+    with out_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            ["trade_seq", "date", "code", "side", "shares", "price", "commission", "realized_pnl"]
+        )
+        writer.writerows(rows)
+
+
+def _format_metric(value: object, digits: int = 6) -> str:
+    if value is None:
+        return "NA"
+    if isinstance(value, float):
+        return f"{value:.{digits}f}"
+    return str(value)
+
+
+def _make_output_dir() -> Path:
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_dir = ARTIFACTS_ROOT / stamp
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return output_dir
+
+
+def _make_db_snapshot(source_db_path: Path, output_dir: Path) -> Path:
+    snapshot_path = output_dir / "kabusys_snapshot.duckdb"
+    shutil.copy2(str(source_db_path), str(snapshot_path))
+    return snapshot_path
+
+
+def main() -> None:
+    context = _build_base_context()
+    output_dir = _make_output_dir()
+    db_path = _make_db_snapshot(context["db_path"], output_dir)
+    log_jsonl_path = output_dir / "results.jsonl"
+    log_csv_path = output_dir / "results.csv"
+
+    (output_dir / "scenarios.json").write_text(
+        json.dumps(SCENARIOS, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    original_strategy_text = STRATEGY_CONFIG_PATH.read_text(encoding="utf-8")
+    original_risk_text = RISK_CONFIG_PATH.read_text(encoding="utf-8")
+
+    fieldnames = [
+        "name",
+        "run_id",
+        "created_at",
+        "cash",
+        "allocation_method",
+        "threshold",
+        "topix_size_multiplier_bear",
+        "trailing_stop_atr",
+        "rsi_overbought_threshold",
+        "max_positions",
+        "max_position_pct",
+        "max_utilization",
+        "risk_pct",
+        "stop_loss_pct",
+        "cagr",
+        "sharpe",
+        "max_drawdown",
+        "win_rate",
+        "payoff_ratio",
+        "profit_factor",
+        "avg_holding_days",
+        "total_trades",
+        "trades_csv",
+    ]
+
+    print(f"output_dir={output_dir}")
+    print("scenario\trun_id\tallocation\tcagr\tsharpe\tmax_dd\twin_rate\tprofit_factor\ttrades")
+
+    with (
+        log_jsonl_path.open("w", encoding="utf-8") as jsonl_file,
+        log_csv_path.open("w", newline="", encoding="utf-8") as csv_file,
+    ):
+        writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+        writer.writeheader()
+
+        try:
+            for scenario in SCENARIOS:
+                strategy_config = _build_strategy_config(context["strategy_config"], scenario)
+                risk_config = _build_risk_config(context["risk_config"], scenario)
+                _save_yaml(STRATEGY_CONFIG_PATH, strategy_config)
+                _save_yaml(RISK_CONFIG_PATH, risk_config)
+
+                scenario_slug = str(scenario["name"])
+                scenario_dir = output_dir / scenario_slug
+                scenario_dir.mkdir(parents=True, exist_ok=True)
+
+                params = _build_backtest_params(scenario)
+                (scenario_dir / "strategy_config.yaml").write_text(
+                    yaml.dump(
+                        strategy_config,
+                        allow_unicode=True,
+                        default_flow_style=False,
+                        sort_keys=False,
+                    ),
+                    encoding="utf-8",
+                )
+                (scenario_dir / "risk_config.yaml").write_text(
+                    yaml.dump(
+                        risk_config, allow_unicode=True, default_flow_style=False, sort_keys=False
+                    ),
+                    encoding="utf-8",
+                )
+                (scenario_dir / "effective_backtest_params.json").write_text(
+                    json.dumps(params, ensure_ascii=False, indent=2),
+                    encoding="utf-8",
+                )
+
+                report_base_dir = scenario_dir / "report"
+                cmd = _build_command(db_path, params, report_base_dir)
+                print(f"\n=== running: {scenario_slug} ===")
+                print("command:", subprocess.list2cmdline(cmd))
+
+                completed = subprocess.run(
+                    cmd,
+                    cwd=str(REPO_ROOT),
+                    capture_output=True,
+                    text=True,
+                    encoding=SUBPROCESS_ENCODING,
+                    errors="replace",
+                )
+
+                (scenario_dir / "stdout.log").write_text(completed.stdout or "", encoding="utf-8")
+                (scenario_dir / "stderr.log").write_text(completed.stderr or "", encoding="utf-8")
+
+                if completed.returncode != 0:
+                    raise RuntimeError(
+                        f"scenario={scenario_slug} failed with exit code {completed.returncode}"
+                    )
+
+                run_id = _extract_run_id(f"{completed.stdout}\n{completed.stderr}")
+                conn = duckdb.connect(str(db_path), read_only=True)
+                try:
+                    metrics = _fetch_metrics(conn, run_id)
+                    trades_csv_path = scenario_dir / "trades.csv"
+                    _export_trades_csv(conn, run_id, trades_csv_path)
+                finally:
+                    conn.close()
+
+                record = {
+                    "name": scenario_slug,
+                    "run_id": run_id,
+                    "created_at": metrics["created_at"],
+                    "cash": params["cash"],
+                    "allocation_method": params["allocation_method"],
+                    "threshold": 0.58,
+                    "topix_size_multiplier_bear": 0.50,
+                    "trailing_stop_atr": params["trailing_stop_atr"],
+                    "rsi_overbought_threshold": 65.0,
+                    "max_positions": params["max_positions"],
+                    "max_position_pct": params["max_position_pct"],
+                    "max_utilization": params["max_utilization"],
+                    "risk_pct": params["risk_pct"],
+                    "stop_loss_pct": params["stop_loss_pct"],
+                    **metrics,
+                    "trades_csv": str(scenario_dir / "trades.csv"),
+                }
+
+                jsonl_file.write(json.dumps(record, ensure_ascii=False) + "\n")
+                jsonl_file.flush()
+                writer.writerow(record)
+                csv_file.flush()
+
+                print(
+                    f"{scenario_slug}\t{run_id}\t{params['allocation_method']}\t"
+                    f"{_format_metric(metrics['cagr'])}\t{_format_metric(metrics['sharpe'])}\t"
+                    f"{_format_metric(metrics['max_drawdown'])}\t{_format_metric(metrics['win_rate'])}\t"
+                    f"{_format_metric(metrics['profit_factor'])}\t{metrics['total_trades']}"
+                )
+        finally:
+            STRATEGY_CONFIG_PATH.write_text(original_strategy_text, encoding="utf-8")
+            RISK_CONFIG_PATH.write_text(original_risk_text, encoding="utf-8")
+
+    print(f"\nresults_jsonl={log_jsonl_path}")
+    print(f"results_csv={log_csv_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_1m_ablation.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_1m_ablation.py
@@ -1,0 +1,403 @@
+"""1m ファクターアブレーション分析スクリプト
+
+各ファクターを1つずつ weight=0 にして 2023/2024/2025 を検証し、
+どのファクターが 2023/2024 の損失を引き起こしているかを特定する。
+
+残りの重みは generate_signals() 内で自動正規化されるため合計が 1.0 でなくても動作する。
+
+シナリオ（計6件）× 3年（2023/2024/2025）= 18ラン:
+  base          : 現行重み（momentum=0.40, value=0.20, vol=0.15, liq=0.15, news=0.10）
+  no_momentum   : momentum weight = 0
+  no_value      : value weight = 0
+  no_volatility : volatility weight = 0
+  no_liquidity  : liquidity weight = 0
+  no_news       : news weight = 0
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import locale
+import re
+import shutil
+import subprocess
+import sys
+from copy import deepcopy
+from datetime import datetime
+from pathlib import Path
+
+import duckdb
+import yaml
+
+
+def _find_repo_root() -> Path:
+    current = Path(__file__).resolve().parent
+    for candidate in [current, *current.parents]:
+        if (candidate / "config" / "strategy_config.yaml").exists():
+            return candidate
+    raise FileNotFoundError("Could not locate repo root containing config/strategy_config.yaml")
+
+
+REPO_ROOT = _find_repo_root()
+ENV_PATH = REPO_ROOT / ".env"
+STRATEGY_CONFIG_PATH = REPO_ROOT / "config" / "strategy_config.yaml"
+RISK_CONFIG_PATH = REPO_ROOT / "config" / "risk_config.yaml"
+RUN_ID_PATTERN = re.compile(r"run_id:\s*([0-9a-fA-F-]+)|run_id=([0-9a-fA-F-]+)")
+SUBPROCESS_ENCODING = locale.getpreferredencoding(False) or "cp932"
+ARTIFACTS_ROOT = REPO_ROOT / "artifacts" / "backtest_improvement_1m_ablation"
+
+# 1m_equal_4slots の固定ベースパラメータ（v2 最良設定）
+_BASE = {
+    "cash": 1_000_000,
+    "allocation_method": "equal",
+    "max_positions": 4,
+    "max_position_pct": 0.22,
+    "max_utilization": 0.80,
+    "risk_pct": 0.005,
+    "stop_loss_pct": 0.09,
+    "threshold": 0.58,
+    "topix_size_multiplier_bear": 0.50,
+    "topix_drawdown_threshold": -0.15,
+    "trailing_stop_atr_mult": 2.0,
+    "max_holding_days": 60,
+}
+
+# 現行の重み（ベースライン）
+_WEIGHTS_BASE = {
+    "momentum": 0.40,
+    "value": 0.20,
+    "volatility": 0.15,
+    "liquidity": 0.15,
+    "news": 0.10,
+}
+
+SCENARIOS = [
+    {**_BASE, "name": "base", "weights": _WEIGHTS_BASE},
+    {**_BASE, "name": "no_momentum", "weights": {**_WEIGHTS_BASE, "momentum": 0.0}},
+    {**_BASE, "name": "no_value",    "weights": {**_WEIGHTS_BASE, "value": 0.0}},
+    {**_BASE, "name": "no_volatility", "weights": {**_WEIGHTS_BASE, "volatility": 0.0}},
+    {**_BASE, "name": "no_liquidity",  "weights": {**_WEIGHTS_BASE, "liquidity": 0.0}},
+    {**_BASE, "name": "no_news",       "weights": {**_WEIGHTS_BASE, "news": 0.0}},
+]
+
+YEARS = [2023, 2024, 2025]
+
+
+def _load_env(path: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    if not path.exists():
+        return result
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        result[key.strip()] = value.strip()
+    return result
+
+
+def _load_yaml(path: Path) -> dict:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return data if isinstance(data, dict) else {}
+
+
+def _save_yaml(path: Path, data: dict) -> None:
+    path.write_text(
+        yaml.dump(data, allow_unicode=True, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def _build_base_context() -> dict[str, object]:
+    env = _load_env(ENV_PATH)
+    strategy_config = _load_yaml(STRATEGY_CONFIG_PATH)
+    risk_config = _load_yaml(RISK_CONFIG_PATH)
+    db_path = Path(env.get("DUCKDB_PATH", "data/kabusys.duckdb"))
+    if not db_path.is_absolute():
+        db_path = REPO_ROOT / db_path
+    return {"db_path": db_path, "strategy_config": strategy_config, "risk_config": risk_config}
+
+
+def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
+    strategy_config = deepcopy(base)
+    strategy_section = strategy_config.setdefault("strategy", {})
+    sector_section = strategy_config.setdefault("sector", {})
+    regime_section = strategy_config.setdefault("regime", {})
+    portfolio_section = strategy_config.setdefault("portfolio", {})
+
+    # ファクター重み（シナリオごとに上書き）
+    strategy_section["weights"] = scenario["weights"]
+
+    strategy_section["threshold"] = scenario.get("threshold", 0.58)
+    strategy_section["gap_up_threshold"] = 0.07
+    strategy_section["gap_down_threshold"] = -0.05
+    strategy_section["rsi_overbought_threshold"] = 65.0
+    strategy_section["stop_loss_rate"] = -0.08
+    strategy_section["min_holding_days"] = 5
+    strategy_section["max_holding_days"] = scenario.get("max_holding_days", 60)
+    strategy_section["trailing_stop_atr_mult"] = scenario.get("trailing_stop_atr_mult", 2.0)
+    strategy_section["reentry_cooldown_days"] = 5
+
+    sector_section["boost"] = 0.05
+    sector_section["quartile"] = 0.30
+
+    regime_section["topix_drawdown_threshold"] = scenario.get("topix_drawdown_threshold", -0.15)
+    regime_section["topix_size_multiplier_bear"] = scenario.get("topix_size_multiplier_bear", 0.50)
+
+    portfolio_section["max_positions"] = scenario.get("max_positions", 4)
+    return strategy_config
+
+
+def _build_risk_config(base: dict, scenario: dict[str, object]) -> dict:
+    risk_config = deepcopy(base)
+    risk_section = risk_config.setdefault("risk", {})
+    risk_section["max_position_pct"] = scenario.get("max_position_pct", 0.22)
+    risk_section["max_utilization"] = scenario.get("max_utilization", 0.80)
+    return risk_config
+
+
+def _build_backtest_params(scenario: dict[str, object], year: int) -> dict[str, object]:
+    return {
+        "start": f"{year}-01-01",
+        "end": f"{year}-12-31",
+        "cash": scenario["cash"],
+        "allocation_method": scenario.get("allocation_method", "equal"),
+        "max_positions": scenario.get("max_positions", 4),
+        "max_position_pct": scenario.get("max_position_pct", 0.22),
+        "max_utilization": scenario.get("max_utilization", 0.80),
+        "risk_pct": scenario.get("risk_pct", 0.005),
+        "stop_loss_pct": scenario.get("stop_loss_pct", 0.09),
+        "min_holding_days": 5,
+        "max_holding_days": scenario.get("max_holding_days", 60),
+        "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
+        "threshold": scenario.get("threshold", 0.58),
+        "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
+        "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+    }
+
+
+def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -> list[str]:
+    return [
+        sys.executable, "-m", "kabusys.backtest.run",
+        "--db", str(db_path),
+        "--start", str(params["start"]),
+        "--end", str(params["end"]),
+        "--cash", str(params["cash"]),
+        "--allocation-method", str(params["allocation_method"]),
+        "--max-position-pct", str(params["max_position_pct"]),
+        "--max-utilization", str(params["max_utilization"]),
+        "--max-positions", str(params["max_positions"]),
+        "--risk-pct", str(params["risk_pct"]),
+        "--stop-loss-pct", str(params["stop_loss_pct"]),
+        "--min-holding-days", str(params["min_holding_days"]),
+        "--max-holding-days", str(params["max_holding_days"]),
+        "--trailing-stop-atr", str(params["trailing_stop_atr"]),
+        "--threshold", str(params["threshold"]),
+        "--topix-drawdown-threshold", str(params["topix_drawdown_threshold"]),
+        "--topix-size-multiplier-bear", str(params["topix_size_multiplier_bear"]),
+        "--output-format", "all",
+        "--output-dir", str(output_dir),
+    ]
+
+
+def _extract_run_id(output: str) -> str:
+    match = RUN_ID_PATTERN.search(output)
+    if not match:
+        raise RuntimeError("run_id could not be found in backtest output.")
+    return match.group(1) or match.group(2)
+
+
+def _fetch_metrics(conn: duckdb.DuckDBPyConnection, run_id: str) -> dict[str, object]:
+    row = conn.execute(
+        """
+        SELECT created_at, cagr, sharpe, max_drawdown, win_rate,
+               payoff_ratio, profit_factor, avg_holding_days, total_trades
+        FROM backtest_runs WHERE run_id = ?
+        """,
+        [run_id],
+    ).fetchone()
+    if row is None:
+        raise RuntimeError(f"backtest_runs does not contain run_id={run_id}.")
+    return {
+        "created_at": str(row[0]),
+        "cagr": row[1],
+        "sharpe": row[2],
+        "max_drawdown": row[3],
+        "win_rate": row[4],
+        "payoff_ratio": row[5],
+        "profit_factor": row[6],
+        "avg_holding_days": row[7],
+        "total_trades": row[8],
+    }
+
+
+def _export_trades_csv(conn: duckdb.DuckDBPyConnection, run_id: str, out_path: Path) -> None:
+    rows = conn.execute(
+        """
+        SELECT trade_seq, date, code, side, shares, price, commission, realized_pnl
+        FROM backtest_trades WHERE run_id = ? ORDER BY trade_seq
+        """,
+        [run_id],
+    ).fetchall()
+    with out_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            ["trade_seq", "date", "code", "side", "shares", "price", "commission", "realized_pnl"]
+        )
+        writer.writerows(rows)
+
+
+def _format_metric(value: object, digits: int = 6) -> str:
+    if value is None:
+        return "NA"
+    if isinstance(value, float):
+        return f"{value:.{digits}f}"
+    return str(value)
+
+
+def _make_output_dir() -> Path:
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_dir = ARTIFACTS_ROOT / stamp
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return output_dir
+
+
+def _make_db_snapshot(source_db_path: Path, output_dir: Path) -> Path:
+    snapshot_path = output_dir / "kabusys_snapshot.duckdb"
+    shutil.copy2(str(source_db_path), str(snapshot_path))
+    return snapshot_path
+
+
+def main() -> None:
+    context = _build_base_context()
+    output_dir = _make_output_dir()
+    db_path = _make_db_snapshot(context["db_path"], output_dir)
+    log_jsonl_path = output_dir / "results.jsonl"
+    log_csv_path = output_dir / "results.csv"
+
+    (output_dir / "scenarios.json").write_text(
+        json.dumps(SCENARIOS, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    original_strategy_text = STRATEGY_CONFIG_PATH.read_text(encoding="utf-8")
+    original_risk_text = RISK_CONFIG_PATH.read_text(encoding="utf-8")
+
+    fieldnames = [
+        "name", "year",
+        "w_momentum", "w_value", "w_volatility", "w_liquidity", "w_news",
+        "run_id", "created_at", "cash", "allocation_method",
+        "threshold", "stop_loss_pct", "trailing_stop_atr", "max_holding_days",
+        "max_positions", "max_position_pct", "max_utilization",
+        "cagr", "sharpe", "max_drawdown", "win_rate",
+        "payoff_ratio", "profit_factor", "avg_holding_days", "total_trades", "trades_csv",
+    ]
+
+    print(f"output_dir={output_dir}")
+    print("scenario\tyear\tcagr\tsharpe\tmax_dd\twin_rate\tpf\ttrades")
+
+    with log_jsonl_path.open("w", encoding="utf-8") as jsonl_file, log_csv_path.open(
+        "w", newline="", encoding="utf-8"
+    ) as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+        writer.writeheader()
+
+        try:
+            for scenario in SCENARIOS:
+                for year in YEARS:
+                    strategy_config = _build_strategy_config(context["strategy_config"], scenario)
+                    risk_config = _build_risk_config(context["risk_config"], scenario)
+                    _save_yaml(STRATEGY_CONFIG_PATH, strategy_config)
+                    _save_yaml(RISK_CONFIG_PATH, risk_config)
+
+                    scenario_name = str(scenario["name"])
+                    run_slug = f"{scenario_name}_{year}"
+                    scenario_dir = output_dir / run_slug
+                    scenario_dir.mkdir(parents=True, exist_ok=True)
+
+                    params = _build_backtest_params(scenario, year)
+                    (scenario_dir / "effective_backtest_params.json").write_text(
+                        json.dumps(params, ensure_ascii=False, indent=2), encoding="utf-8"
+                    )
+
+                    report_base_dir = scenario_dir / "report"
+                    cmd = _build_command(db_path, params, report_base_dir)
+                    print(f"\n=== running: {run_slug} ===")
+
+                    completed = subprocess.run(
+                        cmd,
+                        cwd=str(REPO_ROOT),
+                        capture_output=True,
+                        text=True,
+                        encoding=SUBPROCESS_ENCODING,
+                        errors="replace",
+                    )
+
+                    (scenario_dir / "stdout.log").write_text(
+                        completed.stdout or "", encoding="utf-8"
+                    )
+                    (scenario_dir / "stderr.log").write_text(
+                        completed.stderr or "", encoding="utf-8"
+                    )
+
+                    if completed.returncode != 0:
+                        raise RuntimeError(
+                            f"scenario={run_slug} failed with exit code {completed.returncode}"
+                        )
+
+                    run_id = _extract_run_id(f"{completed.stdout}\n{completed.stderr}")
+                    conn = duckdb.connect(str(db_path), read_only=True)
+                    try:
+                        metrics = _fetch_metrics(conn, run_id)
+                        _export_trades_csv(conn, run_id, scenario_dir / "trades.csv")
+                    finally:
+                        conn.close()
+
+                    weights = scenario["weights"]
+                    record = {
+                        "name": scenario_name,
+                        "year": year,
+                        "w_momentum": weights["momentum"],
+                        "w_value": weights["value"],
+                        "w_volatility": weights["volatility"],
+                        "w_liquidity": weights["liquidity"],
+                        "w_news": weights["news"],
+                        "run_id": run_id,
+                        "created_at": metrics["created_at"],
+                        "cash": params["cash"],
+                        "allocation_method": params["allocation_method"],
+                        "threshold": params["threshold"],
+                        "stop_loss_pct": params["stop_loss_pct"],
+                        "trailing_stop_atr": params["trailing_stop_atr"],
+                        "max_holding_days": params["max_holding_days"],
+                        "max_positions": params["max_positions"],
+                        "max_position_pct": params["max_position_pct"],
+                        "max_utilization": params["max_utilization"],
+                        **metrics,
+                        "trades_csv": str(scenario_dir / "trades.csv"),
+                    }
+
+                    jsonl_file.write(json.dumps(record, ensure_ascii=False) + "\n")
+                    jsonl_file.flush()
+                    writer.writerow(record)
+                    csv_file.flush()
+
+                    print(
+                        f"{run_slug}\t{year}\t"
+                        f"{_format_metric(metrics['cagr'])}\t"
+                        f"{_format_metric(metrics['sharpe'])}\t"
+                        f"{_format_metric(metrics['max_drawdown'])}\t"
+                        f"{_format_metric(metrics['win_rate'])}\t"
+                        f"{_format_metric(metrics['profit_factor'])}\t"
+                        f"{metrics['total_trades']}"
+                    )
+        finally:
+            STRATEGY_CONFIG_PATH.write_text(original_strategy_text, encoding="utf-8")
+            RISK_CONFIG_PATH.write_text(original_risk_text, encoding="utf-8")
+
+    print(f"\nresults_jsonl={log_jsonl_path}")
+    print(f"results_csv={log_csv_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_1m_factors.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_1m_factors.py
@@ -1,17 +1,21 @@
-"""1m ファクターアブレーション分析スクリプト
+"""1m ファクターフィルター比較スクリプト
 
-各ファクターを1つずつ weight=0 にして 2023/2024/2025 を検証し、
-どのファクターが 2023/2024 の損失を引き起こしているかを特定する。
+1m_equal_4slots（v2 最良設定）をベースに MDD 低減を目指す。
 
-残りの重みは generate_signals() 内で自動正規化されるため合計が 1.0 でなくても動作する。
+1M スケールの構造的制約：
+  - 1M × 80% / 4slots = 200K/ポジション → 単元株 100 株で上限 2,000 円株に制限
+  - スロット数を減らすと集中度が上がり MDD が増悪（3slots → MaxDD 26.5%）
+  - スロット数を増やすと 1 ポジションが単元株ギリギリで損益が荒れる
 
-シナリオ（計6件）× 3年（2023/2024/2025）= 18ラン:
-  base          : 現行重み（momentum=0.40, value=0.20, vol=0.15, liq=0.15, news=0.10）
-  no_momentum   : momentum weight = 0
-  no_value      : value weight = 0
-  no_volatility : volatility weight = 0
-  no_liquidity  : liquidity weight = 0
-  no_news       : news weight = 0
+→ スロット数変更は効果が薄く、フィルター強化でエントリー品質を上げることが主戦略。
+
+検証方針：
+  1. 200MA バイナリフィルター    : MA200 上の銘柄のみ BUY
+  2. TOPIX ベアガード前倒し      : topix_drawdown_threshold=-0.10（現行 -0.15）
+  3. 出来高ブレイクアウト 1.5x   : volume_ratio >= 1.5 の銘柄のみ BUY
+  4. MA200 + ベアガード強化       : 組み合わせ
+  5. MA200 + 出来高 1.5x         : 組み合わせ
+  6. MA200 + ベアガード + 出来高  : 全フィルター
 """
 
 from __future__ import annotations
@@ -45,9 +49,9 @@ STRATEGY_CONFIG_PATH = REPO_ROOT / "config" / "strategy_config.yaml"
 RISK_CONFIG_PATH = REPO_ROOT / "config" / "risk_config.yaml"
 RUN_ID_PATTERN = re.compile(r"run_id:\s*([0-9a-fA-F-]+)|run_id=([0-9a-fA-F-]+)")
 SUBPROCESS_ENCODING = locale.getpreferredencoding(False) or "cp932"
-ARTIFACTS_ROOT = REPO_ROOT / "artifacts" / "backtest_improvement_1m_ablation"
+ARTIFACTS_ROOT = REPO_ROOT / "artifacts" / "backtest_improvement_1m_factors"
 
-# 1m_equal_4slots の固定ベースパラメータ（v2 最良設定）
+# 1m_equal_4slots の固定パラメータ（v2 最良設定）
 _BASE = {
     "cash": 1_000_000,
     "allocation_method": "equal",
@@ -61,27 +65,42 @@ _BASE = {
     "topix_drawdown_threshold": -0.15,
     "trailing_stop_atr_mult": 2.0,
     "max_holding_days": 60,
-}
-
-# 現行の重み（ベースライン）
-_WEIGHTS_BASE = {
-    "momentum": 0.40,
-    "value": 0.20,
-    "volatility": 0.15,
-    "liquidity": 0.15,
-    "news": 0.10,
+    "use_ma200_filter": False,
+    "volume_breakout_threshold": None,
 }
 
 SCENARIOS = [
-    {**_BASE, "name": "base", "weights": _WEIGHTS_BASE},
-    {**_BASE, "name": "no_momentum", "weights": {**_WEIGHTS_BASE, "momentum": 0.0}},
-    {**_BASE, "name": "no_value", "weights": {**_WEIGHTS_BASE, "value": 0.0}},
-    {**_BASE, "name": "no_volatility", "weights": {**_WEIGHTS_BASE, "volatility": 0.0}},
-    {**_BASE, "name": "no_liquidity", "weights": {**_WEIGHTS_BASE, "liquidity": 0.0}},
-    {**_BASE, "name": "no_news", "weights": {**_WEIGHTS_BASE, "news": 0.0}},
+    # ── ベースライン（1m_equal_4slots v2 と同設定） ──────────────────────────
+    {**_BASE, "name": "1m_eq4_base"},
+    # ── 200MA フィルター：MA200 上の銘柄のみ BUY ───────────────────────────
+    {**_BASE, "name": "1m_eq4_ma200", "use_ma200_filter": True},
+    # ── TOPIX ベアガード強化：乖離率 -10% 未満でサイズ縮小（現行 -15%）─────
+    {**_BASE, "name": "1m_eq4_bear10", "topix_drawdown_threshold": -0.10},
+    # ── 出来高ブレイクアウト 1.5x ─────────────────────────────────────────
+    {**_BASE, "name": "1m_eq4_vol15", "volume_breakout_threshold": 1.5},
+    # ── MA200 + ベアガード強化 ──────────────────────────────────────────────
+    {
+        **_BASE,
+        "name": "1m_eq4_ma200_bear10",
+        "use_ma200_filter": True,
+        "topix_drawdown_threshold": -0.10,
+    },
+    # ── MA200 + 出来高 1.5x ────────────────────────────────────────────────
+    {
+        **_BASE,
+        "name": "1m_eq4_ma200_vol15",
+        "use_ma200_filter": True,
+        "volume_breakout_threshold": 1.5,
+    },
+    # ── 全フィルター組み合わせ：MA200 + ベアガード強化 + 出来高 1.5x ────────
+    {
+        **_BASE,
+        "name": "1m_eq4_all_filters",
+        "use_ma200_filter": True,
+        "topix_drawdown_threshold": -0.10,
+        "volume_breakout_threshold": 1.5,
+    },
 ]
-
-YEARS = [2023, 2024, 2025]
 
 
 def _load_env(path: Path) -> dict[str, str]:
@@ -113,10 +132,16 @@ def _build_base_context() -> dict[str, object]:
     env = _load_env(ENV_PATH)
     strategy_config = _load_yaml(STRATEGY_CONFIG_PATH)
     risk_config = _load_yaml(RISK_CONFIG_PATH)
+
     db_path = Path(env.get("DUCKDB_PATH", "data/kabusys.duckdb"))
     if not db_path.is_absolute():
         db_path = REPO_ROOT / db_path
-    return {"db_path": db_path, "strategy_config": strategy_config, "risk_config": risk_config}
+
+    return {
+        "db_path": db_path,
+        "strategy_config": strategy_config,
+        "risk_config": risk_config,
+    }
 
 
 def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
@@ -125,9 +150,6 @@ def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
     sector_section = strategy_config.setdefault("sector", {})
     regime_section = strategy_config.setdefault("regime", {})
     portfolio_section = strategy_config.setdefault("portfolio", {})
-
-    # ファクター重み（シナリオごとに上書き）
-    strategy_section["weights"] = scenario["weights"]
 
     strategy_section["threshold"] = scenario.get("threshold", 0.58)
     strategy_section["gap_up_threshold"] = 0.07
@@ -157,10 +179,10 @@ def _build_risk_config(base: dict, scenario: dict[str, object]) -> dict:
     return risk_config
 
 
-def _build_backtest_params(scenario: dict[str, object], year: int) -> dict[str, object]:
+def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
     return {
-        "start": f"{year}-01-01",
-        "end": f"{year}-12-31",
+        "start": "2025-01-01",
+        "end": "2025-12-31",
         "cash": scenario["cash"],
         "allocation_method": scenario.get("allocation_method", "equal"),
         "max_positions": scenario.get("max_positions", 4),
@@ -174,11 +196,13 @@ def _build_backtest_params(scenario: dict[str, object], year: int) -> dict[str, 
         "threshold": scenario.get("threshold", 0.58),
         "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
         "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+        "use_ma200_filter": scenario.get("use_ma200_filter", False),
+        "volume_breakout_threshold": scenario.get("volume_breakout_threshold"),
     }
 
 
 def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -> list[str]:
-    return [
+    cmd = [
         sys.executable,
         "-m",
         "kabusys.backtest.run",
@@ -219,6 +243,11 @@ def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -
         "--output-dir",
         str(output_dir),
     ]
+    if params.get("use_ma200_filter"):
+        cmd.append("--ma200-filter")
+    if params.get("volume_breakout_threshold") is not None:
+        cmd.extend(["--volume-breakout-threshold", str(params["volume_breakout_threshold"])])
+    return cmd
 
 
 def _extract_run_id(output: str) -> str:
@@ -305,12 +334,6 @@ def main() -> None:
 
     fieldnames = [
         "name",
-        "year",
-        "w_momentum",
-        "w_value",
-        "w_volatility",
-        "w_liquidity",
-        "w_news",
         "run_id",
         "created_at",
         "cash",
@@ -322,6 +345,9 @@ def main() -> None:
         "max_positions",
         "max_position_pct",
         "max_utilization",
+        "topix_drawdown_threshold",
+        "use_ma200_filter",
+        "volume_breakout_threshold",
         "cagr",
         "sharpe",
         "max_drawdown",
@@ -334,7 +360,7 @@ def main() -> None:
     ]
 
     print(f"output_dir={output_dir}")
-    print("scenario\tyear\tcagr\tsharpe\tmax_dd\twin_rate\tpf\ttrades")
+    print("scenario\tcagr\tsharpe\tmax_dd\twin_rate\tpf\ttrades\tma200\tbear_thr\tvol_thr")
 
     with (
         log_jsonl_path.open("w", encoding="utf-8") as jsonl_file,
@@ -345,93 +371,87 @@ def main() -> None:
 
         try:
             for scenario in SCENARIOS:
-                for year in YEARS:
-                    strategy_config = _build_strategy_config(context["strategy_config"], scenario)
-                    risk_config = _build_risk_config(context["risk_config"], scenario)
-                    _save_yaml(STRATEGY_CONFIG_PATH, strategy_config)
-                    _save_yaml(RISK_CONFIG_PATH, risk_config)
+                strategy_config = _build_strategy_config(context["strategy_config"], scenario)
+                risk_config = _build_risk_config(context["risk_config"], scenario)
+                _save_yaml(STRATEGY_CONFIG_PATH, strategy_config)
+                _save_yaml(RISK_CONFIG_PATH, risk_config)
 
-                    scenario_name = str(scenario["name"])
-                    run_slug = f"{scenario_name}_{year}"
-                    scenario_dir = output_dir / run_slug
-                    scenario_dir.mkdir(parents=True, exist_ok=True)
+                scenario_slug = str(scenario["name"])
+                scenario_dir = output_dir / scenario_slug
+                scenario_dir.mkdir(parents=True, exist_ok=True)
 
-                    params = _build_backtest_params(scenario, year)
-                    (scenario_dir / "effective_backtest_params.json").write_text(
-                        json.dumps(params, ensure_ascii=False, indent=2), encoding="utf-8"
+                params = _build_backtest_params(scenario)
+                (scenario_dir / "effective_backtest_params.json").write_text(
+                    json.dumps(params, ensure_ascii=False, indent=2), encoding="utf-8"
+                )
+
+                report_base_dir = scenario_dir / "report"
+                cmd = _build_command(db_path, params, report_base_dir)
+                print(f"\n=== running: {scenario_slug} ===")
+                print("command:", subprocess.list2cmdline(cmd))
+
+                completed = subprocess.run(
+                    cmd,
+                    cwd=str(REPO_ROOT),
+                    capture_output=True,
+                    text=True,
+                    encoding=SUBPROCESS_ENCODING,
+                    errors="replace",
+                )
+
+                (scenario_dir / "stdout.log").write_text(completed.stdout or "", encoding="utf-8")
+                (scenario_dir / "stderr.log").write_text(completed.stderr or "", encoding="utf-8")
+
+                if completed.returncode != 0:
+                    raise RuntimeError(
+                        f"scenario={scenario_slug} failed with exit code {completed.returncode}"
                     )
 
-                    report_base_dir = scenario_dir / "report"
-                    cmd = _build_command(db_path, params, report_base_dir)
-                    print(f"\n=== running: {run_slug} ===")
+                run_id = _extract_run_id(f"{completed.stdout}\n{completed.stderr}")
+                conn = duckdb.connect(str(db_path), read_only=True)
+                try:
+                    metrics = _fetch_metrics(conn, run_id)
+                    _export_trades_csv(conn, run_id, scenario_dir / "trades.csv")
+                finally:
+                    conn.close()
 
-                    completed = subprocess.run(
-                        cmd,
-                        cwd=str(REPO_ROOT),
-                        capture_output=True,
-                        text=True,
-                        encoding=SUBPROCESS_ENCODING,
-                        errors="replace",
-                    )
+                record = {
+                    "name": scenario_slug,
+                    "run_id": run_id,
+                    "created_at": metrics["created_at"],
+                    "cash": params["cash"],
+                    "allocation_method": params["allocation_method"],
+                    "threshold": scenario.get("threshold", 0.58),
+                    "stop_loss_pct": params["stop_loss_pct"],
+                    "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
+                    "max_holding_days": params["max_holding_days"],
+                    "max_positions": params["max_positions"],
+                    "max_position_pct": params["max_position_pct"],
+                    "max_utilization": params["max_utilization"],
+                    "topix_drawdown_threshold": params["topix_drawdown_threshold"],
+                    "use_ma200_filter": params["use_ma200_filter"],
+                    "volume_breakout_threshold": params["volume_breakout_threshold"],
+                    **metrics,
+                    "trades_csv": str(scenario_dir / "trades.csv"),
+                }
 
-                    (scenario_dir / "stdout.log").write_text(
-                        completed.stdout or "", encoding="utf-8"
-                    )
-                    (scenario_dir / "stderr.log").write_text(
-                        completed.stderr or "", encoding="utf-8"
-                    )
+                jsonl_file.write(json.dumps(record, ensure_ascii=False) + "\n")
+                jsonl_file.flush()
+                writer.writerow(record)
+                csv_file.flush()
 
-                    if completed.returncode != 0:
-                        raise RuntimeError(
-                            f"scenario={run_slug} failed with exit code {completed.returncode}"
-                        )
-
-                    run_id = _extract_run_id(f"{completed.stdout}\n{completed.stderr}")
-                    conn = duckdb.connect(str(db_path), read_only=True)
-                    try:
-                        metrics = _fetch_metrics(conn, run_id)
-                        _export_trades_csv(conn, run_id, scenario_dir / "trades.csv")
-                    finally:
-                        conn.close()
-
-                    weights = scenario["weights"]
-                    record = {
-                        "name": scenario_name,
-                        "year": year,
-                        "w_momentum": weights["momentum"],
-                        "w_value": weights["value"],
-                        "w_volatility": weights["volatility"],
-                        "w_liquidity": weights["liquidity"],
-                        "w_news": weights["news"],
-                        "run_id": run_id,
-                        "created_at": metrics["created_at"],
-                        "cash": params["cash"],
-                        "allocation_method": params["allocation_method"],
-                        "threshold": params["threshold"],
-                        "stop_loss_pct": params["stop_loss_pct"],
-                        "trailing_stop_atr": params["trailing_stop_atr"],
-                        "max_holding_days": params["max_holding_days"],
-                        "max_positions": params["max_positions"],
-                        "max_position_pct": params["max_position_pct"],
-                        "max_utilization": params["max_utilization"],
-                        **metrics,
-                        "trades_csv": str(scenario_dir / "trades.csv"),
-                    }
-
-                    jsonl_file.write(json.dumps(record, ensure_ascii=False) + "\n")
-                    jsonl_file.flush()
-                    writer.writerow(record)
-                    csv_file.flush()
-
-                    print(
-                        f"{run_slug}\t{year}\t"
-                        f"{_format_metric(metrics['cagr'])}\t"
-                        f"{_format_metric(metrics['sharpe'])}\t"
-                        f"{_format_metric(metrics['max_drawdown'])}\t"
-                        f"{_format_metric(metrics['win_rate'])}\t"
-                        f"{_format_metric(metrics['profit_factor'])}\t"
-                        f"{metrics['total_trades']}"
-                    )
+                print(
+                    f"{scenario_slug}\t"
+                    f"{_format_metric(metrics['cagr'])}\t"
+                    f"{_format_metric(metrics['sharpe'])}\t"
+                    f"{_format_metric(metrics['max_drawdown'])}\t"
+                    f"{_format_metric(metrics['win_rate'])}\t"
+                    f"{_format_metric(metrics['profit_factor'])}\t"
+                    f"{metrics['total_trades']}\t"
+                    f"{params['use_ma200_filter']}\t"
+                    f"{params['topix_drawdown_threshold']}\t"
+                    f"{params['volume_breakout_threshold']}"
+                )
         finally:
             STRATEGY_CONFIG_PATH.write_text(original_strategy_text, encoding="utf-8")
             RISK_CONFIG_PATH.write_text(original_risk_text, encoding="utf-8")

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_1m_oos.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_1m_oos.py
@@ -1,17 +1,14 @@
-"""1m ファクターアブレーション分析スクリプト
+"""1m アウトオブサンプル検証スクリプト
 
-各ファクターを1つずつ weight=0 にして 2023/2024/2025 を検証し、
-どのファクターが 2023/2024 の損失を引き起こしているかを特定する。
+1m_equal_4slots（v2 最良設定）を 2023・2024・2025 の各年度で検証し、
+オーバーフィットでないかを確認する。
 
-残りの重みは generate_signals() 内で自動正規化されるため合計が 1.0 でなくても動作する。
+1M スケールの構造的制約（参考）：
+  - 1M × 80% / 4slots = 200K/ポジション → 単元株 100 株で上限 2,000 円株に制限
+  - 本検証はフィルターなしのベース設定のみ適用し、まず汎化性能を確認する
 
-シナリオ（計6件）× 3年（2023/2024/2025）= 18ラン:
-  base          : 現行重み（momentum=0.40, value=0.20, vol=0.15, liq=0.15, news=0.10）
-  no_momentum   : momentum weight = 0
-  no_value      : value weight = 0
-  no_volatility : volatility weight = 0
-  no_liquidity  : liquidity weight = 0
-  no_news       : news weight = 0
+シナリオ（計3件）:
+  1m_eq4_base_2023 / 2024 / 2025
 """
 
 from __future__ import annotations
@@ -45,9 +42,9 @@ STRATEGY_CONFIG_PATH = REPO_ROOT / "config" / "strategy_config.yaml"
 RISK_CONFIG_PATH = REPO_ROOT / "config" / "risk_config.yaml"
 RUN_ID_PATTERN = re.compile(r"run_id:\s*([0-9a-fA-F-]+)|run_id=([0-9a-fA-F-]+)")
 SUBPROCESS_ENCODING = locale.getpreferredencoding(False) or "cp932"
-ARTIFACTS_ROOT = REPO_ROOT / "artifacts" / "backtest_improvement_1m_ablation"
+ARTIFACTS_ROOT = REPO_ROOT / "artifacts" / "backtest_improvement_1m_oos"
 
-# 1m_equal_4slots の固定ベースパラメータ（v2 最良設定）
+# 1m_equal_4slots の固定パラメータ（v2 最良設定）
 _BASE = {
     "cash": 1_000_000,
     "allocation_method": "equal",
@@ -63,25 +60,11 @@ _BASE = {
     "max_holding_days": 60,
 }
 
-# 現行の重み（ベースライン）
-_WEIGHTS_BASE = {
-    "momentum": 0.40,
-    "value": 0.20,
-    "volatility": 0.15,
-    "liquidity": 0.15,
-    "news": 0.10,
-}
-
 SCENARIOS = [
-    {**_BASE, "name": "base", "weights": _WEIGHTS_BASE},
-    {**_BASE, "name": "no_momentum", "weights": {**_WEIGHTS_BASE, "momentum": 0.0}},
-    {**_BASE, "name": "no_value", "weights": {**_WEIGHTS_BASE, "value": 0.0}},
-    {**_BASE, "name": "no_volatility", "weights": {**_WEIGHTS_BASE, "volatility": 0.0}},
-    {**_BASE, "name": "no_liquidity", "weights": {**_WEIGHTS_BASE, "liquidity": 0.0}},
-    {**_BASE, "name": "no_news", "weights": {**_WEIGHTS_BASE, "news": 0.0}},
+    {**_BASE, "name": "1m_eq4_base_2023", "year": 2023},
+    {**_BASE, "name": "1m_eq4_base_2024", "year": 2024},
+    {**_BASE, "name": "1m_eq4_base_2025", "year": 2025},
 ]
-
-YEARS = [2023, 2024, 2025]
 
 
 def _load_env(path: Path) -> dict[str, str]:
@@ -113,10 +96,16 @@ def _build_base_context() -> dict[str, object]:
     env = _load_env(ENV_PATH)
     strategy_config = _load_yaml(STRATEGY_CONFIG_PATH)
     risk_config = _load_yaml(RISK_CONFIG_PATH)
+
     db_path = Path(env.get("DUCKDB_PATH", "data/kabusys.duckdb"))
     if not db_path.is_absolute():
         db_path = REPO_ROOT / db_path
-    return {"db_path": db_path, "strategy_config": strategy_config, "risk_config": risk_config}
+
+    return {
+        "db_path": db_path,
+        "strategy_config": strategy_config,
+        "risk_config": risk_config,
+    }
 
 
 def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
@@ -125,9 +114,6 @@ def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
     sector_section = strategy_config.setdefault("sector", {})
     regime_section = strategy_config.setdefault("regime", {})
     portfolio_section = strategy_config.setdefault("portfolio", {})
-
-    # ファクター重み（シナリオごとに上書き）
-    strategy_section["weights"] = scenario["weights"]
 
     strategy_section["threshold"] = scenario.get("threshold", 0.58)
     strategy_section["gap_up_threshold"] = 0.07
@@ -157,7 +143,8 @@ def _build_risk_config(base: dict, scenario: dict[str, object]) -> dict:
     return risk_config
 
 
-def _build_backtest_params(scenario: dict[str, object], year: int) -> dict[str, object]:
+def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
+    year = int(scenario.get("year", 2025))
     return {
         "start": f"{year}-01-01",
         "end": f"{year}-12-31",
@@ -306,11 +293,6 @@ def main() -> None:
     fieldnames = [
         "name",
         "year",
-        "w_momentum",
-        "w_value",
-        "w_volatility",
-        "w_liquidity",
-        "w_news",
         "run_id",
         "created_at",
         "cash",
@@ -345,93 +327,82 @@ def main() -> None:
 
         try:
             for scenario in SCENARIOS:
-                for year in YEARS:
-                    strategy_config = _build_strategy_config(context["strategy_config"], scenario)
-                    risk_config = _build_risk_config(context["risk_config"], scenario)
-                    _save_yaml(STRATEGY_CONFIG_PATH, strategy_config)
-                    _save_yaml(RISK_CONFIG_PATH, risk_config)
+                strategy_config = _build_strategy_config(context["strategy_config"], scenario)
+                risk_config = _build_risk_config(context["risk_config"], scenario)
+                _save_yaml(STRATEGY_CONFIG_PATH, strategy_config)
+                _save_yaml(RISK_CONFIG_PATH, risk_config)
 
-                    scenario_name = str(scenario["name"])
-                    run_slug = f"{scenario_name}_{year}"
-                    scenario_dir = output_dir / run_slug
-                    scenario_dir.mkdir(parents=True, exist_ok=True)
+                scenario_slug = str(scenario["name"])
+                scenario_dir = output_dir / scenario_slug
+                scenario_dir.mkdir(parents=True, exist_ok=True)
 
-                    params = _build_backtest_params(scenario, year)
-                    (scenario_dir / "effective_backtest_params.json").write_text(
-                        json.dumps(params, ensure_ascii=False, indent=2), encoding="utf-8"
+                params = _build_backtest_params(scenario)
+                (scenario_dir / "effective_backtest_params.json").write_text(
+                    json.dumps(params, ensure_ascii=False, indent=2), encoding="utf-8"
+                )
+
+                report_base_dir = scenario_dir / "report"
+                cmd = _build_command(db_path, params, report_base_dir)
+                print(f"\n=== running: {scenario_slug} ({params['start']} ~ {params['end']}) ===")
+                print("command:", subprocess.list2cmdline(cmd))
+
+                completed = subprocess.run(
+                    cmd,
+                    cwd=str(REPO_ROOT),
+                    capture_output=True,
+                    text=True,
+                    encoding=SUBPROCESS_ENCODING,
+                    errors="replace",
+                )
+
+                (scenario_dir / "stdout.log").write_text(completed.stdout or "", encoding="utf-8")
+                (scenario_dir / "stderr.log").write_text(completed.stderr or "", encoding="utf-8")
+
+                if completed.returncode != 0:
+                    raise RuntimeError(
+                        f"scenario={scenario_slug} failed with exit code {completed.returncode}"
                     )
 
-                    report_base_dir = scenario_dir / "report"
-                    cmd = _build_command(db_path, params, report_base_dir)
-                    print(f"\n=== running: {run_slug} ===")
+                run_id = _extract_run_id(f"{completed.stdout}\n{completed.stderr}")
+                conn = duckdb.connect(str(db_path), read_only=True)
+                try:
+                    metrics = _fetch_metrics(conn, run_id)
+                    _export_trades_csv(conn, run_id, scenario_dir / "trades.csv")
+                finally:
+                    conn.close()
 
-                    completed = subprocess.run(
-                        cmd,
-                        cwd=str(REPO_ROOT),
-                        capture_output=True,
-                        text=True,
-                        encoding=SUBPROCESS_ENCODING,
-                        errors="replace",
-                    )
+                record = {
+                    "name": scenario_slug,
+                    "year": scenario.get("year"),
+                    "run_id": run_id,
+                    "created_at": metrics["created_at"],
+                    "cash": params["cash"],
+                    "allocation_method": params["allocation_method"],
+                    "threshold": scenario.get("threshold", 0.58),
+                    "stop_loss_pct": params["stop_loss_pct"],
+                    "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
+                    "max_holding_days": params["max_holding_days"],
+                    "max_positions": params["max_positions"],
+                    "max_position_pct": params["max_position_pct"],
+                    "max_utilization": params["max_utilization"],
+                    **metrics,
+                    "trades_csv": str(scenario_dir / "trades.csv"),
+                }
 
-                    (scenario_dir / "stdout.log").write_text(
-                        completed.stdout or "", encoding="utf-8"
-                    )
-                    (scenario_dir / "stderr.log").write_text(
-                        completed.stderr or "", encoding="utf-8"
-                    )
+                jsonl_file.write(json.dumps(record, ensure_ascii=False) + "\n")
+                jsonl_file.flush()
+                writer.writerow(record)
+                csv_file.flush()
 
-                    if completed.returncode != 0:
-                        raise RuntimeError(
-                            f"scenario={run_slug} failed with exit code {completed.returncode}"
-                        )
-
-                    run_id = _extract_run_id(f"{completed.stdout}\n{completed.stderr}")
-                    conn = duckdb.connect(str(db_path), read_only=True)
-                    try:
-                        metrics = _fetch_metrics(conn, run_id)
-                        _export_trades_csv(conn, run_id, scenario_dir / "trades.csv")
-                    finally:
-                        conn.close()
-
-                    weights = scenario["weights"]
-                    record = {
-                        "name": scenario_name,
-                        "year": year,
-                        "w_momentum": weights["momentum"],
-                        "w_value": weights["value"],
-                        "w_volatility": weights["volatility"],
-                        "w_liquidity": weights["liquidity"],
-                        "w_news": weights["news"],
-                        "run_id": run_id,
-                        "created_at": metrics["created_at"],
-                        "cash": params["cash"],
-                        "allocation_method": params["allocation_method"],
-                        "threshold": params["threshold"],
-                        "stop_loss_pct": params["stop_loss_pct"],
-                        "trailing_stop_atr": params["trailing_stop_atr"],
-                        "max_holding_days": params["max_holding_days"],
-                        "max_positions": params["max_positions"],
-                        "max_position_pct": params["max_position_pct"],
-                        "max_utilization": params["max_utilization"],
-                        **metrics,
-                        "trades_csv": str(scenario_dir / "trades.csv"),
-                    }
-
-                    jsonl_file.write(json.dumps(record, ensure_ascii=False) + "\n")
-                    jsonl_file.flush()
-                    writer.writerow(record)
-                    csv_file.flush()
-
-                    print(
-                        f"{run_slug}\t{year}\t"
-                        f"{_format_metric(metrics['cagr'])}\t"
-                        f"{_format_metric(metrics['sharpe'])}\t"
-                        f"{_format_metric(metrics['max_drawdown'])}\t"
-                        f"{_format_metric(metrics['win_rate'])}\t"
-                        f"{_format_metric(metrics['profit_factor'])}\t"
-                        f"{metrics['total_trades']}"
-                    )
+                print(
+                    f"{scenario_slug}\t{scenario.get('year')}\t"
+                    f"{_format_metric(metrics['cagr'])}\t"
+                    f"{_format_metric(metrics['sharpe'])}\t"
+                    f"{_format_metric(metrics['max_drawdown'])}\t"
+                    f"{_format_metric(metrics['win_rate'])}\t"
+                    f"{_format_metric(metrics['profit_factor'])}\t"
+                    f"{metrics['total_trades']}"
+                )
         finally:
             STRATEGY_CONFIG_PATH.write_text(original_strategy_text, encoding="utf-8")
             RISK_CONFIG_PATH.write_text(original_risk_text, encoding="utf-8")

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_1m_v2.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_1m_v2.py
@@ -1,0 +1,541 @@
+"""1m バックテスト改善スイート v2
+
+v1 で equal_4slots（CAGR +31%）が最良だったため、その周辺を深掘りする。
+  1. ストップ収縮   : stop_loss 9% → 6%, trail_atr 2.0 → 1.5
+  2. 閾値引き下げ   : threshold 0.55 で候補銘柄を増やす
+  3. スロット変化   : 3スロット（集中）と 5スロット（分散）も検証
+  4. 保有期間短縮   : max_holding 30日で高速回転を試す
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import locale
+import re
+import shutil
+import subprocess
+import sys
+from copy import deepcopy
+from datetime import datetime
+from pathlib import Path
+
+import duckdb
+import yaml
+
+
+def _find_repo_root() -> Path:
+    current = Path(__file__).resolve().parent
+    for candidate in [current, *current.parents]:
+        if (candidate / "config" / "strategy_config.yaml").exists():
+            return candidate
+    raise FileNotFoundError("Could not locate repo root containing config/strategy_config.yaml")
+
+
+REPO_ROOT = _find_repo_root()
+ENV_PATH = REPO_ROOT / ".env"
+STRATEGY_CONFIG_PATH = REPO_ROOT / "config" / "strategy_config.yaml"
+RISK_CONFIG_PATH = REPO_ROOT / "config" / "risk_config.yaml"
+RUN_ID_PATTERN = re.compile(r"run_id:\s*([0-9a-fA-F-]+)|run_id=([0-9a-fA-F-]+)")
+SUBPROCESS_ENCODING = locale.getpreferredencoding(False) or "cp932"
+ARTIFACTS_ROOT = REPO_ROOT / "artifacts" / "backtest_improvement_1m_v2"
+
+
+SCENARIOS = [
+    # ── ベースライン（v1 winner をそのまま再現） ──────────────────────────────
+    {
+        "name": "1m_equal_4slots",
+        "cash": 1_000_000,
+        "allocation_method": "equal",
+        "max_positions": 4,
+        "max_position_pct": 0.22,
+        "max_utilization": 0.80,
+        "risk_pct": 0.005,
+        "stop_loss_pct": 0.09,
+        "threshold": 0.58,
+        "topix_size_multiplier_bear": 0.50,
+        "topix_drawdown_threshold": -0.15,
+        "trailing_stop_atr_mult": 2.0,
+        "max_holding_days": 60,
+    },
+    # ── ストップ収縮：大負けを早期カット ─────────────────────────────────────
+    {
+        "name": "1m_equal_4slots_tighter_stop",
+        "cash": 1_000_000,
+        "allocation_method": "equal",
+        "max_positions": 4,
+        "max_position_pct": 0.22,
+        "max_utilization": 0.80,
+        "risk_pct": 0.005,
+        "stop_loss_pct": 0.06,
+        "threshold": 0.58,
+        "topix_size_multiplier_bear": 0.50,
+        "topix_drawdown_threshold": -0.15,
+        "trailing_stop_atr_mult": 1.5,
+        "max_holding_days": 40,
+    },
+    # ── 閾値引き下げ：候補銘柄を増やして回転数アップ ─────────────────────────
+    {
+        "name": "1m_equal_4slots_lower_thr",
+        "cash": 1_000_000,
+        "allocation_method": "equal",
+        "max_positions": 4,
+        "max_position_pct": 0.22,
+        "max_utilization": 0.80,
+        "risk_pct": 0.005,
+        "stop_loss_pct": 0.07,
+        "threshold": 0.55,
+        "topix_size_multiplier_bear": 0.50,
+        "topix_drawdown_threshold": -0.15,
+        "trailing_stop_atr_mult": 2.0,
+        "max_holding_days": 60,
+    },
+    # ── 3スロット集中：高確信銘柄のみに絞る ──────────────────────────────────
+    {
+        "name": "1m_equal_3slots",
+        "cash": 1_000_000,
+        "allocation_method": "equal",
+        "max_positions": 3,
+        "max_position_pct": 0.30,
+        "max_utilization": 0.80,
+        "risk_pct": 0.005,
+        "stop_loss_pct": 0.07,
+        "threshold": 0.60,
+        "topix_size_multiplier_bear": 0.50,
+        "topix_drawdown_threshold": -0.15,
+        "trailing_stop_atr_mult": 2.0,
+        "max_holding_days": 60,
+    },
+    # ── 高速エグジット：30日で強制入れ替え ───────────────────────────────────
+    {
+        "name": "1m_equal_4slots_fast_exit",
+        "cash": 1_000_000,
+        "allocation_method": "equal",
+        "max_positions": 4,
+        "max_position_pct": 0.22,
+        "max_utilization": 0.80,
+        "risk_pct": 0.005,
+        "stop_loss_pct": 0.06,
+        "threshold": 0.58,
+        "topix_size_multiplier_bear": 0.50,
+        "topix_drawdown_threshold": -0.15,
+        "trailing_stop_atr_mult": 1.5,
+        "max_holding_days": 30,
+    },
+    # ── 5スロット + ストップ収縮：v1 の equal_5slots（CAGR+1.2%）を改善試み ──
+    {
+        "name": "1m_equal_5slots_tighter_stop",
+        "cash": 1_000_000,
+        "allocation_method": "equal",
+        "max_positions": 5,
+        "max_position_pct": 0.18,
+        "max_utilization": 0.75,
+        "risk_pct": 0.005,
+        "stop_loss_pct": 0.06,
+        "threshold": 0.58,
+        "topix_size_multiplier_bear": 0.50,
+        "topix_drawdown_threshold": -0.15,
+        "trailing_stop_atr_mult": 1.5,
+        "max_holding_days": 40,
+    },
+]
+
+
+def _load_env(path: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    if not path.exists():
+        return result
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        result[key.strip()] = value.strip()
+    return result
+
+
+def _load_yaml(path: Path) -> dict:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return data if isinstance(data, dict) else {}
+
+
+def _save_yaml(path: Path, data: dict) -> None:
+    path.write_text(
+        yaml.dump(data, allow_unicode=True, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def _build_base_context() -> dict[str, object]:
+    env = _load_env(ENV_PATH)
+    strategy_config = _load_yaml(STRATEGY_CONFIG_PATH)
+    risk_config = _load_yaml(RISK_CONFIG_PATH)
+
+    db_path = Path(env.get("DUCKDB_PATH", "data/kabusys.duckdb"))
+    if not db_path.is_absolute():
+        db_path = REPO_ROOT / db_path
+
+    return {
+        "db_path": db_path,
+        "strategy_config": strategy_config,
+        "risk_config": risk_config,
+    }
+
+
+def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
+    strategy_config = deepcopy(base)
+    strategy_section = strategy_config.setdefault("strategy", {})
+    sector_section = strategy_config.setdefault("sector", {})
+    regime_section = strategy_config.setdefault("regime", {})
+    portfolio_section = strategy_config.setdefault("portfolio", {})
+
+    strategy_section["threshold"] = scenario.get("threshold", 0.58)
+    strategy_section["gap_up_threshold"] = 0.07
+    strategy_section["gap_down_threshold"] = -0.05
+    strategy_section["rsi_overbought_threshold"] = 65.0
+    strategy_section["stop_loss_rate"] = -0.08
+    strategy_section["min_holding_days"] = 5
+    strategy_section["max_holding_days"] = scenario.get("max_holding_days", 60)
+    strategy_section["trailing_stop_atr_mult"] = scenario.get("trailing_stop_atr_mult", 2.0)
+    strategy_section["reentry_cooldown_days"] = 5
+
+    sector_section["boost"] = 0.05
+    sector_section["quartile"] = 0.30
+
+    regime_section["topix_drawdown_threshold"] = scenario.get("topix_drawdown_threshold", -0.15)
+    regime_section["topix_size_multiplier_bear"] = scenario.get("topix_size_multiplier_bear", 0.50)
+
+    portfolio_section["max_positions"] = scenario.get("max_positions", 4)
+    return strategy_config
+
+
+def _build_risk_config(base: dict, scenario: dict[str, object]) -> dict:
+    risk_config = deepcopy(base)
+    risk_section = risk_config.setdefault("risk", {})
+    risk_section["max_position_pct"] = scenario.get("max_position_pct", 0.22)
+    risk_section["max_utilization"] = scenario.get("max_utilization", 0.80)
+    return risk_config
+
+
+def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
+    return {
+        "start": "2025-01-01",
+        "end": "2025-12-31",
+        "cash": scenario["cash"],
+        "allocation_method": scenario.get("allocation_method", "equal"),
+        "max_positions": scenario.get("max_positions", 4),
+        "max_position_pct": scenario.get("max_position_pct", 0.22),
+        "max_utilization": scenario.get("max_utilization", 0.80),
+        "risk_pct": scenario.get("risk_pct", 0.005),
+        "stop_loss_pct": scenario.get("stop_loss_pct", 0.09),
+        "min_holding_days": 5,
+        "max_holding_days": scenario.get("max_holding_days", 60),
+        "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
+        "threshold": scenario.get("threshold", 0.58),
+        "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
+        "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+    }
+
+
+def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -> list[str]:
+    return [
+        sys.executable,
+        "-m",
+        "kabusys.backtest.run",
+        "--db",
+        str(db_path),
+        "--start",
+        str(params["start"]),
+        "--end",
+        str(params["end"]),
+        "--cash",
+        str(params["cash"]),
+        "--allocation-method",
+        str(params["allocation_method"]),
+        "--max-position-pct",
+        str(params["max_position_pct"]),
+        "--max-utilization",
+        str(params["max_utilization"]),
+        "--max-positions",
+        str(params["max_positions"]),
+        "--risk-pct",
+        str(params["risk_pct"]),
+        "--stop-loss-pct",
+        str(params["stop_loss_pct"]),
+        "--min-holding-days",
+        str(params["min_holding_days"]),
+        "--max-holding-days",
+        str(params["max_holding_days"]),
+        "--trailing-stop-atr",
+        str(params["trailing_stop_atr"]),
+        "--threshold",
+        str(params["threshold"]),
+        "--topix-drawdown-threshold",
+        str(params["topix_drawdown_threshold"]),
+        "--topix-size-multiplier-bear",
+        str(params["topix_size_multiplier_bear"]),
+        "--output-format",
+        "all",
+        "--output-dir",
+        str(output_dir),
+    ]
+
+
+def _extract_run_id(output: str) -> str:
+    match = RUN_ID_PATTERN.search(output)
+    if not match:
+        raise RuntimeError("run_id could not be found in backtest output.")
+    return match.group(1) or match.group(2)
+
+
+def _fetch_metrics(conn: duckdb.DuckDBPyConnection, run_id: str) -> dict[str, object]:
+    row = conn.execute(
+        """
+        SELECT
+            created_at,
+            cagr,
+            sharpe,
+            max_drawdown,
+            win_rate,
+            payoff_ratio,
+            profit_factor,
+            avg_holding_days,
+            total_trades
+        FROM backtest_runs
+        WHERE run_id = ?
+        """,
+        [run_id],
+    ).fetchone()
+    if row is None:
+        raise RuntimeError(f"backtest_runs does not contain run_id={run_id}.")
+    return {
+        "created_at": str(row[0]),
+        "cagr": row[1],
+        "sharpe": row[2],
+        "max_drawdown": row[3],
+        "win_rate": row[4],
+        "payoff_ratio": row[5],
+        "profit_factor": row[6],
+        "avg_holding_days": row[7],
+        "total_trades": row[8],
+    }
+
+
+def _export_trades_csv(conn: duckdb.DuckDBPyConnection, run_id: str, out_path: Path) -> None:
+    rows = conn.execute(
+        """
+        SELECT
+            trade_seq,
+            date,
+            code,
+            side,
+            shares,
+            price,
+            commission,
+            realized_pnl
+        FROM backtest_trades
+        WHERE run_id = ?
+        ORDER BY trade_seq
+        """,
+        [run_id],
+    ).fetchall()
+    with out_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            ["trade_seq", "date", "code", "side", "shares", "price", "commission", "realized_pnl"]
+        )
+        writer.writerows(rows)
+
+
+def _format_metric(value: object, digits: int = 6) -> str:
+    if value is None:
+        return "NA"
+    if isinstance(value, float):
+        return f"{value:.{digits}f}"
+    return str(value)
+
+
+def _make_output_dir() -> Path:
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_dir = ARTIFACTS_ROOT / stamp
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return output_dir
+
+
+def _make_db_snapshot(source_db_path: Path, output_dir: Path) -> Path:
+    snapshot_path = output_dir / "kabusys_snapshot.duckdb"
+    shutil.copy2(str(source_db_path), str(snapshot_path))
+    return snapshot_path
+
+
+def main() -> None:
+    context = _build_base_context()
+    output_dir = _make_output_dir()
+    db_path = _make_db_snapshot(context["db_path"], output_dir)
+    log_jsonl_path = output_dir / "results.jsonl"
+    log_csv_path = output_dir / "results.csv"
+
+    (output_dir / "scenarios.json").write_text(
+        json.dumps(SCENARIOS, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    original_strategy_text = STRATEGY_CONFIG_PATH.read_text(encoding="utf-8")
+    original_risk_text = RISK_CONFIG_PATH.read_text(encoding="utf-8")
+
+    fieldnames = [
+        "name",
+        "run_id",
+        "created_at",
+        "cash",
+        "allocation_method",
+        "threshold",
+        "topix_size_multiplier_bear",
+        "topix_drawdown_threshold",
+        "trailing_stop_atr",
+        "rsi_overbought_threshold",
+        "max_positions",
+        "max_position_pct",
+        "max_utilization",
+        "risk_pct",
+        "stop_loss_pct",
+        "max_holding_days",
+        "cagr",
+        "sharpe",
+        "max_drawdown",
+        "win_rate",
+        "payoff_ratio",
+        "profit_factor",
+        "avg_holding_days",
+        "total_trades",
+        "trades_csv",
+    ]
+
+    print(f"output_dir={output_dir}")
+    print(
+        "scenario\trun_id\tthreshold\tstop%\ttrail_atr\tmax_hold\tslots"
+        "\tcagr\tsharpe\tmax_dd\tpf\ttrades"
+    )
+
+    with (
+        log_jsonl_path.open("w", encoding="utf-8") as jsonl_file,
+        log_csv_path.open("w", newline="", encoding="utf-8") as csv_file,
+    ):
+        writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+        writer.writeheader()
+
+        try:
+            for scenario in SCENARIOS:
+                strategy_config = _build_strategy_config(context["strategy_config"], scenario)
+                risk_config = _build_risk_config(context["risk_config"], scenario)
+                _save_yaml(STRATEGY_CONFIG_PATH, strategy_config)
+                _save_yaml(RISK_CONFIG_PATH, risk_config)
+
+                scenario_slug = str(scenario["name"])
+                scenario_dir = output_dir / scenario_slug
+                scenario_dir.mkdir(parents=True, exist_ok=True)
+
+                params = _build_backtest_params(scenario)
+                (scenario_dir / "strategy_config.yaml").write_text(
+                    yaml.dump(
+                        strategy_config,
+                        allow_unicode=True,
+                        default_flow_style=False,
+                        sort_keys=False,
+                    ),
+                    encoding="utf-8",
+                )
+                (scenario_dir / "risk_config.yaml").write_text(
+                    yaml.dump(
+                        risk_config,
+                        allow_unicode=True,
+                        default_flow_style=False,
+                        sort_keys=False,
+                    ),
+                    encoding="utf-8",
+                )
+                (scenario_dir / "effective_backtest_params.json").write_text(
+                    json.dumps(params, ensure_ascii=False, indent=2),
+                    encoding="utf-8",
+                )
+
+                report_base_dir = scenario_dir / "report"
+                cmd = _build_command(db_path, params, report_base_dir)
+                print(f"\n=== running: {scenario_slug} ===")
+                print("command:", subprocess.list2cmdline(cmd))
+
+                completed = subprocess.run(
+                    cmd,
+                    cwd=str(REPO_ROOT),
+                    capture_output=True,
+                    text=True,
+                    encoding=SUBPROCESS_ENCODING,
+                    errors="replace",
+                )
+
+                (scenario_dir / "stdout.log").write_text(completed.stdout or "", encoding="utf-8")
+                (scenario_dir / "stderr.log").write_text(completed.stderr or "", encoding="utf-8")
+
+                if completed.returncode != 0:
+                    raise RuntimeError(
+                        f"scenario={scenario_slug} failed with exit code {completed.returncode}"
+                    )
+
+                run_id = _extract_run_id(f"{completed.stdout}\n{completed.stderr}")
+                conn = duckdb.connect(str(db_path), read_only=True)
+                try:
+                    metrics = _fetch_metrics(conn, run_id)
+                    trades_csv_path = scenario_dir / "trades.csv"
+                    _export_trades_csv(conn, run_id, trades_csv_path)
+                finally:
+                    conn.close()
+
+                record = {
+                    "name": scenario_slug,
+                    "run_id": run_id,
+                    "created_at": metrics["created_at"],
+                    "cash": params["cash"],
+                    "allocation_method": params["allocation_method"],
+                    "threshold": scenario.get("threshold", 0.58),
+                    "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+                    "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
+                    "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
+                    "rsi_overbought_threshold": 65.0,
+                    "max_positions": params["max_positions"],
+                    "max_position_pct": params["max_position_pct"],
+                    "max_utilization": params["max_utilization"],
+                    "risk_pct": params["risk_pct"],
+                    "stop_loss_pct": params["stop_loss_pct"],
+                    "max_holding_days": params["max_holding_days"],
+                    **metrics,
+                    "trades_csv": str(scenario_dir / "trades.csv"),
+                }
+
+                jsonl_file.write(json.dumps(record, ensure_ascii=False) + "\n")
+                jsonl_file.flush()
+                writer.writerow(record)
+                csv_file.flush()
+
+                print(
+                    f"{scenario_slug}\t{run_id}\t"
+                    f"{scenario.get('threshold', 0.58)}\t"
+                    f"{scenario.get('stop_loss_pct', 0.09)}\t"
+                    f"{scenario.get('trailing_stop_atr_mult', 2.0)}\t"
+                    f"{scenario.get('max_holding_days', 60)}\t"
+                    f"{scenario.get('max_positions', 4)}\t"
+                    f"{_format_metric(metrics['cagr'])}\t"
+                    f"{_format_metric(metrics['sharpe'])}\t"
+                    f"{_format_metric(metrics['max_drawdown'])}\t"
+                    f"{_format_metric(metrics['profit_factor'])}\t"
+                    f"{metrics['total_trades']}"
+                )
+        finally:
+            STRATEGY_CONFIG_PATH.write_text(original_strategy_text, encoding="utf-8")
+            RISK_CONFIG_PATH.write_text(original_risk_text, encoding="utf-8")
+
+    print(f"\nresults_jsonl={log_jsonl_path}")
+    print(f"results_csv={log_csv_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/superpowers/plans/2026-05-18-backtest-mdd-and-1m-ablation.md
+++ b/docs/superpowers/plans/2026-05-18-backtest-mdd-and-1m-ablation.md
@@ -1,0 +1,1193 @@
+# 10m MDD対策 & 1m アブレーション分析 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `engine.py` にポートフォリオドローダウンストップを追加し、10m MDD対策と1mスコアリングアブレーション分析の検証スクリプトを作成する。
+
+**Architecture:** `_is_entry_blocked()` という純粋関数でドローダウン判定を分離し、`run_backtest()` のメインループにピーク追跡を追加。CLIに `--portfolio-drawdown-stop` を追加した後、6シナリオ×3年の10m MDD検証スクリプトと6シナリオ×3年の1mアブレーション検証スクリプトを作成する。
+
+**Tech Stack:** Python 3.10+, DuckDB, pytest, PyYAML, subprocess
+
+---
+
+## ファイルマップ
+
+| ファイル | 操作 | 役割 |
+|---|---|---|
+| `src/kabusys/backtest/engine.py` | 修正 | `portfolio_drawdown_stop_pct` パラメータ追加・`_is_entry_blocked()` 追加 |
+| `src/kabusys/backtest/run.py` | 修正 | `--portfolio-drawdown-stop` CLI引数追加 |
+| `tests/test_backtest_engine_params.py` | 修正 | `_is_entry_blocked` と新パラメータのテスト追加 |
+| `backtest/backtest_improvement_plan/run_backtest_improvement_10m_mdd.py` | 新規作成 | 10m MDD対策 6シナリオ×3年 スウィープスクリプト |
+| `backtest/backtest_improvement_plan/run_backtest_improvement_1m_ablation.py` | 新規作成 | 1m ファクターアブレーション 6シナリオ×3年 スウィープスクリプト |
+
+---
+
+## Task 1: `_is_entry_blocked()` のテストを書く（RED）
+
+**Files:**
+- Test: `tests/test_backtest_engine_params.py`
+
+- [ ] **Step 1: 既存テストファイルの末尾に以下を追記する**
+
+```python
+# ── _is_entry_blocked ────────────────────────────────────────────────────────
+
+
+def test_is_entry_blocked_returns_false_when_disabled():
+    from kabusys.backtest.engine import _is_entry_blocked
+
+    assert _is_entry_blocked(900_000.0, 1_000_000.0, None) is False
+
+
+def test_is_entry_blocked_returns_false_when_within_threshold():
+    from kabusys.backtest.engine import _is_entry_blocked
+
+    # drawdown = -10%、threshold = 15% → ブロックしない
+    assert _is_entry_blocked(900_000.0, 1_000_000.0, 0.15) is False
+
+
+def test_is_entry_blocked_returns_true_when_exceeded():
+    from kabusys.backtest.engine import _is_entry_blocked
+
+    # drawdown = -20%、threshold = 15% → ブロック
+    assert _is_entry_blocked(800_000.0, 1_000_000.0, 0.15) is True
+
+
+def test_is_entry_blocked_at_exact_threshold_is_not_blocked():
+    from kabusys.backtest.engine import _is_entry_blocked
+
+    # drawdown = -15%（= threshold）→ 厳密に「未満」でないためブロックしない
+    assert _is_entry_blocked(850_000.0, 1_000_000.0, 0.15) is False
+
+
+def test_run_backtest_accepts_portfolio_drawdown_stop_pct():
+    import inspect
+    from kabusys.backtest.engine import run_backtest
+
+    assert "portfolio_drawdown_stop_pct" in inspect.signature(run_backtest).parameters
+
+
+def test_run_backtest_portfolio_drawdown_stop_pct_default_is_none():
+    import inspect
+    from kabusys.backtest.engine import run_backtest
+
+    param = inspect.signature(run_backtest).parameters["portfolio_drawdown_stop_pct"]
+    assert param.default is None
+```
+
+- [ ] **Step 2: テストが失敗することを確認する**
+
+```
+pytest tests/test_backtest_engine_params.py -k "is_entry_blocked or portfolio_drawdown_stop" -v
+```
+
+期待: `ImportError: cannot import name '_is_entry_blocked'` または `AssertionError`
+
+---
+
+## Task 2: `engine.py` に `_is_entry_blocked()` とパラメータを実装する（GREEN）
+
+**Files:**
+- Modify: `src/kabusys/backtest/engine.py`
+
+- [ ] **Step 1: ヘルパー関数セクションの末尾（`_fetch_sector_map` の後）に追加する**
+
+```python
+def _is_entry_blocked(
+    portfolio_value: float,
+    peak_value: float,
+    portfolio_drawdown_stop_pct: float | None,
+) -> bool:
+    """ポートフォリオドローダウンストップ判定。
+
+    portfolio_value がピーク比で portfolio_drawdown_stop_pct を超えて下落している場合 True を返す。
+    portfolio_drawdown_stop_pct が None の場合は常に False（機能無効）。
+    """
+    if portfolio_drawdown_stop_pct is None:
+        return False
+    return portfolio_value / peak_value - 1 < -portfolio_drawdown_stop_pct
+```
+
+- [ ] **Step 2: `run_backtest()` のシグネチャに新パラメータを追加する**
+
+`volume_breakout_threshold: float | None = None,` の行の直後に以下を追加:
+
+```python
+    portfolio_drawdown_stop_pct: float | None = None,
+```
+
+- [ ] **Step 3: `run_backtest()` の docstring に新パラメータの説明を追加する**
+
+`volume_breakout_threshold:` の説明の直後に追加:
+
+```
+        portfolio_drawdown_stop_pct: ポートフォリオがピーク比でこの割合を超えて下落した場合、
+                           新規 BUY エントリーを停止する（既存ポジションの SELL は継続）。
+                           None（デフォルト）で無効。0 < x < 1 の範囲で指定すること。
+```
+
+- [ ] **Step 4: `run_backtest()` のバリデーションブロックに追加する**
+
+`trailing_stop_atr <= 0` の `raise ValueError` の直後に追加:
+
+```python
+    if portfolio_drawdown_stop_pct is not None and not (0 < portfolio_drawdown_stop_pct < 1):
+        raise ValueError(
+            f"portfolio_drawdown_stop_pct は (0, 1) の範囲で指定してください: {portfolio_drawdown_stop_pct}"
+        )
+```
+
+- [ ] **Step 5: ループ前の変数初期化に `peak_value` を追加する**
+
+`next_day_orders: list[dict] = []` の直後に追加:
+
+```python
+    peak_value: float = initial_cash  # ポートフォリオドローダウンストップ用ピーク追跡
+```
+
+- [ ] **Step 6: メインループ内で `current_pv` 計算の直後にドローダウンチェックを追加する**
+
+現在の `current_pv = (...)` 行（`available_cash` 計算の直前）の直後に追加:
+
+```python
+            peak_value = max(peak_value, current_pv)
+            entry_blocked = _is_entry_blocked(current_pv, peak_value, portfolio_drawdown_stop_pct)
+            if entry_blocked:
+                logger.debug(
+                    "run_backtest: ドローダウンストップ発動 date=%s drawdown=%.2f%%",
+                    trading_day,
+                    (current_pv / peak_value - 1) * 100,
+                )
+```
+
+- [ ] **Step 7: `next_day_orders` の BUY 構築部分を `entry_blocked` で条件分岐させる**
+
+現在の `next_day_orders = [...]` ブロックを以下に置き換える:
+
+```python
+            sm_map = {s["code"]: s.get("size_multiplier", 1.0) for s in buy_signals}
+            next_day_orders = (
+                []
+                if entry_blocked
+                else [
+                    {
+                        "code": code,
+                        "side": "buy",
+                        "shares": max(
+                            0, (int(shares * sm_map.get(code, 1.0)) // lot_size) * lot_size
+                        ),
+                    }
+                    for code, shares in sized.items()
+                    if shares > 0 and code not in sell_codes
+                ]
+            ) + [{"code": s["code"], "side": "sell"} for s in sell_signals]
+            # shares=0 になったエントリーを除外
+            next_day_orders = [o for o in next_day_orders if o.get("shares", 1) > 0]
+```
+
+- [ ] **Step 8: テストがすべて通ることを確認する**
+
+```
+pytest tests/test_backtest_engine_params.py -k "is_entry_blocked or portfolio_drawdown_stop" -v
+```
+
+期待: すべて PASS
+
+- [ ] **Step 9: 既存テスト全体が壊れていないことを確認する**
+
+```
+pytest tests/test_backtest_engine_params.py -v
+```
+
+期待: すべて PASS
+
+- [ ] **Step 10: コミット**
+
+```bash
+git add src/kabusys/backtest/engine.py tests/test_backtest_engine_params.py
+git commit -m "feat: run_backtest にポートフォリオドローダウンストップを追加 (portfolio_drawdown_stop_pct)"
+```
+
+---
+
+## Task 3: `run.py` に CLI 引数を追加する（TDD）
+
+**Files:**
+- Test: `tests/test_backtest_engine_params.py`
+- Modify: `src/kabusys/backtest/run.py`
+
+- [ ] **Step 1: テストファイルの末尾に以下を追記する**
+
+```python
+def test_run_py_cli_has_portfolio_drawdown_stop_arg():
+    import argparse
+    import importlib.util
+    import sys
+    from pathlib import Path
+
+    run_path = Path("src/kabusys/backtest/run.py")
+    spec = importlib.util.spec_from_file_location("run_module", run_path)
+    module = importlib.util.module_from_spec(spec)
+
+    original_argv = sys.argv[:]
+    try:
+        sys.argv = ["run.py", "--help"]
+        try:
+            spec.loader.exec_module(module)
+        except SystemExit:
+            pass
+    finally:
+        sys.argv = original_argv
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--portfolio-drawdown-stop", type=float, default=None)
+    args = parser.parse_args(["--portfolio-drawdown-stop", "0.15"])
+    assert args.portfolio_drawdown_stop == 0.15
+```
+
+実際には `run.py` 自体のパーサー定義を確認するため、以下のより直接的なテストを使う:
+
+```python
+def test_run_py_cli_has_portfolio_drawdown_stop_arg():
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-m", "kabusys.backtest.run", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert "--portfolio-drawdown-stop" in result.stdout
+```
+
+- [ ] **Step 2: テストが失敗することを確認する**
+
+```
+pytest tests/test_backtest_engine_params.py -k "portfolio_drawdown_stop_arg" -v
+```
+
+期待: FAIL（`--portfolio-drawdown-stop` が --help に存在しない）
+
+- [ ] **Step 3: `run.py` に引数を追加する**
+
+`--volume-breakout-threshold` の `add_argument` の直後に追加:
+
+```python
+    parser.add_argument(
+        "--portfolio-drawdown-stop",
+        type=float,
+        default=None,
+        help=(
+            "ポートフォリオがピーク比でこの割合（例: 0.15 = 15%%）を超えて下落した場合、"
+            "新規 BUY エントリーを停止する。None（デフォルト）で無効。"
+        ),
+    )
+```
+
+- [ ] **Step 4: `run_backtest()` 呼び出しに新引数を追加する**
+
+`volume_breakout_threshold=args.volume_breakout_threshold,` の直後に追加:
+
+```python
+            portfolio_drawdown_stop_pct=args.portfolio_drawdown_stop,
+```
+
+- [ ] **Step 5: テストが通ることを確認する**
+
+```
+pytest tests/test_backtest_engine_params.py -k "portfolio_drawdown_stop_arg" -v
+```
+
+期待: PASS
+
+- [ ] **Step 6: 全テストが壊れていないことを確認する**
+
+```
+pytest tests/test_backtest_engine_params.py -v
+```
+
+期待: すべて PASS
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add src/kabusys/backtest/run.py tests/test_backtest_engine_params.py
+git commit -m "feat: backtest CLI に --portfolio-drawdown-stop 引数を追加"
+```
+
+---
+
+## Task 4: `run_backtest_improvement_10m_mdd.py` を作成する
+
+**Files:**
+- Create: `backtest/backtest_improvement_plan/run_backtest_improvement_10m_mdd.py`
+
+- [ ] **Step 1: スクリプトを作成する**
+
+```python
+"""10m MDD対策 検証スクリプト
+
+2024年のMaxDD 41%（8月ブラックマンデー）対策として、
+TOPIXベアガード強化とポートフォリオドローダウンストップの
+2段構えを検証する。
+
+シナリオ（計6件）× 3年（2023/2024/2025）= 18ラン:
+  base          : 変更なし（OOS2ベースラインの再現）
+  bear_stronger : TOPIXガード強化のみ（-0.10 / 0.25）
+  dd_stop15     : ポートフォリオストップのみ（15%）
+  dd_stop12     : ポートフォリオストップのみ（12%）
+  combined15    : TOPIX強化 + ポートフォリオストップ15%
+  combined12    : TOPIX強化 + ポートフォリオストップ12%
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import locale
+import re
+import shutil
+import subprocess
+import sys
+from copy import deepcopy
+from datetime import datetime
+from pathlib import Path
+
+import duckdb
+import yaml
+
+
+def _find_repo_root() -> Path:
+    current = Path(__file__).resolve().parent
+    for candidate in [current, *current.parents]:
+        if (candidate / "config" / "strategy_config.yaml").exists():
+            return candidate
+    raise FileNotFoundError("Could not locate repo root containing config/strategy_config.yaml")
+
+
+REPO_ROOT = _find_repo_root()
+ENV_PATH = REPO_ROOT / ".env"
+STRATEGY_CONFIG_PATH = REPO_ROOT / "config" / "strategy_config.yaml"
+RISK_CONFIG_PATH = REPO_ROOT / "config" / "risk_config.yaml"
+RUN_ID_PATTERN = re.compile(r"run_id:\s*([0-9a-fA-F-]+)|run_id=([0-9a-fA-F-]+)")
+SUBPROCESS_ENCODING = locale.getpreferredencoding(False) or "cp932"
+ARTIFACTS_ROOT = REPO_ROOT / "artifacts" / "backtest_improvement_10m_mdd"
+
+# 10m_equal_4slots の固定パラメータ（OOS2 ベースライン設定）
+_BASE = {
+    "cash": 10_000_000,
+    "allocation_method": "equal",
+    "max_positions": 4,
+    "max_position_pct": 0.22,
+    "max_utilization": 0.80,
+    "risk_pct": 0.005,
+    "stop_loss_pct": 0.07,
+    "threshold": 0.58,
+    "topix_size_multiplier_bear": 0.50,
+    "topix_drawdown_threshold": -0.15,
+    "trailing_stop_atr_mult": 2.0,
+    "max_holding_days": 60,
+    "portfolio_drawdown_stop_pct": None,
+}
+
+SCENARIOS = [
+    # ── ベースライン（OOS2 との内部一貫性確認）─────────────────────────────
+    {**_BASE, "name": "base"},
+    # ── TOPIXガード強化のみ ──────────────────────────────────────────────
+    {
+        **_BASE,
+        "name": "bear_stronger",
+        "topix_drawdown_threshold": -0.10,
+        "topix_size_multiplier_bear": 0.25,
+    },
+    # ── ポートフォリオストップのみ（15%）────────────────────────────────────
+    {**_BASE, "name": "dd_stop15", "portfolio_drawdown_stop_pct": 0.15},
+    # ── ポートフォリオストップのみ（12%）────────────────────────────────────
+    {**_BASE, "name": "dd_stop12", "portfolio_drawdown_stop_pct": 0.12},
+    # ── TOPIX強化 + ポートフォリオストップ15% ───────────────────────────────
+    {
+        **_BASE,
+        "name": "combined15",
+        "topix_drawdown_threshold": -0.10,
+        "topix_size_multiplier_bear": 0.25,
+        "portfolio_drawdown_stop_pct": 0.15,
+    },
+    # ── TOPIX強化 + ポートフォリオストップ12% ───────────────────────────────
+    {
+        **_BASE,
+        "name": "combined12",
+        "topix_drawdown_threshold": -0.10,
+        "topix_size_multiplier_bear": 0.25,
+        "portfolio_drawdown_stop_pct": 0.12,
+    },
+]
+
+YEARS = [2023, 2024, 2025]
+
+
+def _load_env(path: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    if not path.exists():
+        return result
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        result[key.strip()] = value.strip()
+    return result
+
+
+def _load_yaml(path: Path) -> dict:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return data if isinstance(data, dict) else {}
+
+
+def _save_yaml(path: Path, data: dict) -> None:
+    path.write_text(
+        yaml.dump(data, allow_unicode=True, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def _build_base_context() -> dict[str, object]:
+    env = _load_env(ENV_PATH)
+    strategy_config = _load_yaml(STRATEGY_CONFIG_PATH)
+    risk_config = _load_yaml(RISK_CONFIG_PATH)
+    db_path = Path(env.get("DUCKDB_PATH", "data/kabusys.duckdb"))
+    if not db_path.is_absolute():
+        db_path = REPO_ROOT / db_path
+    return {"db_path": db_path, "strategy_config": strategy_config, "risk_config": risk_config}
+
+
+def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
+    strategy_config = deepcopy(base)
+    strategy_section = strategy_config.setdefault("strategy", {})
+    sector_section = strategy_config.setdefault("sector", {})
+    regime_section = strategy_config.setdefault("regime", {})
+    portfolio_section = strategy_config.setdefault("portfolio", {})
+
+    strategy_section["threshold"] = scenario.get("threshold", 0.58)
+    strategy_section["gap_up_threshold"] = 0.07
+    strategy_section["gap_down_threshold"] = -0.05
+    strategy_section["rsi_overbought_threshold"] = 65.0
+    strategy_section["stop_loss_rate"] = -0.08
+    strategy_section["min_holding_days"] = 5
+    strategy_section["max_holding_days"] = scenario.get("max_holding_days", 60)
+    strategy_section["trailing_stop_atr_mult"] = scenario.get("trailing_stop_atr_mult", 2.0)
+    strategy_section["reentry_cooldown_days"] = 5
+
+    sector_section["boost"] = 0.05
+    sector_section["quartile"] = 0.30
+
+    regime_section["topix_drawdown_threshold"] = scenario.get("topix_drawdown_threshold", -0.15)
+    regime_section["topix_size_multiplier_bear"] = scenario.get("topix_size_multiplier_bear", 0.50)
+
+    portfolio_section["max_positions"] = scenario.get("max_positions", 4)
+    return strategy_config
+
+
+def _build_risk_config(base: dict, scenario: dict[str, object]) -> dict:
+    risk_config = deepcopy(base)
+    risk_section = risk_config.setdefault("risk", {})
+    risk_section["max_position_pct"] = scenario.get("max_position_pct", 0.22)
+    risk_section["max_utilization"] = scenario.get("max_utilization", 0.80)
+    return risk_config
+
+
+def _build_backtest_params(scenario: dict[str, object], year: int) -> dict[str, object]:
+    return {
+        "start": f"{year}-01-01",
+        "end": f"{year}-12-31",
+        "cash": scenario["cash"],
+        "allocation_method": scenario.get("allocation_method", "equal"),
+        "max_positions": scenario.get("max_positions", 4),
+        "max_position_pct": scenario.get("max_position_pct", 0.22),
+        "max_utilization": scenario.get("max_utilization", 0.80),
+        "risk_pct": scenario.get("risk_pct", 0.005),
+        "stop_loss_pct": scenario.get("stop_loss_pct", 0.07),
+        "min_holding_days": 5,
+        "max_holding_days": scenario.get("max_holding_days", 60),
+        "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
+        "threshold": scenario.get("threshold", 0.58),
+        "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
+        "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+        "portfolio_drawdown_stop_pct": scenario.get("portfolio_drawdown_stop_pct"),
+    }
+
+
+def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -> list[str]:
+    cmd = [
+        sys.executable, "-m", "kabusys.backtest.run",
+        "--db", str(db_path),
+        "--start", str(params["start"]),
+        "--end", str(params["end"]),
+        "--cash", str(params["cash"]),
+        "--allocation-method", str(params["allocation_method"]),
+        "--max-position-pct", str(params["max_position_pct"]),
+        "--max-utilization", str(params["max_utilization"]),
+        "--max-positions", str(params["max_positions"]),
+        "--risk-pct", str(params["risk_pct"]),
+        "--stop-loss-pct", str(params["stop_loss_pct"]),
+        "--min-holding-days", str(params["min_holding_days"]),
+        "--max-holding-days", str(params["max_holding_days"]),
+        "--trailing-stop-atr", str(params["trailing_stop_atr"]),
+        "--threshold", str(params["threshold"]),
+        "--topix-drawdown-threshold", str(params["topix_drawdown_threshold"]),
+        "--topix-size-multiplier-bear", str(params["topix_size_multiplier_bear"]),
+        "--output-format", "all",
+        "--output-dir", str(output_dir),
+    ]
+    if params.get("portfolio_drawdown_stop_pct") is not None:
+        cmd.extend(["--portfolio-drawdown-stop", str(params["portfolio_drawdown_stop_pct"])])
+    return cmd
+
+
+def _extract_run_id(output: str) -> str:
+    match = RUN_ID_PATTERN.search(output)
+    if not match:
+        raise RuntimeError("run_id could not be found in backtest output.")
+    return match.group(1) or match.group(2)
+
+
+def _fetch_metrics(conn: duckdb.DuckDBPyConnection, run_id: str) -> dict[str, object]:
+    row = conn.execute(
+        """
+        SELECT created_at, cagr, sharpe, max_drawdown, win_rate,
+               payoff_ratio, profit_factor, avg_holding_days, total_trades
+        FROM backtest_runs WHERE run_id = ?
+        """,
+        [run_id],
+    ).fetchone()
+    if row is None:
+        raise RuntimeError(f"backtest_runs does not contain run_id={run_id}.")
+    return {
+        "created_at": str(row[0]),
+        "cagr": row[1],
+        "sharpe": row[2],
+        "max_drawdown": row[3],
+        "win_rate": row[4],
+        "payoff_ratio": row[5],
+        "profit_factor": row[6],
+        "avg_holding_days": row[7],
+        "total_trades": row[8],
+    }
+
+
+def _export_trades_csv(conn: duckdb.DuckDBPyConnection, run_id: str, out_path: Path) -> None:
+    rows = conn.execute(
+        """
+        SELECT trade_seq, date, code, side, shares, price, commission, realized_pnl
+        FROM backtest_trades WHERE run_id = ? ORDER BY trade_seq
+        """,
+        [run_id],
+    ).fetchall()
+    with out_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            ["trade_seq", "date", "code", "side", "shares", "price", "commission", "realized_pnl"]
+        )
+        writer.writerows(rows)
+
+
+def _format_metric(value: object, digits: int = 6) -> str:
+    if value is None:
+        return "NA"
+    if isinstance(value, float):
+        return f"{value:.{digits}f}"
+    return str(value)
+
+
+def _make_output_dir() -> Path:
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_dir = ARTIFACTS_ROOT / stamp
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return output_dir
+
+
+def _make_db_snapshot(source_db_path: Path, output_dir: Path) -> Path:
+    snapshot_path = output_dir / "kabusys_snapshot.duckdb"
+    shutil.copy2(str(source_db_path), str(snapshot_path))
+    return snapshot_path
+
+
+def main() -> None:
+    context = _build_base_context()
+    output_dir = _make_output_dir()
+    db_path = _make_db_snapshot(context["db_path"], output_dir)
+    log_jsonl_path = output_dir / "results.jsonl"
+    log_csv_path = output_dir / "results.csv"
+
+    (output_dir / "scenarios.json").write_text(
+        json.dumps(SCENARIOS, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    original_strategy_text = STRATEGY_CONFIG_PATH.read_text(encoding="utf-8")
+    original_risk_text = RISK_CONFIG_PATH.read_text(encoding="utf-8")
+
+    fieldnames = [
+        "name", "year",
+        "topix_drawdown_threshold", "topix_size_multiplier_bear", "portfolio_drawdown_stop_pct",
+        "run_id", "created_at", "cash", "allocation_method",
+        "threshold", "stop_loss_pct", "trailing_stop_atr", "max_holding_days",
+        "max_positions", "max_position_pct", "max_utilization",
+        "cagr", "sharpe", "max_drawdown", "win_rate",
+        "payoff_ratio", "profit_factor", "avg_holding_days", "total_trades", "trades_csv",
+    ]
+
+    print(f"output_dir={output_dir}")
+    print("scenario\tyear\tbear_thr\tbear_mult\tdd_stop\tcagr\tsharpe\tmax_dd\ttrades")
+
+    with log_jsonl_path.open("w", encoding="utf-8") as jsonl_file, log_csv_path.open(
+        "w", newline="", encoding="utf-8"
+    ) as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+        writer.writeheader()
+
+        try:
+            for scenario in SCENARIOS:
+                for year in YEARS:
+                    strategy_config = _build_strategy_config(context["strategy_config"], scenario)
+                    risk_config = _build_risk_config(context["risk_config"], scenario)
+                    _save_yaml(STRATEGY_CONFIG_PATH, strategy_config)
+                    _save_yaml(RISK_CONFIG_PATH, risk_config)
+
+                    scenario_name = str(scenario["name"])
+                    run_slug = f"{scenario_name}_{year}"
+                    scenario_dir = output_dir / run_slug
+                    scenario_dir.mkdir(parents=True, exist_ok=True)
+
+                    params = _build_backtest_params(scenario, year)
+                    (scenario_dir / "effective_backtest_params.json").write_text(
+                        json.dumps(params, ensure_ascii=False, indent=2), encoding="utf-8"
+                    )
+
+                    report_base_dir = scenario_dir / "report"
+                    cmd = _build_command(db_path, params, report_base_dir)
+                    print(f"\n=== running: {run_slug} ===")
+
+                    completed = subprocess.run(
+                        cmd,
+                        cwd=str(REPO_ROOT),
+                        capture_output=True,
+                        text=True,
+                        encoding=SUBPROCESS_ENCODING,
+                        errors="replace",
+                    )
+
+                    (scenario_dir / "stdout.log").write_text(
+                        completed.stdout or "", encoding="utf-8"
+                    )
+                    (scenario_dir / "stderr.log").write_text(
+                        completed.stderr or "", encoding="utf-8"
+                    )
+
+                    if completed.returncode != 0:
+                        raise RuntimeError(
+                            f"scenario={run_slug} failed with exit code {completed.returncode}"
+                        )
+
+                    run_id = _extract_run_id(f"{completed.stdout}\n{completed.stderr}")
+                    conn = duckdb.connect(str(db_path), read_only=True)
+                    try:
+                        metrics = _fetch_metrics(conn, run_id)
+                        _export_trades_csv(conn, run_id, scenario_dir / "trades.csv")
+                    finally:
+                        conn.close()
+
+                    record = {
+                        "name": scenario_name,
+                        "year": year,
+                        "topix_drawdown_threshold": params["topix_drawdown_threshold"],
+                        "topix_size_multiplier_bear": params["topix_size_multiplier_bear"],
+                        "portfolio_drawdown_stop_pct": params["portfolio_drawdown_stop_pct"],
+                        "run_id": run_id,
+                        "created_at": metrics["created_at"],
+                        "cash": params["cash"],
+                        "allocation_method": params["allocation_method"],
+                        "threshold": params["threshold"],
+                        "stop_loss_pct": params["stop_loss_pct"],
+                        "trailing_stop_atr": params["trailing_stop_atr"],
+                        "max_holding_days": params["max_holding_days"],
+                        "max_positions": params["max_positions"],
+                        "max_position_pct": params["max_position_pct"],
+                        "max_utilization": params["max_utilization"],
+                        **metrics,
+                        "trades_csv": str(scenario_dir / "trades.csv"),
+                    }
+
+                    jsonl_file.write(json.dumps(record, ensure_ascii=False) + "\n")
+                    jsonl_file.flush()
+                    writer.writerow(record)
+                    csv_file.flush()
+
+                    print(
+                        f"{run_slug}\t{year}\t"
+                        f"{params['topix_drawdown_threshold']}\t"
+                        f"{params['topix_size_multiplier_bear']}\t"
+                        f"{params['portfolio_drawdown_stop_pct']}\t"
+                        f"{_format_metric(metrics['cagr'])}\t"
+                        f"{_format_metric(metrics['sharpe'])}\t"
+                        f"{_format_metric(metrics['max_drawdown'])}\t"
+                        f"{metrics['total_trades']}"
+                    )
+        finally:
+            STRATEGY_CONFIG_PATH.write_text(original_strategy_text, encoding="utf-8")
+            RISK_CONFIG_PATH.write_text(original_risk_text, encoding="utf-8")
+
+    print(f"\nresults_jsonl={log_jsonl_path}")
+    print(f"results_csv={log_csv_path}")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: コミット**
+
+```bash
+git add backtest/backtest_improvement_plan/run_backtest_improvement_10m_mdd.py
+git commit -m "feat: 10m MDD対策 検証スクリプトを追加 (6シナリオ×3年)"
+```
+
+---
+
+## Task 5: `run_backtest_improvement_1m_ablation.py` を作成する
+
+**Files:**
+- Create: `backtest/backtest_improvement_plan/run_backtest_improvement_1m_ablation.py`
+
+- [ ] **Step 1: スクリプトを作成する**
+
+```python
+"""1m ファクターアブレーション分析スクリプト
+
+各ファクターを1つずつ weight=0 にして 2023/2024/2025 を検証し、
+どのファクターが 2023/2024 の損失を引き起こしているかを特定する。
+
+残りの重みは generate_signals() 内で自動正規化されるため合計が 1.0 でなくても動作する。
+
+シナリオ（計6件）× 3年（2023/2024/2025）= 18ラン:
+  base          : 現行重み（momentum=0.40, value=0.20, vol=0.15, liq=0.15, news=0.10）
+  no_momentum   : momentum weight = 0
+  no_value      : value weight = 0
+  no_volatility : volatility weight = 0
+  no_liquidity  : liquidity weight = 0
+  no_news       : news weight = 0
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import locale
+import re
+import shutil
+import subprocess
+import sys
+from copy import deepcopy
+from datetime import datetime
+from pathlib import Path
+
+import duckdb
+import yaml
+
+
+def _find_repo_root() -> Path:
+    current = Path(__file__).resolve().parent
+    for candidate in [current, *current.parents]:
+        if (candidate / "config" / "strategy_config.yaml").exists():
+            return candidate
+    raise FileNotFoundError("Could not locate repo root containing config/strategy_config.yaml")
+
+
+REPO_ROOT = _find_repo_root()
+ENV_PATH = REPO_ROOT / ".env"
+STRATEGY_CONFIG_PATH = REPO_ROOT / "config" / "strategy_config.yaml"
+RISK_CONFIG_PATH = REPO_ROOT / "config" / "risk_config.yaml"
+RUN_ID_PATTERN = re.compile(r"run_id:\s*([0-9a-fA-F-]+)|run_id=([0-9a-fA-F-]+)")
+SUBPROCESS_ENCODING = locale.getpreferredencoding(False) or "cp932"
+ARTIFACTS_ROOT = REPO_ROOT / "artifacts" / "backtest_improvement_1m_ablation"
+
+# 1m_equal_4slots の固定ベースパラメータ（v2 最良設定）
+_BASE = {
+    "cash": 1_000_000,
+    "allocation_method": "equal",
+    "max_positions": 4,
+    "max_position_pct": 0.22,
+    "max_utilization": 0.80,
+    "risk_pct": 0.005,
+    "stop_loss_pct": 0.09,
+    "threshold": 0.58,
+    "topix_size_multiplier_bear": 0.50,
+    "topix_drawdown_threshold": -0.15,
+    "trailing_stop_atr_mult": 2.0,
+    "max_holding_days": 60,
+}
+
+# 現行の重み（ベースライン）
+_WEIGHTS_BASE = {
+    "momentum": 0.40,
+    "value": 0.20,
+    "volatility": 0.15,
+    "liquidity": 0.15,
+    "news": 0.10,
+}
+
+SCENARIOS = [
+    {**_BASE, "name": "base", "weights": _WEIGHTS_BASE},
+    {**_BASE, "name": "no_momentum", "weights": {**_WEIGHTS_BASE, "momentum": 0.0}},
+    {**_BASE, "name": "no_value",    "weights": {**_WEIGHTS_BASE, "value": 0.0}},
+    {**_BASE, "name": "no_volatility", "weights": {**_WEIGHTS_BASE, "volatility": 0.0}},
+    {**_BASE, "name": "no_liquidity",  "weights": {**_WEIGHTS_BASE, "liquidity": 0.0}},
+    {**_BASE, "name": "no_news",       "weights": {**_WEIGHTS_BASE, "news": 0.0}},
+]
+
+YEARS = [2023, 2024, 2025]
+
+
+def _load_env(path: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    if not path.exists():
+        return result
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        result[key.strip()] = value.strip()
+    return result
+
+
+def _load_yaml(path: Path) -> dict:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return data if isinstance(data, dict) else {}
+
+
+def _save_yaml(path: Path, data: dict) -> None:
+    path.write_text(
+        yaml.dump(data, allow_unicode=True, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def _build_base_context() -> dict[str, object]:
+    env = _load_env(ENV_PATH)
+    strategy_config = _load_yaml(STRATEGY_CONFIG_PATH)
+    risk_config = _load_yaml(RISK_CONFIG_PATH)
+    db_path = Path(env.get("DUCKDB_PATH", "data/kabusys.duckdb"))
+    if not db_path.is_absolute():
+        db_path = REPO_ROOT / db_path
+    return {"db_path": db_path, "strategy_config": strategy_config, "risk_config": risk_config}
+
+
+def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
+    strategy_config = deepcopy(base)
+    strategy_section = strategy_config.setdefault("strategy", {})
+    sector_section = strategy_config.setdefault("sector", {})
+    regime_section = strategy_config.setdefault("regime", {})
+    portfolio_section = strategy_config.setdefault("portfolio", {})
+
+    # ファクター重み（シナリオごとに上書き）
+    strategy_section["weights"] = scenario["weights"]
+
+    strategy_section["threshold"] = scenario.get("threshold", 0.58)
+    strategy_section["gap_up_threshold"] = 0.07
+    strategy_section["gap_down_threshold"] = -0.05
+    strategy_section["rsi_overbought_threshold"] = 65.0
+    strategy_section["stop_loss_rate"] = -0.08
+    strategy_section["min_holding_days"] = 5
+    strategy_section["max_holding_days"] = scenario.get("max_holding_days", 60)
+    strategy_section["trailing_stop_atr_mult"] = scenario.get("trailing_stop_atr_mult", 2.0)
+    strategy_section["reentry_cooldown_days"] = 5
+
+    sector_section["boost"] = 0.05
+    sector_section["quartile"] = 0.30
+
+    regime_section["topix_drawdown_threshold"] = scenario.get("topix_drawdown_threshold", -0.15)
+    regime_section["topix_size_multiplier_bear"] = scenario.get("topix_size_multiplier_bear", 0.50)
+
+    portfolio_section["max_positions"] = scenario.get("max_positions", 4)
+    return strategy_config
+
+
+def _build_risk_config(base: dict, scenario: dict[str, object]) -> dict:
+    risk_config = deepcopy(base)
+    risk_section = risk_config.setdefault("risk", {})
+    risk_section["max_position_pct"] = scenario.get("max_position_pct", 0.22)
+    risk_section["max_utilization"] = scenario.get("max_utilization", 0.80)
+    return risk_config
+
+
+def _build_backtest_params(scenario: dict[str, object], year: int) -> dict[str, object]:
+    return {
+        "start": f"{year}-01-01",
+        "end": f"{year}-12-31",
+        "cash": scenario["cash"],
+        "allocation_method": scenario.get("allocation_method", "equal"),
+        "max_positions": scenario.get("max_positions", 4),
+        "max_position_pct": scenario.get("max_position_pct", 0.22),
+        "max_utilization": scenario.get("max_utilization", 0.80),
+        "risk_pct": scenario.get("risk_pct", 0.005),
+        "stop_loss_pct": scenario.get("stop_loss_pct", 0.09),
+        "min_holding_days": 5,
+        "max_holding_days": scenario.get("max_holding_days", 60),
+        "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
+        "threshold": scenario.get("threshold", 0.58),
+        "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
+        "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+    }
+
+
+def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -> list[str]:
+    return [
+        sys.executable, "-m", "kabusys.backtest.run",
+        "--db", str(db_path),
+        "--start", str(params["start"]),
+        "--end", str(params["end"]),
+        "--cash", str(params["cash"]),
+        "--allocation-method", str(params["allocation_method"]),
+        "--max-position-pct", str(params["max_position_pct"]),
+        "--max-utilization", str(params["max_utilization"]),
+        "--max-positions", str(params["max_positions"]),
+        "--risk-pct", str(params["risk_pct"]),
+        "--stop-loss-pct", str(params["stop_loss_pct"]),
+        "--min-holding-days", str(params["min_holding_days"]),
+        "--max-holding-days", str(params["max_holding_days"]),
+        "--trailing-stop-atr", str(params["trailing_stop_atr"]),
+        "--threshold", str(params["threshold"]),
+        "--topix-drawdown-threshold", str(params["topix_drawdown_threshold"]),
+        "--topix-size-multiplier-bear", str(params["topix_size_multiplier_bear"]),
+        "--output-format", "all",
+        "--output-dir", str(output_dir),
+    ]
+
+
+def _extract_run_id(output: str) -> str:
+    match = RUN_ID_PATTERN.search(output)
+    if not match:
+        raise RuntimeError("run_id could not be found in backtest output.")
+    return match.group(1) or match.group(2)
+
+
+def _fetch_metrics(conn: duckdb.DuckDBPyConnection, run_id: str) -> dict[str, object]:
+    row = conn.execute(
+        """
+        SELECT created_at, cagr, sharpe, max_drawdown, win_rate,
+               payoff_ratio, profit_factor, avg_holding_days, total_trades
+        FROM backtest_runs WHERE run_id = ?
+        """,
+        [run_id],
+    ).fetchone()
+    if row is None:
+        raise RuntimeError(f"backtest_runs does not contain run_id={run_id}.")
+    return {
+        "created_at": str(row[0]),
+        "cagr": row[1],
+        "sharpe": row[2],
+        "max_drawdown": row[3],
+        "win_rate": row[4],
+        "payoff_ratio": row[5],
+        "profit_factor": row[6],
+        "avg_holding_days": row[7],
+        "total_trades": row[8],
+    }
+
+
+def _export_trades_csv(conn: duckdb.DuckDBPyConnection, run_id: str, out_path: Path) -> None:
+    rows = conn.execute(
+        """
+        SELECT trade_seq, date, code, side, shares, price, commission, realized_pnl
+        FROM backtest_trades WHERE run_id = ? ORDER BY trade_seq
+        """,
+        [run_id],
+    ).fetchall()
+    with out_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            ["trade_seq", "date", "code", "side", "shares", "price", "commission", "realized_pnl"]
+        )
+        writer.writerows(rows)
+
+
+def _format_metric(value: object, digits: int = 6) -> str:
+    if value is None:
+        return "NA"
+    if isinstance(value, float):
+        return f"{value:.{digits}f}"
+    return str(value)
+
+
+def _make_output_dir() -> Path:
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_dir = ARTIFACTS_ROOT / stamp
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return output_dir
+
+
+def _make_db_snapshot(source_db_path: Path, output_dir: Path) -> Path:
+    snapshot_path = output_dir / "kabusys_snapshot.duckdb"
+    shutil.copy2(str(source_db_path), str(snapshot_path))
+    return snapshot_path
+
+
+def main() -> None:
+    context = _build_base_context()
+    output_dir = _make_output_dir()
+    db_path = _make_db_snapshot(context["db_path"], output_dir)
+    log_jsonl_path = output_dir / "results.jsonl"
+    log_csv_path = output_dir / "results.csv"
+
+    (output_dir / "scenarios.json").write_text(
+        json.dumps(SCENARIOS, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    original_strategy_text = STRATEGY_CONFIG_PATH.read_text(encoding="utf-8")
+    original_risk_text = RISK_CONFIG_PATH.read_text(encoding="utf-8")
+
+    fieldnames = [
+        "name", "year",
+        "w_momentum", "w_value", "w_volatility", "w_liquidity", "w_news",
+        "run_id", "created_at", "cash", "allocation_method",
+        "threshold", "stop_loss_pct", "trailing_stop_atr", "max_holding_days",
+        "max_positions", "max_position_pct", "max_utilization",
+        "cagr", "sharpe", "max_drawdown", "win_rate",
+        "payoff_ratio", "profit_factor", "avg_holding_days", "total_trades", "trades_csv",
+    ]
+
+    print(f"output_dir={output_dir}")
+    print("scenario\tyear\tcagr\tsharpe\tmax_dd\twin_rate\tpf\ttrades")
+
+    with log_jsonl_path.open("w", encoding="utf-8") as jsonl_file, log_csv_path.open(
+        "w", newline="", encoding="utf-8"
+    ) as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+        writer.writeheader()
+
+        try:
+            for scenario in SCENARIOS:
+                for year in YEARS:
+                    strategy_config = _build_strategy_config(context["strategy_config"], scenario)
+                    risk_config = _build_risk_config(context["risk_config"], scenario)
+                    _save_yaml(STRATEGY_CONFIG_PATH, strategy_config)
+                    _save_yaml(RISK_CONFIG_PATH, risk_config)
+
+                    scenario_name = str(scenario["name"])
+                    run_slug = f"{scenario_name}_{year}"
+                    scenario_dir = output_dir / run_slug
+                    scenario_dir.mkdir(parents=True, exist_ok=True)
+
+                    params = _build_backtest_params(scenario, year)
+                    (scenario_dir / "effective_backtest_params.json").write_text(
+                        json.dumps(params, ensure_ascii=False, indent=2), encoding="utf-8"
+                    )
+
+                    report_base_dir = scenario_dir / "report"
+                    cmd = _build_command(db_path, params, report_base_dir)
+                    print(f"\n=== running: {run_slug} ===")
+
+                    completed = subprocess.run(
+                        cmd,
+                        cwd=str(REPO_ROOT),
+                        capture_output=True,
+                        text=True,
+                        encoding=SUBPROCESS_ENCODING,
+                        errors="replace",
+                    )
+
+                    (scenario_dir / "stdout.log").write_text(
+                        completed.stdout or "", encoding="utf-8"
+                    )
+                    (scenario_dir / "stderr.log").write_text(
+                        completed.stderr or "", encoding="utf-8"
+                    )
+
+                    if completed.returncode != 0:
+                        raise RuntimeError(
+                            f"scenario={run_slug} failed with exit code {completed.returncode}"
+                        )
+
+                    run_id = _extract_run_id(f"{completed.stdout}\n{completed.stderr}")
+                    conn = duckdb.connect(str(db_path), read_only=True)
+                    try:
+                        metrics = _fetch_metrics(conn, run_id)
+                        _export_trades_csv(conn, run_id, scenario_dir / "trades.csv")
+                    finally:
+                        conn.close()
+
+                    weights = scenario["weights"]
+                    record = {
+                        "name": scenario_name,
+                        "year": year,
+                        "w_momentum": weights["momentum"],
+                        "w_value": weights["value"],
+                        "w_volatility": weights["volatility"],
+                        "w_liquidity": weights["liquidity"],
+                        "w_news": weights["news"],
+                        "run_id": run_id,
+                        "created_at": metrics["created_at"],
+                        "cash": params["cash"],
+                        "allocation_method": params["allocation_method"],
+                        "threshold": params["threshold"],
+                        "stop_loss_pct": params["stop_loss_pct"],
+                        "trailing_stop_atr": params["trailing_stop_atr"],
+                        "max_holding_days": params["max_holding_days"],
+                        "max_positions": params["max_positions"],
+                        "max_position_pct": params["max_position_pct"],
+                        "max_utilization": params["max_utilization"],
+                        **metrics,
+                        "trades_csv": str(scenario_dir / "trades.csv"),
+                    }
+
+                    jsonl_file.write(json.dumps(record, ensure_ascii=False) + "\n")
+                    jsonl_file.flush()
+                    writer.writerow(record)
+                    csv_file.flush()
+
+                    print(
+                        f"{run_slug}\t{year}\t"
+                        f"{_format_metric(metrics['cagr'])}\t"
+                        f"{_format_metric(metrics['sharpe'])}\t"
+                        f"{_format_metric(metrics['max_drawdown'])}\t"
+                        f"{_format_metric(metrics['win_rate'])}\t"
+                        f"{_format_metric(metrics['profit_factor'])}\t"
+                        f"{metrics['total_trades']}"
+                    )
+        finally:
+            STRATEGY_CONFIG_PATH.write_text(original_strategy_text, encoding="utf-8")
+            RISK_CONFIG_PATH.write_text(original_risk_text, encoding="utf-8")
+
+    print(f"\nresults_jsonl={log_jsonl_path}")
+    print(f"results_csv={log_csv_path}")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: コミット**
+
+```bash
+git add backtest/backtest_improvement_plan/run_backtest_improvement_1m_ablation.py
+git commit -m "feat: 1m ファクターアブレーション分析スクリプトを追加 (6シナリオ×3年)"
+```
+
+---
+
+## セルフレビュー
+
+**Spec coverage:**
+- [x] `portfolio_drawdown_stop_pct` パラメータを `engine.py` に追加 → Task 2
+- [x] `--portfolio-drawdown-stop` CLI引数 → Task 3
+- [x] `_is_entry_blocked()` 純粋関数でテスト容易な設計 → Task 1-2
+- [x] SELL 処理はブロックしない → Task 2 Step 7 の実装で明示
+- [x] `peak_value` リセットなし → Task 2 Step 5（`max(peak_value, current_pv)` のみ）
+- [x] 10m MDD検証スクリプト 6シナリオ×3年 → Task 4
+- [x] 1m アブレーション 6シナリオ×3年 → Task 5
+- [x] `strategy_config.yaml` の `weights` をシナリオごとに書き換え → Task 5 Step 1 `_build_strategy_config`
+
+**Placeholder scan:** なし
+
+**Type consistency:**
+- `_is_entry_blocked(portfolio_value: float, peak_value: float, portfolio_drawdown_stop_pct: float | None) -> bool` — Task 1 と Task 2 で一致
+- `portfolio_drawdown_stop_pct: float | None = None` — engine.py, run.py, スクリプトで一致

--- a/docs/superpowers/specs/2026-05-18-backtest-mdd-and-1m-redesign-design.md
+++ b/docs/superpowers/specs/2026-05-18-backtest-mdd-and-1m-redesign-design.md
@@ -1,0 +1,190 @@
+# 設計仕様書: 10m MDD対策 & 1m スコアリングアブレーション分析
+
+作成日: 2026-05-18  
+対象ブランチ: feature/issue-342-backfill-features
+
+---
+
+## 背景・問題
+
+### 10m スケール（1,000万円）
+
+OOS検証（2023・2024・2025）の結果、2024年のMaxDDが41.35%に達した。  
+主因は2024年8月のブラックマンデー（TOPIX急落）期間中に新規エントリーが止まらなかったこと。  
+既存のTOPIXベアガード（`topix_drawdown_threshold=-0.15`）では発動が遅すぎた。
+
+### 1m スケール（100万円）
+
+OOS検証で2023年CAGR -9.71%・2024年CAGR -3.70%・2025年CAGR +53.11%という強いオーバーフィットが確認された。  
+2025年固有の相場構造（継続的上昇トレンド）に過適合している可能性が高い。  
+スコアリングの重み（momentum=0.40が最大）がどの年度でも安定して機能しているか不明であり、  
+まずアブレーション分析でどのファクターが2023/2024の損失を引き起こしているかを特定する。
+
+---
+
+## 1. 10m MDD対策
+
+### 1-1. アーキテクチャ
+
+2つの独立したガードを二段構えで実装する。
+
+```
+毎日の処理ループ（engine.py）
+  ├─ ① TOPIXベアガード（既存パラメータ強化）
+  │     topix_drawdown_threshold: -0.15 → -0.10（早めに発動）
+  │     topix_size_multiplier_bear: 0.50 → 0.25（ベア時は75%削減）
+  │
+  └─ ② ポートフォリオドローダウンストップ（新規実装）
+        ピーク資産比 -portfolio_drawdown_stop_pct 超のドローダウン
+        → その日の全BUYシグナルをスキップ
+        → ポートフォリオが回復すれば翌日から自動解除
+```
+
+### 1-2. 変更ファイル
+
+| ファイル | 変更内容 |
+|---|---|
+| `src/kabusys/backtest/engine.py` | `run_backtest()` に `portfolio_drawdown_stop_pct: float \| None = None` パラメータを追加。ピーク資産追跡変数 `peak_value` を初期化し、毎日更新。BUY処理前にドローダウン計算・エントリーブロック判定を挿入。 |
+| `src/kabusys/backtest/run.py` | `--portfolio-drawdown-stop` CLI引数を追加（type=float, default=None）。`run_backtest()` に転送。 |
+
+### 1-3. engine.py 実装詳細
+
+```python
+def run_backtest(
+    ...,
+    portfolio_drawdown_stop_pct: float | None = None,  # 追加
+) -> BacktestResult:
+
+    peak_value: float = initial_cash  # ピーク追跡
+
+    for date in trading_dates:
+        # ポートフォリオ時価を計算
+        portfolio_value = cash + sum(pos.shares * prices[pos.code] for pos in positions)
+        peak_value = max(peak_value, portfolio_value)
+
+        # ② ポートフォリオドローダウンチェック
+        entry_blocked = (
+            portfolio_drawdown_stop_pct is not None
+            and (portfolio_value / peak_value - 1) < -portfolio_drawdown_stop_pct
+        )
+
+        # BUYシグナル処理
+        for signal in buy_signals_today:
+            if entry_blocked:
+                continue  # スキップ（SELLは影響しない）
+            # 既存エントリー処理
+```
+
+**重要な制約:**
+- SELL処理（ストップロス・タイムイグジット・トレーリングストップ）はブロックしない
+- `entry_blocked` はBUYのみに適用
+- ピーク値のリセットは行わない（一度下落したピークは保持し続ける）
+
+### 1-4. 検証スクリプト
+
+**ファイル**: `backtest/backtest_improvement_plan/run_backtest_improvement_10m_mdd.py`  
+**出力先**: `artifacts/backtest/backtest_improvement_10m_mdd/`  
+**シナリオ数**: 6シナリオ × 3年（2023/2024/2025）= 18ラン
+
+| シナリオ名 | topix_thr | topix_mult | dd_stop | 検証目的 |
+|---|---|---|---|---|
+| `base` | -0.15 | 0.50 | なし | OOS2ベースラインの再現（内部一貫性確認） |
+| `bear_stronger` | **-0.10** | **0.25** | なし | TOPIXガード強化のみの効果を分離 |
+| `dd_stop15` | -0.15 | 0.50 | **0.15** | ポートフォリオストップのみの効果を分離 |
+| `dd_stop12` | -0.15 | 0.50 | **0.12** | ポートフォリオストップ厳しめ |
+| `combined15` | **-0.10** | **0.25** | **0.15** | 両者の組み合わせ（標準） |
+| `combined12` | **-0.10** | **0.25** | **0.12** | 両者の組み合わせ（厳格） |
+
+**results.csv 列**: `name`, `year`, `topix_drawdown_threshold`, `topix_size_multiplier_bear`, `portfolio_drawdown_stop_pct`, `cagr`, `sharpe`, `max_drawdown`, `win_rate`, `payoff_ratio`, `profit_factor`, `avg_holding_days`, `total_trades`, `trades_csv`
+
+### 1-5. 成功指標
+
+- 2024年MaxDDを41.35% → **25%以下**に削減
+- 2024年CAGRが base比でプラス方向に改善、またはマイナス幅が縮小
+- 2025年CAGRへの影響が -5pp 以内（過度な機会損失を避ける）
+
+---
+
+## 2. 1m スコアリングアブレーション分析
+
+### 2-1. 概要
+
+各ファクターのウェイトを1つずつ0にして3年間のOOS検証を行い、どのファクターが  
+2023/2024の損失に寄与しているかを特定する。特定後は重みを調整した再検証スクリプトを別途作成する。
+
+### 2-2. ファクター重みの操作方法
+
+`strategy_config.yaml` の `weights` セクションを書き換える（既存スクリプトと同パターン）。  
+残りの重みは `generate_signals()` 内で自動正規化されるため、合計が1.0でなくても動作する。
+
+```yaml
+# 例: no_momentum シナリオ
+strategy:
+  weights:
+    momentum: 0.00   # ← 0 に設定
+    value: 0.20
+    volatility: 0.15
+    liquidity: 0.15
+    news: 0.10
+```
+
+### 2-3. 検証スクリプト
+
+**ファイル**: `backtest/backtest_improvement_plan/run_backtest_improvement_1m_ablation.py`  
+**出力先**: `artifacts/backtest/backtest_improvement_1m_ablation/`  
+**シナリオ数**: 6シナリオ × 3年 = 18ラン
+
+| シナリオ名 | momentum | value | volatility | liquidity | news |
+|---|---|---|---|---|---|
+| `base` | 0.40 | 0.20 | 0.15 | 0.15 | 0.10 |
+| `no_momentum` | **0** | 0.20 | 0.15 | 0.15 | 0.10 |
+| `no_value` | 0.40 | **0** | 0.15 | 0.15 | 0.10 |
+| `no_volatility` | 0.40 | 0.20 | **0** | 0.15 | 0.10 |
+| `no_liquidity` | 0.40 | 0.20 | 0.15 | **0** | 0.10 |
+| `no_news` | 0.40 | 0.20 | 0.15 | 0.15 | **0** |
+
+**ベースパラメータ** (1m_equal_4slots v2 最良設定):
+
+```python
+cash=1_000_000, allocation_method="equal", max_positions=4,
+max_position_pct=0.22, max_utilization=0.80, stop_loss_pct=0.09,
+threshold=0.58, topix_drawdown_threshold=-0.15,
+topix_size_multiplier_bear=0.50, trailing_stop_atr_mult=2.0,
+max_holding_days=60
+```
+
+**results.csv 列**: `name`, `year`, `w_momentum`, `w_value`, `w_volatility`, `w_liquidity`, `w_news`, `cagr`, `sharpe`, `max_drawdown`, `win_rate`, `payoff_ratio`, `profit_factor`, `avg_holding_days`, `total_trades`, `trades_csv`
+
+### 2-4. 分析方法
+
+結果を受け取ったら以下のマトリクスを作成して判定する:
+
+```
+シナリオ        | 2023 Sharpe | 2024 Sharpe | 2025 Sharpe | 判定
+base           |    -0.340   |   -0.021    |    1.946    | ベースライン
+no_momentum    |     ?       |     ?       |     ?       | 改善→momentumが問題
+no_value       |     ?       |     ?       |     ?       | 改善→valueが問題
+...
+```
+
+判定基準:
+- 除外で **2023/2024 Sharpe が改善** → そのファクターが悪化の原因
+- 除外で **2025 Sharpe が大幅低下** → そのファクターは2025年に有効（外せない）
+- 次フェーズ: 問題ファクターの重みを下げ、有効ファクターの重みを上げた設定でOOS再検証
+
+### 2-5. 成功指標
+
+- アブレーション結果から「原因ファクター」を1〜2個特定できること
+- 原因ファクターを下げた設定で2023/2024 Sharpeが `base` 比で改善すること（次フェーズ確認）
+
+---
+
+## 実装順序
+
+1. **engine.py 改修**（`portfolio_drawdown_stop_pct` 追加）+ TDD
+2. **run.py 改修**（CLI引数追加）
+3. **`run_backtest_improvement_10m_mdd.py`** 作成・実行
+4. **`run_backtest_improvement_1m_ablation.py`** 作成・実行（engine.py改修不要）
+5. 結果分析 → 次フェーズ設計
+
+ステップ3と4は engine.py 改修後に並行実行可能。

--- a/src/kabusys/backtest/engine.py
+++ b/src/kabusys/backtest/engine.py
@@ -350,6 +350,21 @@ def _fetch_sector_map(conn: duckdb.DuckDBPyConnection) -> dict[str, str]:
     return {code: sector for code, sector in rows if sector}
 
 
+def _is_entry_blocked(
+    portfolio_value: float,
+    peak_value: float,
+    portfolio_drawdown_stop_pct: float | None,
+) -> bool:
+    """ポートフォリオドローダウンストップ判定。
+
+    portfolio_value がピーク比で portfolio_drawdown_stop_pct を超えて下落している場合 True を返す。
+    portfolio_drawdown_stop_pct が None の場合は常に False（機能無効）。
+    """
+    if portfolio_drawdown_stop_pct is None:
+        return False
+    return (peak_value - portfolio_value) / peak_value > portfolio_drawdown_stop_pct
+
+
 # ---------------------------------------------------------------------------
 # パブリック API
 # ---------------------------------------------------------------------------
@@ -379,6 +394,7 @@ def run_backtest(
     topix_size_multiplier_bear: float | None = None,
     use_ma200_filter: bool = False,
     volume_breakout_threshold: float | None = None,
+    portfolio_drawdown_stop_pct: float | None = None,
 ) -> BacktestResult:
     """バックテストを実行し結果を返す。
 
@@ -418,6 +434,9 @@ def run_backtest(
                            False（デフォルト）で無効。generate_signals() の同名引数に転送。
         volume_breakout_threshold: 指定した場合、volume_ratio が閾値未満の銘柄の BUY を抑制する。
                            None（デフォルト）で無効。generate_signals() の同名引数に転送。
+        portfolio_drawdown_stop_pct: ポートフォリオがピーク比でこの割合を超えて下落した場合、
+                           新規 BUY エントリーを停止する（既存ポジションの SELL は継続）。
+                           None（デフォルト）で無効。0 < x < 1 の範囲で指定すること。
 
     Returns:
         BacktestResult（history, trades, metrics および scope_mode/excluded_codes 等のスコープメタデータ）。
@@ -447,6 +466,10 @@ def run_backtest(
         raise ValueError(f"max_holding_days は 1 以上を指定してください: {max_holding_days}")
     if trailing_stop_atr <= 0:
         raise ValueError(f"trailing_stop_atr は正の値を指定してください: {trailing_stop_atr}")
+    if portfolio_drawdown_stop_pct is not None and not (0 < portfolio_drawdown_stop_pct < 1):
+        raise ValueError(
+            f"portfolio_drawdown_stop_pct は (0, 1) の範囲で指定してください: {portfolio_drawdown_stop_pct}"
+        )
     if threshold is not None and not (0 < threshold < 1):
         raise ValueError(f"threshold は (0, 1) の範囲で指定してください: {threshold}")
     if topix_drawdown_threshold is not None and topix_drawdown_threshold >= 0:
@@ -483,6 +506,7 @@ def run_backtest(
     # バックテストループ内でメモリ上に持ち回る翌日用発注リスト
     # （本番 live trading とは異なり、バックテストは単一関数呼び出し内で完結するためDB永続化不要）
     next_day_orders: list[dict] = []
+    peak_value: float = initial_cash  # ポートフォリオドローダウンストップ用ピーク追跡
 
     try:
         trading_days = get_trading_days(bt_conn, start_date, end_date)
@@ -571,6 +595,14 @@ def run_backtest(
             current_pv = (
                 simulator.history[-1].portfolio_value if simulator.history else initial_cash
             )
+            peak_value = max(peak_value, current_pv)
+            entry_blocked = _is_entry_blocked(current_pv, peak_value, portfolio_drawdown_stop_pct)
+            if entry_blocked:
+                logger.debug(
+                    "run_backtest: ドローダウンストップ発動 date=%s drawdown=%.2f%%",
+                    trading_day,
+                    (current_pv / peak_value - 1) * 100,
+                )
             # max_utilization を全配分方式に一貫適用（risk_based 含む）
             available_cash = min(simulator.cash * multiplier, current_pv * max_utilization)
 
@@ -617,16 +649,23 @@ def run_backtest(
             # 翌日の約定に使う発注リストをメモリ上で更新（次ループの Step 1 で消費）
             # BUY と SELL が同一銘柄になる場合は BUY を除外（SELL を優先）
             # size_multiplier を各 BUY に適用（主要イベント前は 50% 縮小）
+            # ドローダウンストップ発動中は BUY を全スキップ（SELL は継続）
             sm_map = {s["code"]: s.get("size_multiplier", 1.0) for s in buy_signals}
-            next_day_orders = [
-                {
-                    "code": code,
-                    "side": "buy",
-                    "shares": max(0, (int(shares * sm_map.get(code, 1.0)) // lot_size) * lot_size),
-                }
-                for code, shares in sized.items()
-                if shares > 0 and code not in sell_codes
-            ] + [{"code": s["code"], "side": "sell"} for s in sell_signals]
+            next_day_orders = (
+                []
+                if entry_blocked
+                else [
+                    {
+                        "code": code,
+                        "side": "buy",
+                        "shares": max(
+                            0, (int(shares * sm_map.get(code, 1.0)) // lot_size) * lot_size
+                        ),
+                    }
+                    for code, shares in sized.items()
+                    if shares > 0 and code not in sell_codes
+                ]
+            ) + [{"code": s["code"], "side": "sell"} for s in sell_signals]
             # shares=0 になったエントリーを除外
             next_day_orders = [o for o in next_day_orders if o.get("shares", 1) > 0]
     finally:

--- a/src/kabusys/backtest/engine.py
+++ b/src/kabusys/backtest/engine.py
@@ -358,9 +358,9 @@ def _is_entry_blocked(
     """ポートフォリオドローダウンストップ判定。
 
     portfolio_value がピーク比で portfolio_drawdown_stop_pct を超えて下落している場合 True を返す。
-    portfolio_drawdown_stop_pct が None の場合は常に False（機能無効）。
+    portfolio_drawdown_stop_pct が None または peak_value が 0 の場合は常に False（機能無効）。
     """
-    if portfolio_drawdown_stop_pct is None:
+    if portfolio_drawdown_stop_pct is None or peak_value == 0:
         return False
     return (peak_value - portfolio_value) / peak_value > portfolio_drawdown_stop_pct
 
@@ -601,7 +601,7 @@ def run_backtest(
                 logger.debug(
                     "run_backtest: ドローダウンストップ発動 date=%s drawdown=%.2f%%",
                     trading_day,
-                    (current_pv / peak_value - 1) * 100,
+                    (1 - current_pv / peak_value) * 100,
                 )
             # max_utilization を全配分方式に一貫適用（risk_based 含む）
             available_cash = min(simulator.cash * multiplier, current_pv * max_utilization)

--- a/src/kabusys/backtest/run.py
+++ b/src/kabusys/backtest/run.py
@@ -177,6 +177,15 @@ def main() -> None:
         default=None,
         help="Suppress BUY signals when volume_ratio is below this multiplier (e.g. 1.5 means volume must be >= 1.5x 20-day average).",
     )
+    parser.add_argument(
+        "--portfolio-drawdown-stop",
+        type=float,
+        default=None,
+        help=(
+            "ポートフォリオがピーク比でこの割合（例: 0.15 = 15%%）を超えて下落した場合、"
+            "新規 BUY エントリーを停止する。None（デフォルト）で無効。"
+        ),
+    )
     parser.add_argument("--db", required=True, help="DuckDB file path")
     parser.add_argument(
         "--output-format",
@@ -248,6 +257,7 @@ def main() -> None:
             topix_size_multiplier_bear=args.topix_size_multiplier_bear,
             use_ma200_filter=args.ma200_filter,
             volume_breakout_threshold=args.volume_breakout_threshold,
+            portfolio_drawdown_stop_pct=args.portfolio_drawdown_stop,
         )
     finally:
         conn.close()

--- a/tests/test_backtest_engine_params.py
+++ b/tests/test_backtest_engine_params.py
@@ -208,6 +208,7 @@ def test_is_entry_blocked_at_exact_threshold_is_not_blocked():
 
 def test_run_backtest_accepts_portfolio_drawdown_stop_pct():
     import inspect
+
     from kabusys.backtest.engine import run_backtest
 
     assert "portfolio_drawdown_stop_pct" in inspect.signature(run_backtest).parameters
@@ -215,6 +216,7 @@ def test_run_backtest_accepts_portfolio_drawdown_stop_pct():
 
 def test_run_backtest_portfolio_drawdown_stop_pct_default_is_none():
     import inspect
+
     from kabusys.backtest.engine import run_backtest
 
     param = inspect.signature(run_backtest).parameters["portfolio_drawdown_stop_pct"]

--- a/tests/test_backtest_engine_params.py
+++ b/tests/test_backtest_engine_params.py
@@ -219,3 +219,21 @@ def test_run_backtest_portfolio_drawdown_stop_pct_default_is_none():
 
     param = inspect.signature(run_backtest).parameters["portfolio_drawdown_stop_pct"]
     assert param.default is None
+
+
+def test_run_py_cli_has_portfolio_drawdown_stop_arg():
+    import os
+    import pathlib
+    import subprocess
+    import sys
+
+    src_dir = str(pathlib.Path(__file__).parent.parent / "src")
+    env = {**os.environ, "PYTHONPATH": src_dir, "PYTHONUTF8": "1"}
+    result = subprocess.run(
+        [sys.executable, "-m", "kabusys.backtest.run", "--help"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        env=env,
+    )
+    assert "--portfolio-drawdown-stop" in result.stdout

--- a/tests/test_backtest_engine_params.py
+++ b/tests/test_backtest_engine_params.py
@@ -174,3 +174,48 @@ def test_run_py_cli_has_factor_filter_args():
     assert "volume_breakout_threshold" in actions, (
         f"--volume-breakout-threshold が argparse に定義されていない: {actions}"
     )
+
+
+# ── _is_entry_blocked ────────────────────────────────────────────────────────
+
+
+def test_is_entry_blocked_returns_false_when_disabled():
+    from kabusys.backtest.engine import _is_entry_blocked
+
+    assert _is_entry_blocked(900_000.0, 1_000_000.0, None) is False
+
+
+def test_is_entry_blocked_returns_false_when_within_threshold():
+    from kabusys.backtest.engine import _is_entry_blocked
+
+    # drawdown = -10%、threshold = 15% → ブロックしない
+    assert _is_entry_blocked(900_000.0, 1_000_000.0, 0.15) is False
+
+
+def test_is_entry_blocked_returns_true_when_exceeded():
+    from kabusys.backtest.engine import _is_entry_blocked
+
+    # drawdown = -20%、threshold = 15% → ブロック
+    assert _is_entry_blocked(800_000.0, 1_000_000.0, 0.15) is True
+
+
+def test_is_entry_blocked_at_exact_threshold_is_not_blocked():
+    from kabusys.backtest.engine import _is_entry_blocked
+
+    # drawdown = -15%（= threshold）→ 厳密に「未満」でないためブロックしない
+    assert _is_entry_blocked(850_000.0, 1_000_000.0, 0.15) is False
+
+
+def test_run_backtest_accepts_portfolio_drawdown_stop_pct():
+    import inspect
+    from kabusys.backtest.engine import run_backtest
+
+    assert "portfolio_drawdown_stop_pct" in inspect.signature(run_backtest).parameters
+
+
+def test_run_backtest_portfolio_drawdown_stop_pct_default_is_none():
+    import inspect
+    from kabusys.backtest.engine import run_backtest
+
+    param = inspect.signature(run_backtest).parameters["portfolio_drawdown_stop_pct"]
+    assert param.default is None


### PR DESCRIPTION
## Summary

- `engine.py` に `portfolio_drawdown_stop_pct` パラメータを追加。ポートフォリオがピーク比で指定割合を超えて下落した場合に新規 BUY エントリーをブロック（SELL は継続）
- `_is_entry_blocked()` を純粋関数として分離し、TDD で実装・検証済み
- `run.py` に `--portfolio-drawdown-stop` CLI 引数を追加
- 10m MDD対策 検証スクリプト（6シナリオ × 3年 = 18ラン）を追加
- 1m ファクターアブレーション分析スクリプト（6シナリオ × 3年 = 18ラン）を追加

## Background

- **10m**: 2024年 MaxDD 41.35%（8月ブラックマンデー）が主因。既存 TOPIX ベアガードの発動が遅く対策が必要
- **1m**: 2025年 CAGR +53% vs 2023年 -9.71% / 2024年 -3.70% という強いオーバーフィット。各ファクターをアブレーションして原因を特定する

## Changes

| ファイル | 変更内容 |
|---|---|
| `src/kabusys/backtest/engine.py` | `_is_entry_blocked()` 追加・`portfolio_drawdown_stop_pct` パラメータ追加・`peak_value` 追跡ロジック追加 |
| `src/kabusys/backtest/run.py` | `--portfolio-drawdown-stop` CLI 引数追加 |
| `tests/test_backtest_engine_params.py` | `_is_entry_blocked` 境界条件テスト 4件・シグネチャ確認テスト 2件・CLI テスト 1件 追加 |
| `backtest/backtest_improvement_plan/run_backtest_improvement_10m_mdd.py` | 新規作成（base / bear_stronger / dd_stop15 / dd_stop12 / combined15 / combined12） |
| `backtest/backtest_improvement_plan/run_backtest_improvement_1m_ablation.py` | 新規作成（base / no_momentum / no_value / no_volatility / no_liquidity / no_news） |
| `docs/superpowers/specs/` | 設計仕様書追加 |
| `docs/superpowers/plans/` | 実装計画書追加 |

## Test Plan

- [x] `pytest tests/test_backtest_engine_params.py -v` → 14/14 passed
- [ ] `python backtest/backtest_improvement_plan/run_backtest_improvement_10m_mdd.py` を実行して結果を確認
- [ ] `python backtest/backtest_improvement_plan/run_backtest_improvement_1m_ablation.py` を実行して結果を確認
- [ ] 2024年 MaxDD が `base` より改善されるシナリオを特定
- [ ] 2023/2024 Sharpe が改善するファクター除外シナリオを特定

🤖 Generated with [Claude Code](https://claude.com/claude-code)