### PR TITLE
Fix execution signal queue schema read

### DIFF
--- a/src/kabusys/execution/execution_engine.py
+++ b/src/kabusys/execution/execution_engine.py
@@ -64,6 +64,7 @@ class ExecutionEngine:
         self._reconciler = reconciler
         self._pid_file: Path | None = pid_file
         self._monitoring_db = monitoring_db
+        self._columns_cache: dict[str, set[str]] = {}
         self._stop_event = threading.Event()
         self._push_queue: queue.Queue[dict] = queue.Queue()
 
@@ -427,19 +428,27 @@ class ExecutionEngine:
         finally:
             _active_pid_file.unlink(missing_ok=True)
 
-    def _read_signals(self) -> list[dict]:
-        """DuckDB から今日のシグナルを portfolio_targets と JOIN して返す。"""
+    def _duckdb_columns(self, table_name: str) -> set[str]:
+        """DuckDB のカレントスキーマから列名を小文字で返す。"""
+        if table_name in self._columns_cache:
+            return self._columns_cache[table_name]
+
         rows = self._duckdb_conn.execute(
             """
-            SELECT s.code, s.side, pt.target_size AS qty, pt.entry_price AS price,
-                   COALESCE(s.size_multiplier, 1.0) AS size_multiplier
-            FROM signals s
-            JOIN portfolio_targets pt ON s.date = pt.date AND s.code = pt.code
-            WHERE s.date = ?
-            ORDER BY s.signal_rank ASC NULLS LAST
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE lower(table_name) = lower(?)
+              AND table_schema = current_schema()
             """,
-            [self._config.target_date],
+            [table_name],
         ).fetchall()
+        columns = {str(row[0]).lower() for row in rows}
+        self._columns_cache[table_name] = columns
+        return columns
+
+    def _read_signals(self) -> list[dict]:
+        """DuckDB から今日の発注対象シグナルを返す。"""
+        rows = self._read_signal_queue_rows()
         return [
             {
                 "code": r[0],
@@ -450,3 +459,50 @@ class ExecutionEngine:
             }
             for r in rows
         ]
+
+    def _read_signal_queue_rows(self) -> list[tuple]:
+        queue_columns = self._duckdb_columns("signal_queue")
+        required_columns = {"date", "code", "side", "size", "status"}
+        if not required_columns.issubset(queue_columns):
+            missing = sorted(required_columns - queue_columns)
+            raise RuntimeError(f"signal_queue schema missing required columns: {missing}")
+
+        signals_columns = self._duckdb_columns("signals")
+        can_join_signals = {"date", "code", "side"}.issubset(signals_columns)
+        multiplier_expr = (
+            "COALESCE(s.size_multiplier, 1.0)"
+            if can_join_signals and "size_multiplier" in signals_columns
+            else "1.0"
+        )
+        rank_expr = (
+            "s.signal_rank ASC NULLS LAST, "
+            if can_join_signals and "signal_rank" in signals_columns
+            else ""
+        )
+        price_expr = "COALESCE(q.price, 0.0)" if "price" in queue_columns else "0.0"
+        signal_join = (
+            """
+            LEFT JOIN signals s
+              ON q.date = s.date
+             AND q.code = s.code
+             AND q.side = s.side
+            """
+            if can_join_signals
+            else ""
+        )
+
+        try:
+            return self._duckdb_conn.execute(
+                f"""
+                SELECT q.code, q.side, q.size AS qty, {price_expr} AS price,
+                       {multiplier_expr} AS size_multiplier
+                FROM signal_queue q
+                {signal_join}
+                WHERE q.date = ? AND q.status = 'pending'
+                ORDER BY {rank_expr}q.code ASC
+                """,
+                [self._config.target_date],
+            ).fetchall()
+        except duckdb.Error as exc:
+            logger.warning("signal_queue read failed for %s: %s", self._config.target_date, exc)
+            raise RuntimeError("signal_queue read failed") from exc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,7 +93,21 @@ def duckdb_conn():
         CREATE TABLE signals (date DATE, code VARCHAR, side VARCHAR, score FLOAT, signal_rank INTEGER, size_multiplier DOUBLE NOT NULL DEFAULT 1.0)
     """)
     conn.execute("""
