### PR TITLE
fix: バックテスト並列実行 DuckDB ロック競合の完全修正（PR #394 補完）

### DIFF
--- a/backtest/backtest_improvement_plan/run_phase2_group_w.py
+++ b/backtest/backtest_improvement_plan/run_phase2_group_w.py
@@ -31,6 +31,7 @@ import argparse
 import csv
 import json
 import os
+import shutil
 import subprocess
 import sys
 import traceback
@@ -393,10 +394,14 @@ def main() -> None:
         description="Phase 2 Group W — V3 エントリーフィルター gate 緩和検証"
     )
     parser.add_argument("--workers", type=int, default=None)
+    parser.add_argument("--keep-snapshots", action="store_true", default=False)
     args = parser.parse_args()
     workers = args.workers or DEFAULT_WORKERS
 
-    db_path = _get_db_path()
+    source_db = _get_db_path()
+    if not source_db.exists():
+        sys.exit(f"[ERROR] DuckDB が見つかりません: {source_db}")
+
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
     output_dir = ARTIFACTS_ROOT / ts
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -411,22 +416,41 @@ def main() -> None:
         f"[INFO] ベース(V1_score): CAGR={_IS_CAGR:.2%}  Sharpe={_IS_SHARPE}  MaxDD={_IS_MAX_DD:.2%}"
     )
 
+    snapshots_dir = output_dir / "_snapshots"
+    snapshots_dir.mkdir(exist_ok=True)
+    snapshot_paths = []
+    for i in range(workers):
+        snap = snapshots_dir / f"worker_{i:02d}.duckdb"
+        shutil.copy2(str(source_db), str(snap))
+        snapshot_paths.append(str(snap))
+
     n = len(_SCENARIOS)
     batches = [_SCENARIOS[i::workers] for i in range(workers)]
-    batch_args = [(str(db_path), b, str(output_dir), str(REPO_ROOT)) for b in batches if b]
+    batch_args = [
+        (snapshot_paths[i], batches[i], str(output_dir), str(REPO_ROOT))
+        for i, b in enumerate(batches)
+        if b
+    ]
 
     all_results: list[dict] = []
