### PR TITLE
feat: TOPIXベアガードをMA200乖離率からMA25/MA75/MA200クロス判定に変更 (#349)

### DIFF
--- a/backtest/backtest_improvement_plan/run_backtest_improvement_10m.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_10m.py
@@ -446,6 +446,9 @@ def main() -> None:
                     "topix_size_multiplier_weak_bear": scenario.get(
                         "topix_size_multiplier_weak_bear", 0.50
                     ),
+                    "topix_size_multiplier_strong_bear": scenario.get(
+                        "topix_size_multiplier_strong_bear", 0.00
+                    ),
                     "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
                     "rsi_overbought_threshold": 65.0,
                     "max_positions": params["max_positions"],

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_10m.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_10m.py
@@ -184,6 +184,9 @@ def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
         "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
         "threshold": scenario.get("threshold", 0.58),
         "topix_size_multiplier_weak_bear": scenario.get("topix_size_multiplier_weak_bear", 0.50),
+        "topix_size_multiplier_strong_bear": scenario.get(
+            "topix_size_multiplier_strong_bear", 0.00
+        ),
     }
 
 

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_10m.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_10m.py
@@ -43,8 +43,7 @@ SCENARIOS = [
         "risk_pct": 0.005,
         "stop_loss_pct": 0.09,
         "threshold": 0.58,
-        "topix_size_multiplier_bear": 0.50,
-        "topix_drawdown_threshold": -0.15,
+        "topix_size_multiplier_weak_bear": 0.50,
         "trailing_stop_atr_mult": 2.0,
     },
     {
@@ -57,8 +56,7 @@ SCENARIOS = [
         "risk_pct": 0.005,
         "stop_loss_pct": 0.09,
         "threshold": 0.62,
-        "topix_size_multiplier_bear": 0.50,
-        "topix_drawdown_threshold": -0.15,
+        "topix_size_multiplier_weak_bear": 0.50,
         "trailing_stop_atr_mult": 2.0,
     },
     {
@@ -71,8 +69,7 @@ SCENARIOS = [
         "risk_pct": 0.005,
         "stop_loss_pct": 0.09,
         "threshold": 0.62,
-        "topix_size_multiplier_bear": 0.30,
-        "topix_drawdown_threshold": -0.12,
+        "topix_size_multiplier_weak_bear": 0.30,
         "trailing_stop_atr_mult": 2.0,
     },
     {
@@ -85,8 +82,7 @@ SCENARIOS = [
         "risk_pct": 0.005,
         "stop_loss_pct": 0.09,
         "threshold": 0.62,
-        "topix_size_multiplier_bear": 0.30,
-        "topix_drawdown_threshold": -0.12,
+        "topix_size_multiplier_weak_bear": 0.30,
         "trailing_stop_atr_mult": 2.5,
     },
 ]
@@ -153,8 +149,12 @@ def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
     sector_section["boost"] = 0.05
     sector_section["quartile"] = 0.30
 
-    regime_section["topix_drawdown_threshold"] = scenario.get("topix_drawdown_threshold", -0.15)
-    regime_section["topix_size_multiplier_bear"] = scenario.get("topix_size_multiplier_bear", 0.50)
+    regime_section["topix_size_multiplier_weak_bear"] = scenario.get(
+        "topix_size_multiplier_weak_bear", 0.50
+    )
+    regime_section["topix_size_multiplier_strong_bear"] = scenario.get(
+        "topix_size_multiplier_strong_bear", 0.00
+    )
 
     portfolio_section["max_positions"] = scenario.get("max_positions", 7)
     return strategy_config
@@ -183,8 +183,7 @@ def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
         "max_holding_days": 60,
         "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
         "threshold": scenario.get("threshold", 0.58),
-        "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
-        "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+        "topix_size_multiplier_weak_bear": scenario.get("topix_size_multiplier_weak_bear", 0.50),
     }
 
 
@@ -221,10 +220,10 @@ def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -
         str(params["trailing_stop_atr"]),
         "--threshold",
         str(params["threshold"]),
-        "--topix-drawdown-threshold",
-        str(params["topix_drawdown_threshold"]),
-        "--topix-size-multiplier-bear",
-        str(params["topix_size_multiplier_bear"]),
+        "--topix-size-multiplier-weak-bear",
+        str(params["topix_size_multiplier_weak_bear"]),
+        "--topix-size-multiplier-strong-bear",
+        str(params.get("topix_size_multiplier_strong_bear", 0.0)),
         "--output-format",
         "all",
         "--output-dir",
@@ -341,8 +340,8 @@ def main() -> None:
         "cash",
         "allocation_method",
         "threshold",
-        "topix_size_multiplier_bear",
-        "topix_drawdown_threshold",
+        "topix_size_multiplier_weak_bear",
+        "topix_size_multiplier_strong_bear",
         "trailing_stop_atr",
         "rsi_overbought_threshold",
         "max_positions",
@@ -441,8 +440,9 @@ def main() -> None:
                     "cash": params["cash"],
                     "allocation_method": params["allocation_method"],
                     "threshold": scenario.get("threshold", 0.58),
-                    "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
-                    "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
+                    "topix_size_multiplier_weak_bear": scenario.get(
+                        "topix_size_multiplier_weak_bear", 0.50
+                    ),
                     "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
                     "rsi_overbought_threshold": 65.0,
                     "max_positions": params["max_positions"],
@@ -461,7 +461,7 @@ def main() -> None:
 
                 print(
                     f"{scenario_slug}\t{run_id}\t{scenario.get('threshold', 0.58)}\t"
-                    f"{scenario.get('topix_size_multiplier_bear', 0.50)}\t"
+                    f"{scenario.get('topix_size_multiplier_weak_bear', 0.50)}\t"
                     f"{scenario.get('trailing_stop_atr_mult', 2.0)}\t"
                     f"{_format_metric(metrics['cagr'])}\t{_format_metric(metrics['sharpe'])}\t"
                     f"{_format_metric(metrics['max_drawdown'])}\t{_format_metric(metrics['profit_factor'])}\t"

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_10m_factors.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_10m_factors.py
@@ -49,8 +49,7 @@ _BASE = {
     "risk_pct": 0.005,
     "stop_loss_pct": 0.07,
     "threshold": 0.58,
-    "topix_size_multiplier_bear": 0.50,
-    "topix_drawdown_threshold": -0.15,
+    "topix_size_multiplier_weak_bear": 0.50,
     "trailing_stop_atr_mult": 2.0,
     "max_holding_days": 60,
     "use_ma200_filter": False,
@@ -144,8 +143,12 @@ def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
     sector_section["boost"] = 0.05
     sector_section["quartile"] = 0.30
 
-    regime_section["topix_drawdown_threshold"] = scenario.get("topix_drawdown_threshold", -0.15)
-    regime_section["topix_size_multiplier_bear"] = scenario.get("topix_size_multiplier_bear", 0.50)
+    regime_section["topix_size_multiplier_weak_bear"] = scenario.get(
+        "topix_size_multiplier_weak_bear", 0.50
+    )
+    regime_section["topix_size_multiplier_strong_bear"] = scenario.get(
+        "topix_size_multiplier_strong_bear", 0.00
+    )
 
     portfolio_section["max_positions"] = scenario.get("max_positions", 4)
     return strategy_config
@@ -174,8 +177,7 @@ def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
         "max_holding_days": scenario.get("max_holding_days", 60),
         "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
         "threshold": scenario.get("threshold", 0.58),
-        "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
-        "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+        "topix_size_multiplier_weak_bear": scenario.get("topix_size_multiplier_weak_bear", 0.50),
         "use_ma200_filter": scenario.get("use_ma200_filter", False),
         "volume_breakout_threshold": scenario.get("volume_breakout_threshold"),
     }
@@ -214,10 +216,10 @@ def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -
         str(params["trailing_stop_atr"]),
         "--threshold",
         str(params["threshold"]),
-        "--topix-drawdown-threshold",
-        str(params["topix_drawdown_threshold"]),
-        "--topix-size-multiplier-bear",
-        str(params["topix_size_multiplier_bear"]),
+        "--topix-size-multiplier-weak-bear",
+        str(params["topix_size_multiplier_weak_bear"]),
+        "--topix-size-multiplier-strong-bear",
+        str(params.get("topix_size_multiplier_strong_bear", 0.0)),
         "--output-format",
         "all",
         "--output-dir",

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_10m_factors.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_10m_factors.py
@@ -178,6 +178,9 @@ def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
         "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
         "threshold": scenario.get("threshold", 0.58),
         "topix_size_multiplier_weak_bear": scenario.get("topix_size_multiplier_weak_bear", 0.50),
+        "topix_size_multiplier_strong_bear": scenario.get(
+            "topix_size_multiplier_strong_bear", 0.00
+        ),
         "use_ma200_filter": scenario.get("use_ma200_filter", False),
         "volume_breakout_threshold": scenario.get("volume_breakout_threshold"),
     }

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_10m_mdd.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_10m_mdd.py
@@ -56,7 +56,7 @@ _BASE = {
     "risk_pct": 0.005,
     "stop_loss_pct": 0.07,
     "threshold": 0.58,
-    "topix_size_multiplier_weak_bear": 0.50,    # MA25 < MA75 時の size_multiplier
+    "topix_size_multiplier_weak_bear": 0.50,  # MA25 < MA75 時の size_multiplier
     "topix_size_multiplier_strong_bear": 0.00,  # MA75 < MA200 時の size_multiplier（エントリー停止）
     "trailing_stop_atr_mult": 2.0,
     "max_holding_days": 60,
@@ -150,8 +150,12 @@ def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
     sector_section["boost"] = 0.05
     sector_section["quartile"] = 0.30
 
-    regime_section["topix_size_multiplier_weak_bear"] = scenario.get("topix_size_multiplier_weak_bear", 0.50)
-    regime_section["topix_size_multiplier_strong_bear"] = scenario.get("topix_size_multiplier_strong_bear", 0.00)
+    regime_section["topix_size_multiplier_weak_bear"] = scenario.get(
+        "topix_size_multiplier_weak_bear", 0.50
+    )
+    regime_section["topix_size_multiplier_strong_bear"] = scenario.get(
+        "topix_size_multiplier_strong_bear", 0.00
+    )
 
     portfolio_section["max_positions"] = scenario.get("max_positions", 4)
     return strategy_config
@@ -181,7 +185,9 @@ def _build_backtest_params(scenario: dict[str, object], year: int) -> dict[str, 
         "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
         "threshold": scenario.get("threshold", 0.58),
         "topix_size_multiplier_weak_bear": scenario.get("topix_size_multiplier_weak_bear", 0.50),
-        "topix_size_multiplier_strong_bear": scenario.get("topix_size_multiplier_strong_bear", 0.00),
+        "topix_size_multiplier_strong_bear": scenario.get(
+            "topix_size_multiplier_strong_bear", 0.00
+        ),
         "portfolio_drawdown_stop_pct": scenario.get("portfolio_drawdown_stop_pct"),
     }
 
@@ -407,8 +413,12 @@ def main() -> None:
                     record = {
                         "name": scenario_name,
                         "year": year,
-                        "topix_size_multiplier_weak_bear": params["topix_size_multiplier_weak_bear"],
-                        "topix_size_multiplier_strong_bear": params["topix_size_multiplier_strong_bear"],
+                        "topix_size_multiplier_weak_bear": params[
+                            "topix_size_multiplier_weak_bear"
+                        ],
+                        "topix_size_multiplier_strong_bear": params[
+                            "topix_size_multiplier_strong_bear"
+                        ],
                         "portfolio_drawdown_stop_pct": params["portfolio_drawdown_stop_pct"],
                         "run_id": run_id,
                         "created_at": metrics["created_at"],

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_10m_mdd.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_10m_mdd.py
@@ -56,8 +56,8 @@ _BASE = {
     "risk_pct": 0.005,
     "stop_loss_pct": 0.07,
     "threshold": 0.58,
-    "topix_size_multiplier_bear": 0.50,
-    "topix_drawdown_threshold": -0.15,
+    "topix_size_multiplier_weak_bear": 0.50,    # MA25 < MA75 時の size_multiplier
+    "topix_size_multiplier_strong_bear": 0.00,  # MA75 < MA200 時の size_multiplier（エントリー停止）
     "trailing_stop_atr_mult": 2.0,
     "max_holding_days": 60,
     "portfolio_drawdown_stop_pct": None,
@@ -66,12 +66,11 @@ _BASE = {
 SCENARIOS = [
     # ── ベースライン（OOS2 との内部一貫性確認）─────────────────────────────
     {**_BASE, "name": "base"},
-    # ── TOPIXガード強化のみ ──────────────────────────────────────────────
+    # ── TOPIXガード強化のみ（弱いベアも 0.25 に縮小）────────────────────────
     {
         **_BASE,
         "name": "bear_stronger",
-        "topix_drawdown_threshold": -0.10,
-        "topix_size_multiplier_bear": 0.25,
+        "topix_size_multiplier_weak_bear": 0.25,
     },
     # ── ポートフォリオストップのみ（15%）────────────────────────────────────
     {**_BASE, "name": "dd_stop15", "portfolio_drawdown_stop_pct": 0.15},
@@ -81,16 +80,14 @@ SCENARIOS = [
     {
         **_BASE,
         "name": "combined15",
-        "topix_drawdown_threshold": -0.10,
-        "topix_size_multiplier_bear": 0.25,
+        "topix_size_multiplier_weak_bear": 0.25,
         "portfolio_drawdown_stop_pct": 0.15,
     },
     # ── TOPIX強化 + ポートフォリオストップ12% ───────────────────────────────
     {
         **_BASE,
         "name": "combined12",
-        "topix_drawdown_threshold": -0.10,
-        "topix_size_multiplier_bear": 0.25,
+        "topix_size_multiplier_weak_bear": 0.25,
         "portfolio_drawdown_stop_pct": 0.12,
     },
 ]
@@ -153,8 +150,8 @@ def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
     sector_section["boost"] = 0.05
     sector_section["quartile"] = 0.30
 
-    regime_section["topix_drawdown_threshold"] = scenario.get("topix_drawdown_threshold", -0.15)
-    regime_section["topix_size_multiplier_bear"] = scenario.get("topix_size_multiplier_bear", 0.50)
+    regime_section["topix_size_multiplier_weak_bear"] = scenario.get("topix_size_multiplier_weak_bear", 0.50)
+    regime_section["topix_size_multiplier_strong_bear"] = scenario.get("topix_size_multiplier_strong_bear", 0.00)
 
     portfolio_section["max_positions"] = scenario.get("max_positions", 4)
     return strategy_config
@@ -183,8 +180,8 @@ def _build_backtest_params(scenario: dict[str, object], year: int) -> dict[str, 
         "max_holding_days": scenario.get("max_holding_days", 60),
         "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
         "threshold": scenario.get("threshold", 0.58),
-        "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
-        "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+        "topix_size_multiplier_weak_bear": scenario.get("topix_size_multiplier_weak_bear", 0.50),
+        "topix_size_multiplier_strong_bear": scenario.get("topix_size_multiplier_strong_bear", 0.00),
         "portfolio_drawdown_stop_pct": scenario.get("portfolio_drawdown_stop_pct"),
     }
 
@@ -222,10 +219,10 @@ def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -
         str(params["trailing_stop_atr"]),
         "--threshold",
         str(params["threshold"]),
-        "--topix-drawdown-threshold",
-        str(params["topix_drawdown_threshold"]),
-        "--topix-size-multiplier-bear",
-        str(params["topix_size_multiplier_bear"]),
+        "--topix-size-multiplier-weak-bear",
+        str(params["topix_size_multiplier_weak_bear"]),
+        "--topix-size-multiplier-strong-bear",
+        str(params["topix_size_multiplier_strong_bear"]),
         "--output-format",
         "all",
         "--output-dir",
@@ -321,8 +318,8 @@ def main() -> None:
     fieldnames = [
         "name",
         "year",
-        "topix_drawdown_threshold",
-        "topix_size_multiplier_bear",
+        "topix_size_multiplier_weak_bear",
+        "topix_size_multiplier_strong_bear",
         "portfolio_drawdown_stop_pct",
         "run_id",
         "created_at",
@@ -347,7 +344,7 @@ def main() -> None:
     ]
 
     print(f"output_dir={output_dir}")
-    print("scenario\tyear\tbear_thr\tbear_mult\tdd_stop\tcagr\tsharpe\tmax_dd\ttrades")
+    print("scenario\tyear\tweak_bear\tstrong_bear\tdd_stop\tcagr\tsharpe\tmax_dd\ttrades")
 
     with (
         log_jsonl_path.open("w", encoding="utf-8") as jsonl_file,
@@ -410,8 +407,8 @@ def main() -> None:
                     record = {
                         "name": scenario_name,
                         "year": year,
-                        "topix_drawdown_threshold": params["topix_drawdown_threshold"],
-                        "topix_size_multiplier_bear": params["topix_size_multiplier_bear"],
+                        "topix_size_multiplier_weak_bear": params["topix_size_multiplier_weak_bear"],
+                        "topix_size_multiplier_strong_bear": params["topix_size_multiplier_strong_bear"],
                         "portfolio_drawdown_stop_pct": params["portfolio_drawdown_stop_pct"],
                         "run_id": run_id,
                         "created_at": metrics["created_at"],
@@ -435,8 +432,8 @@ def main() -> None:
 
                     print(
                         f"{run_slug}\t{year}\t"
-                        f"{params['topix_drawdown_threshold']}\t"
-                        f"{params['topix_size_multiplier_bear']}\t"
+                        f"{params['topix_size_multiplier_weak_bear']}\t"
+                        f"{params['topix_size_multiplier_strong_bear']}\t"
                         f"{params['portfolio_drawdown_stop_pct']}\t"
                         f"{_format_metric(metrics['cagr'])}\t"
                         f"{_format_metric(metrics['sharpe'])}\t"

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_10m_oos.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_10m_oos.py
@@ -156,6 +156,9 @@ def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
         "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
         "threshold": scenario.get("threshold", 0.58),
         "topix_size_multiplier_weak_bear": scenario.get("topix_size_multiplier_weak_bear", 0.50),
+        "topix_size_multiplier_strong_bear": scenario.get(
+            "topix_size_multiplier_strong_bear", 0.00
+        ),
     }
 
 

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_10m_oos.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_10m_oos.py
@@ -47,8 +47,7 @@ BASE_PARAMS = {
     "risk_pct": 0.005,
     "stop_loss_pct": 0.07,
     "threshold": 0.58,
-    "topix_size_multiplier_bear": 0.50,
-    "topix_drawdown_threshold": -0.15,
+    "topix_size_multiplier_weak_bear": 0.50,
     "trailing_stop_atr_mult": 2.0,
     "max_holding_days": 60,
 }
@@ -121,8 +120,12 @@ def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
     sector_section["boost"] = 0.05
     sector_section["quartile"] = 0.30
 
-    regime_section["topix_drawdown_threshold"] = scenario.get("topix_drawdown_threshold", -0.15)
-    regime_section["topix_size_multiplier_bear"] = scenario.get("topix_size_multiplier_bear", 0.50)
+    regime_section["topix_size_multiplier_weak_bear"] = scenario.get(
+        "topix_size_multiplier_weak_bear", 0.50
+    )
+    regime_section["topix_size_multiplier_strong_bear"] = scenario.get(
+        "topix_size_multiplier_strong_bear", 0.00
+    )
 
     portfolio_section["max_positions"] = scenario.get("max_positions", 4)
     return strategy_config
@@ -152,8 +155,7 @@ def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
         "max_holding_days": scenario.get("max_holding_days", 60),
         "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
         "threshold": scenario.get("threshold", 0.58),
-        "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
-        "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+        "topix_size_multiplier_weak_bear": scenario.get("topix_size_multiplier_weak_bear", 0.50),
     }
 
 
@@ -190,10 +192,10 @@ def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -
         str(params["trailing_stop_atr"]),
         "--threshold",
         str(params["threshold"]),
-        "--topix-drawdown-threshold",
-        str(params["topix_drawdown_threshold"]),
-        "--topix-size-multiplier-bear",
-        str(params["topix_size_multiplier_bear"]),
+        "--topix-size-multiplier-weak-bear",
+        str(params["topix_size_multiplier_weak_bear"]),
+        "--topix-size-multiplier-strong-bear",
+        str(params.get("topix_size_multiplier_strong_bear", 0.0)),
         "--output-format",
         "all",
         "--output-dir",

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_10m_oos2.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_10m_oos2.py
@@ -167,6 +167,9 @@ def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
         "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
         "threshold": scenario.get("threshold", 0.58),
         "topix_size_multiplier_weak_bear": scenario.get("topix_size_multiplier_weak_bear", 0.50),
+        "topix_size_multiplier_strong_bear": scenario.get(
+            "topix_size_multiplier_strong_bear", 0.00
+        ),
         "use_ma200_filter": scenario.get("use_ma200_filter", False),
     }
 

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_10m_oos2.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_10m_oos2.py
@@ -52,8 +52,7 @@ _BASE = {
     "risk_pct": 0.005,
     "stop_loss_pct": 0.07,
     "threshold": 0.58,
-    "topix_size_multiplier_bear": 0.50,
-    "topix_drawdown_threshold": -0.15,
+    "topix_size_multiplier_weak_bear": 0.50,
     "trailing_stop_atr_mult": 2.0,
     "max_holding_days": 60,
     "use_ma200_filter": False,
@@ -132,8 +131,12 @@ def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
     sector_section["boost"] = 0.05
     sector_section["quartile"] = 0.30
 
-    regime_section["topix_drawdown_threshold"] = scenario.get("topix_drawdown_threshold", -0.15)
-    regime_section["topix_size_multiplier_bear"] = scenario.get("topix_size_multiplier_bear", 0.50)
+    regime_section["topix_size_multiplier_weak_bear"] = scenario.get(
+        "topix_size_multiplier_weak_bear", 0.50
+    )
+    regime_section["topix_size_multiplier_strong_bear"] = scenario.get(
+        "topix_size_multiplier_strong_bear", 0.00
+    )
 
     portfolio_section["max_positions"] = scenario.get("max_positions", 4)
     return strategy_config
@@ -163,8 +166,7 @@ def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
         "max_holding_days": scenario.get("max_holding_days", 60),
         "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
         "threshold": scenario.get("threshold", 0.58),
-        "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
-        "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+        "topix_size_multiplier_weak_bear": scenario.get("topix_size_multiplier_weak_bear", 0.50),
         "use_ma200_filter": scenario.get("use_ma200_filter", False),
     }
 
@@ -202,10 +204,10 @@ def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -
         str(params["trailing_stop_atr"]),
         "--threshold",
         str(params["threshold"]),
-        "--topix-drawdown-threshold",
-        str(params["topix_drawdown_threshold"]),
-        "--topix-size-multiplier-bear",
-        str(params["topix_size_multiplier_bear"]),
+        "--topix-size-multiplier-weak-bear",
+        str(params["topix_size_multiplier_weak_bear"]),
+        "--topix-size-multiplier-strong-bear",
+        str(params.get("topix_size_multiplier_strong_bear", 0.0)),
         "--output-format",
         "all",
         "--output-dir",

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_10m_v2.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_10m_v2.py
@@ -500,6 +500,9 @@ def main() -> None:
                     "topix_size_multiplier_weak_bear": scenario.get(
                         "topix_size_multiplier_weak_bear", 0.50
                     ),
+                    "topix_size_multiplier_strong_bear": scenario.get(
+                        "topix_size_multiplier_strong_bear", 0.00
+                    ),
                     "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
                     "rsi_overbought_threshold": 65.0,
                     "max_positions": params["max_positions"],

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_10m_v2.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_10m_v2.py
@@ -53,8 +53,7 @@ SCENARIOS = [
         "risk_pct": 0.005,
         "stop_loss_pct": 0.09,
         "threshold": 0.58,
-        "topix_size_multiplier_bear": 0.50,
-        "topix_drawdown_threshold": -0.15,
+        "topix_size_multiplier_weak_bear": 0.50,
         "trailing_stop_atr_mult": 2.0,
         "max_holding_days": 60,
     },
@@ -69,8 +68,7 @@ SCENARIOS = [
         "risk_pct": 0.005,
         "stop_loss_pct": 0.06,
         "threshold": 0.58,
-        "topix_size_multiplier_bear": 0.50,
-        "topix_drawdown_threshold": -0.15,
+        "topix_size_multiplier_weak_bear": 0.50,
         "trailing_stop_atr_mult": 1.5,
         "max_holding_days": 40,
     },
@@ -85,8 +83,7 @@ SCENARIOS = [
         "risk_pct": 0.005,
         "stop_loss_pct": 0.06,
         "threshold": 0.58,
-        "topix_size_multiplier_bear": 0.50,
-        "topix_drawdown_threshold": -0.15,
+        "topix_size_multiplier_weak_bear": 0.50,
         "trailing_stop_atr_mult": 1.5,
         "max_holding_days": 30,
     },
@@ -101,8 +98,7 @@ SCENARIOS = [
         "risk_pct": 0.005,
         "stop_loss_pct": 0.07,
         "threshold": 0.55,
-        "topix_size_multiplier_bear": 0.50,
-        "topix_drawdown_threshold": -0.15,
+        "topix_size_multiplier_weak_bear": 0.50,
         "trailing_stop_atr_mult": 2.0,
         "max_holding_days": 60,
     },
@@ -117,8 +113,7 @@ SCENARIOS = [
         "risk_pct": 0.005,
         "stop_loss_pct": 0.07,
         "threshold": 0.60,
-        "topix_size_multiplier_bear": 0.50,
-        "topix_drawdown_threshold": -0.15,
+        "topix_size_multiplier_weak_bear": 0.50,
         "trailing_stop_atr_mult": 1.5,
         "max_holding_days": 40,
     },
@@ -133,8 +128,7 @@ SCENARIOS = [
         "risk_pct": 0.005,
         "stop_loss_pct": 0.07,
         "threshold": 0.58,
-        "topix_size_multiplier_bear": 0.50,
-        "topix_drawdown_threshold": -0.15,
+        "topix_size_multiplier_weak_bear": 0.50,
         "trailing_stop_atr_mult": 2.0,
         "max_holding_days": 60,
     },
@@ -202,8 +196,12 @@ def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
     sector_section["boost"] = 0.05
     sector_section["quartile"] = 0.30
 
-    regime_section["topix_drawdown_threshold"] = scenario.get("topix_drawdown_threshold", -0.15)
-    regime_section["topix_size_multiplier_bear"] = scenario.get("topix_size_multiplier_bear", 0.50)
+    regime_section["topix_size_multiplier_weak_bear"] = scenario.get(
+        "topix_size_multiplier_weak_bear", 0.50
+    )
+    regime_section["topix_size_multiplier_strong_bear"] = scenario.get(
+        "topix_size_multiplier_strong_bear", 0.00
+    )
 
     portfolio_section["max_positions"] = scenario.get("max_positions", 7)
     return strategy_config
@@ -232,8 +230,7 @@ def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
         "max_holding_days": scenario.get("max_holding_days", 60),
         "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
         "threshold": scenario.get("threshold", 0.58),
-        "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
-        "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+        "topix_size_multiplier_weak_bear": scenario.get("topix_size_multiplier_weak_bear", 0.50),
     }
 
 
@@ -270,10 +267,10 @@ def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -
         str(params["trailing_stop_atr"]),
         "--threshold",
         str(params["threshold"]),
-        "--topix-drawdown-threshold",
-        str(params["topix_drawdown_threshold"]),
-        "--topix-size-multiplier-bear",
-        str(params["topix_size_multiplier_bear"]),
+        "--topix-size-multiplier-weak-bear",
+        str(params["topix_size_multiplier_weak_bear"]),
+        "--topix-size-multiplier-strong-bear",
+        str(params.get("topix_size_multiplier_strong_bear", 0.0)),
         "--output-format",
         "all",
         "--output-dir",
@@ -390,8 +387,8 @@ def main() -> None:
         "cash",
         "allocation_method",
         "threshold",
-        "topix_size_multiplier_bear",
-        "topix_drawdown_threshold",
+        "topix_size_multiplier_weak_bear",
+        "topix_size_multiplier_strong_bear",
         "trailing_stop_atr",
         "rsi_overbought_threshold",
         "max_positions",
@@ -497,8 +494,9 @@ def main() -> None:
                     "cash": params["cash"],
                     "allocation_method": params["allocation_method"],
                     "threshold": scenario.get("threshold", 0.58),
-                    "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
-                    "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
+                    "topix_size_multiplier_weak_bear": scenario.get(
+                        "topix_size_multiplier_weak_bear", 0.50
+                    ),
                     "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
                     "rsi_overbought_threshold": 65.0,
                     "max_positions": params["max_positions"],

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_10m_v2.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_10m_v2.py
@@ -231,6 +231,9 @@ def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
         "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
         "threshold": scenario.get("threshold", 0.58),
         "topix_size_multiplier_weak_bear": scenario.get("topix_size_multiplier_weak_bear", 0.50),
+        "topix_size_multiplier_strong_bear": scenario.get(
+            "topix_size_multiplier_strong_bear", 0.00
+        ),
     }
 
 

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_1m.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_1m.py
@@ -168,6 +168,9 @@ def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
         "trailing_stop_atr": 2.0,
         "threshold": scenario.get("threshold", 0.58),
         "topix_size_multiplier_weak_bear": scenario.get("topix_size_multiplier_weak_bear", 0.50),
+        "topix_size_multiplier_strong_bear": scenario.get(
+            "topix_size_multiplier_strong_bear", 0.00
+        ),
     }
 
 

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_1m.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_1m.py
@@ -137,8 +137,8 @@ def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
     sector_section["boost"] = 0.05
     sector_section["quartile"] = 0.30
 
-    regime_section["topix_drawdown_threshold"] = -0.15
-    regime_section["topix_size_multiplier_bear"] = 0.50
+    regime_section["topix_size_multiplier_weak_bear"] = 0.50
+    regime_section["topix_size_multiplier_strong_bear"] = 0.00
 
     portfolio_section["max_positions"] = scenario.get("max_positions", 7)
     return strategy_config
@@ -167,8 +167,7 @@ def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
         "max_holding_days": 60,
         "trailing_stop_atr": 2.0,
         "threshold": scenario.get("threshold", 0.58),
-        "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
-        "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+        "topix_size_multiplier_weak_bear": scenario.get("topix_size_multiplier_weak_bear", 0.50),
     }
 
 
@@ -205,10 +204,10 @@ def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -
         str(params["trailing_stop_atr"]),
         "--threshold",
         str(params["threshold"]),
-        "--topix-drawdown-threshold",
-        str(params["topix_drawdown_threshold"]),
-        "--topix-size-multiplier-bear",
-        str(params["topix_size_multiplier_bear"]),
+        "--topix-size-multiplier-weak-bear",
+        str(params["topix_size_multiplier_weak_bear"]),
+        "--topix-size-multiplier-strong-bear",
+        str(params.get("topix_size_multiplier_strong_bear", 0.0)),
         "--output-format",
         "all",
         "--output-dir",
@@ -325,7 +324,7 @@ def main() -> None:
         "cash",
         "allocation_method",
         "threshold",
-        "topix_size_multiplier_bear",
+        "topix_size_multiplier_weak_bear",
         "trailing_stop_atr",
         "rsi_overbought_threshold",
         "max_positions",
@@ -424,7 +423,7 @@ def main() -> None:
                     "cash": params["cash"],
                     "allocation_method": params["allocation_method"],
                     "threshold": 0.58,
-                    "topix_size_multiplier_bear": 0.50,
+                    "topix_size_multiplier_weak_bear": 0.50,
                     "trailing_stop_atr": params["trailing_stop_atr"],
                     "rsi_overbought_threshold": 65.0,
                     "max_positions": params["max_positions"],

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_1m_ablation.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_1m_ablation.py
@@ -176,6 +176,9 @@ def _build_backtest_params(scenario: dict[str, object], year: int) -> dict[str, 
         "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
         "threshold": scenario.get("threshold", 0.58),
         "topix_size_multiplier_weak_bear": scenario.get("topix_size_multiplier_weak_bear", 0.50),
+        "topix_size_multiplier_strong_bear": scenario.get(
+            "topix_size_multiplier_strong_bear", 0.00
+        ),
     }
 
 

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_1m_ablation.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_1m_ablation.py
@@ -57,8 +57,7 @@ _BASE = {
     "risk_pct": 0.005,
     "stop_loss_pct": 0.09,
     "threshold": 0.58,
-    "topix_size_multiplier_bear": 0.50,
-    "topix_drawdown_threshold": -0.15,
+    "topix_size_multiplier_weak_bear": 0.50,
     "trailing_stop_atr_mult": 2.0,
     "max_holding_days": 60,
 }
@@ -142,8 +141,12 @@ def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
     sector_section["boost"] = 0.05
     sector_section["quartile"] = 0.30
 
-    regime_section["topix_drawdown_threshold"] = scenario.get("topix_drawdown_threshold", -0.15)
-    regime_section["topix_size_multiplier_bear"] = scenario.get("topix_size_multiplier_bear", 0.50)
+    regime_section["topix_size_multiplier_weak_bear"] = scenario.get(
+        "topix_size_multiplier_weak_bear", 0.50
+    )
+    regime_section["topix_size_multiplier_strong_bear"] = scenario.get(
+        "topix_size_multiplier_strong_bear", 0.00
+    )
 
     portfolio_section["max_positions"] = scenario.get("max_positions", 4)
     return strategy_config
@@ -172,8 +175,7 @@ def _build_backtest_params(scenario: dict[str, object], year: int) -> dict[str, 
         "max_holding_days": scenario.get("max_holding_days", 60),
         "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
         "threshold": scenario.get("threshold", 0.58),
-        "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
-        "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+        "topix_size_multiplier_weak_bear": scenario.get("topix_size_multiplier_weak_bear", 0.50),
     }
 
 
@@ -210,10 +212,10 @@ def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -
         str(params["trailing_stop_atr"]),
         "--threshold",
         str(params["threshold"]),
-        "--topix-drawdown-threshold",
-        str(params["topix_drawdown_threshold"]),
-        "--topix-size-multiplier-bear",
-        str(params["topix_size_multiplier_bear"]),
+        "--topix-size-multiplier-weak-bear",
+        str(params["topix_size_multiplier_weak_bear"]),
+        "--topix-size-multiplier-strong-bear",
+        str(params.get("topix_size_multiplier_strong_bear", 0.0)),
         "--output-format",
         "all",
         "--output-dir",

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_1m_factors.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_1m_factors.py
@@ -11,7 +11,7 @@
 
 検証方針：
   1. 200MA バイナリフィルター    : MA200 上の銘柄のみ BUY
-  2. TOPIX ベアガード前倒し      : topix_drawdown_threshold=-0.10（現行 -0.15）
+  2. TOPIX ベアガード前倒し      : topix_size_multiplier_weak_bear=0.25（現行 0.5）
   3. 出来高ブレイクアウト 1.5x   : volume_ratio >= 1.5 の銘柄のみ BUY
   4. MA200 + ベアガード強化       : 組み合わせ
   5. MA200 + 出来高 1.5x         : 組み合わせ
@@ -61,8 +61,7 @@ _BASE = {
     "risk_pct": 0.005,
     "stop_loss_pct": 0.09,
     "threshold": 0.58,
-    "topix_size_multiplier_bear": 0.50,
-    "topix_drawdown_threshold": -0.15,
+    "topix_size_multiplier_weak_bear": 0.50,
     "trailing_stop_atr_mult": 2.0,
     "max_holding_days": 60,
     "use_ma200_filter": False,
@@ -75,7 +74,6 @@ SCENARIOS = [
     # ── 200MA フィルター：MA200 上の銘柄のみ BUY ───────────────────────────
     {**_BASE, "name": "1m_eq4_ma200", "use_ma200_filter": True},
     # ── TOPIX ベアガード強化：乖離率 -10% 未満でサイズ縮小（現行 -15%）─────
-    {**_BASE, "name": "1m_eq4_bear10", "topix_drawdown_threshold": -0.10},
     # ── 出来高ブレイクアウト 1.5x ─────────────────────────────────────────
     {**_BASE, "name": "1m_eq4_vol15", "volume_breakout_threshold": 1.5},
     # ── MA200 + ベアガード強化 ──────────────────────────────────────────────
@@ -83,7 +81,6 @@ SCENARIOS = [
         **_BASE,
         "name": "1m_eq4_ma200_bear10",
         "use_ma200_filter": True,
-        "topix_drawdown_threshold": -0.10,
     },
     # ── MA200 + 出来高 1.5x ────────────────────────────────────────────────
     {
@@ -97,7 +94,6 @@ SCENARIOS = [
         **_BASE,
         "name": "1m_eq4_all_filters",
         "use_ma200_filter": True,
-        "topix_drawdown_threshold": -0.10,
         "volume_breakout_threshold": 1.5,
     },
 ]
@@ -164,8 +160,12 @@ def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
     sector_section["boost"] = 0.05
     sector_section["quartile"] = 0.30
 
-    regime_section["topix_drawdown_threshold"] = scenario.get("topix_drawdown_threshold", -0.15)
-    regime_section["topix_size_multiplier_bear"] = scenario.get("topix_size_multiplier_bear", 0.50)
+    regime_section["topix_size_multiplier_weak_bear"] = scenario.get(
+        "topix_size_multiplier_weak_bear", 0.50
+    )
+    regime_section["topix_size_multiplier_strong_bear"] = scenario.get(
+        "topix_size_multiplier_strong_bear", 0.00
+    )
 
     portfolio_section["max_positions"] = scenario.get("max_positions", 4)
     return strategy_config
@@ -194,8 +194,7 @@ def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
         "max_holding_days": scenario.get("max_holding_days", 60),
         "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
         "threshold": scenario.get("threshold", 0.58),
-        "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
-        "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+        "topix_size_multiplier_weak_bear": scenario.get("topix_size_multiplier_weak_bear", 0.50),
         "use_ma200_filter": scenario.get("use_ma200_filter", False),
         "volume_breakout_threshold": scenario.get("volume_breakout_threshold"),
     }
@@ -234,10 +233,10 @@ def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -
         str(params["trailing_stop_atr"]),
         "--threshold",
         str(params["threshold"]),
-        "--topix-drawdown-threshold",
-        str(params["topix_drawdown_threshold"]),
-        "--topix-size-multiplier-bear",
-        str(params["topix_size_multiplier_bear"]),
+        "--topix-size-multiplier-weak-bear",
+        str(params["topix_size_multiplier_weak_bear"]),
+        "--topix-size-multiplier-strong-bear",
+        str(params.get("topix_size_multiplier_strong_bear", 0.0)),
         "--output-format",
         "all",
         "--output-dir",
@@ -345,7 +344,8 @@ def main() -> None:
         "max_positions",
         "max_position_pct",
         "max_utilization",
-        "topix_drawdown_threshold",
+        "topix_size_multiplier_weak_bear",
+        "topix_size_multiplier_strong_bear",
         "use_ma200_filter",
         "volume_breakout_threshold",
         "cagr",
@@ -428,7 +428,6 @@ def main() -> None:
                     "max_positions": params["max_positions"],
                     "max_position_pct": params["max_position_pct"],
                     "max_utilization": params["max_utilization"],
-                    "topix_drawdown_threshold": params["topix_drawdown_threshold"],
                     "use_ma200_filter": params["use_ma200_filter"],
                     "volume_breakout_threshold": params["volume_breakout_threshold"],
                     **metrics,
@@ -449,7 +448,7 @@ def main() -> None:
                     f"{_format_metric(metrics['profit_factor'])}\t"
                     f"{metrics['total_trades']}\t"
                     f"{params['use_ma200_filter']}\t"
-                    f"{params['topix_drawdown_threshold']}\t"
+                    f"{params.get('topix_size_multiplier_weak_bear', 0.5)}\t"
                     f"{params['volume_breakout_threshold']}"
                 )
         finally:

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_1m_factors.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_1m_factors.py
@@ -428,6 +428,12 @@ def main() -> None:
                     "max_positions": params["max_positions"],
                     "max_position_pct": params["max_position_pct"],
                     "max_utilization": params["max_utilization"],
+                    "topix_size_multiplier_weak_bear": params.get(
+                        "topix_size_multiplier_weak_bear", 0.50
+                    ),
+                    "topix_size_multiplier_strong_bear": params.get(
+                        "topix_size_multiplier_strong_bear", 0.00
+                    ),
                     "use_ma200_filter": params["use_ma200_filter"],
                     "volume_breakout_threshold": params["volume_breakout_threshold"],
                     **metrics,

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_1m_oos.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_1m_oos.py
@@ -54,8 +54,7 @@ _BASE = {
     "risk_pct": 0.005,
     "stop_loss_pct": 0.09,
     "threshold": 0.58,
-    "topix_size_multiplier_bear": 0.50,
-    "topix_drawdown_threshold": -0.15,
+    "topix_size_multiplier_weak_bear": 0.50,
     "trailing_stop_atr_mult": 2.0,
     "max_holding_days": 60,
 }
@@ -128,8 +127,12 @@ def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
     sector_section["boost"] = 0.05
     sector_section["quartile"] = 0.30
 
-    regime_section["topix_drawdown_threshold"] = scenario.get("topix_drawdown_threshold", -0.15)
-    regime_section["topix_size_multiplier_bear"] = scenario.get("topix_size_multiplier_bear", 0.50)
+    regime_section["topix_size_multiplier_weak_bear"] = scenario.get(
+        "topix_size_multiplier_weak_bear", 0.50
+    )
+    regime_section["topix_size_multiplier_strong_bear"] = scenario.get(
+        "topix_size_multiplier_strong_bear", 0.00
+    )
 
     portfolio_section["max_positions"] = scenario.get("max_positions", 4)
     return strategy_config
@@ -159,8 +162,7 @@ def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
         "max_holding_days": scenario.get("max_holding_days", 60),
         "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
         "threshold": scenario.get("threshold", 0.58),
-        "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
-        "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+        "topix_size_multiplier_weak_bear": scenario.get("topix_size_multiplier_weak_bear", 0.50),
     }
 
 
@@ -197,10 +199,10 @@ def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -
         str(params["trailing_stop_atr"]),
         "--threshold",
         str(params["threshold"]),
-        "--topix-drawdown-threshold",
-        str(params["topix_drawdown_threshold"]),
-        "--topix-size-multiplier-bear",
-        str(params["topix_size_multiplier_bear"]),
+        "--topix-size-multiplier-weak-bear",
+        str(params["topix_size_multiplier_weak_bear"]),
+        "--topix-size-multiplier-strong-bear",
+        str(params.get("topix_size_multiplier_strong_bear", 0.0)),
         "--output-format",
         "all",
         "--output-dir",

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_1m_oos.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_1m_oos.py
@@ -163,6 +163,9 @@ def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
         "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
         "threshold": scenario.get("threshold", 0.58),
         "topix_size_multiplier_weak_bear": scenario.get("topix_size_multiplier_weak_bear", 0.50),
+        "topix_size_multiplier_strong_bear": scenario.get(
+            "topix_size_multiplier_strong_bear", 0.00
+        ),
     }
 
 

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_1m_v2.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_1m_v2.py
@@ -53,8 +53,7 @@ SCENARIOS = [
         "risk_pct": 0.005,
         "stop_loss_pct": 0.09,
         "threshold": 0.58,
-        "topix_size_multiplier_bear": 0.50,
-        "topix_drawdown_threshold": -0.15,
+        "topix_size_multiplier_weak_bear": 0.50,
         "trailing_stop_atr_mult": 2.0,
         "max_holding_days": 60,
     },
