### PR TITLE
fix: バックテスト並列実行時の DuckDB ロック競合を修正

### DIFF
--- a/src/kabusys/backtest/run.py
+++ b/src/kabusys/backtest/run.py
@@ -422,7 +422,7 @@ def main() -> None:
     )
     from kabusys.data.schema import init_schema
 
-    conn = init_schema(args.db)
+    conn = init_schema(args.db, read_only=True)
     try:
         scope: BacktestScope | None = None
         if args.scope_mode == "manual_codes":

--- a/src/kabusys/data/schema.py
+++ b/src/kabusys/data/schema.py
@@ -561,19 +561,23 @@ _ALL_DDL: list[str] = [
 # ---------------------------------------------------------------------------
 
 
-def init_schema(db_path: str | Path) -> duckdb.DuckDBPyConnection:
+def init_schema(db_path: str | Path, *, read_only: bool = False) -> duckdb.DuckDBPyConnection:
     """DuckDB データベースを初期化し、全テーブルを作成して接続を返す。
 
     既にテーブルが存在する場合はスキップ（冪等）。
     db_path の親ディレクトリが存在しない場合は自動作成する。
 
     Args:
-        db_path: DuckDB ファイルパス。":memory:" でインメモリ DB を使用可能。
+        db_path:   DuckDB ファイルパス。":memory:" でインメモリ DB を使用可能。
+        read_only: True のとき読み取り専用で接続し、スキーマ作成をスキップする。
+                   複数プロセスから同一 DB を並列参照する場合に使用する。
 
     Returns:
         初期化済みの DuckDB 接続。
     """
     db_path_str = str(db_path)
+    if read_only:
+        return duckdb.connect(db_path_str, read_only=True)
     if db_path_str != ":memory:":
         Path(db_path_str).parent.mkdir(parents=True, exist_ok=True)
     conn = duckdb.connect(db_path_str)


### PR DESCRIPTION
## 問題

`run_phase2_group_w.py --workers 4` 等の並列バックテスト実行時に全シナリオが以下のエラーで失敗した。

```
duckdb.IOException: Cannot open file kabusys.duckdb: プロセスはファイルにアクセスできません。別のプロセスが使用中です。
```

## 原因

`run.py` が `init_schema(args.db)` で DuckDB を書き込みモードで開くため、複数ワーカープロセスが同時に同一ファイルをロックしようとして競合が発生していた。DuckDB は同時書き込み接続を 1 つしか許可しない。

## 修正

`schema.py` の `init_schema()` に `read_only` パラメータを追加し、`run.py` のソース接続を `read_only=True` に変更。

- バックテストエンジン (`_build_backtest_conn`) はデータを in-memory DB にコピーして使用するため、ソース DB への書き込みは不要
- 結果保存用の `conn_persist`（バックテスト完了後の DB 書き込み）は従来通り書き込みモードのまま
- DuckDB は read-only モードでは複数プロセスの同時接続を許可する

## Test plan

- [x] `pytest tests/ -q` — 2117 passed（リグレッションなし）
- [ ] `python backtest/backtest_improvement_plan/run_phase2_group_w.py --workers 4` で正常実行確認（ユーザーが手動確認）