### PR TITLE
feat: Phase 2 Group T — sector_rel_20 フィルター追加とバックテストスクリプト (#379)

### DIFF
--- a/backtest/backtest_improvement_plan/run_phase2_group_t.py
+++ b/backtest/backtest_improvement_plan/run_phase2_group_t.py
@@ -525,6 +525,15 @@ def main() -> None:
     success = [r for r in all_results if not r.get("error")]
     failed = [r for r in all_results if r.get("error")]
 
+    # Check if T0 (reference scenario) succeeded
+    if not any(r.get("name") == "T0_r3_ref" for r in success):
+        print(
+            "[ERROR] T0_r3_ref（参照シナリオ）が失敗しました。"
+            "比較対象がないため、結果分析を続行できません。",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     with results_csv.open("w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(f, fieldnames=CSV_FIELDNAMES, extrasaction="ignore")
         writer.writeheader()
@@ -609,6 +618,8 @@ def main() -> None:
             "best_sharpe": best.get("sharpe"),
             "best_max_drawdown": best.get("max_drawdown"),
             "best_profit_factor": best.get("profit_factor"),
+            "best_win_rate": best.get("win_rate"),
+            "best_total_trades": best.get("total_trades"),
         }
     elif improved:
         best = max(improved, key=lambda r: r.get("sharpe") or 0)
@@ -625,6 +636,8 @@ def main() -> None:
             "best_sharpe": best.get("sharpe"),
             "best_max_drawdown": best.get("max_drawdown"),
             "best_profit_factor": best.get("profit_factor"),
+            "best_win_rate": best.get("win_rate"),
+            "best_total_trades": best.get("total_trades"),
         }
     else:
         print("  全シナリオで T0（R3 参照）以下")

--- a/backtest/backtest_improvement_plan/run_phase2_group_t.py
+++ b/backtest/backtest_improvement_plan/run_phase2_group_t.py
@@ -1,0 +1,646 @@
+"""Phase 2 Group T — セクター内相対強度・クオリティフィルター検証 (Issue #379)
+
+2021 年（横ばい）・2022 年（弱気）のマイナスを改善するため、
+セクター内相対強度（sector_rel_20）と既存のクオリティスコアフィルターを
+R3 ベース設定に追加した場合の効果を検証する。
+
+IS 参照値（R3、Phase2_Backtest_Strategy.md Section 48）:
+  CAGR 9.01%、Sharpe 0.445、MaxDD 26.87%、PF 1.402
+
+シナリオ:
+  T0_r3_ref    : フィルターなし（R3 完全参照）
+  T1_sec_50    : sector_rel_20 >= 0.50（セクター内上位50%のみ）
+  T2_sec_60    : sector_rel_20 >= 0.60（セクター内上位40%のみ）
+  T3_sec_70    : sector_rel_20 >= 0.70（セクター内上位30%のみ）
+  T4_quality   : quality_score >= -0.30（クオリティフィルター単体）
+  T5_s60_q     : sector_rel_20 >= 0.60 + quality_score >= -0.30（複合）
+  T6_s50_q     : sector_rel_20 >= 0.50 + quality_score >= -0.30（複合）
+
+Phase 2 採択基準:
+  CAGR  > 8%
+  Sharpe > 0.5  (Phase 2 主目標)
+  MaxDD  < 25%
+  PF     > 1.1
+
+Usage:
+    python backtest/backtest_improvement_plan/run_phase2_group_t.py
+    python backtest/backtest_improvement_plan/run_phase2_group_t.py --workers 4
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import shutil
+import subprocess
+import sys
+import traceback
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from datetime import datetime
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# 定数
+# ---------------------------------------------------------------------------
+
+DEFAULT_WORKERS = 4
+
+
+def _find_repo_root() -> Path:
+    current = Path(__file__).resolve().parent
+    for candidate in [current, *current.parents]:
+        if (candidate / "config" / "strategy_config.yaml").exists():
+            return candidate
+    raise FileNotFoundError("config/strategy_config.yaml が見つかりません")
+
+
+REPO_ROOT = _find_repo_root()
+ENV_PATH = REPO_ROOT / ".env"
+ARTIFACTS_ROOT = REPO_ROOT / "artifacts" / "backtest" / "backtest_phase2_group_t"
+
+# ---------------------------------------------------------------------------
+# R3 ベース固定パラメータ（sector_rel_min / quality_score_min 以外）
+# ---------------------------------------------------------------------------
+
+_COM_BASE = {
+    "cash": 1_000_000,
+    "allocation_method": "equal",
+    "max_position_pct": 0.22,
+    "risk_pct": 0.005,
+    "max_positions": 7,
+    "max_utilization": 0.40,
+    "use_ma200_filter": True,
+    "stop_loss_pct": 0.09,
+    "min_holding_days": 5,
+    "max_holding_days": 60,
+    "trailing_stop_atr": 2.0,
+    "threshold": 0.58,
+    "weak_bear": 1.00,
+    "strong_bear": 1.00,
+    "dd_stop": 0.12,
+    "dd_timeout": 30,
+    # 施策A（現行設定を維持）
+    "adaptive_threshold_vol_regime": True,
+    "topix_vol_window": 20,
+    "topix_vol_low_threshold": 0.12,
+    "adaptive_threshold_hi": 0.62,
+    # 施策B
+    "dynamic_trailing_stop": True,
+    "trail_profit_gate_atr": 1.5,
+    "trail_stage2_mult": 1.8,
+    "trail_stage3_mult": 1.5,
+    "start": "2017-01-01",
+    "end": "2025-12-31",
+}
+
+# IS 参照値（R3、Phase2_Backtest_Strategy.md Section 48）
+_IS_CAGR = 0.0901
+_IS_SHARPE = 0.445
+_IS_MAX_DD = 0.2687
+_IS_PF = 1.402
+
+# Phase 2 採択基準
+_CAGR_MIN = 0.08
+_SHARPE_MIN = 0.5
+_DD_MAX = 0.25
+_PF_MIN = 1.1
+
+# ---------------------------------------------------------------------------
+# シナリオ定義（sector_rel_min / quality_score_min のみ変動）
+# ---------------------------------------------------------------------------
+
+_SCENARIOS: list[dict] = [
+    {
+        "name": "T0_r3_ref",
+        "group": "T",
+        "sector_rel_min": None,
+        "quality_score_min": None,
+        "desc": "R3 参照（フィルターなし）",
+        "is_reference": True,
+    },
+    {
+        "name": "T1_sec_50",
+        "group": "T",
+        "sector_rel_min": 0.50,
+        "quality_score_min": None,
+        "desc": "セクター内上位 50%（単体）",
+        "is_reference": False,
+    },
+    {
+        "name": "T2_sec_60",
+        "group": "T",
+        "sector_rel_min": 0.60,
+        "quality_score_min": None,
+        "desc": "セクター内上位 40%（単体）",
+        "is_reference": False,
+    },
+    {
+        "name": "T3_sec_70",
+        "group": "T",
+        "sector_rel_min": 0.70,
+        "quality_score_min": None,
+        "desc": "セクター内上位 30%（単体）",
+        "is_reference": False,
+    },
+    {
+        "name": "T4_quality",
+        "group": "T",
+        "sector_rel_min": None,
+        "quality_score_min": -0.30,
+        "desc": "クオリティフィルター単体（quality_score >= -0.30）",
+        "is_reference": False,
+    },
+    {
+        "name": "T5_s60_q",
+        "group": "T",
+        "sector_rel_min": 0.60,
+        "quality_score_min": -0.30,
+        "desc": "セクター上位 40% + クオリティ複合",
+        "is_reference": False,
+    },
+    {
+        "name": "T6_s50_q",
+        "group": "T",
+        "sector_rel_min": 0.50,
+        "quality_score_min": -0.30,
+        "desc": "セクター上位 50% + クオリティ複合",
+        "is_reference": False,
+    },
+]
+
+# ---------------------------------------------------------------------------
+# ユーティリティ
+# ---------------------------------------------------------------------------
+
+
+def _load_env(path: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    if not path.exists():
+        return result
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, val = line.split("=", 1)
+        val = val.strip()
+        if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+            val = val[1:-1]
+        result[key.strip()] = val
+    return result
+
+
+def _get_db_path() -> Path:
+    env = _load_env(ENV_PATH)
+    db_path = Path(env.get("DUCKDB_PATH", "data/kabusys.duckdb"))
+    if not db_path.is_absolute():
+        db_path = REPO_ROOT / db_path
+    return db_path
+
+
+def _build_command(db_path: Path, scenario: dict, output_dir: Path) -> list[str]:
+    com = _COM_BASE
+    cmd = [
+        sys.executable,
+        "-m",
+        "kabusys.backtest.run",
+        "--db",
+        str(db_path),
+        "--start",
+        com["start"],
+        "--end",
+        com["end"],
+        "--cash",
+        str(com["cash"]),
+        "--allocation-method",
+        com["allocation_method"],
+        "--max-positions",
+        str(com["max_positions"]),
+        "--max-position-pct",
+        str(com["max_position_pct"]),
+        "--max-utilization",
+        str(com["max_utilization"]),
+        "--risk-pct",
+        str(com["risk_pct"]),
+        "--stop-loss-pct",
+        str(com["stop_loss_pct"]),
+        "--min-holding-days",
+        str(com["min_holding_days"]),
+        "--max-holding-days",
+        str(com["max_holding_days"]),
+        "--trailing-stop-atr",
+        str(com["trailing_stop_atr"]),
+        "--threshold",
+        str(com["threshold"]),
+        "--topix-size-multiplier-weak-bear",
+        str(com["weak_bear"]),
+        "--topix-size-multiplier-strong-bear",
+        str(com["strong_bear"]),
+        "--portfolio-drawdown-stop",
+        str(com["dd_stop"]),
+        "--portfolio-drawdown-stop-timeout",
+        str(com["dd_timeout"]),
+        "--adaptive-threshold-vol-regime",
+        "--topix-vol-window",
+        str(com["topix_vol_window"]),
+        "--topix-vol-low-threshold",
+        str(com["topix_vol_low_threshold"]),
+        "--adaptive-threshold-hi",
+        str(com["adaptive_threshold_hi"]),
+        "--dynamic-trailing-stop",
+        "--trail-profit-gate-atr",
+        str(com["trail_profit_gate_atr"]),
+        "--trail-stage2-mult",
+        str(com["trail_stage2_mult"]),
+        "--trail-stage3-mult",
+        str(com["trail_stage3_mult"]),
+        "--output-format",
+        "all",
+        "--output-dir",
+        str(output_dir),
+    ]
+    if com.get("use_ma200_filter"):
+        cmd.append("--ma200-filter")
+    if scenario.get("sector_rel_min") is not None:
+        cmd += ["--sector-rel-min", str(scenario["sector_rel_min"])]
+    if scenario.get("quality_score_min") is not None:
+        cmd += ["--quality-score-min", str(scenario["quality_score_min"])]
+    return cmd
+
+
+def _read_summary(report_dir: Path) -> dict:
+    summaries = list(report_dir.glob("*/summary.json"))
+    if not summaries:
+        direct = report_dir / "summary.json"
+        if direct.exists():
+            summaries = [direct]
+    if not summaries:
+        raise FileNotFoundError(f"summary.json が見つかりません: {report_dir}")
+    latest = max(summaries, key=lambda p: p.stat().st_mtime)
+    data = json.loads(latest.read_text(encoding="utf-8"))
+    headline = data.get("headline", {})
+    trades = data.get("trades", {})
+    meta = data.get("meta", {})
+    return {
+        "run_id": meta.get("run_id", ""),
+        "created_at": meta.get("generated_at", ""),
+        "cagr": headline.get("cagr"),
+        "sharpe": headline.get("sharpe_ratio"),
+        "max_drawdown": headline.get("max_drawdown"),
+        "calmar": headline.get("calmar_ratio"),
+        "annual_volatility": headline.get("annual_volatility"),
+        "win_rate": trades.get("win_rate"),
+        "payoff_ratio": trades.get("payoff_ratio"),
+        "profit_factor": trades.get("profit_factor"),
+        "avg_holding_days": trades.get("avg_holding_days"),
+        "total_trades": trades.get("total_trades"),
+        "final_value": headline.get("final_portfolio_value"),
+    }
+
+
+def _fmt(value: object, digits: int = 4) -> str:
+    if value is None:
+        return "NA"
+    if isinstance(value, float):
+        return f"{value:.{digits}f}"
+    return str(value)
+
+
+def _pct(v: object) -> str:
+    if v is None:
+        return "NA"
+    return f"{float(v) * 100:.2f}%"
+
+
+# ---------------------------------------------------------------------------
+# ワーカー関数（Windows spawn 対応のためトップレベルに配置）
+# ---------------------------------------------------------------------------
+
+
+def _run_batch(args: tuple) -> list[dict]:
+    snapshot_db, scenario_batch, output_dir_str, repo_root_str = args
+    output_dir = Path(output_dir_str)
+    repo_root = Path(repo_root_str)
+    results: list[dict] = []
+
+    for scenario in scenario_batch:
+        name = scenario["name"]
+        scenario_dir = output_dir / name
+        scenario_dir.mkdir(parents=True, exist_ok=True)
+        report_dir = scenario_dir / "report"
+
+        cmd = _build_command(Path(snapshot_db), scenario, report_dir)
+
+        env = os.environ.copy()
+        src_path = str(repo_root / "src")
+        existing = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = os.pathsep.join(filter(None, [src_path, existing]))
+        env["PYTHONIOENCODING"] = "utf-8"
+
+        stdout_path = scenario_dir / "stdout.log"
+        stderr_path = scenario_dir / "stderr.log"
+        with (
+            stdout_path.open("w", encoding="utf-8", errors="replace") as fo,
+            stderr_path.open("w", encoding="utf-8", errors="replace") as fe,
+        ):
+            completed = subprocess.run(cmd, cwd=str(repo_root), stdout=fo, stderr=fe, env=env)
+
+        if completed.returncode != 0:
+            try:
+                tail = stderr_path.read_text(encoding="utf-8", errors="replace").splitlines()[-10:]
+                print(
+                    f"[ERROR] {name}: exit code {completed.returncode}\n"
+                    + "\n".join(f"  {line}" for line in tail),
+                    file=sys.stderr,
+                    flush=True,
+                )
+            except Exception:
+                print(
+                    f"[ERROR] {name}: exit code {completed.returncode}", file=sys.stderr, flush=True
+                )
+            results.append({"name": name, "group": scenario["group"], "error": True})
+            continue
+
+        try:
+            metrics = _read_summary(report_dir)
+        except Exception as exc:
+            print(f"[ERROR] {name}: summary.json 読み込み失敗 — {exc}", file=sys.stderr, flush=True)
+            results.append({"name": name, "group": scenario["group"], "error": True})
+            continue
+
+        record = {
+            "name": name,
+            "group": scenario["group"],
+            "sector_rel_min": scenario.get("sector_rel_min"),
+            "quality_score_min": scenario.get("quality_score_min"),
+            "desc": scenario.get("desc", ""),
+            "is_reference": scenario.get("is_reference", False),
+            **{k: v for k, v in metrics.items()},
+            "error": False,
+        }
+        results.append(record)
+
+        print(
+            f"[DONE] {name:<14}"
+            f"  sr={str(scenario.get('sector_rel_min')):>6}"
+            f"  qs={str(scenario.get('quality_score_min')):>7}"
+            f"  cagr={_pct(metrics.get('cagr')):>8}"
+            f"  sharpe={_fmt(metrics.get('sharpe'), 3):>6}"
+            f"  dd={_pct(metrics.get('max_drawdown')):>8}"
+            f"  pf={_fmt(metrics.get('profit_factor'), 3):>6}"
+            f"  trades={metrics.get('total_trades')}",
+            flush=True,
+        )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# メイン
+# ---------------------------------------------------------------------------
+
+CSV_FIELDNAMES = [
+    "name",
+    "group",
+    "sector_rel_min",
+    "quality_score_min",
+    "desc",
+    "cagr",
+    "sharpe",
+    "max_drawdown",
+    "calmar",
+    "annual_volatility",
+    "win_rate",
+    "payoff_ratio",
+    "profit_factor",
+    "avg_holding_days",
+    "total_trades",
+    "final_value",
+]
+
+
+def _meets_all(r: dict) -> bool:
+    return (
+        (r.get("cagr") or 0) > _CAGR_MIN
+        and (r.get("sharpe") or 0) > _SHARPE_MIN
+        and (r.get("max_drawdown") or 1) < _DD_MAX
+        and (r.get("profit_factor") or 0) > _PF_MIN
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Phase 2 Group T — セクター内相対強度・クオリティフィルター検証"
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=None,
+        help="並列ワーカー数（デフォルト: CPU コア数とシナリオ数の小さい方）",
+    )
+    parser.add_argument(
+        "--keep-snapshots",
+        action="store_true",
+        default=False,
+        help="実行後もDBスナップショットを削除せず保持する",
+    )
+    args = parser.parse_args()
+
+    scenarios = _SCENARIOS
+    n_workers = max(1, min(args.workers or os.cpu_count() or DEFAULT_WORKERS, len(scenarios)))
+
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_dir = ARTIFACTS_ROOT / stamp
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    source_db = _get_db_path()
+    if not source_db.exists():
+        sys.exit(f"[ERROR] DuckDB が見つかりません: {source_db}")
+
+    snapshots_dir = output_dir / "_snapshots"
+    snapshots_dir.mkdir(exist_ok=True)
+
+    print(f"output_dir = {output_dir}")
+    print(f"scenarios  = {len(scenarios)}, workers = {n_workers}")
+    print(f"source_db  = {source_db}")
+    print(
+        f"IS 参照（R3）= CAGR {_IS_CAGR:.2%}  Sharpe {_IS_SHARPE:.3f}  MaxDD {_IS_MAX_DD:.2%}  PF {_IS_PF:.3f}"
+    )
+    print(
+        f"Phase 2 採択基準: CAGR>{_CAGR_MIN:.0%}  Sharpe>{_SHARPE_MIN}  MaxDD<{_DD_MAX:.0%}  PF>{_PF_MIN}"
+    )
+    print("DBスナップショットを作成中...")
+
+    snapshot_paths = []
+    for i in range(n_workers):
+        snap = snapshots_dir / f"worker_{i:02d}.duckdb"
+        shutil.copy2(str(source_db), str(snap))
+        snapshot_paths.append(str(snap))
+        print(f"  snapshot[{i}] = {snap.name}")
+
+    batches: list[list[dict]] = [[] for _ in range(n_workers)]
+    for idx, scenario in enumerate(scenarios):
+        batches[idx % n_workers].append(scenario)
+
+    batch_args = [
+        (snapshot_paths[i], batches[i], str(output_dir), str(REPO_ROOT)) for i in range(n_workers)
+    ]
+
+    (output_dir / "scenarios.json").write_text(
+        json.dumps(scenarios, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    (output_dir / "config_base.json").write_text(
+        json.dumps(_COM_BASE, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    results_csv = output_dir / "results.csv"
+    results_jsonl = output_dir / "results.jsonl"
+
+    all_results: list[dict] = []
+    print(f"\n並列実行開始: {datetime.now().strftime('%H:%M:%S')}")
+    print("-" * 110)
+
+    try:
+        with ProcessPoolExecutor(max_workers=n_workers) as executor:
+            futures = {executor.submit(_run_batch, ba): i for i, ba in enumerate(batch_args)}
+            for future in as_completed(futures):
+                worker_idx = futures[future]
+                try:
+                    batch_results = future.result()
+                    all_results.extend(batch_results)
+                except Exception as exc:
+                    print(f"[ERROR] worker {worker_idx} で例外: {exc}", file=sys.stderr)
+                    traceback.print_exc(file=sys.stderr)
+    finally:
+        if not args.keep_snapshots:
+            try:
+                shutil.rmtree(snapshots_dir)
+            except Exception as e:
+                print(f"[WARN] スナップショット削除失敗: {e}", file=sys.stderr)
+
+    order = {s["name"]: i for i, s in enumerate(scenarios)}
+    all_results.sort(key=lambda r: order.get(r.get("name", ""), 999))
+
+    success = [r for r in all_results if not r.get("error")]
+    failed = [r for r in all_results if r.get("error")]
+
+    with results_csv.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=CSV_FIELDNAMES, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(success)
+
+    with results_jsonl.open("w", encoding="utf-8") as f:
+        for r in all_results:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+    print("-" * 110)
+    print(f"\n完了: {datetime.now().strftime('%H:%M:%S')}")
+    print(f"成功: {len(success)} / {len(scenarios)}, 失敗: {len(failed)}")
+    print(f"results_csv   = {results_csv}")
+    print(f"results_jsonl = {results_jsonl}")
+
+    if not success:
+        if failed:
+            sys.exit(1)
+        return
+
+    # -----------------------------------------------------------------------
+    # 結果表示
+    # -----------------------------------------------------------------------
+
+    ref = next((r for r in success if r.get("is_reference")), None)
+
+    print("\n" + "=" * 120)
+    print("【Group T 結果】R3 固定 / sector_rel_min・quality_score_min 変動（2017-2025）")
+    print(
+        f"  IS 参照（T0）: CAGR {_IS_CAGR:.2%}  Sharpe {_IS_SHARPE:.3f}"
+        f"  MaxDD {_IS_MAX_DD:.2%}  PF {_IS_PF:.3f}"
+    )
+    print("=" * 120)
+    print(
+        f"  {'シナリオ':<14}  {'sec_rel':>8}  {'qual':>7}"
+        f"  {'CAGR':>8}  {'Sharpe':>7}  {'MaxDD':>8}  {'Calmar':>7}"
+        f"  {'PF':>6}  {'Trades':>7}  採択"
+    )
+    print("  " + "-" * 105)
+
+    for r in success:
+        all_ok = _meets_all(r)
+        ref_sharpe = ref["sharpe"] if ref and ref.get("sharpe") else 0
+        better = (r.get("sharpe") or 0) > ref_sharpe and r["name"] != "T0_r3_ref"
+        marker = " [ALL]" if all_ok else (" [>T0]" if better else "")
+        print(
+            f"  {r['name']:<14}"
+            f"  {str(r.get('sector_rel_min') or '—'):>8}"
+            f"  {str(r.get('quality_score_min') or '—'):>7}"
+            f"  {_pct(r.get('cagr')):>8}"
+            f"  {_fmt(r.get('sharpe'), 3):>7}"
+            f"  {_pct(r.get('max_drawdown')):>8}"
+            f"  {_fmt(r.get('calmar'), 3):>7}"
+            f"  {_fmt(r.get('profit_factor'), 3):>6}"
+            f"  {str(r.get('total_trades', '')):>7}"
+            f"{marker}"
+        )
+
+    # --- 採択判断 ---
+    print("\n" + "=" * 120)
+    print("【採択判断】")
+    adopted = [r for r in success if _meets_all(r)]
+    improved = [
+        r
+        for r in success
+        if (r.get("sharpe") or 0) > (ref["sharpe"] if ref else 0) and r["name"] != "T0_r3_ref"
+    ]
+
+    decision: dict = {}
+    if adopted:
+        best = max(adopted, key=lambda r: r.get("sharpe") or 0)
+        print(f"  全採択基準達成: {[r['name'] for r in adopted]}")
+        print(
+            f"  → 最良設定 {best['name']} を Phase 2 採用候補として選択"
+            f"（Phase2_Backtest_Strategy.md Section 50 に記録）"
+        )
+        decision = {
+            "verdict": "ADOPTED",
+            "best_scenario": best["name"],
+            "adopted_scenarios": [r["name"] for r in adopted],
+            "best_cagr": best.get("cagr"),
+            "best_sharpe": best.get("sharpe"),
+            "best_max_drawdown": best.get("max_drawdown"),
+            "best_profit_factor": best.get("profit_factor"),
+        }
+    elif improved:
+        best = max(improved, key=lambda r: r.get("sharpe") or 0)
+        print(f"  Sharpe が T0 を上回るシナリオ: {[r['name'] for r in improved]}")
+        print(
+            f"  → {best['name']} を Phase 2 ベースとして採用"
+            f"（Sharpe 0.5 未達は Group S との組み合わせで改善を狙う）"
+        )
+        decision = {
+            "verdict": "IMPROVED",
+            "best_scenario": best["name"],
+            "improved_scenarios": [r["name"] for r in improved],
+            "best_cagr": best.get("cagr"),
+            "best_sharpe": best.get("sharpe"),
+            "best_max_drawdown": best.get("max_drawdown"),
+            "best_profit_factor": best.get("profit_factor"),
+        }
+    else:
+        print("  全シナリオで T0（R3 参照）以下")
+        print("  → セクター内相対強度フィルターでは構造改善不可。別アプローチを検討")
+        decision = {"verdict": "NO_IMPROVEMENT", "reason": "All scenarios <= T0"}
+
+    (output_dir / "decision.json").write_text(
+        json.dumps(decision, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    print("=" * 120)
+    print(f"decision.json = {output_dir / 'decision.json'}")
+
+    if failed:
+        print(f"\n失敗したシナリオ: {[r['name'] for r in failed]}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backtest/backtest_improvement_plan/run_phase2_group_t.py
+++ b/backtest/backtest_improvement_plan/run_phase2_group_t.py
@@ -581,8 +581,8 @@ def main() -> None:
         marker = " [ALL]" if all_ok else (" [>T0]" if better else "")
         print(
             f"  {r['name']:<14}"
-            f"  {str(r.get('sector_rel_min') or '—'):>8}"
-            f"  {str(r.get('quality_score_min') or '—'):>7}"
+            f"  {'—' if r.get('sector_rel_min') is None else str(r.get('sector_rel_min')):>8}"
+            f"  {'—' if r.get('quality_score_min') is None else str(r.get('quality_score_min')):>7}"
             f"  {_pct(r.get('cagr')):>8}"
             f"  {_fmt(r.get('sharpe'), 3):>7}"
             f"  {_pct(r.get('max_drawdown')):>8}"

--- a/src/kabusys/backtest/run.py
+++ b/src/kabusys/backtest/run.py
@@ -229,7 +229,7 @@ def main() -> None:
         type=float,
         default=None,
         dest="sector_rel_min",
-        help="セクター内相対強度（sector_rel_20）の最小値フィルター（0〜1）。指定値未満の銘柄の BUY を抑制する。[default: None = 無効]",
+        help="Suppress BUY signals when sector_rel_20 is below this value (0–1). セクター内相対強度（sector_rel_20）の最小値フィルター（0〜1）。指定値未満の銘柄の BUY を抑制する。[default: None = 無効]",
     )
     parser.add_argument(
         "--adaptive-threshold",

--- a/src/kabusys/backtest/run.py
+++ b/src/kabusys/backtest/run.py
@@ -225,6 +225,13 @@ def main() -> None:
         help="Suppress BUY signals when topix_rel_20 is below this value (e.g. -0.1 means exclude stocks underperforming TOPIX by more than 10%% over 20 days).",
     )
     parser.add_argument(
+        "--sector-rel-min",
+        type=float,
+        default=None,
+        dest="sector_rel_min",
+        help="セクター内相対強度（sector_rel_20）の最小値フィルター（0〜1）。指定値未満の銘柄の BUY を抑制する。[default: None = 無効]",
+    )
+    parser.add_argument(
         "--adaptive-threshold",
         action="store_true",
         default=False,
@@ -379,6 +386,7 @@ def main() -> None:
             rsi_oversold_max=args.rsi_oversold_max,
             quality_score_min=args.quality_score_min,
             topix_rel_min=args.topix_rel_min,
+            sector_rel_min=args.sector_rel_min,
             adaptive_threshold=args.adaptive_threshold,
             adaptive_threshold_hi=args.adaptive_threshold_hi,
             topix_ma200_hi_trigger=args.topix_ma200_hi_trigger,

--- a/src/kabusys/data/schema.py
+++ b/src/kabusys/data/schema.py
@@ -208,6 +208,7 @@ CREATE TABLE IF NOT EXISTS features (
     topix_rel_60    DOUBLE,
     quality_score   DOUBLE,
     rsi_14          DOUBLE,
+    sector_rel_20   DOUBLE,
     created_at      TIMESTAMP   NOT NULL DEFAULT current_timestamp,
     PRIMARY KEY (date, code)
 )
@@ -505,6 +506,8 @@ _MIGRATIONS: list[str] = [
     # Issue #353: features に MA25/MA75 乖離率を追加
     "ALTER TABLE features ADD COLUMN IF NOT EXISTS ma25_dev DOUBLE",
     "ALTER TABLE features ADD COLUMN IF NOT EXISTS ma75_dev DOUBLE",
+    # Issue #379: features に sector_rel_20（セクター内相対強度）を追加
+    "ALTER TABLE features ADD COLUMN IF NOT EXISTS sector_rel_20 DOUBLE",
 ]
 
 # ---------------------------------------------------------------------------

--- a/src/kabusys/research/factor_research.py
+++ b/src/kabusys/research/factor_research.py
@@ -634,7 +634,10 @@ def calc_sector_relative(
             WHERE NULLIF(TRIM(s.sector), '') IS NOT NULL
         )
         SELECT code,
-               PERCENT_RANK() OVER (PARTITION BY sector ORDER BY ret_20d) AS sector_rel_20
+               CASE
+                   WHEN COUNT(*) OVER (PARTITION BY sector) = 1 THEN 0.5
+                   ELSE PERCENT_RANK() OVER (PARTITION BY sector ORDER BY ret_20d)
+               END AS sector_rel_20
         FROM with_sector
         ORDER BY code
         """,

--- a/src/kabusys/research/factor_research.py
+++ b/src/kabusys/research/factor_research.py
@@ -572,3 +572,75 @@ def calc_rsi(
     result = [{"code": code, "rsi_14": rsi} for code, rsi in rows]
     logger.debug("calc_rsi: %d 銘柄 date=%s", len(result), target_date)
     return result
+
+
+# ---------------------------------------------------------------------------
+# セクター内相対強度
+# ---------------------------------------------------------------------------
+
+_SECTOR_REL_DAYS = 20  # 相対強度計算期間（営業日）
+_SECTOR_REL_SCAN = _SECTOR_REL_DAYS * 3  # データスキャン範囲（カレンダー日）
+
+
+def calc_sector_relative(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date,
+) -> list[dict[str, Any]]:
+    """セクター内 20 日相対強度（パーセンタイル 0〜1）を計算する。
+
+    銘柄ごとの直近 20 営業日リターンをセクター内で PERCENT_RANK() し、
+    0（最弱）〜1（最強）のパーセンタイル値を返す。
+
+    セクター情報が stocks テーブルに存在しない銘柄は結果に含めない。
+    data 不足で 20 日リターンが計算できない銘柄も結果に含めない。
+
+    Args:
+        conn:        DuckDB 接続。prices_daily / stocks テーブルを参照する。
+        target_date: 計算基準日。
+
+    Returns:
+        [{"code": str, "sector_rel_20": float}] のリスト。
+    """
+    scan_from = target_date - timedelta(days=_SECTOR_REL_SCAN)
+    rows = conn.execute(
+        """
+        WITH price_window AS (
+            SELECT code, date, CAST(close AS DOUBLE) AS close,
+                   ROW_NUMBER() OVER (PARTITION BY code ORDER BY date DESC) AS rn
+            FROM prices_daily
+            WHERE date <= ? AND date >= ? AND close IS NOT NULL
+        ),
+        latest AS (
+            SELECT code, close AS close_now
+            FROM price_window
+            WHERE rn = 1
+        ),
+        base AS (
+            SELECT code, close AS close_base
+            FROM price_window
+            WHERE rn = ?
+        ),
+        returns AS (
+            SELECT l.code,
+                   (l.close_now - b.close_base) / b.close_base AS ret_20d
+            FROM latest l
+            JOIN base b ON l.code = b.code
+            WHERE b.close_base > 0
+        ),
+        with_sector AS (
+            SELECT r.code, r.ret_20d, NULLIF(TRIM(s.sector), '') AS sector
+            FROM returns r
+            JOIN stocks s ON r.code = s.code
+            WHERE NULLIF(TRIM(s.sector), '') IS NOT NULL
+        )
+        SELECT code,
+               PERCENT_RANK() OVER (PARTITION BY sector ORDER BY ret_20d) AS sector_rel_20
+        FROM with_sector
+        ORDER BY code
+        """,
+        [target_date, scan_from, _SECTOR_REL_DAYS + 1],
+    ).fetchall()
+
+    result = [{"code": code, "sector_rel_20": sr} for code, sr in rows if sr is not None]
+    logger.debug("calc_sector_relative: %d 銘柄 date=%s", len(result), target_date)
+    return result

--- a/src/kabusys/strategy/feature_engineering.py
+++ b/src/kabusys/strategy/feature_engineering.py
@@ -29,6 +29,7 @@ from kabusys.research.factor_research import (
     calc_momentum,
     calc_quality,
     calc_rsi,
+    calc_sector_relative,
     calc_topix_relative,
     calc_value,
     calc_volatility,
@@ -114,6 +115,7 @@ def build_features(
     topix_rel_list = calc_topix_relative(conn, target_date)
     quality_list = calc_quality(conn, target_date)
     rsi_list = calc_rsi(conn, target_date)
+    sector_rel_list = calc_sector_relative(conn, target_date)
 
     mom_map: dict[str, dict] = {r["code"]: r for r in mom_list}
     vol_map: dict[str, dict] = {r["code"]: r for r in vol_list}
@@ -121,6 +123,7 @@ def build_features(
     topix_map: dict[str, dict] = {r["code"]: r for r in topix_rel_list}
     quality_map: dict[str, dict] = {r["code"]: r for r in quality_list}
     rsi_map: dict[str, dict] = {r["code"]: r for r in rsi_list}
+    sector_rel_map: dict[str, dict] = {r["code"]: r for r in sector_rel_list}
 
     # 2. current close prices（ユニバースフィルタ用）
     # target_date 以前の最新価格を参照（休場日・当日欠損に対応）
@@ -149,6 +152,7 @@ def build_features(
         t = topix_map.get(code, {})
         q = quality_map.get(code, {})
         r = rsi_map.get(code, {})
+        sr = sector_rel_map.get(code, {})
         merged.append(
             {
                 "code": code,
@@ -169,6 +173,7 @@ def build_features(
                 "rev_growth_yoy": q.get("rev_growth_yoy"),
                 "profit_growth_yoy": q.get("profit_growth_yoy"),
                 "rsi_14": r.get("rsi_14"),
+                "sector_rel_20": sr.get("sector_rel_20"),
             }
         )
 
@@ -214,6 +219,7 @@ def build_features(
             r.get("topix_rel_60"),
             r.get("quality_score"),
             r.get("rsi_14"),
+            r.get("sector_rel_20"),
         )
         for r in normalized
     ]
@@ -226,8 +232,9 @@ def build_features(
                 INSERT INTO features
                     (date, code, momentum_20, momentum_60, volatility_20, volume_ratio,
                      per, pbr, div_yield, ma200_dev, ma25_dev, ma75_dev,
-                     topix_rel_20, topix_rel_60, quality_score, rsi_14, created_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, current_timestamp)
+                     topix_rel_20, topix_rel_60, quality_score, rsi_14, sector_rel_20,
+                     created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, current_timestamp)
                 """,
                 params,
             )

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -1153,6 +1153,7 @@ def generate_signals(
     rsi_oversold_max: float | None = None,
     quality_score_min: float | None = None,
     topix_rel_min: float | None = None,
+    sector_rel_min: float | None = None,
     adaptive_threshold: bool = False,
     adaptive_threshold_hi: float = 0.62,
     topix_ma200_hi_trigger: float = 0.05,
@@ -1578,6 +1579,18 @@ def generate_signals(
                         target_date,
                     )
                     topix_rel_suppressed += 1
+                    continue
+            # セクター内相対強度フィルタ（sector_rel_20 が min 未満の銘柄の BUY を抑制）
+            if sector_rel_min is not None:
+                sr_val = r.get("sector_rel_20")
+                if sr_val is not None and sr_val < sector_rel_min:
+                    logger.debug(
+                        "sector rel filter: %s sector_rel_20=%.4f < min=%.4f — BUY を抑制 date=%s",
+                        r["code"],
+                        sr_val,
+                        sector_rel_min,
+                        target_date,
+                    )
                     continue
             # 銘柄単位 MA クロスフィルタ
             # - ma75_dev < 0（株価が MA75 を下回る）→ BUY スキップ（強ベア）

--- a/src/kabusys/strategy/signal_generator.py
+++ b/src/kabusys/strategy/signal_generator.py
@@ -94,6 +94,7 @@ _FEATURES_SELECT_COLS: tuple[str, ...] = (
     "ma25_dev",
     "rsi_14",
     "topix_rel_20",
+    "sector_rel_20",
     "quality_score",
 )
 
@@ -1449,6 +1450,7 @@ def generate_signals(
                 "ma25_dev": feat.get("ma25_dev"),
                 "volume_ratio": feat.get("volume_ratio"),
                 "topix_rel_20": feat.get("topix_rel_20"),
+                "sector_rel_20": feat.get("sector_rel_20"),
                 "quality_score": feat.get("quality_score"),
             }
         )
@@ -1513,6 +1515,7 @@ def generate_signals(
         volume_suppressed = 0
         quality_suppressed = 0
         topix_rel_suppressed = 0
+        sector_rel_suppressed = 0
         sector_suppressed = 0
         reentry_suppressed = 0
         earnings_suppressed = 0
@@ -1591,6 +1594,7 @@ def generate_signals(
                         sector_rel_min,
                         target_date,
                     )
+                    sector_rel_suppressed += 1
                     continue
             # 銘柄単位 MA クロスフィルタ
             # - ma75_dev < 0（株価が MA75 を下回る）→ BUY スキップ（強ベア）
@@ -1738,6 +1742,12 @@ def generate_signals(
             logger.info(
                 "generate_signals: topix rel filter — %d 銘柄を TOPIX 相対強度不足で抑制 date=%s",
                 topix_rel_suppressed,
+                target_date,
+            )
+        if sector_rel_suppressed:
+            logger.info(
+                "generate_signals: sector rel filter — %d 銘柄をセクター内相対強度不足で抑制 date=%s",
+                sector_rel_suppressed,
                 target_date,
             )
         if gap_suppressed:

--- a/tests/test_generate_signals_config.py
+++ b/tests/test_generate_signals_config.py
@@ -17,7 +17,7 @@ def _make_db():
             date DATE, code VARCHAR, momentum_20 DOUBLE, momentum_60 DOUBLE,
             volatility_20 DOUBLE, volume_ratio DOUBLE, per DOUBLE, pbr DOUBLE,
             div_yield DOUBLE, ma200_dev DOUBLE, ma75_dev DOUBLE, ma25_dev DOUBLE, rsi_14 DOUBLE,
-            topix_rel_20 DOUBLE, quality_score DOUBLE
+            topix_rel_20 DOUBLE, sector_rel_20 DOUBLE, quality_score DOUBLE
         )
     """)
     conn.execute("""
@@ -96,7 +96,7 @@ class TestGenerateSignalsConfigWeights:
         target = date(2025, 1, 6)
         # Insert one stock with high momentum
         conn.execute(
-            "INSERT INTO features VALUES (?, '1001', 3.0, 3.0, 0.0, 0.0, NULL, NULL, NULL, 0.0, NULL, NULL, NULL, NULL, NULL)",
+            "INSERT INTO features VALUES (?, '1001', 3.0, 3.0, 0.0, 0.0, NULL, NULL, NULL, 0.0, NULL, NULL, NULL, NULL, NULL, NULL)",
             [target],
         )
 
@@ -144,7 +144,7 @@ class TestGenerateSignalsConfigWeights:
         target = date(2025, 1, 6)
         # volatility_20 = -3.0 → low volatility (good) → _sigmoid(-(-3.0)) ≈ 0.95 > 0.50
         conn.execute(
-            "INSERT INTO features VALUES (?, '1001', 0.0, 0.0, -3.0, 0.0, NULL, NULL, NULL, 0.0, NULL, NULL, NULL, NULL, NULL)",
+            "INSERT INTO features VALUES (?, '1001', 0.0, 0.0, -3.0, 0.0, NULL, NULL, NULL, 0.0, NULL, NULL, NULL, NULL, NULL, NULL)",
             [target],
         )
 
@@ -206,7 +206,7 @@ class TestGenerateSignalsConfigThreshold:
         target = date(2025, 1, 6)
         # Insert stock with moderate score that would pass 0.60 but not 0.99
         conn.execute(
-            "INSERT INTO features VALUES (?, '1001', 0.5, 0.5, 0.0, 0.0, NULL, NULL, NULL, 0.0, NULL, NULL, NULL, NULL, NULL)",
+            "INSERT INTO features VALUES (?, '1001', 0.5, 0.5, 0.0, 0.0, NULL, NULL, NULL, 0.0, NULL, NULL, NULL, NULL, NULL, NULL)",
             [target],
         )
 
@@ -254,7 +254,7 @@ class TestGenerateSignalsConfigThreshold:
         conn = _make_db()
         target = date(2025, 1, 6)
         conn.execute(
-            "INSERT INTO features VALUES (?, '1001', 3.0, 3.0, 0.0, 0.0, NULL, NULL, NULL, 0.0, NULL, NULL, NULL, NULL, NULL)",
+            "INSERT INTO features VALUES (?, '1001', 3.0, 3.0, 0.0, 0.0, NULL, NULL, NULL, 0.0, NULL, NULL, NULL, NULL, NULL, NULL)",
             [target],
         )
 


### PR DESCRIPTION
## Summary

2021（横ばい）・2022（弱気）のマイナスを改善するため、セクター内相対強度（sector_rel_20）を特徴量として追加し、フィルターとバックテストスクリプトを実装する。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/kabusys/research/factor_research.py` | `calc_sector_relative()` 新規追加。銘柄ごと 20 日リターンをセクター内で PERCENT_RANK() し 0〜1 パーセンタイルを返す |
| `src/kabusys/data/schema.py` | `features` テーブルに `sector_rel_20 DOUBLE` を追加（CREATE TABLE + ALTER TABLE） |
| `src/kabusys/strategy/feature_engineering.py` | `calc_sector_relative()` を呼び出し features UPSERT に含める |
| `src/kabusys/strategy/signal_generator.py` | `sector_rel_min` フィルターパラメータを追加（指定値未満の銘柄の BUY を抑制） |
| `src/kabusys/backtest/run.py` | `--sector-rel-min` CLI フラグを追加 |
| `backtest/backtest_improvement_plan/run_phase2_group_t.py` | 7 シナリオのバックテストスクリプト（新規） |

## シナリオ（7本 × 2017-2025）

| シナリオ | sector_rel_min | quality_score_min | 狙い |
|---|---|---|---|
| T0_r3_ref | — | — | R3 参照 |
| T1_sec_50 | 0.50 | — | セクター内上位 50% 単体 |
| T2_sec_60 | 0.60 | — | セクター内上位 40% 単体 |
| T3_sec_70 | 0.70 | — | セクター内上位 30% 単体 |
| T4_quality | — | −0.30 | クオリティフィルター単体 |
| T5_s60_q | 0.60 | −0.30 | セクター上位 40% + クオリティ複合 |
| T6_s50_q | 0.50 | −0.30 | セクター上位 50% + クオリティ複合 |

ベース設定: R3（max_positions=7, max_utilization=40%, P2_n1b_o2 その他固定）

## 実行方法

```powershell
# features テーブルの再計算（sector_rel_20 を追加後に必要）
python scripts/rebuild_features.py

# バックテスト実行
python backtest/backtest_improvement_plan/run_phase2_group_t.py --workers 4
```

## Test plan

- [ ] `python -m pytest tests/ -q` が 2086 passed で通過する ✅（実施済み）
- [ ] バックテスト実行後、T0_r3_ref の CAGR が R3 実績（9.01%）と概ね一致する
- [ ] sector_rel_min フィルターが機能し、T1〜T3 で取引数が減少する
- [ ] `Phase2_Backtest_Strategy.md` Section 50 に結果を追記する

Closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)