### PR TITLE
fix: PaperSandboxBroker で sandbox + paper 資金を両立 / MonitoringDB を ExecutionEngine に渡す

### DIFF
--- a/src/kabusys/execution/broker_factory.py
+++ b/src/kabusys/execution/broker_factory.py
@@ -25,19 +25,23 @@ class BrokerClientFactory:
     ) -> BrokerAPIProtocol:
         """設定に応じたブローカークライアントを返す。
 
-        - is_paper かつ kabu_use_sandbox → KabuStationClient（検証 URL: port 18081）
+        - is_paper かつ kabu_use_sandbox → PaperSandboxBroker（API は検証環境、資金は paper_cash）
         - is_paper または is_dev         → MockBrokerClient（available_cash / initial_positions を注入）
         - is_live                        → KabuStationClient（本番）
         - それ以外                       → ValueError（settings.env の評価で確定）
         """
         if settings.is_paper and settings.kabu_use_sandbox:
+            from kabusys.execution.paper_sandbox_broker import PaperSandboxBroker
+
             password = settings.kabu_sandbox_api_password or settings.kabu_api_password
-            return create_broker_api(
+            real_broker = create_broker_api(
                 mock=False,
                 api_password=password,
                 trade_password=settings.kabu_trade_password,
                 base_url=_SANDBOX_BASE_URL,
             )
+            cash = available_cash if available_cash is not None else settings.paper_trading_initial_cash
+            return PaperSandboxBroker(real_broker=real_broker, paper_cash=cash)
         if settings.is_paper or settings.is_dev:
             cash = (
                 available_cash

--- a/src/kabusys/execution/broker_factory.py
+++ b/src/kabusys/execution/broker_factory.py
@@ -40,7 +40,11 @@ class BrokerClientFactory:
                 trade_password=settings.kabu_trade_password,
                 base_url=_SANDBOX_BASE_URL,
             )
-            cash = available_cash if available_cash is not None else settings.paper_trading_initial_cash
+            cash = (
+                available_cash
+                if available_cash is not None
+                else settings.paper_trading_initial_cash
+            )
             return PaperSandboxBroker(real_broker=real_broker, paper_cash=cash)
         if settings.is_paper or settings.is_dev:
             cash = (

--- a/src/kabusys/execution/paper_sandbox_broker.py
+++ b/src/kabusys/execution/paper_sandbox_broker.py
@@ -18,9 +18,14 @@ class PaperSandboxBroker:
 
     - send_order / cancel_order / get_order_status / get_positions → 検証環境 API に委譲
     - get_available_cash → paper_trading.db 復元値 or PAPER_TRADING_INITIAL_CASH を返す
+    - close → 検証環境 API クライアントのリソース解放を委譲
 
     kabuステーション検証環境の /wallet/cash は常に 0 を返すため（Issue #317）、
     get_available_cash() だけ paper_cash を返すことで RiskManager の余力チェックを正常化する。
+
+    paper_cash は起動時の復元値または PAPER_TRADING_INITIAL_CASH で固定される。
+    実行中の約定による動的更新は行わない（Paper Trading の検証用途として許容）。
+    将来的に動的更新が必要になった場合は ExecutionEngine 側から set_paper_cash() を呼ぶこと。
     """
 
     def __init__(self, real_broker: BrokerAPIProtocol, paper_cash: float) -> None:
@@ -31,7 +36,7 @@ class PaperSandboxBroker:
         return self._real.send_order(order)
 
     def cancel_order(self, order_id: str) -> None:
-        return self._real.cancel_order(order_id)
+        self._real.cancel_order(order_id)
 
     def get_order_status(self, order_id: str) -> OrderStatus | None:
         return self._real.get_order_status(order_id)
@@ -41,3 +46,11 @@ class PaperSandboxBroker:
 
     def get_available_cash(self) -> float:
         return self._paper_cash
+
+    def close(self) -> None:
+        """検証環境 API クライアント（KabuStationClient）のリソースを解放する。"""
+        self._real.close()
+
+    def __getattr__(self, name: str) -> object:
+        """BrokerAPIProtocol に将来メソッドが追加された場合のフォールバック委譲。"""
+        return getattr(self._real, name)

--- a/src/kabusys/execution/paper_sandbox_broker.py
+++ b/src/kabusys/execution/paper_sandbox_broker.py
@@ -1,0 +1,43 @@
+# src/kabusys/execution/paper_sandbox_broker.py
+"""paper_sandbox_broker.py — Sandbox + Paper Trading ハイブリッドクライアント。"""
+
+from __future__ import annotations
+
+from kabusys.execution.broker_api import (
+    BrokerAPIProtocol,
+    OrderRequest,
+    OrderResponse,
+    OrderStatus,
+    Position,
+)
+
+
+class PaperSandboxBroker:
+    """kabuステーション検証環境への API 接続を維持しつつ、
+    資金残高はペーパートレード用の仮想値を使うラッパー。
+
+    - send_order / cancel_order / get_order_status / get_positions → 検証環境 API に委譲
+    - get_available_cash → paper_trading.db 復元値 or PAPER_TRADING_INITIAL_CASH を返す
+
+    kabuステーション検証環境の /wallet/cash は常に 0 を返すため（Issue #317）、
+    get_available_cash() だけ paper_cash を返すことで RiskManager の余力チェックを正常化する。
+    """
+
+    def __init__(self, real_broker: BrokerAPIProtocol, paper_cash: float) -> None:
+        self._real = real_broker
+        self._paper_cash = paper_cash
+
+    def send_order(self, order: OrderRequest) -> OrderResponse:
+        return self._real.send_order(order)
+
+    def cancel_order(self, order_id: str) -> None:
+        return self._real.cancel_order(order_id)
+
+    def get_order_status(self, order_id: str) -> OrderStatus | None:
+        return self._real.get_order_status(order_id)
+
+    def get_positions(self) -> list[Position]:
+        return self._real.get_positions()
+
+    def get_available_cash(self) -> float:
+        return self._paper_cash

--- a/src/kabusys/execution/paper_sandbox_broker.py
+++ b/src/kabusys/execution/paper_sandbox_broker.py
@@ -25,7 +25,7 @@ class PaperSandboxBroker:
 
     paper_cash は起動時の復元値または PAPER_TRADING_INITIAL_CASH で固定される。
     実行中の約定による動的更新は行わない（Paper Trading の検証用途として許容）。
-    将来的に動的更新が必要になった場合は ExecutionEngine 側から set_paper_cash() を呼ぶこと。
+    動的更新が必要になった場合は別途 setter を追加すること（現状は未実装）。
     """
 
     def __init__(self, real_broker: BrokerAPIProtocol, paper_cash: float) -> None:

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -261,6 +261,8 @@ def main() -> None:
 
     try:
         # 3. ブローカークライアント（paper mode は前回状態を復元）
+        # sandbox モードでは restored_cash → PaperSandboxBroker.paper_cash に使用。
+        # restored_positions は sandbox 分岐では利用しない（ポジションは検証環境 API から取得）。
         restored_cash: float | None = None
         restored_positions: list[Position] | None = None
         if settings.is_paper:

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -32,7 +32,7 @@ from kabusys.execution.order_repository import (  # noqa: E402
 )
 from kabusys.execution.reconciler import Reconciler  # noqa: E402
 from kabusys.execution.risk_manager import RiskConfig, RiskManager  # noqa: E402
-from kabusys.monitoring.monitoring_db import init_monitoring_db  # noqa: E402
+from kabusys.monitoring.monitoring_db import MonitoringDB, init_monitoring_db  # noqa: E402
 from kabusys.operations.execution_startup_report import (  # noqa: E402
     build_report,
     format_cli_summary,
@@ -260,10 +260,10 @@ def main() -> None:
     duckdb_conn = duckdb.connect(str(settings.duckdb_path), read_only=True)
 
     try:
-        # 3. ブローカークライアント（paper mode かつ非サンドボックスは前回状態を復元）
+        # 3. ブローカークライアント（paper mode は前回状態を復元）
         restored_cash: float | None = None
         restored_positions: list[Position] | None = None
-        if settings.is_paper and not settings.kabu_use_sandbox:
+        if settings.is_paper:
             restored_cash, restored_positions = _restore_paper_state(
                 settings.paper_sqlite_path, settings.paper_trading_initial_cash
             )
@@ -325,6 +325,7 @@ def main() -> None:
             logger.warning("朝の LINE 通知に失敗しました（起動を続行します）", exc_info=True)
 
         # 5. ExecutionEngine 起動（reconciliation は上で完了済みのため reconciler=None）
+        monitoring_db = MonitoringDB(sqlite_conn)
         engine = ExecutionEngine(
             broker=broker,
             repo=repo,
@@ -335,6 +336,7 @@ def main() -> None:
             config=EngineConfig(target_date=today),
             reconciler=None,
             pid_file=_EXECUTION_PID,
+            monitoring_db=monitoring_db,
         )
         # 停止フラグが既に立っている場合は起動せず終了
         if _STOP_FLAG.exists():

--- a/tests/test_broker_factory.py
+++ b/tests/test_broker_factory.py
@@ -200,40 +200,53 @@ class TestBrokerClientFactoryInitialCash:
         assert len(positions) == 1
         assert positions[0].code == "1234"
 
-    def test_sandbox_mode_returns_kabu_client(self, monkeypatch):
-        from kabusys.execution.kabu_client import KabuStationClient
+    def test_sandbox_mode_returns_paper_sandbox_broker(self, monkeypatch):
+        from kabusys.execution.paper_sandbox_broker import PaperSandboxBroker
 
         monkeypatch.setenv("KABUSYS_ENV", "paper_trading")
         monkeypatch.setenv("KABU_USE_SANDBOX", "true")
         monkeypatch.setenv("KABU_API_PASSWORD", "api_pass")
         monkeypatch.setenv("KABU_SANDBOX_API_PASSWORD", "sandbox_pass")
+        broker = BrokerClientFactory.create(Settings(), available_cash=5_000_000.0)
+        assert isinstance(broker, PaperSandboxBroker)
+        assert broker.get_available_cash() == 5_000_000.0
+        broker._real.close()
+
+    def test_sandbox_mode_uses_initial_cash_from_settings(self, monkeypatch):
+        from kabusys.execution.paper_sandbox_broker import PaperSandboxBroker
+
+        monkeypatch.setenv("KABUSYS_ENV", "paper_trading")
+        monkeypatch.setenv("KABU_USE_SANDBOX", "true")
+        monkeypatch.setenv("KABU_API_PASSWORD", "api_pass")
+        monkeypatch.setenv("PAPER_TRADING_INITIAL_CASH", "3000000")
         broker = BrokerClientFactory.create(Settings())
-        assert isinstance(broker, KabuStationClient)
-        broker.close()
+        assert isinstance(broker, PaperSandboxBroker)
+        assert broker.get_available_cash() == 3_000_000.0
+        broker._real.close()
 
     def test_sandbox_falls_back_to_api_password(self, monkeypatch):
-        from kabusys.execution.kabu_client import KabuStationClient
+        from kabusys.execution.paper_sandbox_broker import PaperSandboxBroker
 
         monkeypatch.setenv("KABUSYS_ENV", "paper_trading")
         monkeypatch.setenv("KABU_USE_SANDBOX", "true")
         monkeypatch.setenv("KABU_API_PASSWORD", "api_pass")
         monkeypatch.delenv("KABU_SANDBOX_API_PASSWORD", raising=False)
         broker = BrokerClientFactory.create(Settings())
-        assert isinstance(broker, KabuStationClient)
-        broker.close()
+        assert isinstance(broker, PaperSandboxBroker)
+        broker._real.close()
 
-    def test_sandbox_uses_port_18081(self, monkeypatch):
+    def test_sandbox_real_broker_uses_port_18081(self, monkeypatch):
         from kabusys.execution.broker_factory import _SANDBOX_BASE_URL
-        from kabusys.execution.kabu_client import KabuStationClient
+        from kabusys.execution.paper_sandbox_broker import PaperSandboxBroker
 
         monkeypatch.setenv("KABUSYS_ENV", "paper_trading")
         monkeypatch.setenv("KABU_USE_SANDBOX", "true")
         monkeypatch.setenv("KABU_API_PASSWORD", "api_pass")
         monkeypatch.delenv("KABU_SANDBOX_API_PASSWORD", raising=False)
         broker = BrokerClientFactory.create(Settings())
-        assert isinstance(broker, KabuStationClient)
+        assert isinstance(broker, PaperSandboxBroker)
         assert "18081" in _SANDBOX_BASE_URL
-        broker.close()
+        broker._real.close()
 
 
 class TestKabuTradePassword:

--- a/tests/test_broker_factory.py
+++ b/tests/test_broker_factory.py
@@ -210,7 +210,7 @@ class TestBrokerClientFactoryInitialCash:
         broker = BrokerClientFactory.create(Settings(), available_cash=5_000_000.0)
         assert isinstance(broker, PaperSandboxBroker)
         assert broker.get_available_cash() == 5_000_000.0
-        broker._real.close()
+        broker.close()
 
     def test_sandbox_mode_uses_initial_cash_from_settings(self, monkeypatch):
         from kabusys.execution.paper_sandbox_broker import PaperSandboxBroker
@@ -222,7 +222,7 @@ class TestBrokerClientFactoryInitialCash:
         broker = BrokerClientFactory.create(Settings())
         assert isinstance(broker, PaperSandboxBroker)
         assert broker.get_available_cash() == 3_000_000.0
-        broker._real.close()
+        broker.close()
 
     def test_sandbox_falls_back_to_api_password(self, monkeypatch):
         from kabusys.execution.paper_sandbox_broker import PaperSandboxBroker
@@ -233,7 +233,7 @@ class TestBrokerClientFactoryInitialCash:
         monkeypatch.delenv("KABU_SANDBOX_API_PASSWORD", raising=False)
         broker = BrokerClientFactory.create(Settings())
         assert isinstance(broker, PaperSandboxBroker)
-        broker._real.close()
+        broker.close()
 
     def test_sandbox_real_broker_uses_port_18081(self, monkeypatch):
         from kabusys.execution.broker_factory import _SANDBOX_BASE_URL
@@ -246,7 +246,7 @@ class TestBrokerClientFactoryInitialCash:
         broker = BrokerClientFactory.create(Settings())
         assert isinstance(broker, PaperSandboxBroker)
         assert "18081" in _SANDBOX_BASE_URL
-        broker._real.close()
+        broker.close()
 
 
 class TestKabuTradePassword:

--- a/tests/test_paper_sandbox_broker.py
+++ b/tests/test_paper_sandbox_broker.py
@@ -1,0 +1,78 @@
+# tests/test_paper_sandbox_broker.py
+"""PaperSandboxBroker のユニットテスト。"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from kabusys.execution.broker_api import (
+    OrderRequest,
+    OrderResponse,
+    OrderStatus,
+    Position,
+)
+from kabusys.execution.paper_sandbox_broker import PaperSandboxBroker
+
+
+@pytest.fixture
+def real_broker():
+    mock = MagicMock()
+    mock.send_order.return_value = OrderResponse(order_id="SB001")
+    mock.get_order_status.return_value = OrderStatus(
+        order_id="SB001",
+        code="7203",
+        side="buy",
+        qty=100,
+        filled_qty=100,
+        status="filled",
+        price=2000.0,
+    )
+    mock.get_positions.return_value = [Position(code="7203", qty=100, avg_price=2000.0)]
+    return mock
+
+
+class TestPaperSandboxBrokerCash:
+    def test_get_available_cash_returns_paper_cash(self, real_broker):
+        broker = PaperSandboxBroker(real_broker=real_broker, paper_cash=5_000_000.0)
+        assert broker.get_available_cash() == 5_000_000.0
+
+    def test_get_available_cash_ignores_real_broker(self, real_broker):
+        real_broker.get_available_cash.return_value = 0.0
+        broker = PaperSandboxBroker(real_broker=real_broker, paper_cash=10_000_000.0)
+        assert broker.get_available_cash() == 10_000_000.0
+        real_broker.get_available_cash.assert_not_called()
+
+
+class TestPaperSandboxBrokerDelegation:
+    def test_send_order_delegates_to_real(self, real_broker):
+        broker = PaperSandboxBroker(real_broker=real_broker, paper_cash=10_000_000.0)
+        req = OrderRequest(code="7203", side="buy", qty=100, price=2000.0)
+        resp = broker.send_order(req)
+        assert resp.order_id == "SB001"
+        real_broker.send_order.assert_called_once_with(req)
+
+    def test_cancel_order_delegates_to_real(self, real_broker):
+        broker = PaperSandboxBroker(real_broker=real_broker, paper_cash=10_000_000.0)
+        broker.cancel_order("SB001")
+        real_broker.cancel_order.assert_called_once_with("SB001")
+
+    def test_get_order_status_delegates_to_real(self, real_broker):
+        broker = PaperSandboxBroker(real_broker=real_broker, paper_cash=10_000_000.0)
+        status = broker.get_order_status("SB001")
+        assert status is not None
+        assert status.order_id == "SB001"
+        real_broker.get_order_status.assert_called_once_with("SB001")
+
+    def test_get_positions_delegates_to_real(self, real_broker):
+        broker = PaperSandboxBroker(real_broker=real_broker, paper_cash=10_000_000.0)
+        positions = broker.get_positions()
+        assert len(positions) == 1
+        assert positions[0].code == "7203"
+        real_broker.get_positions.assert_called_once()
+
+
+class TestPaperSandboxBrokerProtocol:
+    def test_implements_broker_protocol(self, real_broker):
+        from kabusys.execution.broker_api import BrokerAPIProtocol
+
+        broker = PaperSandboxBroker(real_broker=real_broker, paper_cash=10_000_000.0)
+        assert isinstance(broker, BrokerAPIProtocol)

--- a/tests/test_paper_sandbox_broker.py
+++ b/tests/test_paper_sandbox_broker.py
@@ -71,6 +71,20 @@ class TestPaperSandboxBrokerDelegation:
         real_broker.get_positions.assert_called_once()
 
 
+class TestPaperSandboxBrokerClose:
+    def test_close_delegates_to_real(self, real_broker):
+        broker = PaperSandboxBroker(real_broker=real_broker, paper_cash=10_000_000.0)
+        broker.close()
+        real_broker.close.assert_called_once()
+
+
+class TestPaperSandboxBrokerGetattr:
+    def test_getattr_falls_back_to_real(self, real_broker):
+        real_broker.some_future_method = lambda: "future"
+        broker = PaperSandboxBroker(real_broker=real_broker, paper_cash=10_000_000.0)
+        assert broker.some_future_method() == "future"
+
+
 class TestPaperSandboxBrokerProtocol:
     def test_implements_broker_protocol(self, real_broker):
         from kabusys.execution.broker_api import BrokerAPIProtocol

--- a/tests/test_paper_sandbox_broker.py
+++ b/tests/test_paper_sandbox_broker.py
@@ -1,5 +1,6 @@
 # tests/test_paper_sandbox_broker.py
 """PaperSandboxBroker のユニットテスト。"""
+
 from unittest.mock import MagicMock
 
 import pytest


### PR DESCRIPTION
## 概要

Closes #363, Closes #364

`paper_trading + KABU_USE_SANDBOX=true` 時に BUY 注文が余力不足で落ちるバグ（#363）と、`trade_logs` が記録されないバグ（#364）を修正します。

## 変更内容

### 新規: `PaperSandboxBroker`（#363 案A）

`src/kabusys/execution/paper_sandbox_broker.py` を追加。

kabuステーション検証環境（port 18081）への API 接続はそのままに、`get_available_cash()` だけ `PAPER_TRADING_INITIAL_CASH` または `paper_trading.db` 復元値を返すラッパークラス。

```
send_order / cancel_order / get_order_status / get_positions → KabuStationClient に委譲
get_available_cash → paper_cash（復元値 or PAPER_TRADING_INITIAL_CASH）を返す
```

### `BrokerClientFactory`（#363）

sandbox 分岐の戻り値を `KabuStationClient` → `PaperSandboxBroker` に変更。

### `run_execution.py`（#363 + #364）

- sandbox 時も `_restore_paper_state()` を呼ぶよう条件を修正（`not settings.kabu_use_sandbox` 削除）
- `MonitoringDB(sqlite_conn)` を生成して `ExecutionEngine` に渡すよう追加

## テスト

- `tests/test_paper_sandbox_broker.py` を新規追加（7件）
- `tests/test_broker_factory.py` の sandbox 関連テストを `PaperSandboxBroker` 対応に更新
- 全テスト 2079 件 PASS 確認済み

## テスト方法

```powershell
python -m pytest tests/test_paper_sandbox_broker.py tests/test_broker_factory.py -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)