### PR TITLE
feat: 夜LINE通知にシグナル詳細（証券コード・銘柄名・購入株数）を追加

### DIFF
--- a/docs/superpowers/specs/2026-06-27-evening-line-signal-details-design.md
+++ b/docs/superpowers/specs/2026-06-27-evening-line-signal-details-design.md
@@ -103,5 +103,6 @@ ORDER BY s.code
 ## 制約
 
 - LINE通知の送信失敗はジョブ失敗にしない（既存ポリシー踏襲）
-- クエリ失敗時は `buy_signals=None` にフォールバック（LINE通知は件数のみ表示）
+- BUY クエリ失敗時は `(None, None)` を返し `buy_signals=None` 扱い（件数のみ表示にフォールバック）
+- SELL クエリ失敗時は `(buy, [])` を返す。`sell_signals=[]`（0件）として BUY 詳細は継続表示し、警告ログを出すのみでジョブは失敗にしない
 - `stocks.name` が NULL の場合は `code` を代用（`COALESCE` で対応）

--- a/docs/superpowers/specs/2026-06-27-evening-line-signal-details-design.md
+++ b/docs/superpowers/specs/2026-06-27-evening-line-signal-details-design.md
@@ -1,0 +1,106 @@
+# 夜LINE通知へのシグナル詳細追加 Design Spec
+
+## Goal
+
+夜間バッチ完了後のLINE通知（`format_evening_message`）に、翌日BUY/SELLシグナルの証券コード・証券名・購入株数を含める。
+
+## Architecture
+
+`run_portfolio_construction.py` が `signal_queue JOIN stocks` をクエリしてシグナル詳細リストを生成し、`format_evening_message()` に渡す。`format_evening_message()` はリストを受け取り整形する純粋関数として実装する。
+
+変更は `line_reports.py`（フォーマット）・`run_portfolio_construction.py`（クエリ追加）・`test_line_reports.py`（テスト）の3ファイルのみ。
+
+## Tech Stack
+
+Python 3.10+, DuckDB (JOIN クエリ), pytest
+
+---
+
+## 変更ファイル
+
+| ファイル | 変更種別 | 内容 |
+|---|---|---|
+| `src/kabusys/operations/line_reports.py` | Modify | `format_evening_message()` にパラメータ追加 |
+| `scripts/run_portfolio_construction.py` | Modify | シグナル詳細クエリと呼び出し更新 |
+| `tests/test_line_reports.py` | Modify | 新パラメータのテスト追加 |
+
+---
+
+## 詳細設計
+
+### 1. `format_evening_message()` シグネチャ変更
+
+```python
+def format_evening_message(
+    *,
+    inserted: int,
+    report_date: str,
+    daily_return: float | None = None,
+    buy_signals: list[dict] | None = None,
+    sell_signals: list[dict] | None = None,
+    max_signals: int = 10,
+) -> str:
+```
+
+- `buy_signals=None` / `sell_signals=None` のとき件数表示のみ（後方互換維持）
+- `buy_signals` 各要素: `{"code": str, "name": str, "size": int}`
+- `sell_signals` 各要素: `{"code": str, "name": str}`
+
+### 2. LINE通知フォーマット
+
+```
+【KabuSys 夜】2026-06-27
+翌日BUY: 3件 / SELL: 1件
+当日リターン: +1.2%
+───────────────
+BUY銘柄:
+  7203 トヨタ自動車  100株
+  6758 ソニーグループ  200株
+  9984 ソフトバンクG  50株
+SELL銘柄:
+  4661 オリエンタルランド
+```
+
+- BUY/SELLともに最大 `max_signals`（デフォルト10）件を表示し、超過分は「他N件」
+- `buy_signals=None` のとき（シグナルなし or クエリ失敗）は従来通り件数行のみ
+
+### 3. `run_portfolio_construction.py` クエリ
+
+`signal_queue` 挿入後、LINE通知送信直前に以下をクエリ:
+
+```sql
+-- BUY シグナル
+SELECT q.code, COALESCE(st.name, q.code) AS name, q.size
+FROM signal_queue q
+LEFT JOIN stocks st ON q.code = st.code
+WHERE q.date = ? AND q.side = 'buy' AND q.status = 'pending'
+ORDER BY q.code
+
+-- SELL シグナル
+SELECT q.code, COALESCE(st.name, q.code) AS name
+FROM signal_queue q
+LEFT JOIN stocks st ON q.code = st.code
+WHERE q.date = ? AND q.side = 'sell' AND q.status = 'pending'
+ORDER BY q.code
+```
+
+- クエリ失敗時は `buy_signals=None` / `sell_signals=None` にフォールバックし、LINE通知は件数のみ表示（ジョブ失敗にはしない）
+
+### 4. テスト方針
+
+`tests/test_line_reports.py` に以下を追加:
+
+- `buy_signals=None` → 既存フォーマット（後方互換）
+- `buy_signals=[]` → BUY銘柄セクションなし
+- BUY 1件 → コード・名前・株数が含まれる
+- BUY 12件 → 10件表示 + 「他2件」
+- SELL 1件 → コード・名前のみ（株数なし）
+- BUY + SELL 混在 → 両セクションが正しく出力される
+
+---
+
+## 制約
+
+- LINE通知の送信失敗はジョブ失敗にしない（既存ポリシー踏襲）
+- クエリ失敗時は `buy_signals=None` にフォールバック（LINE通知は件数のみ表示）
+- `stocks.name` が NULL の場合は `code` を代用（`COALESCE` で対応）

