### PR TITLE
Fix Paper Trading verification report events

### DIFF
--- a/src/kabusys/execution/execution_engine.py
+++ b/src/kabusys/execution/execution_engine.py
@@ -24,7 +24,6 @@ from kabusys.execution.broker_api import BrokerAPIProtocol, OrderSentPendingErro
 
 # DuplicateOrderError は _process_signals() (Task 7) で使用
 from kabusys.execution.order_manager import DuplicateOrderError, OrderManager
-from kabusys.execution.order_record import OrderState
 from kabusys.execution.order_repository import OrderRepository
 from kabusys.execution.reconciler import Reconciler
 from kabusys.execution.risk_manager import RiskManager, RiskRejectReason
@@ -73,7 +72,9 @@ class ExecutionEngine:
         event_type: str,
         record,
         *,
+        filled_qty: int | None = None,
         latency_ms: float | None = None,
+        state: str | None = None,
     ) -> None:
         if self._monitoring_db is None:
             return
@@ -86,8 +87,8 @@ class ExecutionEngine:
                 updated.side,
                 updated.qty,
                 updated.price,
-                updated.filled_qty,
-                updated.state.value,
+                updated.filled_qty if filled_qty is None else filled_qty,
+                updated.state.value if state is None else state,
                 latency_ms=latency_ms,
             )
         except Exception as exc:
@@ -210,12 +211,6 @@ class ExecutionEngine:
             # SELL pending は記録しない（保有中のポジションのクローズ確定前のため）
             # NOTE: _process_signals はメインスレッドからのみ呼び出される。
             #       sqlite_conn は check_same_thread=True（デフォルト）のため他スレッドからアクセス不可。
-            if _order_sent and record.broker_order_id:
-                try:
-                    record = self._order_manager.sync_order(record.client_order_id)
-                except Exception as exc:
-                    logger.debug("post-send sync_order skipped: %s", exc)
-
             if _order_sent and self._sqlite_conn is not None:
                 try:
                     fill_date = next_trading_day(self._duckdb_conn, self._config.target_date)
@@ -254,10 +249,19 @@ class ExecutionEngine:
                 except Exception as _mon_exc:
                     logger.warning("監視DB書き込み失敗（発注フローは継続）: %s", _mon_exc)
 
-            if latency_ms is not None:
-                updated = self._repo.get(record.client_order_id)
-                if updated is not None and updated.state == OrderState.Filled:
-                    self._log_trade_event("Filled", updated, latency_ms=latency_ms)
+            if latency_ms is not None and record.broker_order_id:
+                try:
+                    status = self._broker.get_order_status(record.broker_order_id)
+                    if status is not None and status.status == "filled":
+                        self._log_trade_event(
+                            "Filled",
+                            record,
+                            filled_qty=status.filled_qty,
+                            latency_ms=latency_ms,
+                            state="filled",
+                        )
+                except Exception as exc:
+                    logger.debug("post-send status check skipped: %s", exc)
 
     def _drain_push_queue(self) -> None:
         """_push_queue を全件処理する（sync_order + Gate 3 チェック）。"""

--- a/src/kabusys/execution/execution_engine.py
+++ b/src/kabusys/execution/execution_engine.py
@@ -24,6 +24,7 @@ from kabusys.execution.broker_api import BrokerAPIProtocol, OrderSentPendingErro
 
 # DuplicateOrderError は _process_signals() (Task 7) で使用
 from kabusys.execution.order_manager import DuplicateOrderError, OrderManager
+from kabusys.execution.order_record import OrderState
 from kabusys.execution.order_repository import OrderRepository
 from kabusys.execution.reconciler import Reconciler
 from kabusys.execution.risk_manager import RiskManager, RiskRejectReason
@@ -66,6 +67,31 @@ class ExecutionEngine:
         self._monitoring_db = monitoring_db
         self._stop_event = threading.Event()
         self._push_queue: queue.Queue[dict] = queue.Queue()
+
+    def _log_trade_event(
+        self,
+        event_type: str,
+        record,
+        *,
+        latency_ms: float | None = None,
+    ) -> None:
+        if self._monitoring_db is None:
+            return
+        try:
+            updated = self._repo.get(record.client_order_id) or record
+            self._monitoring_db.log_trade_event(
+                event_type,
+                updated.client_order_id,
+                updated.code,
+                updated.side,
+                updated.qty,
+                updated.price,
+                updated.filled_qty,
+                updated.state.value,
+                latency_ms=latency_ms,
+            )
+        except Exception as exc:
+            logger.warning("monitoring DB write failed; order flow continues: %s", exc)
 
     def _process_signals(self) -> None:
         """今日のシグナルを読み込み、Gate 1/2 を通して発注する。"""
@@ -149,6 +175,7 @@ class ExecutionEngine:
                         price=price,
                     ),
                 )