@@ -69,8 +68,7 @@ SCENARIOS = [
         "risk_pct": 0.005,
         "stop_loss_pct": 0.06,
         "threshold": 0.58,
-        "topix_size_multiplier_bear": 0.50,
-        "topix_drawdown_threshold": -0.15,
+        "topix_size_multiplier_weak_bear": 0.50,
         "trailing_stop_atr_mult": 1.5,
         "max_holding_days": 40,
     },
@@ -85,8 +83,7 @@ SCENARIOS = [
         "risk_pct": 0.005,
         "stop_loss_pct": 0.07,
         "threshold": 0.55,
-        "topix_size_multiplier_bear": 0.50,
-        "topix_drawdown_threshold": -0.15,
+        "topix_size_multiplier_weak_bear": 0.50,
         "trailing_stop_atr_mult": 2.0,
         "max_holding_days": 60,
     },
@@ -101,8 +98,7 @@ SCENARIOS = [
         "risk_pct": 0.005,
         "stop_loss_pct": 0.07,
         "threshold": 0.60,
-        "topix_size_multiplier_bear": 0.50,
-        "topix_drawdown_threshold": -0.15,
+        "topix_size_multiplier_weak_bear": 0.50,
         "trailing_stop_atr_mult": 2.0,
         "max_holding_days": 60,
     },
