### PR TITLE
fix: 夜間バッチレポートの翌営業日算出を next_trading_day に修正

### DIFF
--- a/scripts/run_night_batch_report.py
+++ b/scripts/run_night_batch_report.py
@@ -19,6 +19,7 @@ import duckdb
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 from kabusys.config import Settings
+from kabusys.data.calendar_management import next_trading_day
 from kabusys.operations.job_run_recorder import read_job_results
 from kabusys.operations.night_batch_report import (
     JobRunResult,
@@ -201,20 +202,16 @@ def main() -> None:
 
             # --- DB クエリ ---
             db_path = args.db or str(Settings().duckdb_path)
-            target_date: date = run_date + timedelta(days=1)
             conn = duckdb.connect(db_path)
             update_counts = collect_update_counts(conn, run_date)
             next_day = collect_next_day_summary(conn, run_date)
             try:
-                row = conn.execute(
-                    "SELECT MIN(date) FROM prices_daily WHERE date > ?", [run_date]
-                ).fetchone()
-                if row and row[0]:
-                    target_date = row[0]
+                target_date: date = next_trading_day(conn, run_date)
             except Exception:
                 logger.warning(
                     "翌営業日の取得に失敗しました。run_date+1 を使用します。", exc_info=True
                 )
+                target_date = run_date + timedelta(days=1)
 
             # --- レポート構築・保存 ---
             report = build_report(

--- a/scripts/run_night_batch_report.py
+++ b/scripts/run_night_batch_report.py
@@ -205,13 +205,19 @@ def main() -> None:
             conn = duckdb.connect(db_path)
             update_counts = collect_update_counts(conn, run_date)
             next_day = collect_next_day_summary(conn, run_date)
+            target_date: date | None = None
             try:
-                target_date: date = next_trading_day(conn, run_date)
+                target_date = next_trading_day(conn, run_date)
             except Exception:
-                logger.warning(
-                    "翌営業日の取得に失敗しました。run_date+1 を使用します。", exc_info=True
-                )
+                logger.warning("翌営業日の取得に失敗しました。run_date=%s", run_date, exc_info=True)
+            if target_date is None:
                 target_date = run_date + timedelta(days=1)
+                logger.warning(
+                    "翌営業日が取得できなかったため run_date+1 を使用します。"
+                    " run_date=%s fallback=%s",
+                    run_date,
+                    target_date,
+                )
 
             # --- レポート構築・保存 ---
             report = build_report(


### PR DESCRIPTION
## 問題

金曜・祝前日の夜間バッチ実行時、レポートの「翌営業日」が土曜・祝日になるバグ。

### 原因

```python
# 変更前
target_date = run_date + timedelta(days=1)  # デフォルト: 翌日
row = conn.execute("SELECT MIN(date) FROM prices_daily WHERE date > ?", [run_date]).fetchone()
if row and row[0]:
    target_date = row[0]  # prices_daily に翌日以降のデータがあれば上書き
```

夜間バッチ実行時点では `prices_daily` に翌日以降のデータが存在しないため `NULL` が返り、デフォルトの `run_date + 1日`（土曜など）が使われてしまっていた。

## 修正

既存の `next_trading_day(conn, run_date)` を使用。`market_calendar` テーブルを参照し、未登録日は曜日ベースフォールバックで土日・祝日を正しくスキップした翌営業日を返す。

```python
# 変更後
try:
    target_date: date = next_trading_day(conn, run_date)
except Exception:
    logger.warning("翌営業日の取得に失敗しました。run_date+1 を使用します。", exc_info=True)
    target_date = run_date + timedelta(days=1)
```

## Test plan

- [ ] 金曜日付で `--date 2026-06-06` を指定して実行し、`target_date` が月曜（2026-06-08）になること
- [ ] 通常の平日（月〜木）でも `target_date` が翌営業日になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)