### PR TITLE
feat: 銘柄単位 MA25/MA75 クロスフィルター実装 (#353)

### DIFF
--- a/src/kabusys/data/schema.py
+++ b/src/kabusys/data/schema.py
@@ -202,6 +202,8 @@ CREATE TABLE IF NOT EXISTS features (
     pbr             DOUBLE,
     div_yield       DOUBLE,
     ma200_dev       DOUBLE,
+    ma25_dev        DOUBLE,
+    ma75_dev        DOUBLE,
     topix_rel_20    DOUBLE,
     topix_rel_60    DOUBLE,
     quality_score   DOUBLE,
@@ -500,6 +502,9 @@ _MIGRATIONS: list[str] = [
     "ALTER TABLE topix_daily ADD COLUMN IF NOT EXISTS ma25 DOUBLE",
     "ALTER TABLE topix_daily ADD COLUMN IF NOT EXISTS ma75 DOUBLE",
     "ALTER TABLE topix_daily ADD COLUMN IF NOT EXISTS ma200 DOUBLE",
+    # Issue #353: features に MA25/MA75 乖離率を追加
+    "ALTER TABLE features ADD COLUMN IF NOT EXISTS ma25_dev DOUBLE",
+    "ALTER TABLE features ADD COLUMN IF NOT EXISTS ma75_dev DOUBLE",
 ]
 
 # ---------------------------------------------------------------------------

--- a/src/kabusys/research/factor_research.py
+++ b/src/kabusys/research/factor_research.py
@@ -34,9 +34,9 @@ logger = logging.getLogger(__name__)
 _MOMENTUM_SHORT_DAYS = 21  # 約1ヶ月（営業日）
 _MOMENTUM_MID_DAYS = 63  # 約3ヶ月（営業日）
 _MOMENTUM_LONG_DAYS = 126  # 約6ヶ月（営業日）
-_MA_SHORT_DAYS = 25   # 短期移動平均
-_MA_MID_DAYS = 75     # 中期移動平均
-_MA_LONG_DAYS = 200   # 長期移動平均
+_MA_SHORT_DAYS = 25  # 短期移動平均
+_MA_MID_DAYS = 75  # 中期移動平均
+_MA_LONG_DAYS = 200  # 長期移動平均
 _ATR_DAYS = 20  # ATR 計算期間
 _VOLUME_DAYS = 20  # 出来高移動平均期間
 

--- a/src/kabusys/research/factor_research.py
+++ b/src/kabusys/research/factor_research.py
@@ -34,7 +34,9 @@ logger = logging.getLogger(__name__)
 _MOMENTUM_SHORT_DAYS = 21  # 約1ヶ月（営業日）
 _MOMENTUM_MID_DAYS = 63  # 約3ヶ月（営業日）
 _MOMENTUM_LONG_DAYS = 126  # 約6ヶ月（営業日）
-_MA_LONG_DAYS = 200  # 長期移動平均
+_MA_SHORT_DAYS = 25   # 短期移動平均
+_MA_MID_DAYS = 75     # 中期移動平均
+_MA_LONG_DAYS = 200   # 長期移動平均
 _ATR_DAYS = 20  # ATR 計算期間
 _VOLUME_DAYS = 20  # 出来高移動平均期間
 
@@ -60,6 +62,8 @@ def calc_momentum(
       - mom_6m : 約6ヶ月前終値に対するリターン
       - ma200_dev: 200日移動平均に対する乖離率（(close - MA200) / MA200）
                    ウィンドウ内データが 200 行未満の場合は None を返す。
+      - ma75_dev : 75日移動平均に対する乖離率。ウィンドウ内データが 75 行未満の場合は None。
+      - ma25_dev : 25日移動平均に対する乖離率。ウィンドウ内データが 25 行未満の場合は None。
 
     データ不足（過去データが少ない）銘柄は None を返す。
 
@@ -92,7 +96,23 @@ def calc_momentum(
                 COUNT(close) OVER (
                     PARTITION BY code ORDER BY date
                     ROWS BETWEEN {_MA_LONG_DAYS - 1} PRECEDING AND CURRENT ROW
-                ) AS cnt_200
+                ) AS cnt_200,
+                AVG(close) OVER (
+                    PARTITION BY code ORDER BY date
+                    ROWS BETWEEN {_MA_MID_DAYS - 1} PRECEDING AND CURRENT ROW
+                ) AS ma75,
+                COUNT(close) OVER (
+                    PARTITION BY code ORDER BY date
+                    ROWS BETWEEN {_MA_MID_DAYS - 1} PRECEDING AND CURRENT ROW
+                ) AS cnt_75,
+                AVG(close) OVER (
+                    PARTITION BY code ORDER BY date
+                    ROWS BETWEEN {_MA_SHORT_DAYS - 1} PRECEDING AND CURRENT ROW
+                ) AS ma25,
+                COUNT(close) OVER (
+                    PARTITION BY code ORDER BY date
+                    ROWS BETWEEN {_MA_SHORT_DAYS - 1} PRECEDING AND CURRENT ROW
+                ) AS cnt_25
             FROM prices_daily
             WHERE date BETWEEN ? AND ?
         )
@@ -106,7 +126,11 @@ def calc_momentum(
             CASE WHEN close_6m_ago > 0
                  THEN (close - close_6m_ago) / close_6m_ago END AS mom_6m,
             CASE WHEN ma200 > 0 AND cnt_200 >= {_MA_LONG_DAYS}
-                 THEN (close - ma200) / ma200 END AS ma200_dev
+                 THEN (close - ma200) / ma200 END AS ma200_dev,
+            CASE WHEN ma75 > 0 AND cnt_75 >= {_MA_MID_DAYS}
+                 THEN (close - ma75) / ma75 END AS ma75_dev,
+            CASE WHEN ma25 > 0 AND cnt_25 >= {_MA_SHORT_DAYS}
+                 THEN (close - ma25) / ma25 END AS ma25_dev
         FROM base
         WHERE date = (SELECT MAX(date) FROM prices_daily WHERE date <= ?)
         ORDER BY code
@@ -114,7 +138,7 @@ def calc_momentum(
         [start_date, target_date, target_date],
     ).fetchall()
 
-    cols = ["date", "code", "mom_1m", "mom_3m", "mom_6m", "ma200_dev"]
+    cols = ["date", "code", "mom_1m", "mom_3m", "mom_6m", "ma200_dev", "ma75_dev", "ma25_dev"]
     result = [dict(zip(cols, r)) for r in rows]
     logger.debug("calc_momentum: %d 銘柄 date=%s", len(result), target_date)
     return result

--- a/src/kabusys/strategy/feature_engineering.py
+++ b/src/kabusys/strategy/feature_engineering.py
@@ -156,6 +156,8 @@ def build_features(
                 "mom_1m": m.get("mom_1m"),
                 "mom_3m": m.get("mom_3m"),
                 "ma200_dev": m.get("ma200_dev"),
+                "ma75_dev": m.get("ma75_dev"),
+                "ma25_dev": m.get("ma25_dev"),
                 "atr_pct": v.get("atr_pct"),
                 "volume_ratio": v.get("volume_ratio"),
                 "per": f.get("per"),
@@ -206,6 +208,8 @@ def build_features(
             r.get("pbr"),
             r.get("div_yield"),
             r.get("ma200_dev"),
+            r.get("ma25_dev"),
+            r.get("ma75_dev"),
             r.get("topix_rel_20"),
             r.get("topix_rel_60"),
             r.get("quality_score"),
@@ -221,9 +225,9 @@ def build_features(
                 """
                 INSERT INTO features
                     (date, code, momentum_20, momentum_60, volatility_20, volume_ratio,
-                     per, pbr, div_yield, ma200_dev,
+                     per, pbr, div_yield, ma200_dev, ma25_dev, ma75_dev,
                      topix_rel_20, topix_rel_60, quality_score, rsi_14, created_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, current_timestamp)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, current_timestamp)
                 """,
                 params,
             )

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -1105,6 +1105,7 @@ def generate_signals(
     topix_size_multiplier_strong_bear: float | None = None,
     use_ma200_filter: bool = False,
     use_stock_ma_cross_filter: bool = False,
+    stock_ma_cross_weak_bear_multiplier: float = 0.5,
     volume_breakout_threshold: float | None = None,
     *,
     regime_provider: RegimeProvider | None = None,
@@ -1138,9 +1139,12 @@ def generate_signals(
                            False（デフォルト）では無効。
         use_stock_ma_cross_filter: True のとき銘柄単位の MA クロスで BUY を段階制御する。
                            - ma75_dev < 0（株価が MA75 を下回る）→ BUY スキップ（強ベア）
-                           - ma25_dev < 0 かつ ma75_dev >= 0 → size_multiplier を 0.5 に縮小（弱ベア）
-                           ma75_dev / ma25_dev が None の場合は安全側で BUY 許可。
+                           - ma75_dev >= 0 かつ ma25_dev < 0 → size_multiplier を縮小（弱ベア）
+                           ma75_dev / ma25_dev のどちらかが None の場合は安全側で BUY 許可。
                            False（デフォルト）では無効。
+        stock_ma_cross_weak_bear_multiplier: 弱ベア時（ma75_dev >= 0 かつ ma25_dev < 0）の
+                           size_multiplier 縮小率（0 < x <= 1）。デフォルト 0.5。
+                           use_stock_ma_cross_filter=True のときのみ有効。
         volume_breakout_threshold: 指定した場合、volume_ratio（20日平均出来高比）が
                            この値を下回る銘柄の BUY を抑制する（例: 1.5 = 1.5倍未満を除外）。
                            volume_ratio が None の場合は安全側で BUY 許可。
@@ -1418,7 +1422,8 @@ def generate_signals(
                     continue
             # 銘柄単位 MA クロスフィルタ
             # - ma75_dev < 0（株価が MA75 を下回る）→ BUY スキップ（強ベア）
-            # - ma25_dev < 0 かつ ma75_dev >= 0 → size_multiplier を 0.5 に縮小（弱ベア）
+            # - ma75_dev >= 0 かつ ma25_dev < 0 → size_multiplier を縮小（弱ベア）
+            # - どちらかが None（データ不足）→ 安全側で制御しない
             stock_ma_cross_size_multiplier: float | None = None
             if use_stock_ma_cross_filter:
                 ma75_dev_val = r.get("ma75_dev")
@@ -1433,9 +1438,10 @@ def generate_signals(
                     stock_ma_cross_suppressed += 1
                     continue
                 if (
-                    ma25_dev_val is not None
+                    ma75_dev_val is not None
+                    and ma75_dev_val >= 0
+                    and ma25_dev_val is not None
                     and ma25_dev_val < 0
-                    and (ma75_dev_val is None or ma75_dev_val >= 0)
                 ):
                     logger.debug(
                         "stock ma cross filter: %s ma25_dev=%.4f — size 縮小 date=%s",
@@ -1443,7 +1449,7 @@ def generate_signals(
                         ma25_dev_val,
                         target_date,
                     )
-                    stock_ma_cross_size_multiplier = 0.5
+                    stock_ma_cross_size_multiplier = stock_ma_cross_weak_bear_multiplier
                     stock_ma_cross_reduced += 1
             # 出来高ブレイクアウトフィルタ（threshold 指定時に volume_ratio が閾値未満の銘柄を抑制）
             if volume_breakout_threshold is not None:

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -1104,10 +1104,10 @@ def generate_signals(
     topix_size_multiplier_weak_bear: float | None = None,
     topix_size_multiplier_strong_bear: float | None = None,
     use_ma200_filter: bool = False,
-    use_stock_ma_cross_filter: bool = False,
-    stock_ma_cross_weak_bear_multiplier: float = 0.5,
     volume_breakout_threshold: float | None = None,
     *,
+    use_stock_ma_cross_filter: bool = False,
+    stock_ma_cross_weak_bear_multiplier: float = 0.5,
     regime_provider: RegimeProvider | None = None,
     sqlite_conn: sqlite3.Connection | None = None,
 ) -> int:

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -90,6 +90,8 @@ _FEATURES_SELECT_COLS: tuple[str, ...] = (
     "pbr",
     "div_yield",
     "ma200_dev",
+    "ma75_dev",
+    "ma25_dev",
     "rsi_14",
 )
 
@@ -1102,6 +1104,7 @@ def generate_signals(
     topix_size_multiplier_weak_bear: float | None = None,
     topix_size_multiplier_strong_bear: float | None = None,
     use_ma200_filter: bool = False,
+    use_stock_ma_cross_filter: bool = False,
     volume_breakout_threshold: float | None = None,
     *,
     regime_provider: RegimeProvider | None = None,
@@ -1132,6 +1135,11 @@ def generate_signals(
                            None の場合は strategy_config.yaml から読み込む。
         use_ma200_filter:  True のとき株価が 200 日移動平均線を下回る銘柄（ma200_dev < 0）
                            の BUY を抑制する。ma200_dev が None の場合は安全側で BUY 許可。
+                           False（デフォルト）では無効。
+        use_stock_ma_cross_filter: True のとき銘柄単位の MA クロスで BUY を段階制御する。
+                           - ma75_dev < 0（株価が MA75 を下回る）→ BUY スキップ（強ベア）
+                           - ma25_dev < 0 かつ ma75_dev >= 0 → size_multiplier を 0.5 に縮小（弱ベア）
+                           ma75_dev / ma25_dev が None の場合は安全側で BUY 許可。
                            False（デフォルト）では無効。
         volume_breakout_threshold: 指定した場合、volume_ratio（20日平均出来高比）が
                            この値を下回る銘柄の BUY を抑制する（例: 1.5 = 1.5倍未満を除外）。
@@ -1346,6 +1354,8 @@ def generate_signals(
                 "score": final_score,
                 "rsi_14": feat.get("rsi_14"),
                 "ma200_dev": feat.get("ma200_dev"),
+                "ma75_dev": feat.get("ma75_dev"),
+                "ma25_dev": feat.get("ma25_dev"),
                 "volume_ratio": feat.get("volume_ratio"),
             }
         )
@@ -1374,6 +1384,8 @@ def generate_signals(
         gap_suppressed = 0
         rsi_suppressed = 0
         ma200_suppressed = 0
+        stock_ma_cross_suppressed = 0
+        stock_ma_cross_reduced = 0
         volume_suppressed = 0
         sector_suppressed = 0
         reentry_suppressed = 0
@@ -1404,6 +1416,31 @@ def generate_signals(
                     )
                     ma200_suppressed += 1
                     continue
+            # 銘柄単位 MA クロスフィルタ
+            # - ma75_dev < 0（株価が MA75 を下回る）→ BUY スキップ（強ベア）
+            # - ma25_dev < 0 かつ ma75_dev >= 0 → size_multiplier を 0.5 に縮小（弱ベア）
+            stock_ma_cross_size_multiplier: float | None = None
+            if use_stock_ma_cross_filter:
+                ma75_dev_val = r.get("ma75_dev")
+                ma25_dev_val = r.get("ma25_dev")
+                if ma75_dev_val is not None and ma75_dev_val < 0:
+                    logger.debug(
+                        "stock ma cross filter: %s ma75_dev=%.4f — BUY を抑制 date=%s",
+                        r["code"],
+                        ma75_dev_val,
+                        target_date,
+                    )
+                    stock_ma_cross_suppressed += 1
+                    continue
+                if ma25_dev_val is not None and ma25_dev_val < 0 and (ma75_dev_val is None or ma75_dev_val >= 0):
+                    logger.debug(
+                        "stock ma cross filter: %s ma25_dev=%.4f — size 縮小 date=%s",
+                        r["code"],
+                        ma25_dev_val,
+                        target_date,
+                    )
+                    stock_ma_cross_size_multiplier = 0.5
+                    stock_ma_cross_reduced += 1
             # 出来高ブレイクアウトフィルタ（threshold 指定時に volume_ratio が閾値未満の銘柄を抑制）
             if volume_breakout_threshold is not None:
                 volume_ratio_val = r.get("volume_ratio")
@@ -1460,7 +1497,10 @@ def generate_signals(
                 )
                 earnings_suppressed += 1
                 continue
-            buy_signals.append({"code": r["code"], "score": r["score"], "rank": rank})
+            per_signal_multiplier = size_multiplier
+            if stock_ma_cross_size_multiplier is not None:
+                per_signal_multiplier = min(per_signal_multiplier, stock_ma_cross_size_multiplier)
+            buy_signals.append({"code": r["code"], "score": r["score"], "rank": rank, "size_multiplier": per_signal_multiplier})
         if rsi_suppressed:
             logger.info(
                 "generate_signals: rsi filter — %d 銘柄を RSI 過熱(%s超)で抑制 date=%s",
@@ -1472,6 +1512,18 @@ def generate_signals(
             logger.info(
                 "generate_signals: ma200 filter — %d 銘柄を MA200 下で抑制 date=%s",
                 ma200_suppressed,
+                target_date,
+            )
+        if stock_ma_cross_suppressed:
+            logger.info(
+                "generate_signals: stock ma cross filter — %d 銘柄を MA75 下で抑制 date=%s",
+                stock_ma_cross_suppressed,
+                target_date,
+            )
+        if stock_ma_cross_reduced:
+            logger.info(
+                "generate_signals: stock ma cross filter — %d 銘柄を MA25 下で size 縮小 date=%s",
+                stock_ma_cross_reduced,
                 target_date,
             )
         if volume_suppressed:
@@ -1528,7 +1580,8 @@ def generate_signals(
 
     # 8. signals テーブルへ日付単位の置換（トランザクション＋バルク挿入で原子性を保証）
     buy_params = [
-        (target_date, r["code"], r["score"], r["rank"], size_multiplier) for r in buy_signals
+        (target_date, r["code"], r["score"], r["rank"], r.get("size_multiplier", size_multiplier))
+        for r in buy_signals
     ]
     sell_params = [(target_date, r["code"], r["score"]) for r in sell_signals]
     conn.execute("BEGIN")

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -1432,7 +1432,11 @@ def generate_signals(
                     )
                     stock_ma_cross_suppressed += 1
                     continue
-                if ma25_dev_val is not None and ma25_dev_val < 0 and (ma75_dev_val is None or ma75_dev_val >= 0):
+                if (
+                    ma25_dev_val is not None
+                    and ma25_dev_val < 0
+                    and (ma75_dev_val is None or ma75_dev_val >= 0)
+                ):
                     logger.debug(
                         "stock ma cross filter: %s ma25_dev=%.4f — size 縮小 date=%s",
                         r["code"],
@@ -1500,7 +1504,14 @@ def generate_signals(
             per_signal_multiplier = size_multiplier
             if stock_ma_cross_size_multiplier is not None:
                 per_signal_multiplier = min(per_signal_multiplier, stock_ma_cross_size_multiplier)
-            buy_signals.append({"code": r["code"], "score": r["score"], "rank": rank, "size_multiplier": per_signal_multiplier})
+            buy_signals.append(
+                {
+                    "code": r["code"],
+                    "score": r["score"],
+                    "rank": rank,
+                    "size_multiplier": per_signal_multiplier,
+                }
+            )
         if rsi_suppressed:
             logger.info(
                 "generate_signals: rsi filter — %d 銘柄を RSI 過熱(%s超)で抑制 date=%s",

--- a/tests/test_generate_signals_config.py
+++ b/tests/test_generate_signals_config.py
@@ -16,7 +16,7 @@ def _make_db():
         CREATE TABLE features (
             date DATE, code VARCHAR, momentum_20 DOUBLE, momentum_60 DOUBLE,
             volatility_20 DOUBLE, volume_ratio DOUBLE, per DOUBLE, pbr DOUBLE,
-            div_yield DOUBLE, ma200_dev DOUBLE, rsi_14 DOUBLE
+            div_yield DOUBLE, ma200_dev DOUBLE, ma75_dev DOUBLE, ma25_dev DOUBLE, rsi_14 DOUBLE
         )
     """)
     conn.execute("""
@@ -95,7 +95,7 @@ class TestGenerateSignalsConfigWeights:
         target = date(2025, 1, 6)
         # Insert one stock with high momentum
         conn.execute(
-            "INSERT INTO features VALUES (?, '1001', 3.0, 3.0, 0.0, 0.0, NULL, NULL, NULL, 0.0, NULL)",
+            "INSERT INTO features VALUES (?, '1001', 3.0, 3.0, 0.0, 0.0, NULL, NULL, NULL, 0.0, NULL, NULL, NULL)",
             [target],
         )
 
@@ -143,7 +143,7 @@ class TestGenerateSignalsConfigWeights:
         target = date(2025, 1, 6)
         # volatility_20 = -3.0 → low volatility (good) → _sigmoid(-(-3.0)) ≈ 0.95 > 0.50
         conn.execute(
-            "INSERT INTO features VALUES (?, '1001', 0.0, 0.0, -3.0, 0.0, NULL, NULL, NULL, 0.0, NULL)",
+            "INSERT INTO features VALUES (?, '1001', 0.0, 0.0, -3.0, 0.0, NULL, NULL, NULL, 0.0, NULL, NULL, NULL)",
             [target],
         )
 
@@ -205,7 +205,7 @@ class TestGenerateSignalsConfigThreshold:
         target = date(2025, 1, 6)
         # Insert stock with moderate score that would pass 0.60 but not 0.99
         conn.execute(
-            "INSERT INTO features VALUES (?, '1001', 0.5, 0.5, 0.0, 0.0, NULL, NULL, NULL, 0.0, NULL)",
+            "INSERT INTO features VALUES (?, '1001', 0.5, 0.5, 0.0, 0.0, NULL, NULL, NULL, 0.0, NULL, NULL, NULL)",
             [target],
         )
 
@@ -253,7 +253,7 @@ class TestGenerateSignalsConfigThreshold:
         conn = _make_db()
         target = date(2025, 1, 6)
         conn.execute(
-            "INSERT INTO features VALUES (?, '1001', 3.0, 3.0, 0.0, 0.0, NULL, NULL, NULL, 0.0, NULL)",
+            "INSERT INTO features VALUES (?, '1001', 3.0, 3.0, 0.0, 0.0, NULL, NULL, NULL, 0.0, NULL, NULL, NULL)",
             [target],
         )
 

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -1276,6 +1276,103 @@ class TestStockMaCrossFilter:
         ]
         assert "9005" in buy_codes
 
+    def test_none_ma75_negative_ma25_no_reduction(self, conn):
+        """ma75_dev=None かつ ma25_dev<0 → データ不足のため縮小しない（安全側で BUY 許可）。"""
+        from kabusys.strategy.signal_generator import generate_signals
+
+        _insert_regime(conn, TARGET_DATE, "bull")
+        _insert_breadth(conn, TARGET_DATE, breadth_stop=False)
+        _insert_feature_with_values(conn, "9006", TARGET_DATE, ma75_dev=None, ma25_dev=-0.05)
+
+        generate_signals(conn, TARGET_DATE, use_stock_ma_cross_filter=True)
+
+        rows = conn.execute(
+            "SELECT code, size_multiplier FROM signals WHERE date = ? AND side = 'buy' AND code = '9006'",
+            [TARGET_DATE],
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0][1] == pytest.approx(1.0)
+
+    def test_custom_weak_bear_multiplier(self, conn):
+        """stock_ma_cross_weak_bear_multiplier=0.3 → 弱ベア時に 0.3 が適用される。"""
+        from kabusys.strategy.signal_generator import generate_signals
+
+        _insert_regime(conn, TARGET_DATE, "bull")
+        _insert_breadth(conn, TARGET_DATE, breadth_stop=False)
+        _insert_feature_with_values(conn, "9007", TARGET_DATE, ma75_dev=0.03, ma25_dev=-0.02)
+
+        generate_signals(
+            conn,
+            TARGET_DATE,
+            use_stock_ma_cross_filter=True,
+            stock_ma_cross_weak_bear_multiplier=0.3,
+        )
+
+        rows = conn.execute(
+            "SELECT code, size_multiplier FROM signals WHERE date = ? AND side = 'buy' AND code = '9007'",
+            [TARGET_DATE],
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0][1] == pytest.approx(0.3)
+
+    def test_min_takes_global_when_smaller(self, conn):
+        """TOPIX 弱ベア (batch=0.4) かつ 銘柄弱ベア (weak_bear=0.5) → min(0.4, 0.5)=0.4。"""
+        from kabusys.strategy.signal_generator import generate_signals
+
+        _insert_regime(conn, TARGET_DATE, "bull")
+        _insert_breadth(conn, TARGET_DATE, breadth_stop=False)
+        # TOPIX 弱ベア状態 (MA25 < MA75 かつ MA75 > MA200)
+        conn.execute(
+            "INSERT INTO topix_daily (date, open, high, low, close, ma25, ma75, ma200) "
+            "VALUES (?, 2000.0, 2000.0, 2000.0, 2000.0, ?, ?, ?)",
+            [TARGET_DATE, 1950.0, 2000.0, 1980.0],
+        )
+        _insert_feature_with_values(conn, "9008", TARGET_DATE, ma75_dev=0.03, ma25_dev=-0.02)
+
+        generate_signals(
+            conn,
+            TARGET_DATE,
+            use_stock_ma_cross_filter=True,
+            topix_size_multiplier_weak_bear=0.4,
+            stock_ma_cross_weak_bear_multiplier=0.5,
+        )
+
+        rows = conn.execute(
+            "SELECT code, size_multiplier FROM signals WHERE date = ? AND side = 'buy' AND code = '9008'",
+            [TARGET_DATE],
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0][1] == pytest.approx(0.4)
+
+    def test_min_takes_local_when_smaller(self, conn):
+        """TOPIX 弱ベア (batch=0.7) かつ 銘柄弱ベア (weak_bear=0.5) → min(0.7, 0.5)=0.5。"""
+        from kabusys.strategy.signal_generator import generate_signals
+
+        _insert_regime(conn, TARGET_DATE, "bull")
+        _insert_breadth(conn, TARGET_DATE, breadth_stop=False)
+        # TOPIX 弱ベア状態 (MA25 < MA75 かつ MA75 > MA200)
+        conn.execute(
+            "INSERT INTO topix_daily (date, open, high, low, close, ma25, ma75, ma200) "
+            "VALUES (?, 2000.0, 2000.0, 2000.0, 2000.0, ?, ?, ?)",
+            [TARGET_DATE, 1950.0, 2000.0, 1980.0],
+        )
+        _insert_feature_with_values(conn, "9009", TARGET_DATE, ma75_dev=0.03, ma25_dev=-0.02)
+
+        generate_signals(
+            conn,
+            TARGET_DATE,
+            use_stock_ma_cross_filter=True,
+            topix_size_multiplier_weak_bear=0.7,
+            stock_ma_cross_weak_bear_multiplier=0.5,
+        )
+
+        rows = conn.execute(
+            "SELECT code, size_multiplier FROM signals WHERE date = ? AND side = 'buy' AND code = '9009'",
+            [TARGET_DATE],
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0][1] == pytest.approx(0.5)
+
 
 class TestVolumeBreakoutFilter:
     """volume_breakout_threshold が指定されると出来高比率が低い銘柄の BUY を抑制する。"""

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -1093,7 +1093,18 @@ def _insert_feature_with_values(
         "INSERT INTO features "
         "(date, code, momentum_20, momentum_60, volatility_20, volume_ratio, per, ma200_dev, ma75_dev, ma25_dev) "
         "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        [d, code, momentum_20, momentum_60, volatility_20, volume_ratio, per, ma200_dev, ma75_dev, ma25_dev],
+        [
+            d,
+            code,
+            momentum_20,
+            momentum_60,
+            volatility_20,
+            volume_ratio,
+            per,
+            ma200_dev,
+            ma75_dev,
+            ma25_dev,
+        ],
     )
 
 

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -1086,12 +1086,14 @@ def _insert_feature_with_values(
     volume_ratio: float = 3.0,
     per: float = 5.0,
     ma200_dev: float = 3.0,
+    ma75_dev: float | None = None,
+    ma25_dev: float | None = None,
 ) -> None:
     conn.execute(
         "INSERT INTO features "
-        "(date, code, momentum_20, momentum_60, volatility_20, volume_ratio, per, ma200_dev) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-        [d, code, momentum_20, momentum_60, volatility_20, volume_ratio, per, ma200_dev],
+        "(date, code, momentum_20, momentum_60, volatility_20, volume_ratio, per, ma200_dev, ma75_dev, ma25_dev) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [d, code, momentum_20, momentum_60, volatility_20, volume_ratio, per, ma200_dev, ma75_dev, ma25_dev],
     )
 
 
@@ -1169,6 +1171,99 @@ class TestMa200Filter:
             ).fetchall()
         ]
         assert "8004" in buy_codes
+
+
+class TestStockMaCrossFilter:
+    """use_stock_ma_cross_filter=True のとき銘柄 MA クロスで BUY を制御する。"""
+
+    def test_below_ma75_suppressed(self, conn):
+        """ma75_dev < 0（株価が MA75 を下回る）→ BUY をスキップする（強ベア）。"""
+        from kabusys.strategy.signal_generator import generate_signals
+
+        _insert_regime(conn, TARGET_DATE, "bull")
+        _insert_breadth(conn, TARGET_DATE, breadth_stop=False)
+        _insert_feature_with_values(conn, "9001", TARGET_DATE, ma75_dev=-0.05, ma25_dev=-0.10)
+
+        generate_signals(conn, TARGET_DATE, use_stock_ma_cross_filter=True)
+
+        buy_codes = [
+            r[0]
+            for r in conn.execute(
+                "SELECT code FROM signals WHERE date = ? AND side = 'buy'", [TARGET_DATE]
+            ).fetchall()
+        ]
+        assert "9001" not in buy_codes
+
+    def test_above_ma75_allowed(self, conn):
+        """ma75_dev >= 0（株価が MA75 を上回る）→ BUY を許可する。"""
+        from kabusys.strategy.signal_generator import generate_signals
+
+        _insert_regime(conn, TARGET_DATE, "bull")
+        _insert_breadth(conn, TARGET_DATE, breadth_stop=False)
+        _insert_feature_with_values(conn, "9002", TARGET_DATE, ma75_dev=0.05, ma25_dev=0.02)
+
+        generate_signals(conn, TARGET_DATE, use_stock_ma_cross_filter=True)
+
+        buy_codes = [
+            r[0]
+            for r in conn.execute(
+                "SELECT code FROM signals WHERE date = ? AND side = 'buy'", [TARGET_DATE]
+            ).fetchall()
+        ]
+        assert "9002" in buy_codes
+
+    def test_below_ma25_size_reduced(self, conn):
+        """ma25_dev < 0 かつ ma75_dev >= 0 → BUY は通すが size_multiplier が 0.5 に縮小される（弱ベア）。"""
+        from kabusys.strategy.signal_generator import generate_signals
+
+        _insert_regime(conn, TARGET_DATE, "bull")
+        _insert_breadth(conn, TARGET_DATE, breadth_stop=False)
+        _insert_feature_with_values(conn, "9003", TARGET_DATE, ma75_dev=0.03, ma25_dev=-0.02)
+
+        generate_signals(conn, TARGET_DATE, use_stock_ma_cross_filter=True)
+
+        rows = conn.execute(
+            "SELECT code, size_multiplier FROM signals WHERE date = ? AND side = 'buy' AND code = '9003'",
+            [TARGET_DATE],
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0][1] == pytest.approx(0.5)
+
+    def test_filter_disabled_by_default(self, conn):
+        """use_stock_ma_cross_filter=False（デフォルト）→ ma75_dev < 0 でも BUY を許可する。"""
+        from kabusys.strategy.signal_generator import generate_signals
+
+        _insert_regime(conn, TARGET_DATE, "bull")
+        _insert_breadth(conn, TARGET_DATE, breadth_stop=False)
+        _insert_feature_with_values(conn, "9004", TARGET_DATE, ma75_dev=-0.05, ma25_dev=-0.10)
+
+        generate_signals(conn, TARGET_DATE)
+
+        buy_codes = [
+            r[0]
+            for r in conn.execute(
+                "SELECT code FROM signals WHERE date = ? AND side = 'buy'", [TARGET_DATE]
+            ).fetchall()
+        ]
+        assert "9004" in buy_codes
+
+    def test_none_ma75_allowed(self, conn):
+        """ma75_dev が None（データ不足）→ 安全側で BUY を許可する。"""
+        from kabusys.strategy.signal_generator import generate_signals
+
+        _insert_regime(conn, TARGET_DATE, "bull")
+        _insert_breadth(conn, TARGET_DATE, breadth_stop=False)
+        _insert_feature_with_values(conn, "9005", TARGET_DATE, ma75_dev=None, ma25_dev=None)
+
+        generate_signals(conn, TARGET_DATE, use_stock_ma_cross_filter=True)
+
+        buy_codes = [
+            r[0]
+            for r in conn.execute(
+                "SELECT code FROM signals WHERE date = ? AND side = 'buy'", [TARGET_DATE]
+            ).fetchall()
+        ]
+        assert "9005" in buy_codes
 
 
 class TestVolumeBreakoutFilter:


### PR DESCRIPTION
## Summary

- **schema.py**: `features` テーブルに `ma25_dev` / `ma75_dev` カラムを追加。ALTER TABLE migration も追記し既存 DB へのオンライン適用に対応
- **factor_research.py**: `calc_momentum()` に MA25/MA75 ウィンドウ関数を追加（MA200 と同じ計算パターン）
- **feature_engineering.py**: `build_features()` に `ma25_dev` / `ma75_dev` を追加。`_NORM_COLS` には含めない（MA クロス判定は生値で比較するため Z スコア正規化しない）
- **signal_generator.py**: `use_stock_ma_cross_filter` フラグを追加
  - `ma75_dev < 0`（株価が MA75 を下回る）→ BUY スキップ（強ベア）
  - `ma25_dev < 0` かつ `ma75_dev >= 0` → `size_multiplier` を 0.5 に縮小（弱ベア）
  - per-signal の `size_multiplier` を `buy_signals` dict に持たせるよう変更（バッチ全体の値を上書きしない）

## 背景

Group H バックテスト（2026-05-20）で MA200 バイナリフィルターの限界が判明。Group I として MA25/MA75 クロス判定に置き換える実装。詳細は Issue #353 / `documents/07_Research/Phase1_Backtest_Strategy.md` Section 19 参照。

## Test plan

- [x] `TestStockMaCrossFilter` 5ケース追加（スキップ・許可・size縮小・デフォルト無効・NULL許可）
- [x] 既存テスト 2018 ケース全通過（`python -m pytest tests/ -q`）
- [ ] `backfill_features.py --start 2017-01-01 --end 2025-12-31 --force` で features テーブルを再生成（手動実行が必要）
- [ ] Group I バックテストスクリプト作成・実行は別 Issue で対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)