-    if workers == 1:
-        for ba in batch_args:
-            all_results.extend(_run_batch(ba))
-    else:
-        with ProcessPoolExecutor(max_workers=workers) as pool:
-            futures = {pool.submit(_run_batch, ba): ba for ba in batch_args}
-            for fut in as_completed(futures):
-                try:
-                    all_results.extend(fut.result())
-                except Exception:
-                    traceback.print_exc()
+    try:
+        if workers == 1:
+            for ba in batch_args:
+                all_results.extend(_run_batch(ba))
+        else:
+            with ProcessPoolExecutor(max_workers=workers) as pool:
+                futures = {pool.submit(_run_batch, ba): ba for ba in batch_args}
+                for fut in as_completed(futures):
+                    try:
+                        all_results.extend(fut.result())
+                    except Exception:
+                        traceback.print_exc()
+    finally:
+        if not args.keep_snapshots:
+            try:
+                shutil.rmtree(snapshots_dir)
+            except Exception as e:
+                print(f"[WARN] スナップショット削除失敗: {e}", file=sys.stderr)
 
     all_results.sort(
         key=lambda r: (

--- a/backtest/backtest_improvement_plan/run_phase2_group_x.py
+++ b/backtest/backtest_improvement_plan/run_phase2_group_x.py
@@ -28,6 +28,7 @@ import argparse
 import csv
 import json
 import os
+import shutil
 import subprocess
 import sys
 import traceback
@@ -365,10 +366,14 @@ def _meets_all(r: dict) -> bool:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Phase 2 Group X — quality_score 閾値の厳格化検証")
     parser.add_argument("--workers", type=int, default=None)
+    parser.add_argument("--keep-snapshots", action="store_true", default=False)
     args = parser.parse_args()
     workers = args.workers or DEFAULT_WORKERS
 
-    db_path = _get_db_path()
+    source_db = _get_db_path()
+    if not source_db.exists():
+        sys.exit(f"[ERROR] DuckDB が見つかりません: {source_db}")
+
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
     output_dir = ARTIFACTS_ROOT / ts
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -383,22 +388,41 @@ def main() -> None:
         f"[INFO] ベース(V1_score): CAGR={_IS_CAGR:.2%}  Sharpe={_IS_SHARPE}  MaxDD={_IS_MAX_DD:.2%}"
     )
 
+    snapshots_dir = output_dir / "_snapshots"
+    snapshots_dir.mkdir(exist_ok=True)
+    snapshot_paths = []
+    for i in range(workers):
+        snap = snapshots_dir / f"worker_{i:02d}.duckdb"
+        shutil.copy2(str(source_db), str(snap))
+        snapshot_paths.append(str(snap))
+
     n = len(_SCENARIOS)
     batches = [_SCENARIOS[i::workers] for i in range(workers)]
-    batch_args = [(str(db_path), b, str(output_dir), str(REPO_ROOT)) for b in batches if b]
+    batch_args = [
+        (snapshot_paths[i], batches[i], str(output_dir), str(REPO_ROOT))
+        for i, b in enumerate(batches)
+        if b
+    ]
 
     all_results: list[dict] = []
-    if workers == 1:
-        for ba in batch_args:
-            all_results.extend(_run_batch(ba))
-    else:
-        with ProcessPoolExecutor(max_workers=workers) as pool:
-            futures = {pool.submit(_run_batch, ba): ba for ba in batch_args}
-            for fut in as_completed(futures):
-                try:
-                    all_results.extend(fut.result())
-                except Exception:
-                    traceback.print_exc()
+    try:
+        if workers == 1:
+            for ba in batch_args:
+                all_results.extend(_run_batch(ba))
+        else:
+            with ProcessPoolExecutor(max_workers=workers) as pool:
+                futures = {pool.submit(_run_batch, ba): ba for ba in batch_args}
+                for fut in as_completed(futures):
+                    try:
+                        all_results.extend(fut.result())
+                    except Exception:
+                        traceback.print_exc()
+    finally:
+        if not args.keep_snapshots:
+            try:
+                shutil.rmtree(snapshots_dir)
+            except Exception as e:
+                print(f"[WARN] スナップショット削除失敗: {e}", file=sys.stderr)
 
     all_results.sort(
         key=lambda r: (

--- a/backtest/backtest_improvement_plan/run_phase2_group_y.py
+++ b/backtest/backtest_improvement_plan/run_phase2_group_y.py
@@ -35,6 +35,7 @@ import argparse
 import csv
 import json
 import os
+import shutil
 import subprocess
 import sys
 import traceback
@@ -413,10 +414,14 @@ def main() -> None:
         description="Phase 2 Group Y — TOPIX 騰落率ベースのレジーム検知強化検証"
     )
     parser.add_argument("--workers", type=int, default=None)
+    parser.add_argument("--keep-snapshots", action="store_true", default=False)
     args = parser.parse_args()
     workers = args.workers or DEFAULT_WORKERS
 
-    db_path = _get_db_path()
+    source_db = _get_db_path()
+    if not source_db.exists():
+        sys.exit(f"[ERROR] DuckDB が見つかりません: {source_db}")
+
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
     output_dir = ARTIFACTS_ROOT / ts
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -431,22 +436,41 @@ def main() -> None:
         f"[INFO] ベース(V1_score): CAGR={_IS_CAGR:.2%}  Sharpe={_IS_SHARPE}  MaxDD={_IS_MAX_DD:.2%}"
     )
 
+    snapshots_dir = output_dir / "_snapshots"
+    snapshots_dir.mkdir(exist_ok=True)
+    snapshot_paths = []
+    for i in range(workers):
+        snap = snapshots_dir / f"worker_{i:02d}.duckdb"
+        shutil.copy2(str(source_db), str(snap))
+        snapshot_paths.append(str(snap))
+
     n = len(_SCENARIOS)
     batches = [_SCENARIOS[i::workers] for i in range(workers)]
-    batch_args = [(str(db_path), b, str(output_dir), str(REPO_ROOT)) for b in batches if b]
+    batch_args = [
+        (snapshot_paths[i], batches[i], str(output_dir), str(REPO_ROOT))
+        for i, b in enumerate(batches)
+        if b
+    ]
 
     all_results: list[dict] = []
-    if workers == 1:
-        for ba in batch_args:
-            all_results.extend(_run_batch(ba))
-    else:
-        with ProcessPoolExecutor(max_workers=workers) as pool:
-            futures = {pool.submit(_run_batch, ba): ba for ba in batch_args}
-            for fut in as_completed(futures):
-                try:
-                    all_results.extend(fut.result())
-                except Exception:
-                    traceback.print_exc()
+    try:
+        if workers == 1:
+            for ba in batch_args:
+                all_results.extend(_run_batch(ba))
+        else:
+            with ProcessPoolExecutor(max_workers=workers) as pool:
+                futures = {pool.submit(_run_batch, ba): ba for ba in batch_args}
+                for fut in as_completed(futures):
+                    try:
+                        all_results.extend(fut.result())
+                    except Exception:
+                        traceback.print_exc()
+    finally:
+        if not args.keep_snapshots:
+            try:
+                shutil.rmtree(snapshots_dir)
+            except Exception as e:
+                print(f"[WARN] スナップショット削除失敗: {e}", file=sys.stderr)
 
     all_results.sort(
         key=lambda r: (

--- a/src/kabusys/backtest/run.py
+++ b/src/kabusys/backtest/run.py
@@ -422,7 +422,7 @@ def main() -> None:
     )
     from kabusys.data.schema import init_schema
 
-    conn = init_schema(args.db, read_only=True)
+    conn = init_schema(args.db)
     try:
         scope: BacktestScope | None = None
         if args.scope_mode == "manual_codes":


### PR DESCRIPTION
## 問題

PR #394 では `run.py` の `read_only=True` revert と Group W/X/Y スナップショット追加が main に反映されず、並列実行が引き続き失敗していた。

## 変更内容

**`run.py`**
- `init_schema(args.db, read_only=True)` → `init_schema(args.db)` に revert

**`run_phase2_group_w/x/y.py`**（Group V と同じスナップショット方式を適用）
- `shutil` をインポート
- 起動時に `_snapshots/worker_NN.duckdb` を `shutil.copy2` で作成
- 各ワーカーがスナップショットを `--db` として使用（ロック競合なし）
- `--keep-snapshots` フラグ追加（デバッグ用）
- `finally` でスナップショットを自動削除

## Test plan

- [x] `pytest tests/ -q` — 2117 passed
- [x] `ruff check / format --check` — clean
- [ ] `python backtest/backtest_improvement_plan/run_phase2_group_w.py --workers 4` で正常実行確認（ユーザーが手動確認）