--- a/docs/superpowers/specs/2026-06-27-evening-line-signal-details-design.md
+++ b/docs/superpowers/specs/2026-06-27-evening-line-signal-details-design.md
@@ -69,19 +69,20 @@ SELL銘柄:
 `signal_queue` 挿入後、LINE通知送信直前に以下をクエリ:
 
 ```sql
--- BUY シグナル
+-- BUY シグナル（signal_queue: 発注キューに積まれた翌日執行予定シグナル）
 SELECT q.code, COALESCE(st.name, q.code) AS name, q.size
 FROM signal_queue q
 LEFT JOIN stocks st ON q.code = st.code
 WHERE q.date = ? AND q.side = 'buy' AND q.status = 'pending'
 ORDER BY q.code
 
--- SELL シグナル
-SELECT q.code, COALESCE(st.name, q.code) AS name
-FROM signal_queue q
-LEFT JOIN stocks st ON q.code = st.code
-WHERE q.date = ? AND q.side = 'sell' AND q.status = 'pending'
-ORDER BY q.code
+-- SELL シグナル（signals: 戦略エンジンが生成した翌日手仕舞い予定シグナル）
+-- BUY と異なり signals テーブルを参照する。SELL は signal_queue には積まれない。
+SELECT s.code, COALESCE(st.name, s.code) AS name
+FROM signals s
+LEFT JOIN stocks st ON s.code = st.code
+WHERE s.date = ? AND s.side = 'sell'
+ORDER BY s.code
 ```
 
 - クエリ失敗時は `buy_signals=None` / `sell_signals=None` にフォールバックし、LINE通知は件数のみ表示（ジョブ失敗にはしない）