@@ -117,8 +113,7 @@ SCENARIOS = [
         "risk_pct": 0.005,
         "stop_loss_pct": 0.06,
         "threshold": 0.58,
-        "topix_size_multiplier_bear": 0.50,
-        "topix_drawdown_threshold": -0.15,
+        "topix_size_multiplier_weak_bear": 0.50,
         "trailing_stop_atr_mult": 1.5,
         "max_holding_days": 30,
     },
@@ -133,8 +128,7 @@ SCENARIOS = [
         "risk_pct": 0.005,
         "stop_loss_pct": 0.06,
         "threshold": 0.58,
-        "topix_size_multiplier_bear": 0.50,
-        "topix_drawdown_threshold": -0.15,
+        "topix_size_multiplier_weak_bear": 0.50,
         "trailing_stop_atr_mult": 1.5,
         "max_holding_days": 40,
     },
@@ -202,8 +196,12 @@ def _build_strategy_config(base: dict, scenario: dict[str, object]) -> dict:
     sector_section["boost"] = 0.05
     sector_section["quartile"] = 0.30
 
-    regime_section["topix_drawdown_threshold"] = scenario.get("topix_drawdown_threshold", -0.15)
-    regime_section["topix_size_multiplier_bear"] = scenario.get("topix_size_multiplier_bear", 0.50)
+    regime_section["topix_size_multiplier_weak_bear"] = scenario.get(
+        "topix_size_multiplier_weak_bear", 0.50
+    )
+    regime_section["topix_size_multiplier_strong_bear"] = scenario.get(
+        "topix_size_multiplier_strong_bear", 0.00
+    )
 
     portfolio_section["max_positions"] = scenario.get("max_positions", 4)
     return strategy_config
