### PR TITLE
feat: 翌日シグナルレポートに銘柄名・コード・推定購入数量を追加

### DIFF
--- a/scripts/run_strategy_signal.py
+++ b/scripts/run_strategy_signal.py
@@ -27,11 +27,165 @@ from kabusys.utils.logging_setup import log_run_end, log_run_start, setup_loggin
 _DD_STOP_PCT = 0.12  # ポートフォリオが peak 比 12% 以上下落したら BUY を停止
 _DD_STOP_TIMEOUT_DAYS = 30  # 停止発動から 30 カレンダー日後に自動解除
 
+_REPORT_LOT_SIZE = 100
+_REPORT_MAX_UTILIZATION = 0.30
+_REPORT_MAX_POSITION_PCT = 0.10
+
 _run_log = setup_logging(app_name="strategy_signal", capture_stdio=True)
 logger = logging.getLogger(__name__)
 
 _JOB_NAME = "strategy_signal_job"
 _APP_NAME = "strategy_signal"
+
+
+def _print_signal_report(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date,
+    portfolio_value: float | None,
+) -> None:
+    """翌日シグナルの銘柄名・コード・推定購入数量を標準出力に出力する。"""
+
+    # --- BUY シグナル ---
+    try:
+        buy_rows = conn.execute(
+            """
+            SELECT s.code, COALESCE(st.name, s.code) AS name,
+                   s.signal_rank, COALESCE(s.size_multiplier, 1.0) AS sm
+            FROM signals s
+            LEFT JOIN stocks st ON s.code = st.code
+            WHERE s.date = ? AND s.side = 'buy'
+            ORDER BY COALESCE(s.signal_rank, 9999), s.code
+            """,
+            [target_date],
+        ).fetchall()
+    except Exception:
+        logger.warning("BUY シグナル取得に失敗しました", exc_info=True)
+        buy_rows = []
+
+    # --- SELL シグナル ---
+    try:
+        sell_rows = conn.execute(
+            """
+            SELECT s.code, COALESCE(st.name, s.code) AS name
+            FROM signals s
+            LEFT JOIN stocks st ON s.code = st.code
+            WHERE s.date = ? AND s.side = 'sell'
+            ORDER BY s.code
+            """,
+            [target_date],
+        ).fetchall()
+    except Exception:
+        logger.warning("SELL シグナル取得に失敗しました", exc_info=True)
+        sell_rows = []
+
+    # --- 最新終値 ---
+    all_codes = list({r[0] for r in buy_rows} | {r[0] for r in sell_rows})
+    prices: dict[str, float] = {}
+    if all_codes:
+        try:
+            ph = ", ".join("?" * len(all_codes))
+            price_rows = conn.execute(
+                f"""
+                SELECT p.code, p.close
+                FROM prices_daily p
+                INNER JOIN (
+                    SELECT code, MAX(date) AS max_date
+                    FROM prices_daily
+                    WHERE date <= ? AND code IN ({ph})
+                    GROUP BY code
+                ) t ON p.code = t.code AND p.date = t.max_date
+                """,  # noqa: S608
+                [target_date, *all_codes],
+            ).fetchall()
+            prices = {r[0]: float(r[1]) for r in price_rows}
+        except Exception:
+            logger.warning("終値取得に失敗しました", exc_info=True)
+
+    # --- 推定数量計算 (等配分) ---
+    n_buy = len(buy_rows)
+
+    def _est_qty(price: float, sm: float) -> int | None:
+        """等配分・size_multiplier 適用で推定数量を計算する。None は不明。"""
+        if not portfolio_value or portfolio_value <= 0 or price <= 0 or n_buy == 0:
+            return None
+        slot = portfolio_value * _REPORT_MAX_UTILIZATION / n_buy
+        base = int(slot / price / _REPORT_LOT_SIZE) * _REPORT_LOT_SIZE
+        after_sm = int(base * sm / _REPORT_LOT_SIZE) * _REPORT_LOT_SIZE
+        cap = int(portfolio_value * _REPORT_MAX_POSITION_PCT / price / _REPORT_LOT_SIZE) * _REPORT_LOT_SIZE
+        return min(after_sm, cap)
+
+    # --- 出力 ---
+    sep = "=" * 66
+    lines: list[str] = []
+    lines.append(sep)
+    lines.append(f"  [Signal Report] date={target_date}")
+    if portfolio_value is not None:
+        lines.append(
+            f"  PF={portfolio_value:,.0f}円"
+            f"  max_util={_REPORT_MAX_UTILIZATION:.0%}"
+            f"  max_pos={_REPORT_MAX_POSITION_PCT:.0%}"
+            f"  lot={_REPORT_LOT_SIZE}"
+        )
+    lines.append(sep)
+
+    # BUY
+    lines.append(f"\n[BUY] {n_buy} 件")
+    if buy_rows:
+        lines.append(f"  {'Rk':>2}  {'Code':<6}  {'Name':<22}  {'Close':>8}  {'Est.Qty':>10}  {'Est.Amt':>12}")
+        lines.append("  " + "-" * 64)
+        total_est = 0.0
+        for code, name, rank, sm in buy_rows:
+            price = prices.get(code, 0.0)
+            rk_s = str(rank) if rank is not None else "-"
+            qty = _est_qty(price, float(sm))
+            price_s = f"{price:,.0f}" if price > 0 else "---"
+            if qty is None:
+                qty_s, amt_s = "N/A", "---"
+            elif qty == 0:
+                qty_s, amt_s = "0(<1 lot)", "---"
+            else:
+                est = qty * price
+                total_est += est
+                qty_s = f"{qty:,}"
+                amt_s = f"{est:,.0f}"
+            name_s = (name or "")[:20]
+            lines.append(
+                f"  {rk_s:>2}  {code:<6}  {name_s:<22}  {price_s:>8}  {qty_s:>10}  {amt_s:>12}"
+            )
+        if portfolio_value and total_est > 0:
+            pct = total_est / portfolio_value * 100
+            lines.append(f"\n  Est.Total: {total_est:,.0f}円 ({pct:.1f}% of PF)")
+    else:
+        lines.append("  (なし)")
+
+    # SELL
+    lines.append(f"\n[SELL] {len(sell_rows)} 件")
+    if sell_rows:
+        lines.append(f"  {'Code':<6}  {'Name':<26}  {'Close':>8}")
+        lines.append("  " + "-" * 44)
+        for code, name in sell_rows:
+            price = prices.get(code, 0.0)
+            price_s = f"{price:,.0f}" if price > 0 else "---"
+            name_s = (name or "")[:24]
+            lines.append(f"  {code:<6}  {name_s:<26}  {price_s:>8}")
+    else:
+        lines.append("  (なし)")
+
+    lines.append("\n" + sep)
+    lines.append("  ※ Est.Qty は等配分/close price 基準の推定値。実際の発注量と異なる場合があります。")
+
+    report_text = "\n".join(lines)
+    print(report_text)
+
+    # --- ファイル保存 ---
+    try:
+        out_dir = Path("artifacts/signal_queue")
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / f"{target_date}_signal_report.txt"
+        out_path.write_text(report_text + "\n", encoding="utf-8")
+        logger.info("シグナルレポート保存: %s", out_path)
+    except Exception:
+        logger.warning("シグナルレポートのファイル保存に失敗しました", exc_info=True)
 
 
 def main() -> None:
@@ -60,6 +214,7 @@ def main() -> None:
         # --- ポートフォリオ DD 停止チェック ---
         mdb = MonitoringDB(sqlite_conn)
         dashboard = mdb.get_dashboard()
+        pf_value: float | None = float(dashboard["portfolio_value"]) if dashboard is not None else None
         entry_blocked = False
         if dashboard is not None:
             drawdown_pct = float(dashboard["drawdown_pct"])
@@ -128,6 +283,7 @@ def main() -> None:
         )
         _updated_rows["signals"] = n
         logger.info("シグナル生成完了: %d 件 (date=%s)", n, target_date)
+        _print_signal_report(conn, target_date, pf_value)
     except Exception as exc:
         logger.exception("generate_signals が失敗しました")
         _errors.append(str(exc))

--- a/scripts/run_strategy_signal.py
+++ b/scripts/run_strategy_signal.py
@@ -109,29 +109,33 @@ def _print_signal_report(
         if not portfolio_value or portfolio_value <= 0 or price <= 0 or n_buy == 0:
             return None
         slot = portfolio_value * _REPORT_MAX_UTILIZATION / n_buy
-        base = int(slot / price / _REPORT_LOT_SIZE) * _REPORT_LOT_SIZE
-        after_sm = int(base * sm / _REPORT_LOT_SIZE) * _REPORT_LOT_SIZE
-        cap = int(portfolio_value * _REPORT_MAX_POSITION_PCT / price / _REPORT_LOT_SIZE) * _REPORT_LOT_SIZE
-        return min(after_sm, cap)
+        qty = int(slot * sm / price / _REPORT_LOT_SIZE) * _REPORT_LOT_SIZE
+        cap = (
+            int(portfolio_value * _REPORT_MAX_POSITION_PCT / price / _REPORT_LOT_SIZE)
+            * _REPORT_LOT_SIZE
+        )
+        return min(qty, cap)
 
     # --- 出力 ---
     sep = "=" * 66
     lines: list[str] = []
     lines.append(sep)
     lines.append(f"  [Signal Report] date={target_date}")
-    if portfolio_value is not None:
-        lines.append(
-            f"  PF={portfolio_value:,.0f}円"
-            f"  max_util={_REPORT_MAX_UTILIZATION:.0%}"
-            f"  max_pos={_REPORT_MAX_POSITION_PCT:.0%}"
-            f"  lot={_REPORT_LOT_SIZE}"
-        )
+    pf_s = f"{portfolio_value:,.0f}円" if portfolio_value is not None else "N/A"
+    lines.append(
+        f"  PF={pf_s}"
+        f"  max_util={_REPORT_MAX_UTILIZATION:.0%}"
+        f"  max_pos={_REPORT_MAX_POSITION_PCT:.0%}"
+        f"  lot={_REPORT_LOT_SIZE}"
+    )
     lines.append(sep)
 
     # BUY
     lines.append(f"\n[BUY] {n_buy} 件")
     if buy_rows:
-        lines.append(f"  {'Rk':>2}  {'Code':<6}  {'Name':<22}  {'Close':>8}  {'Est.Qty':>10}  {'Est.Amt':>12}")
+        lines.append(
+            f"  {'Rk':>2}  {'Code':<6}  {'Name':<22}  {'Close':>8}  {'Est.Qty':>10}  {'Est.Amt':>12}"
+        )
         lines.append("  " + "-" * 64)
         total_est = 0.0
         for code, name, rank, sm in buy_rows:
@@ -172,7 +176,9 @@ def _print_signal_report(
         lines.append("  (なし)")
 
     lines.append("\n" + sep)
-    lines.append("  ※ Est.Qty は等配分/close price 基準の推定値。実際の発注量と異なる場合があります。")
+    lines.append(
+        "  ※ Est.Qty は等配分/close price 基準の推定値。実際の発注量と異なる場合があります。"
+    )
 
     report_text = "\n".join(lines)
     print(report_text)
@@ -214,7 +220,15 @@ def main() -> None:
         # --- ポートフォリオ DD 停止チェック ---
         mdb = MonitoringDB(sqlite_conn)
         dashboard = mdb.get_dashboard()
-        pf_value: float | None = float(dashboard["portfolio_value"]) if dashboard is not None else None
+        pf_value: float | None = None
+        if dashboard is not None:
+            val = dashboard.get("portfolio_value")
+            try:
+                pf_value = float(val) if val is not None else None
+            except Exception:
+                logger.warning(
+                    "dashboard.portfolio_value の変換に失敗しました: %r", val, exc_info=True
+                )
         entry_blocked = False
         if dashboard is not None:
             drawdown_pct = float(dashboard["drawdown_pct"])


### PR DESCRIPTION
## Summary

- `scripts/run_strategy_signal.py` に `_print_signal_report()` ヘルパー関数を追加
- `generate_signals()` 完了後に翌日シグナルの詳細レポートを出力する
- BUY/SELL それぞれの銘柄コード・銘柄名・終値・推定購入数量をコンソール表示
- `artifacts/signal_queue/{date}_signal_report.txt` にも UTF-8 で保存

## Report Format

```
==================================================================
  [Signal Report] date=2026-06-15
  PF=10,000,000円  max_util=30%  max_pos=10%  lot=100
==================================================================

[BUY] 3 件
  Rk  Code    Name                    Close    Est.Qty      Est.Amt
  ----------------------------------------------------------------
   1  1234    銘柄A                   3,500    1,000    3,500,000
   2  5678    銘柄B                   1,200    2,500    3,000,000
   3  9012    銘柄C                  15,000      200    3,000,000

  Est.Total: 9,500,000円 (95.0% of PF)

[SELL] 1 件
  Code    Name                        Close
  --------------------------------------------
  3456    銘柄D                       2,800
```

## Quantity Estimation Logic

- 等配分: `slot = PF × max_util(30%) / n_buy`
- `size_multiplier` 適用後に lot(100株) 単位に切り下げ
- `max_position_pct(10%)` キャップ適用
- PF 評価額が MonitoringDB から取得できない場合は `N/A` 表示

## Test plan

- [ ] `generate_signals()` 実行後にレポートがコンソールに出力されること
- [ ] BUY/SELL シグナルの銘柄名が `stocks` テーブルから正しく取得されること
- [ ] `artifacts/signal_queue/{date}_signal_report.txt` が保存されること
- [ ] signals テーブルが空の場合でもエラーにならないこと
- [ ] MonitoringDB dashboard が None の場合に Est.Qty が N/A になること
- [ ] ruff lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)