-        CREATE TABLE portfolio_targets (date DATE, code VARCHAR, target_size INTEGER, entry_price FLOAT)
+        CREATE TABLE portfolio_targets (date DATE, code VARCHAR, target_weight DOUBLE, target_size BIGINT)
+    """)
+    conn.execute("""
+        CREATE TABLE signal_queue (
+            signal_id VARCHAR PRIMARY KEY,
+            date DATE NOT NULL,
+            code VARCHAR NOT NULL,
+            side VARCHAR NOT NULL,
+            size BIGINT NOT NULL,
+            order_type VARCHAR NOT NULL,
+            price DECIMAL(18,4),
+            status VARCHAR NOT NULL DEFAULT 'pending',
+            created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+            processed_at TIMESTAMP
+        )
     """)
     conn.execute("""
         CREATE TABLE IF NOT EXISTS position_entries (

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -59,7 +59,7 @@ def mon_conn():
 
 @pytest.fixture
 def duck_conn():
-    """Execution テスト用 in-memory DuckDB（signals + portfolio_targets）"""
+    """Execution テスト用 in-memory DuckDB（本番相当の signal_queue schema）"""
     conn = duckdb.connect(":memory:")
     conn.execute(
         "CREATE TABLE signals "
@@ -67,7 +67,23 @@ def duck_conn():
     )
     conn.execute(
         "CREATE TABLE portfolio_targets "
-        "(date DATE, code VARCHAR, target_size INTEGER, entry_price FLOAT)"
+        "(date DATE, code VARCHAR, target_weight DOUBLE, target_size BIGINT)"
+    )
+    conn.execute(
+        """
+        CREATE TABLE signal_queue (
+            signal_id VARCHAR PRIMARY KEY,
+            date DATE NOT NULL,
+            code VARCHAR NOT NULL,
+            side VARCHAR NOT NULL,
+            size BIGINT NOT NULL,
+            order_type VARCHAR NOT NULL,
+            price DECIMAL(18,4),
+            status VARCHAR NOT NULL DEFAULT 'pending',
+            created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+            processed_at TIMESTAMP
+        )
+        """
     )
     yield conn
     conn.close()
@@ -85,9 +101,22 @@ def _insert_signal(
 def _insert_target(
     conn: duckdb.DuckDBPyConnection, code: str, qty: int = 100, price: float = 1500.0
 ):
+    side_row = conn.execute(
+        "SELECT side FROM signals WHERE date = ? AND code = ? ORDER BY signal_rank ASC NULLS LAST LIMIT 1",
+        [TARGET_DATE, code],
+    ).fetchone()
+    side = side_row[0] if side_row else "buy"
     conn.execute(
-        "INSERT INTO portfolio_targets VALUES (?, ?, ?, ?)",
-        [TARGET_DATE, code, qty, price],
+        "INSERT INTO portfolio_targets (date, code, target_weight, target_size) VALUES (?, ?, ?, ?)",
+        [TARGET_DATE, code, None, qty],
+    )
+    conn.execute(
+        """
+        INSERT INTO signal_queue
+            (signal_id, date, code, side, size, order_type, price, status)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [f"{TARGET_DATE}_{code}_{side}", TARGET_DATE, code, side, qty, "limit", price, "pending"],
     )
 
 
@@ -196,7 +225,7 @@ class TestSignalQueueExecution:
         return [r[0] for r in rows]
 
     def test_signals_processed_and_orders_created(self, orders_conn, duck_conn):
-        """signals + portfolio_targets から発注レコードが作成されること"""
+        """signal_queue から発注レコードが作成されること"""
         _insert_signal(duck_conn, "7203")
         _insert_target(duck_conn, "7203", qty=100, price=2500.0)
 

--- a/tests/integration/test_paper_trading.py
+++ b/tests/integration/test_paper_trading.py
@@ -50,9 +50,22 @@ def _sig(conn, code: str, side: str = "buy"):
 
 
 def _tgt(conn, code: str, qty: int = 100, price: float = 1500.0):
+    side_row = conn.execute(
+        "SELECT side FROM signals WHERE date = ? AND code = ? ORDER BY signal_rank ASC NULLS LAST LIMIT 1",
+        [TARGET_DATE, code],
+    ).fetchone()
+    side = side_row[0] if side_row else "buy"
     conn.execute(
-        "INSERT INTO portfolio_targets VALUES (?, ?, ?, ?)",
-        [TARGET_DATE, code, qty, price],
+        "INSERT INTO portfolio_targets (date, code, target_weight, target_size) VALUES (?, ?, ?, ?)",
+        [TARGET_DATE, code, None, qty],
+    )
+    conn.execute(
+        """
+        INSERT INTO signal_queue
+            (signal_id, date, code, side, size, order_type, price, status)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [f"{TARGET_DATE}_{code}_{side}", TARGET_DATE, code, side, qty, "limit", price, "pending"],
     )
 
 

--- a/tests/test_execution_engine.py
+++ b/tests/test_execution_engine.py
@@ -6,6 +6,7 @@ import sqlite3
 from datetime import date, time
 from unittest.mock import patch
 
+import duckdb
 import pytest
 
 from kabusys.execution.execution_engine import EngineConfig, ExecutionEngine
@@ -48,14 +49,27 @@ def _insert_signal(conn, code: str, side: str = "buy", score: float = 0.8):
 
 
 def _insert_target(conn, code: str, qty: int = 100, price: float = 1500.0):
+    side_row = conn.execute(
+        "SELECT side FROM signals WHERE date = ? AND code = ? ORDER BY signal_rank ASC NULLS LAST LIMIT 1",
+        [TARGET_DATE, code],
+    ).fetchone()
+    side = side_row[0] if side_row else "buy"
     conn.execute(
-        "INSERT INTO portfolio_targets VALUES (?, ?, ?, ?)",
-        [TARGET_DATE, code, qty, price],
+        "INSERT INTO portfolio_targets (date, code, target_weight, target_size) VALUES (?, ?, ?, ?)",
+        [TARGET_DATE, code, None, qty],
+    )
+    conn.execute(
+        """
+        INSERT INTO signal_queue
+            (signal_id, date, code, side, size, order_type, price, status)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [f"{TARGET_DATE}_{code}_{side}", TARGET_DATE, code, side, qty, "limit", price, "pending"],
     )
 
 
 class TestReadSignals:
-    def test_reads_signals_joined_with_portfolio_targets(self, sqlite_conn, duckdb_conn):
+    def test_reads_pending_signal_queue(self, sqlite_conn, duckdb_conn):
         _insert_signal(duckdb_conn, "1234")
         _insert_target(duckdb_conn, "1234", qty=100, price=1500.0)
         broker = MockBrokerClient(available_cash=5_000_000.0)
@@ -67,13 +81,112 @@ class TestReadSignals:
         assert signals[0]["qty"] == 100
         assert signals[0]["price"] == 1500.0
 
-    def test_excludes_signals_without_portfolio_targets(self, sqlite_conn, duckdb_conn):
+    def test_empty_signal_queue_does_not_read_targets(self, sqlite_conn, duckdb_conn):
         _insert_signal(duckdb_conn, "1234")
-        # portfolio_targets なし → JOIN で除外される
+        duckdb_conn.execute(
+            "INSERT INTO portfolio_targets (date, code, target_weight, target_size) VALUES (?, ?, ?, ?)",
+            [TARGET_DATE, "1234", None, 100],
+        )
+        broker = MockBrokerClient(available_cash=5_000_000.0)
+        engine = _make_engine(broker, sqlite_conn, duckdb_conn)
+
+        signals = engine._read_signals()
+
+        assert signals == []
+
+    def test_excludes_signals_without_pending_queue(self, sqlite_conn, duckdb_conn):
+        _insert_signal(duckdb_conn, "1234")
         broker = MockBrokerClient(available_cash=5_000_000.0)
         engine = _make_engine(broker, sqlite_conn, duckdb_conn)
         signals = engine._read_signals()
         assert len(signals) == 0
+
+    def test_reads_queue_without_joinable_signals_table(self, sqlite_conn):
+        conn = duckdb.connect(":memory:")
+        conn.execute("""
+            CREATE TABLE signal_queue (
+                signal_id VARCHAR PRIMARY KEY,
+                date DATE NOT NULL,
+                code VARCHAR NOT NULL,
+                side VARCHAR NOT NULL,
+                size BIGINT NOT NULL,
+                price DECIMAL(18,4),
+                status VARCHAR NOT NULL DEFAULT 'pending'
+            )
+        """)
+        conn.execute("CREATE TABLE signals (signal_rank INTEGER, size_multiplier DOUBLE)")
+        conn.execute(
+            """
+            INSERT INTO signal_queue
+                (signal_id, date, code, side, size, price, status)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            ["sig-joinless", TARGET_DATE, "7203", "buy", 100, 2500.0, "pending"],
+        )
+        broker = MockBrokerClient(available_cash=5_000_000.0)
+        engine = _make_engine(broker, sqlite_conn, conn)
+
+        signals = engine._read_signals()
+
+        assert signals == [
+            {
+                "code": "7203",
+                "side": "buy",
+                "qty": 100,
+                "price": 2500.0,
+                "size_multiplier": 1.0,
+            }
+        ]
+
+    def test_reads_queue_without_price_column_as_market_order(self, sqlite_conn):
+        conn = duckdb.connect(":memory:")
+        conn.execute("""
+            CREATE TABLE signal_queue (
+                signal_id VARCHAR PRIMARY KEY,
+                date DATE NOT NULL,
+                code VARCHAR NOT NULL,
+                side VARCHAR NOT NULL,
+                size BIGINT NOT NULL,
+                status VARCHAR NOT NULL DEFAULT 'pending'
+            )
+        """)
+        conn.execute(
+            """
+            CREATE TABLE signals (
+                date DATE NOT NULL,
+                code VARCHAR NOT NULL,
+                side VARCHAR NOT NULL,
+                signal_rank INTEGER,
+                size_multiplier DOUBLE NOT NULL DEFAULT 1.0
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO signal_queue
+                (signal_id, date, code, side, size, status)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            ["sig-market", TARGET_DATE, "7203", "buy", 100, "pending"],
+        )
+        conn.execute(
+            "INSERT INTO signals VALUES (?, ?, ?, ?, ?)",
+            [TARGET_DATE, "7203", "buy", 1, 0.5],
+        )
+        broker = MockBrokerClient(available_cash=5_000_000.0)
+        engine = _make_engine(broker, sqlite_conn, conn)
+
+        signals = engine._read_signals()
+
+        assert signals == [
+            {
+                "code": "7203",
+                "side": "buy",
+                "qty": 100,
+                "price": 0.0,
+                "size_multiplier": 0.5,
+            }
+        ]
 
 
 class TestProcessSignals:


### PR DESCRIPTION
## Summary

- Read pending execution targets from `signal_queue` instead of assuming `portfolio_targets.entry_price` exists
- Align execution test fixtures with the production schema for `portfolio_targets` and `signal_queue`
- Remove the legacy `signals + portfolio_targets.entry_price` fallback to prevent test/production schema drift
- Add/adjust regression tests so empty `signal_queue` does not read `portfolio_targets` directly
- Harden `signal_queue` reads for unjoinable `signals` schemas and optional `price` columns

Closes #370

## Verification

```text
.\.venv\Scripts\python -m pytest tests\test_execution_engine.py tests\integration\test_integration.py tests\integration\test_paper_trading.py -q
52 passed

.\.venv\Scripts\python -m ruff check .
All checks passed!

.\.venv\Scripts\python -m ruff format --check .
279 files already formatted
```