--- a/scripts/run_portfolio_construction.py
+++ b/scripts/run_portfolio_construction.py
@@ -262,6 +262,7 @@ def _collect_evening_signals(
             """,
             [target_date],
         ).fetchall()
+        # signal_queue.size は BIGINT NOT NULL のため r[2] が None になることはない
         buy = [{"code": r[0], "name": r[1], "size": int(r[2])} for r in rows]
     except Exception:
         logger.warning("LINE通知用BUYシグナル詳細の取得に失敗しました", exc_info=True)

--- a/scripts/run_portfolio_construction.py
+++ b/scripts/run_portfolio_construction.py
@@ -240,6 +240,52 @@ def _get_today_return(conn: duckdb.DuckDBPyConnection, target_date: date, env: s
     return float(row[0])
 
 
+def _collect_evening_signals(
+    conn: duckdb.DuckDBPyConnection,
+    target_date: date,
+) -> tuple[list[dict] | None, list[dict] | None]:
+    """LINE 夜通知用の BUY/SELL シグナル詳細を取得する。
+
+    BUY は signal_queue JOIN stocks（size あり）。
+    SELL は signals JOIN stocks（size なし）。
+    BUY クエリ失敗時は (None, None) を返し、呼び出し元が件数表示にフォールバックする。
+    """
+    buy: list[dict] = []
+    try:
+        rows = conn.execute(
+            """
+            SELECT q.code, COALESCE(st.name, q.code) AS name, CAST(q.size AS BIGINT) AS size
+            FROM signal_queue q
+            LEFT JOIN stocks st ON q.code = st.code
+            WHERE q.date = ? AND q.side = 'buy' AND q.status = 'pending'
+            ORDER BY q.code
+            """,
+            [target_date],
+        ).fetchall()
+        buy = [{"code": r[0], "name": r[1], "size": int(r[2])} for r in rows]
+    except Exception:
+        logger.warning("LINE通知用BUYシグナル詳細の取得に失敗しました", exc_info=True)
+        return None, None
+
+    sell: list[dict] = []
+    try:
+        rows = conn.execute(
+            """
+            SELECT s.code, COALESCE(st.name, s.code) AS name
+            FROM signals s
+            LEFT JOIN stocks st ON s.code = st.code
+            WHERE s.date = ? AND s.side = 'sell'
+            ORDER BY s.code
+            """,
+            [target_date],
+        ).fetchall()
+        sell = [{"code": r[0], "name": r[1]} for r in rows]
+    except Exception:
+        logger.warning("LINE通知用SELLシグナル詳細の取得に失敗しました", exc_info=True)
+
+    return buy, sell
+
+
 def main() -> None:
     started_at = datetime.now(timezone.utc)
     log_run_start(_APP_NAME)
@@ -386,11 +432,14 @@ def main() -> None:
 
             # 夜の日次通知
             daily_return = _get_today_return(conn, target_date, env)
+            buy_sigs, sell_sigs = _collect_evening_signals(conn, target_date)
             notifier.send(
                 format_evening_message(
                     inserted=inserted,
                     report_date=target_date.isoformat(),
                     daily_return=daily_return,
+                    buy_signals=buy_sigs,
+                    sell_signals=sell_sigs,
                 )
             )
 

--- a/src/kabusys/operations/line_reports.py
+++ b/src/kabusys/operations/line_reports.py
@@ -140,13 +140,50 @@ def format_evening_message(
     inserted: int,
     report_date: str,
     daily_return: float | None = None,
+    buy_signals: list[dict] | None = None,
+    sell_signals: list[dict] | None = None,
+    max_signals: int = 10,
 ) -> str:
-    """portfolio_construction 完了後の夜通知メッセージを生成する。"""
+    """portfolio_construction 完了後の夜通知メッセージを生成する。
+
+    buy_signals=None のとき件数のみの旧フォーマット（後方互換）。
+    buy_signals が list のとき BUY/SELL 詳細を展開する。
+    """
+    if buy_signals is not None:
+        buy_count = len(buy_signals)
+        sell_count = len(sell_signals) if sell_signals is not None else 0
+        header_signal = f"翌日BUY: {buy_count}件 / SELL: {sell_count}件"
+    else:
+        header_signal = f"翌日シグナル: {inserted} 件"
+
     lines = [
         f"【KabuSys 夜】{report_date}",
-        f"翌日シグナル: {inserted} 件",
+        header_signal,
         f"当日リターン: {_fmt_rate(daily_return)}",
     ]
+
+    has_details = (buy_signals is not None and len(buy_signals) > 0) or (
+        sell_signals is not None and len(sell_signals) > 0
+    )
+    if has_details:
+        lines.append("───────────────")
+
+    if buy_signals:
+        lines.append("BUY銘柄:")
+        shown = buy_signals[:max_signals]
+        for s in shown:
+            lines.append(f"  {s['code']} {s['name']}  {s['size']}株")
+        if len(buy_signals) > max_signals:
+            lines.append(f"  … 他 {len(buy_signals) - max_signals} 件")
+
+    if sell_signals:
+        lines.append("SELL銘柄:")
+        shown = sell_signals[:max_signals]
+        for s in shown:
+            lines.append(f"  {s['code']} {s['name']}")
+        if len(sell_signals) > max_signals:
+            lines.append(f"  … 他 {len(sell_signals) - max_signals} 件")
+
     return "\n".join(lines)
 
 

--- a/src/kabusys/operations/line_reports.py
+++ b/src/kabusys/operations/line_reports.py
@@ -148,6 +148,9 @@ def format_evening_message(
 
     buy_signals=None のとき件数のみの旧フォーマット（後方互換）。
     buy_signals が list のとき BUY/SELL 詳細を展開する。
+    buy_signals 各要素: {"code": str, "name": str, "size": int}
+    sell_signals 各要素: {"code": str, "name": str}
+    inserted は buy_signals=None のとき（後方互換）のみ使用される。
     """
     if buy_signals is not None:
         buy_count = len(buy_signals)
@@ -162,10 +165,7 @@ def format_evening_message(
         f"当日リターン: {_fmt_rate(daily_return)}",
     ]
 
-    has_details = (buy_signals is not None and len(buy_signals) > 0) or (
-        sell_signals is not None and len(sell_signals) > 0
-    )
-    if has_details:
+    if buy_signals or sell_signals:
         lines.append("───────────────")
 
     if buy_signals:

--- a/src/kabusys/operations/line_reports.py
+++ b/src/kabusys/operations/line_reports.py
@@ -165,24 +165,25 @@ def format_evening_message(
         f"当日リターン: {_fmt_rate(daily_return)}",
     ]
 
-    if buy_signals or sell_signals:
-        lines.append("───────────────")
+    if buy_signals is not None:
+        if buy_signals or sell_signals:
+            lines.append("───────────────")
 
-    if buy_signals:
-        lines.append("BUY銘柄:")
-        shown = buy_signals[:max_signals]
-        for s in shown:
-            lines.append(f"  {s['code']} {s['name']}  {s['size']}株")
-        if len(buy_signals) > max_signals:
-            lines.append(f"  … 他 {len(buy_signals) - max_signals} 件")
+        if buy_signals:
+            lines.append("BUY銘柄:")
+            shown = buy_signals[:max_signals]
+            for s in shown:
+                lines.append(f"  {s['code']} {s['name']}  {s['size']}株")
+            if len(buy_signals) > max_signals:
+                lines.append(f"  … 他 {len(buy_signals) - max_signals} 件")
 
-    if sell_signals:
-        lines.append("SELL銘柄:")
-        shown = sell_signals[:max_signals]
-        for s in shown:
-            lines.append(f"  {s['code']} {s['name']}")
-        if len(sell_signals) > max_signals:
-            lines.append(f"  … 他 {len(sell_signals) - max_signals} 件")
+        if sell_signals:
+            lines.append("SELL銘柄:")
+            shown = sell_signals[:max_signals]
+            for s in shown:
+                lines.append(f"  {s['code']} {s['name']}")
+            if len(sell_signals) > max_signals:
+                lines.append(f"  … 他 {len(sell_signals) - max_signals} 件")
 
     return "\n".join(lines)
 

--- a/src/kabusys/utils/logging_setup.py
+++ b/src/kabusys/utils/logging_setup.py
@@ -47,6 +47,7 @@ class _WindowsSafeRotatingFileHandler(TimedRotatingFileHandler):
             super().doRollover()
         except PermissionError as exc:
             import sys as _sys
+
             print(
                 f"WARNING: ログローテーション失敗 (ファイルが別プロセスに使用中のためスキップ):"
                 f" {self.baseFilename} — {exc}",

--- a/tests/test_broker_api.py
+++ b/tests/test_broker_api.py
@@ -303,6 +303,7 @@ class TestIsBrokerOffline:
     def test_false_when_timeout(self):
         """タイムアウト例外は False。"""
         import httpx
+
         inner = httpx.TimeoutException("timeout")
         outer = BrokerAPIError("タイムアウト")
         outer.__cause__ = inner

--- a/tests/test_line_reports.py
+++ b/tests/test_line_reports.py
@@ -201,6 +201,19 @@ class TestFormatEveningMessage:
         assert "SELL銘柄:" not in msg
         assert "BUY: 1件" in msg
 
+    def test_buy_signals_none_with_sell_signals_hides_all_details(self):
+        """buy_signals=None のとき sell_signals が非空でも詳細セクションを出さない（後方互換）。"""
+        msg = format_evening_message(
+            inserted=0,
+            report_date="2026-06-28",
+            daily_return=None,
+            buy_signals=None,
+            sell_signals=[{"code": "4661", "name": "オリエンタルランド"}],
+        )
+        assert "翌日シグナル: 0 件" in msg
+        assert "SELL銘柄:" not in msg
+        assert "───────────────" not in msg
+
 
 class TestFormatWeeklyMessage:
     def test_with_full_summary(self):

--- a/tests/test_line_reports.py
+++ b/tests/test_line_reports.py
@@ -114,7 +114,7 @@ class TestFormatEveningMessage:
             buy_signals=[],
             sell_signals=[],
         )
-        assert "BUY: 0件 / SELL: 0件" in msg
+        assert "翌日BUY: 0件 / SELL: 0件" in msg
         assert "BUY銘柄:" not in msg
         assert "SELL銘柄:" not in msg
 
@@ -185,7 +185,7 @@ class TestFormatEveningMessage:
         )
         assert "BUY銘柄:" in msg
         assert "SELL銘柄:" in msg