+                self._log_trade_event("Created", record)
             except DuplicateOrderError:
                 logger.info("DuplicateOrderError - skip: signal_id=%s", signal_id)
                 continue
@@ -158,7 +185,7 @@ class ExecutionEngine:
             _order_sent = False
             _order_pending = False
             try:
-                self._order_manager.send_order(record.client_order_id)
+                record = self._order_manager.send_order(record.client_order_id)
                 latency_ms = (_time_module.perf_counter() - t0) * 1000
                 self._risk_manager.record_api_success()
                 _order_sent = True
@@ -183,6 +210,12 @@ class ExecutionEngine:
             # SELL pending は記録しない（保有中のポジションのクローズ確定前のため）
             # NOTE: _process_signals はメインスレッドからのみ呼び出される。
             #       sqlite_conn は check_same_thread=True（デフォルト）のため他スレッドからアクセス不可。
+            if _order_sent and record.broker_order_id:
+                try:
+                    record = self._order_manager.sync_order(record.client_order_id)
+                except Exception as exc:
+                    logger.debug("post-send sync_order skipped: %s", exc)
+
             if _order_sent and self._sqlite_conn is not None:
                 try:
                     fill_date = next_trading_day(self._duckdb_conn, self._config.target_date)
@@ -220,6 +253,11 @@ class ExecutionEngine:
                     )
                 except Exception as _mon_exc:
                     logger.warning("監視DB書き込み失敗（発注フローは継続）: %s", _mon_exc)
+
+            if latency_ms is not None:
+                updated = self._repo.get(record.client_order_id)
+                if updated is not None and updated.state == OrderState.Filled:
+                    self._log_trade_event("Filled", updated, latency_ms=latency_ms)
 
     def _drain_push_queue(self) -> None:
         """_push_queue を全件処理する（sync_order + Gate 3 チェック）。"""
@@ -363,8 +401,15 @@ class ExecutionEngine:
 
             # シグナル処理ループ（8:50 ～ 9:10）
             # 現在時刻が signal_send_end を超えている場合はシグナル処理をスキップ
-            if not self._stop_event.is_set() and _now_time() < self._config.signal_send_end:
+            current_time = _now_time()
+            if not self._stop_event.is_set() and current_time < self._config.signal_send_end:
                 self._process_signals()
+            elif not self._stop_event.is_set():
+                logger.warning(
+                    "Signal processing skipped: now=%s is at or after signal_send_end=%s",
+                    current_time,
+                    self._config.signal_send_end,
+                )
 
             # push drain ループ（9:10 ～ 15:30）
             while _now_time() < self._config.market_close and not self._stop_event.is_set():

--- a/src/kabusys/run_execution.py
+++ b/src/kabusys/run_execution.py
@@ -8,9 +8,10 @@ data/paper_trading.db に記録する（本番 DB と完全分離）。
 from __future__ import annotations
 
 import logging
+import os
 import sqlite3
 import threading
-from datetime import date, datetime, timezone
+from datetime import date, datetime, time, timezone
 from pathlib import Path
 
 import duckdb
@@ -45,6 +46,16 @@ from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_loggin
 from kabusys.utils.process_priority import set_process_priority  # noqa: E402
 
 logger = logging.getLogger(__name__)
+
+
+def _env_time(name: str, default: time) -> time:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return time.fromisoformat(raw.strip())
+    except ValueError as exc:
+        raise ValueError(f"{name} must be HH:MM or HH:MM:SS, got {raw!r}") from exc
 
 
 def _count_pending_signals(conn: duckdb.DuckDBPyConnection, target_date: date) -> int:
@@ -335,7 +346,12 @@ def main() -> None:
             order_manager=order_manager,
             duckdb_conn=duckdb_conn,
             sqlite_conn=sqlite_conn,
-            config=EngineConfig(target_date=today),
+            config=EngineConfig(
+                target_date=today,
+                signal_send_start=_env_time("KABUSYS_SIGNAL_SEND_START", time(8, 50)),
+                signal_send_end=_env_time("KABUSYS_SIGNAL_SEND_END", time(9, 10)),
+                market_close=_env_time("KABUSYS_MARKET_CLOSE", time(15, 30)),
+            ),
             reconciler=None,
             pid_file=_EXECUTION_PID,
             monitoring_db=monitoring_db,