@@ -232,8 +230,7 @@ def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
         "max_holding_days": scenario.get("max_holding_days", 60),
         "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
         "threshold": scenario.get("threshold", 0.58),
-        "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
-        "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
+        "topix_size_multiplier_weak_bear": scenario.get("topix_size_multiplier_weak_bear", 0.50),
     }
 
 
@@ -270,10 +267,10 @@ def _build_command(db_path: Path, params: dict[str, object], output_dir: Path) -
         str(params["trailing_stop_atr"]),
         "--threshold",
         str(params["threshold"]),
-        "--topix-drawdown-threshold",
-        str(params["topix_drawdown_threshold"]),
-        "--topix-size-multiplier-bear",
-        str(params["topix_size_multiplier_bear"]),
+        "--topix-size-multiplier-weak-bear",
+        str(params["topix_size_multiplier_weak_bear"]),
+        "--topix-size-multiplier-strong-bear",
+        str(params.get("topix_size_multiplier_strong_bear", 0.0)),
         "--output-format",
         "all",
         "--output-dir",
@@ -390,8 +387,8 @@ def main() -> None:
         "cash",
         "allocation_method",
         "threshold",
-        "topix_size_multiplier_bear",
-        "topix_drawdown_threshold",
+        "topix_size_multiplier_weak_bear",
+        "topix_size_multiplier_strong_bear",
         "trailing_stop_atr",
         "rsi_overbought_threshold",
         "max_positions",
@@ -497,8 +494,9 @@ def main() -> None:
                     "cash": params["cash"],
                     "allocation_method": params["allocation_method"],
                     "threshold": scenario.get("threshold", 0.58),
-                    "topix_size_multiplier_bear": scenario.get("topix_size_multiplier_bear", 0.50),
-                    "topix_drawdown_threshold": scenario.get("topix_drawdown_threshold", -0.15),
+                    "topix_size_multiplier_weak_bear": scenario.get(
+                        "topix_size_multiplier_weak_bear", 0.50
+                    ),
                     "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
                     "rsi_overbought_threshold": 65.0,
                     "max_positions": params["max_positions"],

--- a/backtest/backtest_improvement_plan/run_backtest_improvement_1m_v2.py
+++ b/backtest/backtest_improvement_plan/run_backtest_improvement_1m_v2.py
@@ -231,6 +231,9 @@ def _build_backtest_params(scenario: dict[str, object]) -> dict[str, object]:
         "trailing_stop_atr": scenario.get("trailing_stop_atr_mult", 2.0),
         "threshold": scenario.get("threshold", 0.58),
         "topix_size_multiplier_weak_bear": scenario.get("topix_size_multiplier_weak_bear", 0.50),
+        "topix_size_multiplier_strong_bear": scenario.get(
+            "topix_size_multiplier_strong_bear", 0.00
+        ),
     }
 
 

--- a/config/strategy_config.yaml
+++ b/config/strategy_config.yaml
@@ -47,10 +47,10 @@ sector:
   quartile: 0.25
 
 regime:
-  # TOPIX 200MA 乖離率がこの値未満で地合い悪化と判定（負値）
-  topix_drawdown_threshold: -0.15
-  # 地合い悪化時の size_multiplier（0 < x ≤ 1）
-  topix_size_multiplier_bear: 0.5
+  # MA25 < MA75（弱いベア）時の size_multiplier（0 ≤ x ≤ 1）
+  topix_size_multiplier_weak_bear: 0.5
+  # MA75 < MA200（強いベア）時の size_multiplier（0 ≤ x ≤ 1、0.0 でエントリー停止）
+  topix_size_multiplier_strong_bear: 0.0
 
 portfolio:
   # 最大保有銘柄数（select_candidates() に渡される上限値、1 以上の整数）

--- a/scripts/backfill_features.py
+++ b/scripts/backfill_features.py
@@ -28,7 +28,7 @@ import duckdb
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 from kabusys.config import Settings
 from kabusys.data.calendar_management import get_trading_days
-from kabusys.strategy.feature_engineering import build_features
+from kabusys.strategy.feature_engineering import build_features, update_topix_ma
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
@@ -140,6 +140,46 @@ def backfill(
     return processed, skipped, no_price
 
 
+def backfill_topix_ma(
+    conn: duckdb.DuckDBPyConnection,
+    start: date,
+    end: date,
+    dry_run: bool = False,
+) -> tuple[int, int]:
+    """指定期間の TOPIX MA (MA25/MA75/MA200) を topix_daily に一括保存する。
+
+    topix_daily にデータが存在する日付のみを処理する（冪等）。
+
+    Returns:
+        (updated, skipped) のタプル。
+    """
+    rows = conn.execute(
+        "SELECT date FROM topix_daily WHERE date >= ? AND date <= ? ORDER BY date",
+        [start, end],
+    ).fetchall()
+    topix_dates = [r[0] for r in rows]
+
+    if not topix_dates:
+        logger.warning("指定期間に topix_daily データが見つかりません: %s ~ %s", start, end)
+        return 0, 0
+
+    updated = skipped = 0
+    for i, target_date in enumerate(topix_dates, 1):
+        prefix = f"[{i}/{len(topix_dates)}] {target_date}"
+        if dry_run:
+            logger.info("%s — [dry-run] TOPIX MA 更新対象", prefix)
+            updated += 1
+            continue
+        if update_topix_ma(conn, target_date):
+            logger.debug("%s — TOPIX MA 更新完了", prefix)
+            updated += 1
+        else:
+            logger.warning("%s — TOPIX MA 更新スキップ（データなし）", prefix)
+            skipped += 1
+
+    return updated, skipped
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="バックテスト用特徴量バックフィル",
@@ -187,6 +227,12 @@ def main() -> None:
             force=args.force,
             dry_run=args.dry_run,
         )
+        topix_updated, topix_skipped = backfill_topix_ma(
+            conn,
+            start=start_date,
+            end=end_date,
+            dry_run=args.dry_run,
+        )
     except Exception:
         logger.exception("backfill_features が失敗しました")
         sys.exit(1)
@@ -200,6 +246,12 @@ def main() -> None:
         processed,
         skipped,
         no_price,
+    )
+    logger.info(
+        "%sTOPIX MA — 更新: %d 日 / スキップ: %d 日",
+        label,
+        topix_updated,
+        topix_skipped,
     )
 
     if no_price > 0:

--- a/scripts/run_feature_gen.py
+++ b/scripts/run_feature_gen.py
@@ -18,7 +18,7 @@ from kabusys.config import Settings
 from kabusys.operations.job_run_recorder import write_job_result
 from kabusys.operations.night_batch_report import JobRunResult
 from kabusys.operations.process_registry import register_process, update_process
-from kabusys.strategy.feature_engineering import build_features
+from kabusys.strategy.feature_engineering import build_features, update_topix_ma
 from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_logging
 
 _run_log = setup_logging(app_name="feature_gen", capture_stdio=True)
@@ -48,6 +48,10 @@ def main() -> None:
         n = build_features(conn, target_date)
         _updated_rows["features"] = n
         logger.info("特徴量生成完了: %d 件 (date=%s)", n, target_date)
+        if update_topix_ma(conn, target_date):
+            logger.info("TOPIX MA 更新完了 (date=%s)", target_date)
+        else:
+            logger.warning("TOPIX MA 更新スキップ: topix_daily にデータなし (date=%s)", target_date)
     except Exception as exc:
         logger.exception("build_features が失敗しました")
         _errors.append(str(exc))

--- a/src/kabusys/ai/backtest_summarizer.py
+++ b/src/kabusys/ai/backtest_summarizer.py
@@ -95,8 +95,8 @@ def load_latest_summary(conn: duckdb.DuckDBPyConnection) -> str | None:
             f"gap_down_threshold={params.get('gap_down_threshold', 'N/A')}",
             f"min_holding_days={params.get('min_holding_days', 'N/A')}",
             f"max_holding_days={params.get('max_holding_days', 'N/A')}",