-        assert "BUY: 1件 / SELL: 1件" in msg
+        assert "翌日BUY: 1件 / SELL: 1件" in msg
         assert "トヨタ自動車" in msg
         assert "オリエンタルランド" in msg
 

--- a/tests/test_line_reports.py
+++ b/tests/test_line_reports.py
@@ -94,6 +94,113 @@ class TestFormatEveningMessage:
         assert isinstance(msg, str)
         assert len(msg) > 0
 
+    def test_buy_signals_none_keeps_legacy_format(self):
+        """buy_signals=None のとき既存フォーマット（後方互換）。"""
+        msg = format_evening_message(
+            inserted=3,
+            report_date="2026-06-28",
+            daily_return=0.01,
+            buy_signals=None,
+        )
+        assert "翌日シグナル: 3 件" in msg
+        assert "BUY銘柄:" not in msg
+
+    def test_buy_signals_empty_list_shows_new_header(self):
+        """buy_signals=[] のとき件数ヘッダーが新形式で BUY セクションなし。"""
+        msg = format_evening_message(
+            inserted=0,
+            report_date="2026-06-28",
+            daily_return=None,
+            buy_signals=[],
+            sell_signals=[],
+        )
+        assert "BUY: 0件 / SELL: 0件" in msg
+        assert "BUY銘柄:" not in msg
+        assert "SELL銘柄:" not in msg
+
+    def test_buy_signals_shows_code_name_size(self):
+        """BUY 1件のとき証券コード・銘柄名・株数が含まれる。"""
+        msg = format_evening_message(
+            inserted=1,
+            report_date="2026-06-28",
+            daily_return=None,
+            buy_signals=[{"code": "7203", "name": "トヨタ自動車", "size": 100}],
+            sell_signals=[],
+        )
+        assert "7203" in msg
+        assert "トヨタ自動車" in msg
+        assert "100株" in msg
+        assert "BUY銘柄:" in msg
+
+    def test_buy_signals_truncated_at_max(self):
+        """BUY 12件のとき max_signals=10 で切り捨て「他2件」が表示される。"""
+        signals = [{"code": str(i), "name": f"銘柄{i}", "size": 100} for i in range(12)]
+        msg = format_evening_message(
+            inserted=12,
+            report_date="2026-06-28",
+            daily_return=None,
+            buy_signals=signals,
+            sell_signals=[],
+            max_signals=10,
+        )
+        assert "他 2 件" in msg
+        assert "銘柄0" in msg
+        assert "銘柄10" not in msg
+
+    def test_sell_signals_shows_code_name_no_size(self):
+        """SELL 1件のとき証券コード・銘柄名のみ（株数なし）。"""
+        msg = format_evening_message(
+            inserted=0,
+            report_date="2026-06-28",
+            daily_return=None,
+            buy_signals=[],
+            sell_signals=[{"code": "4661", "name": "オリエンタルランド"}],
+        )
+        assert "4661" in msg
+        assert "オリエンタルランド" in msg
+        assert "SELL銘柄:" in msg
+        assert "株" not in msg
+
+    def test_sell_signals_truncated_at_max(self):
+        """SELL 12件のとき max_signals=10 で切り捨て「他2件」が表示される。"""
+        signals = [{"code": str(i), "name": f"銘柄{i}"} for i in range(12)]
+        msg = format_evening_message(
+            inserted=0,
+            report_date="2026-06-28",
+            daily_return=None,
+            buy_signals=[],
+            sell_signals=signals,
+            max_signals=10,
+        )
+        assert "他 2 件" in msg
+
+    def test_buy_and_sell_signals_both_shown(self):
+        """BUY + SELL 混在のとき両セクションが出力される。"""
+        msg = format_evening_message(
+            inserted=1,
+            report_date="2026-06-28",
+            daily_return=0.005,
+            buy_signals=[{"code": "7203", "name": "トヨタ自動車", "size": 100}],
+            sell_signals=[{"code": "4661", "name": "オリエンタルランド"}],
+        )
+        assert "BUY銘柄:" in msg
+        assert "SELL銘柄:" in msg
+        assert "BUY: 1件 / SELL: 1件" in msg
+        assert "トヨタ自動車" in msg
+        assert "オリエンタルランド" in msg
+
+    def test_sell_signals_none_shows_no_sell_section(self):
+        """sell_signals=None のとき SELL セクションなし。"""
+        msg = format_evening_message(
+            inserted=1,
+            report_date="2026-06-28",
+            daily_return=None,
+            buy_signals=[{"code": "7203", "name": "トヨタ自動車", "size": 100}],
+            sell_signals=None,
+        )
+        assert "SELL銘柄:" not in msg
+        assert "BUY: 1件" in msg
+
 
 class TestFormatWeeklyMessage:
     def test_with_full_summary(self):

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -84,6 +84,7 @@ class TestSetupLogging:
     def test_stream_and_file_handlers_added(self, tmp_path):
         """StreamHandler と TimedRotatingFileHandler (Safe 実装) と FileHandler の3つが追加される。"""
         from kabusys.utils.logging_setup import _WindowsSafeRotatingFileHandler