--- a/src/kabusys/tools/paper_verification_report.py
+++ b/src/kabusys/tools/paper_verification_report.py
@@ -212,6 +212,7 @@ def generate_report(
     db_path: str,
     from_date: Optional[str] = None,
     to_date: Optional[str] = None,
+    monitoring_db_path: Optional[str] = None,
 ) -> None:
     """検証レポートを生成して標準出力に印字する。
 
@@ -236,13 +237,22 @@ def generate_report(
         )
         return
 
+    stability_db_path = monitoring_db_path or db_path
+    if not Path(stability_db_path).exists():
+        stability_db_path = db_path
+
+    stability_conn = sqlite3.connect(stability_db_path)
+    try:
+        try:
+            stability = _query_system_stability(stability_conn, from_dt, to_dt)
+        except sqlite3.OperationalError:
+            stability = {"total_polls": 0, "error_count": 0, "uptime_pct": None}
+    finally:
+        stability_conn.close()
+
     # DB 接続
     conn = sqlite3.connect(db_path)
     try:
-        try:
-            stability = _query_system_stability(conn, from_dt, to_dt)
-        except sqlite3.OperationalError:
-            stability = {"total_polls": 0, "error_count": 0, "uptime_pct": None}
         try:
             orders = _query_order_stats(conn, from_dt, to_dt)
         except sqlite3.OperationalError:
@@ -346,15 +356,25 @@ def main() -> None:
         metavar="PATH",
         help="SQLite DBファイルパス (環境変数 PAPER_TRADING_SQLITE_PATH でも指定可能)",
     )
+    parser.add_argument(
+        "--monitoring-db",
+        dest="monitoring_db_path",
+        metavar="PATH",
+        help="system_status を読む SQLite DB パス (既定: SQLITE_PATH または data/monitoring.db)",
+    )
     args = parser.parse_args()
 
     # DB パスの解決: --db > 環境変数 > デフォルト
     db_path = args.db_path or os.environ.get("PAPER_TRADING_SQLITE_PATH") or "data/paper_trading.db"
+    monitoring_db_path = (
+        args.monitoring_db_path or os.environ.get("SQLITE_PATH") or "data/monitoring.db"
+    )
 
     generate_report(
         db_path=db_path,
         from_date=args.from_date,
         to_date=args.to_date,
+        monitoring_db_path=monitoring_db_path,
     )
 
 

--- a/tests/test_execution_engine.py
+++ b/tests/test_execution_engine.py
@@ -169,6 +169,24 @@ class TestProcessSignals:
         assert row["latency_ms"] is not None
         assert row["latency_ms"] >= 0.0
 
+    def test_created_and_filled_events_recorded_for_instant_fill(
+        self, sqlite_conn, duckdb_conn, monitoring_conn
+    ):
+        _insert_signal(duckdb_conn, "1234")
+        _insert_target(duckdb_conn, "1234", qty=100, price=1500.0)
+        broker = MockBrokerClient(available_cash=5_000_000.0, fill_mode="instant")
+        mdb = MonitoringDB(monitoring_conn)
+        engine = _make_engine(broker, sqlite_conn, duckdb_conn, monitoring_db=mdb)
+        engine._process_signals()
+
+        rows = monitoring_conn.execute(
+            "SELECT event_type, filled_qty, state FROM trade_logs ORDER BY id"
+        ).fetchall()
+        events = [row[0] for row in rows]
+        assert "Created" in events
+        assert "Sent" in events
+        assert "Filled" in events
+
     def test_latency_ms_recorded_for_pending_order(self, sqlite_conn, duckdb_conn, monitoring_conn):
         """fill_mode=never (OrderSentPendingError) でも latency_ms が記録される"""
         _insert_signal(duckdb_conn, "1234")

--- a/tests/test_run_execution.py
+++ b/tests/test_run_execution.py
@@ -1,6 +1,6 @@
 # tests/test_run_execution.py
-from pathlib import Path
 from datetime import time
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/test_run_execution.py
+++ b/tests/test_run_execution.py
@@ -1,5 +1,6 @@
 # tests/test_run_execution.py
 from pathlib import Path
+from datetime import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -56,6 +57,10 @@ def _run_main(is_paper: bool = False):
 
 
 class TestRunExecutionMain:
+    def test_env_time_override(self, monkeypatch):
+        monkeypatch.setenv("KABUSYS_SIGNAL_SEND_END", "15:30")
+        assert re_mod._env_time("KABUSYS_SIGNAL_SEND_END", time(9, 10)) == time(15, 30)
+
     def test_sets_high_priority_first(self):
         mock_priority, _, _, _ = _run_main()
         mock_priority.assert_called_once_with("high")


### PR DESCRIPTION
## Summary

Closes #368.

- Record `Created` events when execution creates an order.
- Sync immediately after send and record `Filled` events when instant fills are observed.
- Log explicitly when signal processing is skipped because `run_execution` starts after `signal_send_end`.
- Allow execution time windows to be overridden with `KABUSYS_SIGNAL_SEND_START`, `KABUSYS_SIGNAL_SEND_END`, and `KABUSYS_MARKET_CLOSE` for verification runs.
- Let `paper_verification_report` read `system_status` from `SQLITE_PATH` / `data/monitoring.db` via `--monitoring-db`, while keeping order metrics on `paper_trading.db`.

## Verification

```powershell
.\.venv\Scripts\python -m pytest tests/test_execution_engine.py tests/test_run_execution.py
.\.venv\Scripts\python -m kabusys.tools.paper_verification_report --help
```

Both passed locally.