-            f"topix_drawdown_threshold={params.get('topix_drawdown_threshold', 'N/A')}",
-            f"topix_size_multiplier_bear={params.get('topix_size_multiplier_bear', 'N/A')}",
+            f"topix_size_multiplier_weak_bear={params.get('topix_size_multiplier_weak_bear', 'N/A')}",
+            f"topix_size_multiplier_strong_bear={params.get('topix_size_multiplier_strong_bear', 'N/A')}",
         ]
         lines += [
             "",

--- a/src/kabusys/ai/config_manager.py
+++ b/src/kabusys/ai/config_manager.py
@@ -29,8 +29,8 @@ _SECTOR_KEY_MAP = {
 
 _REGIME_KEYS = frozenset(
     {
-        "topix_drawdown_threshold",
-        "topix_size_multiplier_bear",
+        "topix_size_multiplier_weak_bear",
+        "topix_size_multiplier_strong_bear",
     }
 )
 
@@ -55,7 +55,7 @@ def apply_params(config_path: Path, params: dict) -> None:
     - weights.*                                 → strategy.weights.*（他は保持）
     - threshold, stop_loss_rate 等               → strategy.*
     - sector_boost, sector_quartile             → sector.boost, sector.quartile
-    - topix_drawdown_threshold 等               → regime.*
+    - topix_size_multiplier_weak_bear 等        → regime.*
 
     YAML 全体を読み込み→パッチ→書き戻す。コメントは失われる。
     """

--- a/src/kabusys/ai/param_extractor.py
+++ b/src/kabusys/ai/param_extractor.py
@@ -20,8 +20,8 @@ ALLOWED_KEYS = frozenset(
         "gap_down_threshold",
         "min_holding_days",
         "max_holding_days",
-        "topix_drawdown_threshold",
-        "topix_size_multiplier_bear",
+        "topix_size_multiplier_weak_bear",
+        "topix_size_multiplier_strong_bear",
     }
 )
 
@@ -45,8 +45,8 @@ _VALUE_RANGES: dict[str, tuple[float, float]] = {
     "gap_down_threshold": (-1.0, 0.0),
     "min_holding_days": (0.0, 365.0),
     "max_holding_days": (1.0, 365.0),
-    "topix_drawdown_threshold": (-1.0, -0.001),
-    "topix_size_multiplier_bear": (0.01, 1.0),
+    "topix_size_multiplier_weak_bear": (0.0, 1.0),
+    "topix_size_multiplier_strong_bear": (0.0, 1.0),
 }
 
 _INT_KEYS = frozenset({"min_holding_days", "max_holding_days"})

--- a/src/kabusys/backtest/engine.py
+++ b/src/kabusys/backtest/engine.py
@@ -472,11 +472,15 @@ def run_backtest(
         )
     if threshold is not None and not (0 < threshold < 1):
         raise ValueError(f"threshold は (0, 1) の範囲で指定してください: {threshold}")
-    if topix_size_multiplier_weak_bear is not None and not (0.0 <= topix_size_multiplier_weak_bear <= 1.0):
+    if topix_size_multiplier_weak_bear is not None and not (
+        0.0 <= topix_size_multiplier_weak_bear <= 1.0
+    ):
         raise ValueError(
             f"topix_size_multiplier_weak_bear は [0, 1] の範囲で指定してください: {topix_size_multiplier_weak_bear}"
         )
-    if topix_size_multiplier_strong_bear is not None and not (0.0 <= topix_size_multiplier_strong_bear <= 1.0):
+    if topix_size_multiplier_strong_bear is not None and not (
+        0.0 <= topix_size_multiplier_strong_bear <= 1.0
+    ):
         raise ValueError(
             f"topix_size_multiplier_strong_bear は [0, 1] の範囲で指定してください: {topix_size_multiplier_strong_bear}"
         )

--- a/src/kabusys/backtest/engine.py
+++ b/src/kabusys/backtest/engine.py
@@ -484,6 +484,15 @@ def run_backtest(
         raise ValueError(
             f"topix_size_multiplier_strong_bear は [0, 1] の範囲で指定してください: {topix_size_multiplier_strong_bear}"
         )
+    if (
+        topix_size_multiplier_weak_bear is not None
+        and topix_size_multiplier_strong_bear is not None
+        and topix_size_multiplier_strong_bear > topix_size_multiplier_weak_bear
+    ):
+        raise ValueError(
+            f"topix_size_multiplier_strong_bear ({topix_size_multiplier_strong_bear}) は"
+            f" topix_size_multiplier_weak_bear ({topix_size_multiplier_weak_bear}) 以下にしてください"
+        )
 
     # try ブロック外でも参照できるようデフォルト初期化
     _scope_mode: Literal["default_universe", "manual_codes"] = (

--- a/src/kabusys/backtest/engine.py
+++ b/src/kabusys/backtest/engine.py
@@ -390,8 +390,8 @@ def run_backtest(
     max_holding_days: int = 60,
     trailing_stop_atr: float = 2.0,
     threshold: float | None = None,
-    topix_drawdown_threshold: float | None = None,
-    topix_size_multiplier_bear: float | None = None,
+    topix_size_multiplier_weak_bear: float | None = None,
+    topix_size_multiplier_strong_bear: float | None = None,
     use_ma200_filter: bool = False,
     volume_breakout_threshold: float | None = None,
     portfolio_drawdown_stop_pct: float | None = None,
@@ -426,10 +426,10 @@ def run_backtest(
                            close < peak_close - trailing_stop_atr × ATR_20d のとき SELL 発動。
                            正の値を指定すること。
         threshold:         BUY シグナル生成の final_score 閾値（None のとき strategy_config.yaml から読み込む）。
-        topix_drawdown_threshold: TOPIX 200MA 乖離率のベア判定閾値（None のとき strategy_config.yaml から読み込む）。
-                           負の値を指定すること（例: -0.12）。
-        topix_size_multiplier_bear: ベア判定時の size_multiplier（None のとき strategy_config.yaml から読み込む）。
-                           0 < x <= 1 の範囲で指定すること。
+        topix_size_multiplier_weak_bear: MA25 < MA75（弱いベア）時の size_multiplier（None のとき strategy_config.yaml から読み込む）。
+                           0 <= x <= 1 の範囲で指定すること。
+        topix_size_multiplier_strong_bear: MA75 < MA200（強いベア）時の size_multiplier（None のとき strategy_config.yaml から読み込む）。
+                           0 <= x <= 1 の範囲で指定すること。
         use_ma200_filter:  True のとき株価が 200 日移動平均線を下回る銘柄の BUY を抑制する。
                            False（デフォルト）で無効。generate_signals() の同名引数に転送。
         volume_breakout_threshold: 指定した場合、volume_ratio が閾値未満の銘柄の BUY を抑制する。
@@ -472,13 +472,13 @@ def run_backtest(
         )
     if threshold is not None and not (0 < threshold < 1):
         raise ValueError(f"threshold は (0, 1) の範囲で指定してください: {threshold}")
-    if topix_drawdown_threshold is not None and topix_drawdown_threshold >= 0:
+    if topix_size_multiplier_weak_bear is not None and not (0.0 <= topix_size_multiplier_weak_bear <= 1.0):
         raise ValueError(
-            f"topix_drawdown_threshold は負の値を指定してください: {topix_drawdown_threshold}"
+            f"topix_size_multiplier_weak_bear は [0, 1] の範囲で指定してください: {topix_size_multiplier_weak_bear}"
         )
-    if topix_size_multiplier_bear is not None and not (0 < topix_size_multiplier_bear <= 1):
+    if topix_size_multiplier_strong_bear is not None and not (0.0 <= topix_size_multiplier_strong_bear <= 1.0):
         raise ValueError(
-            f"topix_size_multiplier_bear は (0, 1] の範囲で指定してください: {topix_size_multiplier_bear}"
+            f"topix_size_multiplier_strong_bear は [0, 1] の範囲で指定してください: {topix_size_multiplier_strong_bear}"
         )
 
     # try ブロック外でも参照できるようデフォルト初期化
@@ -583,8 +583,8 @@ def run_backtest(
                 min_holding_days=min_holding_days,
                 max_holding_days=max_holding_days,
                 trailing_stop_atr=trailing_stop_atr,
-                topix_drawdown_threshold=topix_drawdown_threshold,
-                topix_size_multiplier_bear=topix_size_multiplier_bear,
+                topix_size_multiplier_weak_bear=topix_size_multiplier_weak_bear,
+                topix_size_multiplier_strong_bear=topix_size_multiplier_strong_bear,
             )
 
             # Step 5: ポートフォリオ構築（Phase 5 モジュール使用）

--- a/src/kabusys/backtest/run.py
+++ b/src/kabusys/backtest/run.py
@@ -154,16 +154,16 @@ def main() -> None:
         help="BUY signal score threshold. Overrides strategy_config.yaml when specified.",
     )
     parser.add_argument(
-        "--topix-drawdown-threshold",
+        "--topix-size-multiplier-weak-bear",
         type=float,
         default=None,
-        help="TOPIX 200MA deviation threshold for bear guard (negative value, e.g. -0.12). Overrides strategy_config.yaml when specified.",
+        help="size_multiplier when MA25 < MA75 (weak bear, 0 <= x <= 1). Overrides strategy_config.yaml when specified.",
     )
     parser.add_argument(
-        "--topix-size-multiplier-bear",
+        "--topix-size-multiplier-strong-bear",
         type=float,
         default=None,
-        help="size_multiplier applied when TOPIX bear guard triggers (0 < x <= 1). Overrides strategy_config.yaml when specified.",
+        help="size_multiplier when MA75 < MA200 (strong bear, 0 <= x <= 1). Overrides strategy_config.yaml when specified.",
     )
     parser.add_argument(
         "--ma200-filter",
@@ -253,8 +253,8 @@ def main() -> None:
             max_holding_days=args.max_holding_days,
             trailing_stop_atr=args.trailing_stop_atr,
             threshold=args.threshold,
-            topix_drawdown_threshold=args.topix_drawdown_threshold,
-            topix_size_multiplier_bear=args.topix_size_multiplier_bear,
+            topix_size_multiplier_weak_bear=args.topix_size_multiplier_weak_bear,
+            topix_size_multiplier_strong_bear=args.topix_size_multiplier_strong_bear,
             use_ma200_filter=args.ma200_filter,
             volume_breakout_threshold=args.volume_breakout_threshold,
             portfolio_drawdown_stop_pct=args.portfolio_drawdown_stop,

--- a/src/kabusys/data/schema.py
+++ b/src/kabusys/data/schema.py
@@ -379,7 +379,10 @@ CREATE TABLE IF NOT EXISTS topix_daily (
     open   DECIMAL(18,4) NOT NULL,
     high   DECIMAL(18,4) NOT NULL,
     low    DECIMAL(18,4) NOT NULL,
-    close  DECIMAL(18,4) NOT NULL
+    close  DECIMAL(18,4) NOT NULL,
+    ma25   DOUBLE,
+    ma75   DOUBLE,
+    ma200  DOUBLE
 )
 """
 
@@ -493,6 +496,10 @@ _MIGRATIONS: list[str] = [
     "ALTER TABLE features ADD COLUMN IF NOT EXISTS quality_score DOUBLE",
     # Issue #338: features に RSI(14) を追加
     "ALTER TABLE features ADD COLUMN IF NOT EXISTS rsi_14 DOUBLE",
+    # Issue #349: topix_daily に MA 列を追加
+    "ALTER TABLE topix_daily ADD COLUMN IF NOT EXISTS ma25 DOUBLE",
+    "ALTER TABLE topix_daily ADD COLUMN IF NOT EXISTS ma75 DOUBLE",
+    "ALTER TABLE topix_daily ADD COLUMN IF NOT EXISTS ma200 DOUBLE",
 ]
 
 # ---------------------------------------------------------------------------

--- a/src/kabusys/monitoring/components/param_review.py
+++ b/src/kabusys/monitoring/components/param_review.py
@@ -27,8 +27,8 @@ _DISPLAY_NAMES: dict[str, str] = {
     "gap_down_threshold": "gap_down_threshold（ギャップダウン閾値）",
     "sector_boost": "sector_boost（セクターブースト）",
     "sector_quartile": "sector_quartile（セクター区切り）",
-    "topix_drawdown_threshold": "topix_drawdown_threshold（TOPIX 下落閾値）",
-    "topix_size_multiplier_bear": "topix_size_multiplier_bear（弱気相場サイズ係数）",
+    "topix_size_multiplier_weak_bear": "topix_size_multiplier_weak_bear（弱いベア時サイズ係数）",
+    "topix_size_multiplier_strong_bear": "topix_size_multiplier_strong_bear（強いベア時サイズ係数）",
 }
 
 
@@ -64,7 +64,7 @@ def _read_current_params(config_path: Path) -> dict:
         result["sector_quartile"] = sec["quartile"]
 
     reg = data.get("regime", {}) or {}
-    for key in ("topix_drawdown_threshold", "topix_size_multiplier_bear"):
+    for key in ("topix_size_multiplier_weak_bear", "topix_size_multiplier_strong_bear"):
         if key in reg:
             result[key] = reg[key]
 

--- a/src/kabusys/strategy/feature_engineering.py
+++ b/src/kabusys/strategy/feature_engineering.py
@@ -238,3 +238,50 @@ def build_features(
     count = len(normalized)
     logger.info("build_features: %d 銘柄 date=%s", count, target_date)
     return count
+
+
+# ---------------------------------------------------------------------------
+# TOPIX MA 事前計算
+# ---------------------------------------------------------------------------
+
+
+def ensure_topix_ma_columns(conn: duckdb.DuckDBPyConnection) -> None:
+    """既存 DB に ma25/ma75/ma200 列がなければ追加する（冪等）。"""
+    for col in ("ma25", "ma75", "ma200"):
+        conn.execute(f"ALTER TABLE topix_daily ADD COLUMN IF NOT EXISTS {col} DOUBLE")
+
+
+def update_topix_ma(conn: duckdb.DuckDBPyConnection, target_date: date) -> bool:
+    """target_date の TOPIX MA25/MA75/MA200 を計算して topix_daily に保存する。
+
+    データ不足の場合は対応 MA を NULL にして保存する。
+    対象日付のレコードがない場合は False を返す。
+    """
+    row = conn.execute(
+        """
+        WITH topix_data AS (
+            SELECT date, close,
+                   CASE WHEN COUNT(*) OVER (ORDER BY date ROWS BETWEEN 24 PRECEDING AND CURRENT ROW) >= 25
+                        THEN AVG(close) OVER (ORDER BY date ROWS BETWEEN 24 PRECEDING AND CURRENT ROW)
+                        ELSE NULL END AS ma25,
+                   CASE WHEN COUNT(*) OVER (ORDER BY date ROWS BETWEEN 74 PRECEDING AND CURRENT ROW) >= 75
+                        THEN AVG(close) OVER (ORDER BY date ROWS BETWEEN 74 PRECEDING AND CURRENT ROW)
+                        ELSE NULL END AS ma75,
+                   CASE WHEN COUNT(*) OVER (ORDER BY date ROWS BETWEEN 199 PRECEDING AND CURRENT ROW) >= 200
+                        THEN AVG(close) OVER (ORDER BY date ROWS BETWEEN 199 PRECEDING AND CURRENT ROW)
+                        ELSE NULL END AS ma200
+            FROM topix_daily
+        )
+        SELECT ma25, ma75, ma200 FROM topix_data WHERE date = ?
+        """,
+        [target_date],
+    ).fetchone()
+
+    if row is None:
+        return False
+
+    conn.execute(
+        "UPDATE topix_daily SET ma25 = ?, ma75 = ?, ma200 = ? WHERE date = ?",
+        [row[0], row[1], row[2], target_date],
+    )
+    return True

--- a/src/kabusys/strategy/feature_engineering.py
+++ b/src/kabusys/strategy/feature_engineering.py
@@ -256,7 +256,10 @@ def update_topix_ma(conn: duckdb.DuckDBPyConnection, target_date: date) -> bool:
 
     データ不足の場合は対応 MA を NULL にして保存する。
     対象日付のレコードがない場合は False を返す。
+    既存 DB に MA 列がなければ冪等に追加してから計算する。
     """
+    ensure_topix_ma_columns(conn)
+
     row = conn.execute(
         """
         WITH topix_data AS (
@@ -271,10 +274,11 @@ def update_topix_ma(conn: duckdb.DuckDBPyConnection, target_date: date) -> bool:
                         THEN AVG(close) OVER (ORDER BY date ROWS BETWEEN 199 PRECEDING AND CURRENT ROW)
                         ELSE NULL END AS ma200
             FROM topix_daily
+            WHERE date <= ?
         )
         SELECT ma25, ma75, ma200 FROM topix_data WHERE date = ?
         """,
-        [target_date],
+        [target_date, target_date],
     ).fetchone()
 
     if row is None:

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -74,9 +74,8 @@ _MAX_HOLDING_DAYS: int = 60  # この営業日数を超えた保有は time_exit
 _TRAILING_STOP_ATR_MULT: float = 2.0  # peak_close から ATR × N 下落で trailing_stop SELL を発動
 _REENTRY_COOLDOWN_DAYS: int = 5  # SELL 後この営業日数を経過するまで同一銘柄の BUY を禁止
 
-_TOPIX_DRAWDOWN_THRESHOLD: float = -0.15  # 200MA 乖離率がこの値未満で縮小
-_TOPIX_SIZE_MULTIPLIER_BEAR: float = 0.5  # 地合い悪化時の size_multiplier
-_TOPIX_MIN_DATA_COUNT: int = 100  # 200MA を信頼できる最低データ数（初期運用でのデータ蓄積期間を考慮し 200 でなく 100 に設定）
+_TOPIX_SIZE_MULTIPLIER_WEAK_BEAR: float = 0.5   # MA25 < MA75（弱いベア）の size_multiplier
+_TOPIX_SIZE_MULTIPLIER_STRONG_BEAR: float = 0.0  # MA75 < MA200（強いベア）の size_multiplier
 
 _RSI_OVERBOUGHT_THRESHOLD: float = 65.0  # RSI(14) > この値の銘柄は BUY 抑制（過熱判定）
 
@@ -111,8 +110,8 @@ _STRATEGY_CONFIG_DEFAULTS: dict = {
     "reentry_cooldown_days": _REENTRY_COOLDOWN_DAYS,
     "sector_boost": _SECTOR_BOOST,
     "sector_quartile": _SECTOR_QUARTILE,
-    "topix_drawdown_threshold": _TOPIX_DRAWDOWN_THRESHOLD,
-    "topix_size_multiplier_bear": _TOPIX_SIZE_MULTIPLIER_BEAR,
+    "topix_size_multiplier_weak_bear": _TOPIX_SIZE_MULTIPLIER_WEAK_BEAR,
+    "topix_size_multiplier_strong_bear": _TOPIX_SIZE_MULTIPLIER_STRONG_BEAR,
     "rsi_overbought_threshold": _RSI_OVERBOUGHT_THRESHOLD,
 }
 
@@ -142,8 +141,8 @@ def _load_strategy_config() -> dict:
             "reentry_cooldown_days": int,
             "sector_boost": float,
             "sector_quartile": float,
-            "topix_drawdown_threshold": float,
-            "topix_size_multiplier_bear": float,
+            "topix_size_multiplier_weak_bear": float,
+            "topix_size_multiplier_strong_bear": float,
             "rsi_overbought_threshold": float,
         }
     """
@@ -270,25 +269,25 @@ def _load_strategy_config() -> dict:
     # regime セクション
     reg = data.get("regime")
     if isinstance(reg, dict):
-        v = reg.get("topix_drawdown_threshold")
+        v = reg.get("topix_size_multiplier_weak_bear")
         if (
             v is not None
             and isinstance(v, (int, float))
             and not isinstance(v, bool)
             and math.isfinite(float(v))
-            and float(v) < 0
+            and 0.0 <= float(v) <= 1.0
         ):
-            result["topix_drawdown_threshold"] = float(v)
+            result["topix_size_multiplier_weak_bear"] = float(v)
 
-        v = reg.get("topix_size_multiplier_bear")
+        v = reg.get("topix_size_multiplier_strong_bear")
         if (
             v is not None
             and isinstance(v, (int, float))
             and not isinstance(v, bool)
             and math.isfinite(float(v))
-            and 0.0 < float(v) <= 1.0
+            and 0.0 <= float(v) <= 1.0
         ):
-            result["topix_size_multiplier_bear"] = float(v)
+            result["topix_size_multiplier_strong_bear"] = float(v)
 
     # rsi_overbought_threshold: strategy セクション配下（50 < x <= 100）
     v = s.get("rsi_overbought_threshold") if isinstance(s, dict) else None
@@ -517,39 +516,34 @@ def _is_breadth_stop(
 def _get_topix_size_multiplier(
     conn: duckdb.DuckDBPyConnection,
     target_date: date,
-    drawdown_threshold: float = _TOPIX_DRAWDOWN_THRESHOLD,
-    size_multiplier_bear: float = _TOPIX_SIZE_MULTIPLIER_BEAR,
+    size_multiplier_weak_bear: float = _TOPIX_SIZE_MULTIPLIER_WEAK_BEAR,
+    size_multiplier_strong_bear: float = _TOPIX_SIZE_MULTIPLIER_STRONG_BEAR,
 ) -> float:
-    """TOPIX の 200 日移動平均乖離率に基づく size_multiplier を返す。
+    """TOPIX の MA クロス状態に基づく size_multiplier を返す。
 
-    TOPIX の 200 日 MA に対する乖離率が drawdown_threshold 未満（より低い側）の場合は
-    size_multiplier_bear を返す。
-    データ不足または topix_daily が空の場合は 1.0 を返す（制限なし）。
+    topix_daily に事前計算済みの ma25/ma75/ma200 を参照する。
+    - MA75 < MA200（強いベア）: size_multiplier_strong_bear を返す（デフォルト 0.0）
+    - MA25 < MA75（弱いベア）: size_multiplier_weak_bear を返す（デフォルト 0.5）
+    - それ以外（強気）: 1.0 を返す
+    - MA が NULL（データ不足）またはレコードなし: 1.0 を返す
 
     Args:
-        conn:                DuckDB 接続。topix_daily テーブルを参照する。
-        target_date:         基準日（この日以前の最新 TOPIX を使用）。
-        drawdown_threshold:  Bear 判定の乖離率閾値（デフォルト: _TOPIX_DRAWDOWN_THRESHOLD）。
-        size_multiplier_bear: Bear 時の size_multiplier（デフォルト: _TOPIX_SIZE_MULTIPLIER_BEAR）。
+        conn:                       DuckDB 接続。topix_daily テーブルを参照する。
+        target_date:                基準日（この日以前の最新 TOPIX を使用）。
+        size_multiplier_weak_bear:  弱いベア時の size_multiplier（MA25 < MA75）。
+        size_multiplier_strong_bear: 強いベア時の size_multiplier（MA75 < MA200）。
 
     Returns:
-        size_multiplier（size_multiplier_bear または 1.0）。
+        size_multiplier（0.0、0.5、または 1.0）。
     """
     try:
         row = conn.execute(
             """
-            WITH topix_data AS (
-                SELECT date, close,
-                       AVG(close) OVER (ORDER BY date ROWS BETWEEN 199 PRECEDING AND CURRENT ROW) AS ma200,
-                       COUNT(*) OVER (ORDER BY date ROWS BETWEEN 199 PRECEDING AND CURRENT ROW) AS cnt
-                FROM topix_daily
-                WHERE date <= ?
-            )
-            SELECT close, ma200, cnt
-            FROM topix_data
+            SELECT ma25, ma75, ma200
+            FROM topix_daily
             WHERE date = (SELECT MAX(date) FROM topix_daily WHERE date <= ?)
             """,
-            [target_date, target_date],
+            [target_date],
         ).fetchone()
     except Exception:
         logger.debug(
@@ -558,11 +552,14 @@ def _get_topix_size_multiplier(
         )
         return 1.0
 
-    if row is None or row[1] is None or row[2] < _TOPIX_MIN_DATA_COUNT:
+    if row is None or row[0] is None or row[1] is None or row[2] is None:
         return 1.0
-    close, ma200, _ = float(row[0]), float(row[1]), row[2]
-    if ma200 > 0 and (close / ma200 - 1.0) < drawdown_threshold:
-        return size_multiplier_bear
+
+    ma25, ma75, ma200 = float(row[0]), float(row[1]), float(row[2])
+    if ma75 < ma200:
+        return size_multiplier_strong_bear
+    if ma25 < ma75:
+        return size_multiplier_weak_bear
     return 1.0
 
 
@@ -1101,8 +1098,8 @@ def generate_signals(
     min_holding_days: int | None = None,
     max_holding_days: int | None = None,
     trailing_stop_atr: float | None = None,
-    topix_drawdown_threshold: float | None = None,
-    topix_size_multiplier_bear: float | None = None,
+    topix_size_multiplier_weak_bear: float | None = None,
+    topix_size_multiplier_strong_bear: float | None = None,
     use_ma200_filter: bool = False,
     volume_breakout_threshold: float | None = None,
     *,
@@ -1128,10 +1125,9 @@ def generate_signals(
                            1 以上を指定すること。
         trailing_stop_atr: ATR 乗数。peak_close − N×ATR を下回ったら trailing_stop SELL。
                            正の値を指定すること（None の場合は config から読み込む）。
-        topix_drawdown_threshold: TOPIX 200MA 乖離率のベア判定閾値（負の値、例: -0.12）。
-                           この値未満のとき size_multiplier_bear を適用する。
+        topix_size_multiplier_weak_bear: MA25 < MA75（弱いベア）時の BUY size_multiplier（0 <= x <= 1）。
                            None の場合は strategy_config.yaml から読み込む。
-        topix_size_multiplier_bear: ベア判定時の BUY size_multiplier（0 < x <= 1）。
+        topix_size_multiplier_strong_bear: MA75 < MA200（強いベア）時の BUY size_multiplier（0 <= x <= 1）。
                            None の場合は strategy_config.yaml から読み込む。
         use_ma200_filter:  True のとき株価が 200 日移動平均線を下回る銘柄（ma200_dev < 0）
                            の BUY を抑制する。ma200_dev が None の場合は安全側で BUY 許可。
@@ -1205,15 +1201,15 @@ def generate_signals(
     topix_multiplier = _get_topix_size_multiplier(
         conn,
         target_date,
-        drawdown_threshold=(
-            topix_drawdown_threshold
-            if topix_drawdown_threshold is not None
-            else _cfg["topix_drawdown_threshold"]
+        size_multiplier_weak_bear=(
+            topix_size_multiplier_weak_bear
+            if topix_size_multiplier_weak_bear is not None
+            else _cfg["topix_size_multiplier_weak_bear"]
         ),
-        size_multiplier_bear=(
-            topix_size_multiplier_bear
-            if topix_size_multiplier_bear is not None
-            else _cfg["topix_size_multiplier_bear"]
+        size_multiplier_strong_bear=(
+            topix_size_multiplier_strong_bear
+            if topix_size_multiplier_strong_bear is not None
+            else _cfg["topix_size_multiplier_strong_bear"]
         ),
     )
     size_multiplier = min(size_multiplier, topix_multiplier)

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -522,10 +522,11 @@ def _get_topix_size_multiplier(
     """TOPIX の MA クロス状態に基づく size_multiplier を返す。
 
     topix_daily に事前計算済みの ma25/ma75/ma200 を参照する。
+    強いベア判定（MA75 < MA200）が弱いベア（MA25 < MA75）に常に優先する。
     - MA75 < MA200（強いベア）: size_multiplier_strong_bear を返す（デフォルト 0.0）
     - MA25 < MA75（弱いベア）: size_multiplier_weak_bear を返す（デフォルト 0.5）
     - それ以外（強気）: 1.0 を返す
-    - MA が NULL（データ不足）またはレコードなし: 1.0 を返す
+    - MA が NULL（データ不足）またはレコードなし: 安全側フォールバックとして 1.0 を返す
 
     Args:
         conn:                       DuckDB 接続。topix_daily テーブルを参照する。

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -74,7 +74,7 @@ _MAX_HOLDING_DAYS: int = 60  # この営業日数を超えた保有は time_exit
 _TRAILING_STOP_ATR_MULT: float = 2.0  # peak_close から ATR × N 下落で trailing_stop SELL を発動
 _REENTRY_COOLDOWN_DAYS: int = 5  # SELL 後この営業日数を経過するまで同一銘柄の BUY を禁止
 
-_TOPIX_SIZE_MULTIPLIER_WEAK_BEAR: float = 0.5   # MA25 < MA75（弱いベア）の size_multiplier
+_TOPIX_SIZE_MULTIPLIER_WEAK_BEAR: float = 0.5  # MA25 < MA75（弱いベア）の size_multiplier
 _TOPIX_SIZE_MULTIPLIER_STRONG_BEAR: float = 0.0  # MA75 < MA200（強いベア）の size_multiplier
 
 _RSI_OVERBOUGHT_THRESHOLD: float = 65.0  # RSI(14) > この値の銘柄は BUY 抑制（過熱判定）

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -535,7 +535,7 @@ def _get_topix_size_multiplier(
         size_multiplier_strong_bear: 強いベア時の size_multiplier（MA75 < MA200）。
 
     Returns:
-        size_multiplier（0.0、0.5、または 1.0）。
+        size_multiplier（設定値に依存。デフォルトは strong_bear=0.0 / weak_bear=0.5 / bull=1.0）。
     """
     try:
         row = conn.execute(
@@ -1199,19 +1199,27 @@ def generate_signals(
 
     event_dates = event_dates or {}
     size_multiplier = _get_event_size_multiplier(event_dates, target_date, conn)
+
+    _weak_bear: float = (
+        topix_size_multiplier_weak_bear
+        if topix_size_multiplier_weak_bear is not None
+        else _cfg["topix_size_multiplier_weak_bear"]
+    )
+    _strong_bear: float = (
+        topix_size_multiplier_strong_bear
+        if topix_size_multiplier_strong_bear is not None
+        else _cfg["topix_size_multiplier_strong_bear"]
+    )
+    if _strong_bear > _weak_bear:
+        raise ValueError(
+            f"topix_size_multiplier_strong_bear ({_strong_bear}) は"
+            f" topix_size_multiplier_weak_bear ({_weak_bear}) 以下にしてください"
+        )
     topix_multiplier = _get_topix_size_multiplier(
         conn,
         target_date,
-        size_multiplier_weak_bear=(
-            topix_size_multiplier_weak_bear
-            if topix_size_multiplier_weak_bear is not None
-            else _cfg["topix_size_multiplier_weak_bear"]
-        ),
-        size_multiplier_strong_bear=(
-            topix_size_multiplier_strong_bear
-            if topix_size_multiplier_strong_bear is not None
-            else _cfg["topix_size_multiplier_strong_bear"]
-        ),
+        size_multiplier_weak_bear=_weak_bear,
+        size_multiplier_strong_bear=_strong_bear,
     )
     size_multiplier = min(size_multiplier, topix_multiplier)
 

--- a/tests/test_backtest_engine_params.py
+++ b/tests/test_backtest_engine_params.py
@@ -223,6 +223,21 @@ def test_run_backtest_portfolio_drawdown_stop_pct_default_is_none():
     assert param.default is None
 
 
+def test_strong_bear_greater_than_weak_bear_raises():
+    """topix_size_multiplier_strong_bear > weak_bear のとき ValueError が上がること。"""
+    from kabusys.backtest.engine import run_backtest
+
+    with pytest.raises(ValueError, match="topix_size_multiplier_strong_bear"):
+        run_backtest(
+            conn=None,  # type: ignore[arg-type]
+            start_date=date(2025, 1, 6),
+            end_date=date(2025, 1, 10),
+            initial_cash=1_000_000,
+            topix_size_multiplier_weak_bear=0.5,
+            topix_size_multiplier_strong_bear=0.8,
+        )
+
+
 def test_run_py_cli_has_portfolio_drawdown_stop_arg():
     import os
     import pathlib

--- a/tests/test_backtest_engine_params.py
+++ b/tests/test_backtest_engine_params.py
@@ -61,17 +61,17 @@ def test_run_backtest_accepts_threshold_param():
 
 
 def test_run_backtest_accepts_topix_params():
-    """run_backtest() が topix_drawdown_threshold / topix_size_multiplier_bear を受け取れること。"""
+    """run_backtest() が topix_size_multiplier_weak_bear / topix_size_multiplier_strong_bear を受け取れること。"""
     import inspect
 
     from kabusys.backtest.engine import run_backtest
 
     sig = inspect.signature(run_backtest)
-    assert "topix_drawdown_threshold" in sig.parameters, (
-        "run_backtest() に topix_drawdown_threshold パラメータが存在しない"
+    assert "topix_size_multiplier_weak_bear" in sig.parameters, (
+        "run_backtest() に topix_size_multiplier_weak_bear パラメータが存在しない"
     )
-    assert "topix_size_multiplier_bear" in sig.parameters, (
-        "run_backtest() に topix_size_multiplier_bear パラメータが存在しない"
+    assert "topix_size_multiplier_strong_bear" in sig.parameters, (
+        "run_backtest() に topix_size_multiplier_strong_bear パラメータが存在しない"
     )
 
 
@@ -117,7 +117,7 @@ def test_run_py_cli_has_threshold_arg():
 
 
 def test_run_py_cli_has_topix_args():
-    """kabusys.backtest.run の argparse に --topix-drawdown-threshold / --topix-size-multiplier-bear が定義されていること。"""
+    """kabusys.backtest.run の argparse に --topix-size-multiplier-weak-bear / --topix-size-multiplier-strong-bear が定義されていること。"""
     import argparse
     import importlib
     from unittest.mock import patch
@@ -139,11 +139,11 @@ def test_run_py_cli_has_topix_args():
 
     assert captured
     actions = {a.dest for a in captured[0]._actions}
-    assert "topix_drawdown_threshold" in actions, (
-        f"--topix-drawdown-threshold が argparse に定義されていない: {actions}"
+    assert "topix_size_multiplier_weak_bear" in actions, (
+        f"--topix-size-multiplier-weak-bear が argparse に定義されていない: {actions}"
     )
-    assert "topix_size_multiplier_bear" in actions, (
-        f"--topix-size-multiplier-bear が argparse に定義されていない: {actions}"
+    assert "topix_size_multiplier_strong_bear" in actions, (
+        f"--topix-size-multiplier-strong-bear が argparse に定義されていない: {actions}"
     )
 
 

--- a/tests/test_backtest_summarizer.py
+++ b/tests/test_backtest_summarizer.py
@@ -44,8 +44,8 @@ _SAMPLE_PARAMS = {
     "gap_down_threshold": -0.04,
     "min_holding_days": 5,
     "max_holding_days": 60,
-    "topix_drawdown_threshold": -0.15,
-    "topix_size_multiplier_bear": 0.5,
+    "topix_size_multiplier_weak_bear": 0.5,
+    "topix_size_multiplier_strong_bear": 0.0,
 }
 
 
@@ -106,7 +106,7 @@ class TestLoadLatestSummary:
         assert result is not None
         assert "stop_loss_rate=-0.08" in result
         assert "trailing_stop_atr_mult=2.0" in result
-        assert "topix_drawdown_threshold=-0.15" in result
+        assert "topix_size_multiplier_weak_bear=0.5" in result
 
     def test_invalid_params_json_no_crash(self, bt_conn):
         bt_conn.execute(

--- a/tests/test_bootstrap_schema.py
+++ b/tests/test_bootstrap_schema.py
@@ -35,7 +35,7 @@ def test_topix_daily_table_exists(schema_conn):
         "SELECT column_name FROM information_schema.columns WHERE table_name='topix_daily'"
     ).fetchall()
     cols = {r[0] for r in rows}
-    assert cols == {"date", "open", "high", "low", "close"}
+    assert cols == {"date", "open", "high", "low", "close", "ma25", "ma75", "ma200"}
 
 
 def test_bootstrap_load_history_table_exists(schema_conn):

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -32,8 +32,8 @@ def config_file(tmp_path: Path) -> Path:
         },
         "sector": {"boost": 0.03, "quartile": 0.25},
         "regime": {
-            "topix_drawdown_threshold": -0.15,
-            "topix_size_multiplier_bear": 0.5,
+            "topix_size_multiplier_weak_bear": 0.5,
+            "topix_size_multiplier_strong_bear": 0.0,
         },
     }
     cfg.write_text(yaml.dump(content, allow_unicode=True), encoding="utf-8")
@@ -110,13 +110,13 @@ class TestApplyParams:
         apply_params(
             config_file,
             {
-                "topix_drawdown_threshold": -0.20,
-                "topix_size_multiplier_bear": 0.3,
+                "topix_size_multiplier_weak_bear": 0.3,
+                "topix_size_multiplier_strong_bear": 0.0,
             },
         )
         data = yaml.safe_load(config_file.read_text(encoding="utf-8"))
-        assert data["regime"]["topix_drawdown_threshold"] == pytest.approx(-0.20)
-        assert data["regime"]["topix_size_multiplier_bear"] == pytest.approx(0.3)
+        assert data["regime"]["topix_size_multiplier_weak_bear"] == pytest.approx(0.3)
+        assert data["regime"]["topix_size_multiplier_strong_bear"] == pytest.approx(0.0)
 
     def test_trailing_stop_updated(self, config_file):
         from kabusys.ai.config_manager import apply_params

--- a/tests/test_param_review.py
+++ b/tests/test_param_review.py
@@ -32,8 +32,8 @@ def config_file(tmp_path: Path) -> Path:
         },
         "sector": {"boost": 0.03, "quartile": 0.25},
         "regime": {
-            "topix_drawdown_threshold": -0.15,
-            "topix_size_multiplier_bear": 0.5,
+            "topix_size_multiplier_weak_bear": 0.5,
+            "topix_size_multiplier_strong_bear": 0.0,
         },
     }
     cfg.write_text(yaml.dump(content, allow_unicode=True), encoding="utf-8")

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -1245,3 +1245,38 @@ class TestVolumeBreakoutFilter:
             ).fetchall()
         ]
         assert "9004" in buy_codes
+
+
+class TestGenerateSignalsTopixMultiplierValidation:
+    """generate_signals() が YAML 設定値で strong_bear > weak_bear のとき ValueError を上げること。"""
+
+    def test_yaml_strong_bear_greater_than_weak_bear_raises(self, conn, tmp_path, monkeypatch):
+        import kabusys.strategy.signal_generator as _sg
+
+        yaml_text = """
+strategy:
+  weights: {momentum: 1.0, value: 0.0, volatility: 0.0, liquidity: 0.0, news: 0.0}
+  threshold: 0.5
+  stop_loss_rate: -0.08
+  trailing_stop_atr_mult: 2.0
+  min_holding_days: 1
+  max_holding_days: 60
+  gap_up_threshold: 0.05
+  gap_down_threshold: -0.03
+sector:
+  boost: 0.03
+  quartile: 0.25
+regime:
+  topix_size_multiplier_weak_bear: 0.3
+  topix_size_multiplier_strong_bear: 0.8
+"""
+        cfg_file = tmp_path / "strategy_config.yaml"
+        cfg_file.write_text(yaml_text, encoding="utf-8")
+        monkeypatch.setattr(_sg, "_STRATEGY_CONFIG_PATH", cfg_file)
+        monkeypatch.setattr(_sg, "_strategy_config_cache", None)
+        monkeypatch.setattr(_sg, "_strategy_config_mtime", -1.0)
+
+        from kabusys.strategy.signal_generator import generate_signals
+
+        with pytest.raises(ValueError, match="topix_size_multiplier_strong_bear"):
+            generate_signals(conn, TARGET_DATE)

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -676,17 +676,13 @@ class TestGetTopixSizeMultiplier:
     def test_custom_weak_bear_multiplier(self, conn):
         """カスタム size_multiplier_weak_bear が適用される。"""
         self._insert_topix_with_ma(conn, TARGET_DATE, 1950.0, 2000.0, 1980.0)
-        result = _get_topix_size_multiplier(
-            conn, TARGET_DATE, size_multiplier_weak_bear=0.3
-        )
+        result = _get_topix_size_multiplier(conn, TARGET_DATE, size_multiplier_weak_bear=0.3)
         assert result == 0.3
 
     def test_custom_strong_bear_multiplier(self, conn):
         """カスタム size_multiplier_strong_bear が適用される。"""
         self._insert_topix_with_ma(conn, TARGET_DATE, 1900.0, 1950.0, 2000.0)
-        result = _get_topix_size_multiplier(
-            conn, TARGET_DATE, size_multiplier_strong_bear=0.25
-        )
+        result = _get_topix_size_multiplier(conn, TARGET_DATE, size_multiplier_strong_bear=0.25)
         assert result == 0.25
 
     def test_uses_latest_date_not_after_target(self, conn):
@@ -763,18 +759,24 @@ regime:
         assert cfg["sector_quartile"] == 0.25  # default
 
     def test_topix_weak_bear_over_one_falls_back(self, tmp_path, monkeypatch):
-        yaml_text = "strategy:\n  threshold: 0.60\nregime:\n  topix_size_multiplier_weak_bear: 1.5\n"
+        yaml_text = (
+            "strategy:\n  threshold: 0.60\nregime:\n  topix_size_multiplier_weak_bear: 1.5\n"
+        )
         cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
         assert cfg["topix_size_multiplier_weak_bear"] == 0.5  # default
 
     def test_topix_weak_bear_exactly_one_accepted(self, tmp_path, monkeypatch):
-        yaml_text = "strategy:\n  threshold: 0.60\nregime:\n  topix_size_multiplier_weak_bear: 1.0\n"
+        yaml_text = (
+            "strategy:\n  threshold: 0.60\nregime:\n  topix_size_multiplier_weak_bear: 1.0\n"
+        )
         cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
         assert cfg["topix_size_multiplier_weak_bear"] == 1.0
 
     def test_topix_strong_bear_zero_accepted(self, tmp_path, monkeypatch):
         """strong_bear=0.0 は有効（エントリー完全停止を意味する）。"""
-        yaml_text = "strategy:\n  threshold: 0.60\nregime:\n  topix_size_multiplier_strong_bear: 0.0\n"
+        yaml_text = (
+            "strategy:\n  threshold: 0.60\nregime:\n  topix_size_multiplier_strong_bear: 0.0\n"
+        )
         cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
         assert cfg["topix_size_multiplier_strong_bear"] == 0.0
 

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -613,79 +613,89 @@ def test_generate_signals_no_ai_warning_when_ai_disabled(conn, monkeypatch, capl
 
 
 # ---------------------------------------------------------------------------
-# Task 6: TOPIX 200MA 乖離率に基づく size_multiplier 縮小
+# Task 6: TOPIX MA クロスに基づく size_multiplier 縮小
 # ---------------------------------------------------------------------------
 
 from kabusys.strategy.signal_generator import _get_topix_size_multiplier  # noqa: E402
 
 
 class TestGetTopixSizeMultiplier:
-    """TOPIX 200MA 乖離率に基づく size_multiplier のテスト。"""
+    """TOPIX MA25/MA75/MA200 クロスに基づく size_multiplier のテスト。"""
 
-    def _insert_topix(self, conn, rows: list[tuple]) -> None:
-        conn.executemany(
-            "INSERT INTO topix_daily (date, open, high, low, close) VALUES (?, ?, ?, ?, ?) "
-            "ON CONFLICT DO NOTHING",
-            rows,
+    def _insert_topix_with_ma(
+        self,
+        conn,
+        target_date: date,
+        ma25: float | None,
+        ma75: float | None,
+        ma200: float | None,
+    ) -> None:
+        """target_date に MA 列付きで topix_daily へ1行挿入する。"""
+        conn.execute(
+            "INSERT INTO topix_daily (date, open, high, low, close, ma25, ma75, ma200) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            [target_date, 2000.0, 2000.0, 2000.0, 2000.0, ma25, ma75, ma200],
         )
 
-    def _make_topix_series(
-        self, conn, start: date, days: int, start_close: float, end_close: float
-    ) -> None:
-        from datetime import timedelta
-
-        rows = []
-        for i in range(days):
-            d = start + timedelta(days=i)
-            c = start_close + (end_close - start_close) * i / max(days - 1, 1)
-            rows.append((d, c, c, c, c))
-        self._insert_topix(conn, rows)
-
     def test_returns_1_when_no_topix_data(self, conn):
+        """topix_daily にデータがない場合は 1.0 を返す（エントリー規制なし）。"""
         assert _get_topix_size_multiplier(conn, TARGET_DATE) == 1.0
 
-    def test_returns_1_when_above_ma200(self, conn):
-        self._make_topix_series(conn, TARGET_DATE - timedelta(days=250), 250, 2000.0, 2000.0)
+    def test_returns_1_when_all_ma_none(self, conn):
+        """MA 列がすべて NULL（データ不足）のとき 1.0 を返す。"""
+        self._insert_topix_with_ma(conn, TARGET_DATE, None, None, None)
         assert _get_topix_size_multiplier(conn, TARGET_DATE) == 1.0
 
-    def test_returns_05_when_below_ma200_by_15_percent(self, conn):
-        from datetime import timedelta
+    def test_returns_1_in_bull_market(self, conn):
+        """MA25 > MA75 > MA200 のとき（強気相場）1.0 を返す。"""
+        # MA25 > MA75 > MA200
+        self._insert_topix_with_ma(conn, TARGET_DATE, 2100.0, 2050.0, 2000.0)
+        assert _get_topix_size_multiplier(conn, TARGET_DATE) == 1.0
 
-        self._make_topix_series(conn, TARGET_DATE - timedelta(days=250), 240, 2000.0, 2000.0)
-        # 直近 10 日を 1600 に設定（200MA ≈ 2000 なので乖離率 ≈ -0.20）
-        recent_start = TARGET_DATE - timedelta(days=10)
-        self._make_topix_series(conn, recent_start, 11, 1600.0, 1600.0)
+    def test_returns_weak_bear_when_ma25_below_ma75(self, conn):
+        """MA25 < MA75 かつ MA75 > MA200 のとき（弱いベア）size_multiplier_weak_bear を返す。"""
+        # MA25 < MA75、MA75 > MA200
+        self._insert_topix_with_ma(conn, TARGET_DATE, 1950.0, 2000.0, 1980.0)
         result = _get_topix_size_multiplier(conn, TARGET_DATE)
-        assert result == 0.5
+        assert result == 0.5  # デフォルト weak_bear
 
-    def test_returns_1_when_insufficient_data(self, conn):
-        from datetime import timedelta
+    def test_returns_strong_bear_when_ma75_below_ma200(self, conn):
+        """MA75 < MA200 のとき（強いベア）size_multiplier_strong_bear を返す。"""
+        # MA75 < MA200（強いベア）
+        self._insert_topix_with_ma(conn, TARGET_DATE, 1900.0, 1950.0, 2000.0)
+        result = _get_topix_size_multiplier(conn, TARGET_DATE)
+        assert result == 0.0  # デフォルト strong_bear
 
-        self._make_topix_series(conn, TARGET_DATE - timedelta(days=50), 50, 2000.0, 2000.0)
-        assert _get_topix_size_multiplier(conn, TARGET_DATE) == 1.0
+    def test_strong_bear_takes_priority_over_weak_bear(self, conn):
+        """MA75 < MA200 のときは MA25 < MA75 でも strong_bear が優先される。"""
+        # MA25 < MA75 < MA200（両条件成立）
+        self._insert_topix_with_ma(conn, TARGET_DATE, 1800.0, 1900.0, 2000.0)
+        result = _get_topix_size_multiplier(conn, TARGET_DATE)
+        assert result == 0.0  # strong_bear 優先
 
-    def test_custom_drawdown_threshold_and_multiplier(self, conn):
-        """カスタム drawdown_threshold と size_multiplier_bear が適用されることを確認する。"""
-        # 240日は 2000.0、直近11日は 1600.0（乖離率≈-20%）
-        self._make_topix_series(conn, TARGET_DATE - timedelta(days=250), 240, 2000.0, 2000.0)
-        recent_start = TARGET_DATE - timedelta(days=10)
-        self._make_topix_series(conn, recent_start, 11, 1600.0, 1600.0)
-
-        # drawdown_threshold=-0.10 → 乖離率-20% < -10% → Bear 判定 → 0.3 を返す
+    def test_custom_weak_bear_multiplier(self, conn):
+        """カスタム size_multiplier_weak_bear が適用される。"""
+        self._insert_topix_with_ma(conn, TARGET_DATE, 1950.0, 2000.0, 1980.0)
         result = _get_topix_size_multiplier(
-            conn, TARGET_DATE, drawdown_threshold=-0.10, size_multiplier_bear=0.3
+            conn, TARGET_DATE, size_multiplier_weak_bear=0.3
         )
         assert result == 0.3
 
-    def test_custom_threshold_not_triggered(self, conn):
-        """乖離率が drawdown_threshold を超えない場合は 1.0 を返すことを確認する。"""
-        # 250日すべて 2000.0（乖離率≈0%）
-        self._make_topix_series(conn, TARGET_DATE - timedelta(days=250), 250, 2000.0, 2000.0)
-        # drawdown_threshold=-0.10 → 乖離率≈0% > -10% → Bear 未判定 → 1.0
+    def test_custom_strong_bear_multiplier(self, conn):
+        """カスタム size_multiplier_strong_bear が適用される。"""
+        self._insert_topix_with_ma(conn, TARGET_DATE, 1900.0, 1950.0, 2000.0)
         result = _get_topix_size_multiplier(
-            conn, TARGET_DATE, drawdown_threshold=-0.10, size_multiplier_bear=0.3
+            conn, TARGET_DATE, size_multiplier_strong_bear=0.25
         )
-        assert result == 1.0
+        assert result == 0.25
+
+    def test_uses_latest_date_not_after_target(self, conn):
+        """target_date 以前の直近データを参照する（当日データがなくても OK）。"""
+        yesterday = TARGET_DATE - timedelta(days=1)
+        self._insert_topix_with_ma(conn, yesterday, 1900.0, 1950.0, 2000.0)
+        # TARGET_DATE のレコードはなし
+        result = _get_topix_size_multiplier(conn, TARGET_DATE)
+        assert result == 0.0  # 昨日のデータ（strong_bear）を参照
 
 
 # ---------------------------------------------------------------------------
@@ -716,14 +726,14 @@ sector:
   boost: 0.05
   quartile: 0.30
 regime:
-  topix_drawdown_threshold: -0.20
-  topix_size_multiplier_bear: 0.4
+  topix_size_multiplier_weak_bear: 0.4
+  topix_size_multiplier_strong_bear: 0.0
 """
         cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
         assert cfg["sector_boost"] == 0.05
         assert cfg["sector_quartile"] == 0.30
-        assert cfg["topix_drawdown_threshold"] == -0.20
-        assert cfg["topix_size_multiplier_bear"] == 0.4
+        assert cfg["topix_size_multiplier_weak_bear"] == 0.4
+        assert cfg["topix_size_multiplier_strong_bear"] == 0.0
 
     def test_missing_sector_section_uses_defaults(self, tmp_path, monkeypatch):
         yaml_text = "strategy:\n  threshold: 0.60\n"
@@ -734,8 +744,8 @@ regime:
     def test_missing_regime_section_uses_defaults(self, tmp_path, monkeypatch):
         yaml_text = "strategy:\n  threshold: 0.60\n"
         cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
-        assert cfg["topix_drawdown_threshold"] == -0.15
-        assert cfg["topix_size_multiplier_bear"] == 0.5
+        assert cfg["topix_size_multiplier_weak_bear"] == 0.5
+        assert cfg["topix_size_multiplier_strong_bear"] == 0.0
 
     def test_sector_boost_negative_falls_back(self, tmp_path, monkeypatch):
         yaml_text = "strategy:\n  threshold: 0.60\nsector:\n  boost: -0.01\n  quartile: 0.25\n"
@@ -752,20 +762,21 @@ regime:
         cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
         assert cfg["sector_quartile"] == 0.25  # default
 
-    def test_topix_drawdown_threshold_positive_falls_back(self, tmp_path, monkeypatch):
-        yaml_text = "strategy:\n  threshold: 0.60\nregime:\n  topix_drawdown_threshold: 0.10\n  topix_size_multiplier_bear: 0.5\n"
+    def test_topix_weak_bear_over_one_falls_back(self, tmp_path, monkeypatch):
+        yaml_text = "strategy:\n  threshold: 0.60\nregime:\n  topix_size_multiplier_weak_bear: 1.5\n"
         cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
-        assert cfg["topix_drawdown_threshold"] == -0.15  # default
+        assert cfg["topix_size_multiplier_weak_bear"] == 0.5  # default
 
-    def test_topix_size_multiplier_bear_over_one_falls_back(self, tmp_path, monkeypatch):
-        yaml_text = "strategy:\n  threshold: 0.60\nregime:\n  topix_drawdown_threshold: -0.15\n  topix_size_multiplier_bear: 1.5\n"
+    def test_topix_weak_bear_exactly_one_accepted(self, tmp_path, monkeypatch):
+        yaml_text = "strategy:\n  threshold: 0.60\nregime:\n  topix_size_multiplier_weak_bear: 1.0\n"
         cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
-        assert cfg["topix_size_multiplier_bear"] == 0.5  # default
+        assert cfg["topix_size_multiplier_weak_bear"] == 1.0
 
-    def test_topix_size_multiplier_bear_exactly_one_accepted(self, tmp_path, monkeypatch):
-        yaml_text = "strategy:\n  threshold: 0.60\nregime:\n  topix_drawdown_threshold: -0.15\n  topix_size_multiplier_bear: 1.0\n"
+    def test_topix_strong_bear_zero_accepted(self, tmp_path, monkeypatch):
+        """strong_bear=0.0 は有効（エントリー完全停止を意味する）。"""
+        yaml_text = "strategy:\n  threshold: 0.60\nregime:\n  topix_size_multiplier_strong_bear: 0.0\n"
         cfg = _load_cfg_with_yaml(yaml_text, tmp_path, monkeypatch)
-        assert cfg["topix_size_multiplier_bear"] == 1.0
+        assert cfg["topix_size_multiplier_strong_bear"] == 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_topix_ma_feature.py
+++ b/tests/test_topix_ma_feature.py
@@ -1,0 +1,187 @@
+"""
+TOPIX MA (MA25/MA75/MA200) 事前計算・保存機能のテスト (Issue #349)
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import duckdb
+import pytest
+
+from kabusys.data.schema import init_schema
+
+
+@pytest.fixture
+def conn():
+    c = init_schema(":memory:")
+    yield c
+    c.close()
+
+
+def _insert_topix(conn: duckdb.DuckDBPyConnection, start: date, count: int, base: float = 2000.0) -> None:
+    """count 日分の TOPIX データを挿入（close は base + 日連番）"""
+    rows = []
+    for i in range(count):
+        d = start + timedelta(days=i)
+        close = base + i
+        rows.append((d, close, close, close, close))
+    conn.executemany(
+        "INSERT INTO topix_daily (date, open, high, low, close) VALUES (?, ?, ?, ?, ?)",
+        rows,
+    )
+
+
+# ---------------------------------------------------------------------------
+# schema: topix_daily に MA 列が存在することを確認
+# ---------------------------------------------------------------------------
+
+class TestTopixDailySchema:
+    def test_ma_columns_exist_in_new_db(self, conn):
+        """新規 DB では topix_daily に ma25/ma75/ma200 列が存在する"""
+        cols = {r[1] for r in conn.execute("PRAGMA table_info('topix_daily')").fetchall()}
+        assert "ma25" in cols
+        assert "ma75" in cols
+        assert "ma200" in cols
+
+    def test_ma_columns_are_nullable(self, conn):
+        """MA 列は NULL 許容（データ不足時は NULL のまま）"""
+        d = date(2024, 1, 1)
+        conn.execute(
+            "INSERT INTO topix_daily (date, open, high, low, close) VALUES (?, ?, ?, ?, ?)",
+            [d, 2000, 2000, 2000, 2000],
+        )
+        row = conn.execute("SELECT ma25, ma75, ma200 FROM topix_daily WHERE date = ?", [d]).fetchone()
+        assert row is not None
+        assert row[0] is None
+        assert row[1] is None
+        assert row[2] is None
+
+
+# ---------------------------------------------------------------------------
+# ensure_topix_ma_columns: 既存 DB への移行（冪等性）
+# ---------------------------------------------------------------------------
+
+class TestEnsureTopixMaColumns:
+    def test_ensure_is_idempotent(self, conn):
+        """2 回呼んでもエラーにならない"""
+        from kabusys.strategy.feature_engineering import ensure_topix_ma_columns
+
+        ensure_topix_ma_columns(conn)
+        ensure_topix_ma_columns(conn)  # 2 回目もエラーなし
+
+        cols = {r[1] for r in conn.execute("PRAGMA table_info('topix_daily')").fetchall()}
+        assert "ma25" in cols
+        assert "ma75" in cols
+        assert "ma200" in cols
+
+    def test_ensure_on_db_without_columns(self):
+        """ma 列のない既存 DB に列を追加できる"""
+        from kabusys.strategy.feature_engineering import ensure_topix_ma_columns
+
+        c = duckdb.connect(":memory:")
+        c.execute("""
+            CREATE TABLE topix_daily (
+                date  DATE PRIMARY KEY,
+                open  DOUBLE NOT NULL,
+                high  DOUBLE NOT NULL,
+                low   DOUBLE NOT NULL,
+                close DOUBLE NOT NULL
+            )
+        """)
+        # MA 列なし状態で ensure を呼ぶ
+        ensure_topix_ma_columns(c)
+
+        cols = {r[1] for r in c.execute("PRAGMA table_info('topix_daily')").fetchall()}
+        assert "ma25" in cols
+        assert "ma75" in cols
+        assert "ma200" in cols
+        c.close()
+
+
+# ---------------------------------------------------------------------------
+# update_topix_ma: MA を計算して topix_daily に保存
+# ---------------------------------------------------------------------------
+
+class TestUpdateTopixMa:
+    def test_returns_false_when_no_data(self, conn):
+        """対象日付のデータがない場合 False を返す"""
+        from kabusys.strategy.feature_engineering import update_topix_ma
+
+        result = update_topix_ma(conn, date(2024, 1, 1))
+        assert result is False
+
+    def test_returns_true_when_data_exists(self, conn):
+        """対象日付のデータがある場合 True を返す"""
+        from kabusys.strategy.feature_engineering import update_topix_ma
+
+        _insert_topix(conn, date(2024, 1, 1), 1)
+        result = update_topix_ma(conn, date(2024, 1, 1))
+        assert result is True
+
+    def test_ma_is_null_when_insufficient_data(self, conn):
+        """データ不足（25 日未満）のとき MA は NULL"""
+        from kabusys.strategy.feature_engineering import update_topix_ma
+
+        _insert_topix(conn, date(2024, 1, 1), 10)  # 10 日分のみ
+        update_topix_ma(conn, date(2024, 1, 10))
+        row = conn.execute(
+            "SELECT ma25, ma75, ma200 FROM topix_daily WHERE date = ?", [date(2024, 1, 10)]
+        ).fetchone()
+        assert row[0] is None  # ma25: 25 日未満
+        assert row[1] is None  # ma75: 75 日未満
+        assert row[2] is None  # ma200: 200 日未満
+
+    def test_ma25_computed_when_25_days_available(self, conn):
+        """25 日分のデータがあれば ma25 が計算される"""
+        from kabusys.strategy.feature_engineering import update_topix_ma
+
+        _insert_topix(conn, date(2024, 1, 1), 25, base=2000.0)
+        update_topix_ma(conn, date(2024, 1, 25))
+        row = conn.execute(
+            "SELECT ma25, ma75, ma200 FROM topix_daily WHERE date = ?", [date(2024, 1, 25)]
+        ).fetchone()
+        # 2000, 2001, ..., 2024 の平均 = 2012.0
+        assert row[0] is not None
+        assert abs(row[0] - 2012.0) < 0.01
+        assert row[1] is None   # ma75: まだ不足
+        assert row[2] is None   # ma200: まだ不足
+
+    def test_ma75_computed_when_75_days_available(self, conn):
+        """75 日分のデータがあれば ma75 も計算される"""
+        from kabusys.strategy.feature_engineering import update_topix_ma
+
+        _insert_topix(conn, date(2024, 1, 1), 75, base=2000.0)
+        update_topix_ma(conn, date(2024, 3, 15))
+        row = conn.execute(
+            "SELECT ma25, ma75, ma200 FROM topix_daily WHERE date = ?", [date(2024, 3, 15)]
+        ).fetchone()
+        assert row[0] is not None  # ma25 あり
+        assert row[1] is not None  # ma75 あり
+        assert row[2] is None      # ma200: まだ不足
+
+    def test_all_ma_computed_when_200_days_available(self, conn):
+        """200 日分のデータがあれば ma25/ma75/ma200 すべて計算される"""
+        from kabusys.strategy.feature_engineering import update_topix_ma
+
+        _insert_topix(conn, date(2023, 1, 1), 200, base=2000.0)
+        target = date(2023, 1, 1) + timedelta(days=199)
+        update_topix_ma(conn, target)
+        row = conn.execute(
+            "SELECT ma25, ma75, ma200 FROM topix_daily WHERE date = ?", [target]
+        ).fetchone()
+        assert row[0] is not None  # ma25
+        assert row[1] is not None  # ma75
+        assert row[2] is not None  # ma200
+
+    def test_update_is_idempotent(self, conn):
+        """同じ日付を 2 回更新してもエラーにならず同じ値を返す"""
+        from kabusys.strategy.feature_engineering import update_topix_ma
+
+        _insert_topix(conn, date(2024, 1, 1), 25, base=2000.0)
+        update_topix_ma(conn, date(2024, 1, 25))
+        update_topix_ma(conn, date(2024, 1, 25))  # 2 回目
+        row = conn.execute(
+            "SELECT ma25 FROM topix_daily WHERE date = ?", [date(2024, 1, 25)]
+        ).fetchone()
+        assert row[0] is not None

--- a/tests/test_topix_ma_feature.py
+++ b/tests/test_topix_ma_feature.py
@@ -19,7 +19,9 @@ def conn():
     c.close()
 
 
-def _insert_topix(conn: duckdb.DuckDBPyConnection, start: date, count: int, base: float = 2000.0) -> None:
+def _insert_topix(
+    conn: duckdb.DuckDBPyConnection, start: date, count: int, base: float = 2000.0
+) -> None:
     """count 日分の TOPIX データを挿入（close は base + 日連番）"""
     rows = []
     for i in range(count):
@@ -36,6 +38,7 @@ def _insert_topix(conn: duckdb.DuckDBPyConnection, start: date, count: int, base
 # schema: topix_daily に MA 列が存在することを確認
 # ---------------------------------------------------------------------------
 
+
 class TestTopixDailySchema:
     def test_ma_columns_exist_in_new_db(self, conn):
         """新規 DB では topix_daily に ma25/ma75/ma200 列が存在する"""
@@ -51,7 +54,9 @@ class TestTopixDailySchema:
             "INSERT INTO topix_daily (date, open, high, low, close) VALUES (?, ?, ?, ?, ?)",
             [d, 2000, 2000, 2000, 2000],
         )
-        row = conn.execute("SELECT ma25, ma75, ma200 FROM topix_daily WHERE date = ?", [d]).fetchone()
+        row = conn.execute(
+            "SELECT ma25, ma75, ma200 FROM topix_daily WHERE date = ?", [d]
+        ).fetchone()
         assert row is not None
         assert row[0] is None
         assert row[1] is None
@@ -61,6 +66,7 @@ class TestTopixDailySchema:
 # ---------------------------------------------------------------------------
 # ensure_topix_ma_columns: 既存 DB への移行（冪等性）
 # ---------------------------------------------------------------------------
+
 
 class TestEnsureTopixMaColumns:
     def test_ensure_is_idempotent(self, conn):
@@ -103,6 +109,7 @@ class TestEnsureTopixMaColumns:
 # update_topix_ma: MA を計算して topix_daily に保存
 # ---------------------------------------------------------------------------
 
+
 class TestUpdateTopixMa:
     def test_returns_false_when_no_data(self, conn):
         """対象日付のデータがない場合 False を返す"""
@@ -144,8 +151,8 @@ class TestUpdateTopixMa:
         # 2000, 2001, ..., 2024 の平均 = 2012.0
         assert row[0] is not None
         assert abs(row[0] - 2012.0) < 0.01
-        assert row[1] is None   # ma75: まだ不足
-        assert row[2] is None   # ma200: まだ不足
+        assert row[1] is None  # ma75: まだ不足
+        assert row[2] is None  # ma200: まだ不足
 
     def test_ma75_computed_when_75_days_available(self, conn):
         """75 日分のデータがあれば ma75 も計算される"""
@@ -158,7 +165,7 @@ class TestUpdateTopixMa:
         ).fetchone()
         assert row[0] is not None  # ma25 あり
         assert row[1] is not None  # ma75 あり
-        assert row[2] is None      # ma200: まだ不足
+        assert row[2] is None  # ma200: まだ不足
 
     def test_all_ma_computed_when_200_days_available(self, conn):
         """200 日分のデータがあれば ma25/ma75/ma200 すべて計算される"""


### PR DESCRIPTION
## Summary

- `topix_daily` テーブルに `ma25` / `ma75` / `ma200` 列を追加（スキーマ定義 + _MIGRATIONS による既存DB移行）
- `feature_engineering.py` に `update_topix_ma()` / `ensure_topix_ma_columns()` を追加し、事前計算アプローチを採用
- `signal_generator.py` の `_get_topix_size_multiplier()` を on-the-fly SQL計算から事前計算MA参照に変更
  - MA75 < MA200（強いベア）→ `size_multiplier_strong_bear`（デフォルト 0.0、エントリー完全停止）
  - MA25 < MA75（弱いベア）→ `size_multiplier_weak_bear`（デフォルト 0.5）
  - その他（強気相場）→ 1.0
- `run_feature_gen.py` / `backfill_features.py` で `update_topix_ma()` を呼び出し、本番運用との整合性を保証
- `engine.py` / `run.py` のパラメータ名を `weak_bear` / `strong_bear` 体系に更新
- `strategy_config.yaml` の `regime` セクションを新パラメータ名に更新
- `run_backtest_improvement_10m_mdd.py` のシナリオ定義を新パラメータに更新

## Test Plan

- [x] `tests/test_topix_ma_feature.py` 新規作成（11テスト）: スキーマ・`ensure_topix_ma_columns()`・`update_topix_ma()` の動作確認
- [x] `tests/test_signal_generator.py::TestGetTopixSizeMultiplier` をMAクロス判定に書き換え（9テスト）
- [x] `tests/test_signal_generator.py::TestLoadStrategyConfigSectorRegime` を新パラメータ名に更新
- [x] `tests/test_backtest_engine_params.py` を新パラメータ名に更新
- [x] `tests/test_bootstrap_schema.py` の `topix_daily` 列セットを更新
- [x] 全テスト: 2007 passed

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)