+
         setup_logging(app_name="test", log_dir=tmp_path)
         root = logging.getLogger()
         assert any(type(h) is logging.StreamHandler for h in root.handlers)
@@ -445,6 +446,7 @@ class TestWindowsSafeRotatingFileHandler:
     def test_dorollover_permission_error_is_suppressed(self, tmp_path):
         """doRollover() が PermissionError を raise しても例外が外に漏れない。"""
         from unittest.mock import patch
+
         from kabusys.utils.logging_setup import _WindowsSafeRotatingFileHandler
 
         log_file = tmp_path / "test.log"
@@ -463,6 +465,7 @@ class TestWindowsSafeRotatingFileHandler:
     def test_dorollover_success_still_works(self, tmp_path):
         """PermissionError がない場合は親クラスの doRollover が呼ばれる。"""
         from unittest.mock import patch
+
         from kabusys.utils.logging_setup import _WindowsSafeRotatingFileHandler
 
         log_file = tmp_path / "test.log"
@@ -483,7 +486,10 @@ class TestWindowsSafeRotatingFileHandler:
     def test_setup_logging_uses_safe_handler(self, tmp_path):
         """setup_logging() が _WindowsSafeRotatingFileHandler を使う。"""
         from kabusys.utils.logging_setup import _WindowsSafeRotatingFileHandler
+
         setup_logging(app_name="test_safe", log_dir=tmp_path)
         root = logging.getLogger()
-        rotating_handlers = [h for h in root.handlers if isinstance(h, _WindowsSafeRotatingFileHandler)]
+        rotating_handlers = [
+            h for h in root.handlers if isinstance(h, _WindowsSafeRotatingFileHandler)
+        ]
         assert len(rotating_handlers) == 1


### PR DESCRIPTION
## Summary

- `format_evening_message()` に `buy_signals` / `sell_signals` / `max_signals` パラメータを追加
- BUY銘柄：証券コード・銘柄名・購入株数を表示（最大10件、超過時「他N件」）
- SELL銘柄：証券コード・銘柄名を表示（最大10件）
- `buy_signals=None` のとき旧フォーマット維持（後方互換）
- クエリ失敗時（BUY）は件数表示にフォールバック、SELL失敗は警告ログのみ
- `_collect_evening_signals()` が `signal_queue JOIN stocks`（BUY）と `signals JOIN stocks`（SELL）をクエリ

## Commits

- `1d79a43d` feat: format_evening_message にシグナル詳細（BUY/SELL銘柄名・株数）を追加
- `516fbffc` refactor: format_evening_message docstring・テスト表明・has_details を整理
- `44dc1c28` feat: 夜LINE通知にBUY/SELLシグナル詳細クエリを追加 (code/name/size)

## Test plan

- [x] `python -m pytest tests/test_line_reports.py -v` — 12件全 PASS（既存4 + 新規8）
- [x] `python -m pytest --tb=short -q` — 2133件全 PASS（リグレッションなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)